### PR TITLE
Refactor av proptypes-re-import.

### DIFF
--- a/src/proptypes/arbeidsforhold.js
+++ b/src/proptypes/arbeidsforhold.js
@@ -1,7 +1,9 @@
 /* eslint import/prefer-default-export:"off" */
 import PT from 'prop-types';
 
-import { Periode, Arbeidsavtale, OrgnummerNavn } from './';
+import { Periode } from './periode';
+import { Arbeidsavtale } from './arbeidsavtale';
+import { OrgnummerNavn } from './organisasjon';
 
 const ArbeidsforholdPropType = PT.shape({
   arbeidsforholdID: PT.string,

--- a/src/proptypes/medlemskap.js
+++ b/src/proptypes/medlemskap.js
@@ -1,6 +1,7 @@
 import PT from 'prop-types';
 
-import { Kodeverk, Periode } from './';
+import { Kodeverk } from './kodeverk';
+import { Periode } from './periode';
 
 const MedlemskapPeriodePropType = PT.shape({
   id: PT.number,

--- a/src/proptypes/permisjon.js
+++ b/src/proptypes/permisjon.js
@@ -1,6 +1,6 @@
 import PT from 'prop-types';
 
-import { Periode } from './';
+import { Periode } from './periode';
 
 const PermisjonOgPermitteringPropType = PT.shape({
   permisjonsId: PT.number,


### PR DESCRIPTION
Proptypes importerer direkte fra modulen for å unngå circular dependency som oppstår i Babel.

Klar for merge.