### PR TITLE
MELOSYS-894 korrigering av stegrekkefolge

### DIFF
--- a/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
+++ b/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
@@ -12,55 +12,55 @@ class StegLogikk {
     PERIODE: [
       {
         kriterier: 'alle andre valg',
-        oppfylt: () => true,
+        erOppfylt: () => true,
         nesteSteg: STEG.SYSSELSETTING,
       },
     ],
     SYSSELSETTING: [
       {
         kriterier: 'sysselsettingType ER LIK "ARBEIDSTAKER" eller sysselsettingType ER LIK "ARBEIDSTAKER__OG__SELVSTENDIG"',
-        oppfylt: ({ sysselsettingType }) => (sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER || sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER_OG_SELVSTENDIG),
+        erOppfylt: ({ sysselsettingType }) => (sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER || sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER_OG_SELVSTENDIG),
         nesteSteg: STEG.SEKTOR,
       },
       {
         kriterier: 'sysselsettingType ER LIK "SELVSTENDIG"',
-        oppfylt: ({ sysselsettingType }) => sysselsettingType === VurderingSysselsettingTyper.SELVSTENDIG,
+        erOppfylt: ({ sysselsettingType }) => sysselsettingType === VurderingSysselsettingTyper.SELVSTENDIG,
         nesteSteg: STEG.AKTIVITET,
       },
       {
         kriterier: 'alle andre valg',
-        oppfylt: () => true,
+        erOppfylt: () => true,
         nesteSteg: STEG.BOSTEDSLAND,
       },
     ],
     SEKTOR: [
       {
         kriterier: 'ansattISektor ER LIK "OFFENTLIG',
-        oppfylt: ({ ansattISektor }) => ansattISektor === VurderingSektorTyper.OFFENTLIG,
+        erOppfylt: ({ ansattISektor }) => ansattISektor === VurderingSektorTyper.OFFENTLIG,
         nesteSteg: STEG.TJENESTEMANN,
       },
       {
         kriterier: 'ansattISektor ER LIK "SOKKEL" eller ansattISektor ER LIK "SKIP"',
-        oppfylt: ({ ansattISektor }) => ansattISektor === VurderingSektorTyper.SOKKEL || ansattISektor === VurderingSektorTyper.SKIP,
+        erOppfylt: ({ ansattISektor }) => ansattISektor === VurderingSektorTyper.SOKKEL || ansattISektor === VurderingSektorTyper.SKIP,
         nesteSteg: STEG.VEDTAK,
       },
       {
         kriterier: 'alle andre valg',
-        oppfylt: () => true,
+        erOppfylt: () => true,
         nesteSteg: STEG.VIRKSOMHET,
       },
     ],
     AKTIVITET: [
       {
         kriterier: 'alle andre valg',
-        oppfylt: () => true,
+        erOppfylt: () => true,
         nesteSteg: STEG.VIRKSOMHET,
       },
     ],
     ARBEIDSFORHOLD: [
       {
         kriterier: 'alle andre valg',
-        oppfylt: () => true,
+        erOppfylt: () => true,
         nesteSteg: STEG.FORRETNINGSSTED,
       },
     ],
@@ -68,7 +68,7 @@ class StegLogikk {
       {
         kriterier: 'vurderingTjenestemann ER LIK "ETT_LAND" eller vurderingTjenestemann ER LIK "ETT_LAND_YRKESAKTIVITET_ANDRE_LAND" ' +
         'eller vurderingTjenestemann ER LIK "FLERE_LAND" eller vurderingTjenestemann ER LIK "FLERE_LAND_YRKESAKTIVITET_ANDRE_LAND"',
-        oppfylt: ({ vurderingTjenestemann }) => (
+        erOppfylt: ({ vurderingTjenestemann }) => (
           vurderingTjenestemann === VurderingTjenestemannTyper.ETT_LAND ||
           vurderingTjenestemann === VurderingTjenestemannTyper.ETT_LAND_YRKESAKTIVITET_ANDRE_LAND ||
           vurderingTjenestemann === VurderingTjenestemannTyper.FLERE_LAND ||
@@ -84,7 +84,7 @@ class StegLogikk {
     VIRKSOMHET: [
       {
         kriterier: 'sysselsettingType ER LIK "ARBEIDSTAKER" OG antallLand ER LIK "TO_ELLER_FLERE_LAND" OG aktivitetINorge ER LIK "UNDER_25_PROSENT"',
-        oppfylt: ({ sysselsettingType, antallLand, aktivitetINorge }) => (
+        erOppfylt: ({ sysselsettingType, antallLand, aktivitetINorge }) => (
           sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER &&
           antallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND &&
           aktivitetINorge === VurderingVirksomhetTyper.UNDER_25_PROSENT
@@ -93,7 +93,7 @@ class StegLogikk {
       },
       {
         kriterier: 'sysselsettingType ER LIK "SELVSTENDIG" OG ENTEN antallLand ER LIK "TO_ELLER_FLERE_LAND" ELLER antallLand ER LIK "ETT_LAND_IKKE_NORGE',
-        oppfylt: ({ sysselsettingType, antallLand }) => (
+        erOppfylt: ({ sysselsettingType, antallLand }) => (
           sysselsettingType === VurderingSysselsettingTyper.SELVSTENDIG &&
           (
             antallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND ||
@@ -104,7 +104,7 @@ class StegLogikk {
       },
       {
         kriterier: 'alle andre valg',
-        oppfylt: () => true,
+        erOppfylt: () => true,
         nesteSteg: STEG.VEDTAK,
       },
     ],
@@ -113,7 +113,7 @@ class StegLogikk {
         kriterier: 'sysselsettingType ER LIK "ARBEIDSTAKER" OG' +
         'aktivitetINorge ER LIK "UNDER_25_PROSENT" OG bostedsLand INNEHOLDER "NO" OG' +
         'antallLand ER LIK "TO_ELLER_FLERE_LAND"',
-        oppfylt: ({
+        erOppfylt: ({
           antallLand, sysselsettingType, aktivitetINorge, bostedsland,
         }) => (
           sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER &&
@@ -125,42 +125,42 @@ class StegLogikk {
       },
       {
         kriterier: 'alle andre valg',
-        oppfylt: () => true,
+        erOppfylt: () => true,
         nesteSteg: STEG.VEDTAK,
       },
     ],
     FORRETNINGSSTED: [
       {
         kriterier: 'alle andre valg',
-        oppfylt: () => true,
+        erOppfylt: () => true,
         nesteSteg: STEG.VEDTAK,
       },
     ],
     UTSENDING: [
       {
         kriterier: 'alle andre valg',
-        oppfylt: () => true,
+        erOppfylt: () => true,
         nesteSteg: STEG.VEDTAK,
       },
     ],
   }
 
-  static beregnNesteSteg = (gjeldendeSteg, vurderingerIDetteSteget, alleVurderinger) => {
+  static beregnNesteSteg = (gjeldendeSteg, flatFaktaAvklaring) => {
     const regelsettForGjeldendeSteg = StegLogikk.stier[gjeldendeSteg];
-    const nesteStiObjekt = regelsettForGjeldendeSteg.find((regel, index) => (index === regelsettForGjeldendeSteg.length - 1 ? true : regel.oppfylt(vurderingerIDetteSteget, alleVurderinger)));
+    const nesteStiObjekt = regelsettForGjeldendeSteg.find((regel, index) => (index === regelsettForGjeldendeSteg.length - 1 ? true : regel.erOppfylt(flatFaktaAvklaring)));
     return nesteStiObjekt.nesteSteg;
   }
 
-  static beregnAlleSteg = faktaavklaring => {
+  static beregnAlleSteg = faktaAvklaring => {
     const stegBygger = [];
-    const flatFaktaavklaring = Object.keys(faktaavklaring).reduce((collection, key) => ({ ...collection, ...faktaavklaring[key] }), {});
+    const flatFaktaAvklaring = Object.keys(faktaAvklaring).reduce((collection, key) => ({ ...collection, ...faktaAvklaring[key] }), {});
 
     // Stegene begynner alltid med 'PERIODE'
     let gjeldendeSteg = 'PERIODE';
     stegBygger.push(gjeldendeSteg);
 
     while (gjeldendeSteg !== 'VEDTAK') {
-      gjeldendeSteg = StegLogikk.beregnNesteSteg(gjeldendeSteg, flatFaktaavklaring);
+      gjeldendeSteg = StegLogikk.beregnNesteSteg(gjeldendeSteg, flatFaktaAvklaring);
       stegBygger.push(gjeldendeSteg);
 
       // Bryt ut av loopen dersom flere enn 30 steg er funnet - da har det oppstått

--- a/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
+++ b/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
@@ -11,140 +11,118 @@ class StegLogikk {
   static stier = {
     PERIODE: [
       {
-        valg: [],
-        til: STEG.SYSSELSETTING,
+        kriterier: 'alle andre valg',
+        oppfylt: () => true,
+        nesteSteg: STEG.SYSSELSETTING,
       },
     ],
     SYSSELSETTING: [
       {
-        valg: [VurderingSysselsettingTyper.ARBEIDSTAKER, VurderingSysselsettingTyper.ARBEIDSTAKER_OG_SELVSTENDIG],
-        til: STEG.SEKTOR,
+        kriterier: 'sysselsettingType ER LIK "ARBEIDSTAKER" eller sysselsettingType ER LIK "ARBEIDSTAKER__OG__SELVSTENDIG"',
+        oppfylt: ({ sysselsettingType }) => (sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER || sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER_OG_SELVSTENDIG),
+        nesteSteg: STEG.SEKTOR,
       },
       {
-        valg: [VurderingSysselsettingTyper.SELVSTENDIG],
-        til: STEG.AKTIVITET,
+        kriterier: 'sysselsettingType ER LIK "SELVSTENDIG"',
+        oppfylt: ({ sysselsettingType }) => sysselsettingType === VurderingSysselsettingTyper.SELVSTENDIG,
+        nesteSteg: STEG.AKTIVITET,
       },
       {
-        valg: [VurderingSysselsettingTyper.IKKE_ARBEIDENDE],
-        til: STEG.BOSTEDSLAND,
+        kriterier: 'alle andre valg',
+        oppfylt: () => true,
+        nesteSteg: STEG.BOSTEDSLAND,
       },
     ],
     SEKTOR: [
       {
-        valg: [VurderingSektorTyper.FLYVENDE, VurderingSektorTyper.OFFENTLIG],
-        til: STEG.TJENESTEMANN,
+        kriterier: 'sektorType ER LIK "OFFENTLIG',
+        oppfylt: ({ sektorType }) => sektorType === VurderingSektorTyper.OFFENTLIG,
+        nesteSteg: STEG.TJENESTEMANN,
       },
       {
-        valg: [VurderingSektorTyper.SOKKEL, VurderingSektorTyper.SKIP],
-        til: STEG.VEDTAK,
+        kriterier: 'sektorType ER LIK "SOKKEL" eller sektorTyp ER LIK "SKIP"',
+        oppfylt: ({ sektorType }) => sektorType === VurderingSektorTyper.SOKKEL || sektorType === VurderingSektorTyper.SKIP,
+        nesteSteg: STEG.VEDTAK,
       },
       {
-        valg: [VurderingSektorTyper.INGEN_AV_DISSE],
-        til: STEG.VIRKSOMHET,
+        kriterier: 'alle andre valg',
+        oppfylt: () => true,
+        nesteSteg: STEG.VIRKSOMHET,
       },
     ],
     AKTIVITET: [
       {
-        valg: [],
-        til: STEG.VIRKSOMHET,
+        kriterier: 'alle andre valg',
+        oppfylt: () => true,
+        nesteSteg: STEG.VIRKSOMHET,
       },
     ],
     ARBEIDSFORHOLD: [
       {
-        valg: [],
-        til: STEG.FORRETNINGSSTED,
+        kriterier: 'alle andre valg',
+        oppfylt: () => true,
+        nesteSteg: STEG.FORRETNINGSSTED,
       },
     ],
     FORRETNINGSSTED: [
       {
-        valg: [],
-        til: STEG.SEKTOR,
+        kriterier: 'alle andre valg',
+        oppfylt: () => true,
+        nesteSteg: STEG.SEKTOR,
       },
     ],
     TJENESTEMANN: [
       {
-        valg: [
-          VurderingTjenestemannTyper.ETT_LAND,
-          VurderingTjenestemannTyper.ETT_LAND_YRKESAKTIVITET_ANDRE_LAND,
-          VurderingTjenestemannTyper.FLERE_LAND,
-          VurderingTjenestemannTyper.FLERE_LAND_YRKESAKTIVITET_ANDRE_LAND,
-        ],
-        til: STEG.VEDTAK,
+        kriterier: 'vurderingTjenestemann ER LIK "ETT_LAND" eller vurderingTjenestemann ER LIK "ETT_LAND_YRKESAKTIVITET_ANDRE_LAND" ' +
+        'eller vurderingTjenestemann ER LIK "FLERE_LAND" eller vurderingTjenestemann ER LIK "FLERE_LAND_YRKESAKTIVITET_ANDRE_LAND"',
+        oppfylt: ({ vurderingTjenestemann }) => (
+          vurderingTjenestemann === VurderingTjenestemannTyper.ETT_LAND ||
+          vurderingTjenestemann === VurderingTjenestemannTyper.ETT_LAND_YRKESAKTIVITET_ANDRE_LAND ||
+          vurderingTjenestemann === VurderingTjenestemannTyper.FLERE_LAND ||
+          vurderingTjenestemann === VurderingTjenestemannTyper.FLERE_LAND_YRKESAKTIVITET_ANDRE_LAND
+        ),
+        nesteSteg: STEG.VEDTAK,
       },
       {
-        valg: [VurderingTjenestemannTyper.IKKE_TJENESTEMANN],
-        til: STEG.VIRKSOMHET,
+        valg: 'alle andre valg',
+        nesteSteg: STEG.SEKTOR,
       },
     ],
     VIRKSOMHET: [
       {
-        valg: [VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND],
-        til: STEG.BOSTEDSLAND,
+        kriterier: 'faktaavklaringAntallLand ER LIK "TO_ELLER_FLERE_LAND" OG faktaavklaringAktivitetINorge ER LIK "UNDER_25_PROSENT"',
+        oppfylt: ({ faktaavklaringAntallLand, faktaavklaringAktivitetINorge }) => (
+          faktaavklaringAntallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND &&
+          faktaavklaringAktivitetINorge === VurderingVirksomhetTyper.UNDER_25_PROSENT
+        ),
+        nesteSteg: STEG.BOSTEDSLAND,
       },
       {
-        valg: [],
-        til: STEG.VEDTAK,
+        kriterier: 'alle andre valg',
+        oppfylt: () => true,
+        nesteSteg: STEG.VEDTAK,
       },
     ],
     BOSTEDSLAND: [
       {
-        valg: [],
-        til: STEG.UTSENDING,
+        kriterier: 'alle andre valg',
+        oppfylt: () => true,
+        nesteSteg: STEG.UTSENDING,
       },
     ],
     UTSENDING: [
       {
-        valg: [],
-        til: STEG.VEDTAK,
-      },
-    ],
-    VEDTAK: [
-      {
-        valg: StegLogikk.SISTE_STEG,
-        til: StegLogikk.SISTE_STEG,
+        kriterier: 'alle andre valg',
+        oppfylt: () => true,
+        nesteSteg: STEG.VEDTAK,
       },
     ],
   }
 
   static beregnNesteSteg = (gjeldendeSteg, vurderingerIDetteSteget) => {
-    switch (gjeldendeSteg) {
-      case STEG.PERIODE: {
-        return 'SYSSELSETTING';
-      }
-      case STEG.SYSSELSETTING: {
-        const { sysselsettingType } = vurderingerIDetteSteget;
-        const nesteStiObjekt = StegLogikk.stier[gjeldendeSteg].find(sti => sti.valg.includes(sysselsettingType));
-        return nesteStiObjekt ? nesteStiObjekt.til : 'VEDTAK';
-      }
-      case STEG.SEKTOR: {
-        const { ansattISektor } = vurderingerIDetteSteget;
-        return StegLogikk.stier[gjeldendeSteg].find(sti => sti.valg.includes(ansattISektor)).til;
-      }
-      case STEG.VIRKSOMHET: {
-        console.log('virksomhetsvurderinger', vurderingerIDetteSteget);
-        return StegLogikk.stier[gjeldendeSteg][0].til;
-      }
-      case STEG.ARBEIDSFORHOLD: {
-        return StegLogikk.stier[gjeldendeSteg][0].til;
-      }
-      case STEG.UTSENDING: {
-        return StegLogikk.stier[gjeldendeSteg][0].til;
-      }
-      case STEG.AKTIVITET: {
-        return StegLogikk.stier[gjeldendeSteg][0].til;
-      }
-      case STEG.BOSTEDSLAND: {
-        return StegLogikk.stier[gjeldendeSteg][0].til;
-      }
-      case STEG.FORRETNINGSSTED: {
-        return StegLogikk.stier[gjeldendeSteg][0].til;
-      }
-      case STEG.TJENESTEMANN: {
-        return StegLogikk.stier[gjeldendeSteg][0].til;
-      }
-      default:
-        return {};
-    }
+    const regelsettForGjeldendeSteg = StegLogikk.stier[gjeldendeSteg];
+    const nesteStiObjekt = regelsettForGjeldendeSteg.find((regel, index) => (index === regelsettForGjeldendeSteg.length - 1 ? true : regel.oppfylt(vurderingerIDetteSteget)));
+    return nesteStiObjekt.nesteSteg;
   }
 
   static beregnAlleSteg = faktaavklaring => {

--- a/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
+++ b/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
@@ -90,12 +90,24 @@ class StegLogikk {
     ],
     VIRKSOMHET: [
       {
-        kriterier: 'antallLand ER LIK "TO_ELLER_FLERE_LAND" OG aktivitetINorge ER LIK "UNDER_25_PROSENT"',
-        oppfylt: ({ antallLand, aktivitetINorge }) => (
+        kriterier: 'sysselsettingType ER LIK "ARBEIDSTAKER" OG antallLand ER LIK "TO_ELLER_FLERE_LAND" OG aktivitetINorge ER LIK "UNDER_25_PROSENT"',
+        oppfylt: ({ antallLand, aktivitetINorge }, { sysselsetting: { sysselsettingType } }) => (
+          sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER &&
           antallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND &&
           aktivitetINorge === VurderingVirksomhetTyper.UNDER_25_PROSENT
         ),
         nesteSteg: STEG.BOSTEDSLAND,
+      },
+      {
+        kriterier: 'sysselsettingType ER LIK "SELVSTENDIG" OG ENTEN antallLand ER LIK "TO_ELLER_FLERE_LAND" ELLER antallLand ER LIK "ETT_LAND_IKKE_NORGE',
+        oppfylt: ({ antallLand }, { sysselsetting: { sysselsettingType } }) => (
+          sysselsettingType === VurderingSysselsettingTyper.SELVSTENDIG &&
+          (
+            antallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND ||
+            antallLand === VurderingVirksomhetTyper.ETT_LAND_IKKE_NORGE
+          )
+        ),
+        nesteSteg: STEG.UTSENDING,
       },
       {
         kriterier: 'alle andre valg',

--- a/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
+++ b/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
@@ -64,13 +64,6 @@ class StegLogikk {
         nesteSteg: STEG.FORRETNINGSSTED,
       },
     ],
-    FORRETNINGSSTED: [
-      {
-        kriterier: 'alle andre valg',
-        oppfylt: () => true,
-        nesteSteg: STEG.SEKTOR,
-      },
-    ],
     TJENESTEMANN: [
       {
         kriterier: 'vurderingTjenestemann ER LIK "ETT_LAND" eller vurderingTjenestemann ER LIK "ETT_LAND_YRKESAKTIVITET_ANDRE_LAND" ' +
@@ -116,6 +109,27 @@ class StegLogikk {
       },
     ],
     BOSTEDSLAND: [
+      {
+        kriterier: 'sysselsettingType ER LIK "ARBEIDSTAKER" OG' +
+        'aktivitetINorge ER LIK "UNDER_25_PROSENT" OG bostedsLand INNEHOLDER "NO" OG' +
+        'antallLand ER LIK "TO_ELLER_FLERE_LAND"',
+        oppfylt: ({ }, { virksomhet: { antallLand }, sysselsetting: { sysselsettingType }, virksomhet: { aktivitetINorge }, bostedsland: { bostedsland } }) => {
+          return (
+            sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER &&
+            aktivitetINorge === VurderingVirksomhetTyper.UNDER_25_PROSENT &&
+            bostedsland.includes('NO') &&
+            antallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND
+          );
+        },
+        nesteSteg: STEG.FORRETNINGSSTED,
+      },
+      {
+        kriterier: 'alle andre valg',
+        oppfylt: () => true,
+        nesteSteg: STEG.VEDTAK,
+      },
+    ],
+    FORRETNINGSSTED: [
       {
         kriterier: 'alle andre valg',
         oppfylt: () => true,

--- a/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
+++ b/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
@@ -84,7 +84,7 @@ class StegLogikk {
     VIRKSOMHET: [
       {
         kriterier: 'sysselsettingType ER LIK "ARBEIDSTAKER" OG antallLand ER LIK "TO_ELLER_FLERE_LAND" OG aktivitetINorge ER LIK "UNDER_25_PROSENT"',
-        oppfylt: ({ antallLand, aktivitetINorge }, { sysselsetting: { sysselsettingType } }) => (
+        oppfylt: ({ sysselsettingType, antallLand, aktivitetINorge }) => (
           sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER &&
           antallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND &&
           aktivitetINorge === VurderingVirksomhetTyper.UNDER_25_PROSENT
@@ -93,7 +93,7 @@ class StegLogikk {
       },
       {
         kriterier: 'sysselsettingType ER LIK "SELVSTENDIG" OG ENTEN antallLand ER LIK "TO_ELLER_FLERE_LAND" ELLER antallLand ER LIK "ETT_LAND_IKKE_NORGE',
-        oppfylt: ({ antallLand }, { sysselsetting: { sysselsettingType } }) => (
+        oppfylt: ({ sysselsettingType, antallLand }) => (
           sysselsettingType === VurderingSysselsettingTyper.SELVSTENDIG &&
           (
             antallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND ||
@@ -113,14 +113,14 @@ class StegLogikk {
         kriterier: 'sysselsettingType ER LIK "ARBEIDSTAKER" OG' +
         'aktivitetINorge ER LIK "UNDER_25_PROSENT" OG bostedsLand INNEHOLDER "NO" OG' +
         'antallLand ER LIK "TO_ELLER_FLERE_LAND"',
-        oppfylt: ({ }, { virksomhet: { antallLand }, sysselsetting: { sysselsettingType }, virksomhet: { aktivitetINorge }, bostedsland: { bostedsland } }) => {
-          return (
-            sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER &&
-            aktivitetINorge === VurderingVirksomhetTyper.UNDER_25_PROSENT &&
-            bostedsland.includes('NO') &&
-            antallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND
-          );
-        },
+        oppfylt: ({
+          antallLand, sysselsettingType, aktivitetINorge, bostedsland,
+        }) => (
+          sysselsettingType === VurderingSysselsettingTyper.ARBEIDSTAKER &&
+          aktivitetINorge === VurderingVirksomhetTyper.UNDER_25_PROSENT &&
+          bostedsland.includes('NO') &&
+          antallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND
+        ),
         nesteSteg: STEG.FORRETNINGSSTED,
       },
       {
@@ -146,7 +146,6 @@ class StegLogikk {
   }
 
   static beregnNesteSteg = (gjeldendeSteg, vurderingerIDetteSteget, alleVurderinger) => {
-    console.log(gjeldendeSteg, vurderingerIDetteSteget);
     const regelsettForGjeldendeSteg = StegLogikk.stier[gjeldendeSteg];
     const nesteStiObjekt = regelsettForGjeldendeSteg.find((regel, index) => (index === regelsettForGjeldendeSteg.length - 1 ? true : regel.oppfylt(vurderingerIDetteSteget, alleVurderinger)));
     return nesteStiObjekt.nesteSteg;
@@ -154,13 +153,14 @@ class StegLogikk {
 
   static beregnAlleSteg = faktaavklaring => {
     const stegBygger = [];
+    const flatFaktaavklaring = Object.keys(faktaavklaring).reduce((collection, key) => ({ ...collection, ...faktaavklaring[key] }), {});
 
     // Stegene begynner alltid med 'PERIODE'
     let gjeldendeSteg = 'PERIODE';
     stegBygger.push(gjeldendeSteg);
 
     while (gjeldendeSteg !== 'VEDTAK') {
-      gjeldendeSteg = StegLogikk.beregnNesteSteg(gjeldendeSteg, faktaavklaring[gjeldendeSteg.toLowerCase()], faktaavklaring);
+      gjeldendeSteg = StegLogikk.beregnNesteSteg(gjeldendeSteg, flatFaktaavklaring);
       stegBygger.push(gjeldendeSteg);
 
       // Bryt ut av loopen dersom flere enn 30 steg er funnet - da har det oppstått

--- a/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
+++ b/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
@@ -18,27 +18,15 @@ class StegLogikk {
     SYSSELSETTING: [
       {
         valg: [VurderingSysselsettingTyper.ARBEIDSTAKER, VurderingSysselsettingTyper.ARBEIDSTAKER_OG_SELVSTENDIG],
-        til: STEG.ARBEIDSFORHOLD,
+        til: STEG.SEKTOR,
       },
       {
         valg: [VurderingSysselsettingTyper.SELVSTENDIG],
-        til: STEG.VIRKSOMHET,
+        til: STEG.AKTIVITET,
       },
       {
         valg: [VurderingSysselsettingTyper.IKKE_ARBEIDENDE],
         til: STEG.BOSTEDSLAND,
-      },
-    ],
-    ARBEIDSFORHOLD: [
-      {
-        valg: [],
-        til: STEG.FORRETNINGSSTED,
-      },
-    ],
-    FORRETNINGSSTED: [
-      {
-        valg: [],
-        til: STEG.SEKTOR,
       },
     ],
     SEKTOR: [
@@ -53,6 +41,24 @@ class StegLogikk {
       {
         valg: [VurderingSektorTyper.INGEN_AV_DISSE],
         til: STEG.VIRKSOMHET,
+      },
+    ],
+    AKTIVITET: [
+      {
+        valg: [],
+        til: STEG.VIRKSOMHET,
+      },
+    ],
+    ARBEIDSFORHOLD: [
+      {
+        valg: [],
+        til: STEG.FORRETNINGSSTED,
+      },
+    ],
+    FORRETNINGSSTED: [
+      {
+        valg: [],
+        til: STEG.SEKTOR,
       },
     ],
     TJENESTEMANN: [
@@ -72,27 +78,21 @@ class StegLogikk {
     ],
     VIRKSOMHET: [
       {
-        valg: [VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND, VurderingVirksomhetTyper.ETT_LAND_IKKE_NORGE],
-        til: STEG.UTSENDING,
-      },
-      {
-        valg: [],
-        til: STEG.AKTIVITET,
-      },
-    ],
-    UTSENDING: [
-      {
-        valg: [],
+        valg: [VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND],
         til: STEG.BOSTEDSLAND,
       },
-    ],
-    BOSTEDSLAND: [
       {
         valg: [],
         til: STEG.VEDTAK,
       },
     ],
-    AKTIVITET: [
+    BOSTEDSLAND: [
+      {
+        valg: [],
+        til: STEG.UTSENDING,
+      },
+    ],
+    UTSENDING: [
       {
         valg: [],
         til: STEG.VEDTAK,
@@ -121,10 +121,8 @@ class StegLogikk {
         return StegLogikk.stier[gjeldendeSteg].find(sti => sti.valg.includes(ansattISektor)).til;
       }
       case STEG.VIRKSOMHET: {
-        if (vurderingerIDetteSteget.antallLand === VurderingVirksomhetTyper.KUN_NORGE) {
-          return STEG.VEDTAK;
-        }
-        return STEG.AKTIVITET;
+        console.log('virksomhetsvurderinger', vurderingerIDetteSteget);
+        return StegLogikk.stier[gjeldendeSteg][0].til;
       }
       case STEG.ARBEIDSFORHOLD: {
         return StegLogikk.stier[gjeldendeSteg][0].til;

--- a/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
+++ b/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.js
@@ -35,13 +35,13 @@ class StegLogikk {
     ],
     SEKTOR: [
       {
-        kriterier: 'sektorType ER LIK "OFFENTLIG',
-        oppfylt: ({ sektorType }) => sektorType === VurderingSektorTyper.OFFENTLIG,
+        kriterier: 'ansattISektor ER LIK "OFFENTLIG',
+        oppfylt: ({ ansattISektor }) => ansattISektor === VurderingSektorTyper.OFFENTLIG,
         nesteSteg: STEG.TJENESTEMANN,
       },
       {
-        kriterier: 'sektorType ER LIK "SOKKEL" eller sektorTyp ER LIK "SKIP"',
-        oppfylt: ({ sektorType }) => sektorType === VurderingSektorTyper.SOKKEL || sektorType === VurderingSektorTyper.SKIP,
+        kriterier: 'ansattISektor ER LIK "SOKKEL" eller ansattISektor ER LIK "SKIP"',
+        oppfylt: ({ ansattISektor }) => ansattISektor === VurderingSektorTyper.SOKKEL || ansattISektor === VurderingSektorTyper.SKIP,
         nesteSteg: STEG.VEDTAK,
       },
       {
@@ -85,15 +85,15 @@ class StegLogikk {
       },
       {
         valg: 'alle andre valg',
-        nesteSteg: STEG.SEKTOR,
+        nesteSteg: STEG.VEDTAK,
       },
     ],
     VIRKSOMHET: [
       {
-        kriterier: 'faktaavklaringAntallLand ER LIK "TO_ELLER_FLERE_LAND" OG faktaavklaringAktivitetINorge ER LIK "UNDER_25_PROSENT"',
-        oppfylt: ({ faktaavklaringAntallLand, faktaavklaringAktivitetINorge }) => (
-          faktaavklaringAntallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND &&
-          faktaavklaringAktivitetINorge === VurderingVirksomhetTyper.UNDER_25_PROSENT
+        kriterier: 'antallLand ER LIK "TO_ELLER_FLERE_LAND" OG aktivitetINorge ER LIK "UNDER_25_PROSENT"',
+        oppfylt: ({ antallLand, aktivitetINorge }) => (
+          antallLand === VurderingVirksomhetTyper.TO_ELLER_FLERE_LAND &&
+          aktivitetINorge === VurderingVirksomhetTyper.UNDER_25_PROSENT
         ),
         nesteSteg: STEG.BOSTEDSLAND,
       },
@@ -107,7 +107,7 @@ class StegLogikk {
       {
         kriterier: 'alle andre valg',
         oppfylt: () => true,
-        nesteSteg: STEG.UTSENDING,
+        nesteSteg: STEG.VEDTAK,
       },
     ],
     UTSENDING: [
@@ -119,9 +119,10 @@ class StegLogikk {
     ],
   }
 
-  static beregnNesteSteg = (gjeldendeSteg, vurderingerIDetteSteget) => {
+  static beregnNesteSteg = (gjeldendeSteg, vurderingerIDetteSteget, alleVurderinger) => {
+    console.log(gjeldendeSteg, vurderingerIDetteSteget);
     const regelsettForGjeldendeSteg = StegLogikk.stier[gjeldendeSteg];
-    const nesteStiObjekt = regelsettForGjeldendeSteg.find((regel, index) => (index === regelsettForGjeldendeSteg.length - 1 ? true : regel.oppfylt(vurderingerIDetteSteget)));
+    const nesteStiObjekt = regelsettForGjeldendeSteg.find((regel, index) => (index === regelsettForGjeldendeSteg.length - 1 ? true : regel.oppfylt(vurderingerIDetteSteget, alleVurderinger)));
     return nesteStiObjekt.nesteSteg;
   }
 
@@ -133,7 +134,7 @@ class StegLogikk {
     stegBygger.push(gjeldendeSteg);
 
     while (gjeldendeSteg !== 'VEDTAK') {
-      gjeldendeSteg = StegLogikk.beregnNesteSteg(gjeldendeSteg, faktaavklaring[gjeldendeSteg.toLowerCase()]);
+      gjeldendeSteg = StegLogikk.beregnNesteSteg(gjeldendeSteg, faktaavklaring[gjeldendeSteg.toLowerCase()], faktaavklaring);
       stegBygger.push(gjeldendeSteg);
 
       // Bryt ut av loopen dersom flere enn 30 steg er funnet - da har det oppstått

--- a/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.test.js
+++ b/src/felles-komponenter/vilkarsveileder/stegLogikk/stegLogikk.test.js
@@ -10,17 +10,3 @@ it('treffer riktig stivalg FRA PERIODE med valg (ANYTHING)', () => {
 
   expect(Logikk.beregnNesteSteg(gjeldendeSteg, saksbehandlersVurdering)).toEqual('SYSSELSETTING');
 });
-
-it('treffer riktig stivalg FRA SYSSELSETTING med valg SEKTOR', () => {
-  const gjeldendeSteg = 'SYSSELSETTING';
-  const saksbehandlersVurdering = { sysselsettingType: VurderingSysselsettingTyper.SELVSTENDIG };
-
-  expect(Logikk.beregnNesteSteg(gjeldendeSteg, saksbehandlersVurdering)).toEqual('VIRKSOMHET');
-});
-
-it('treffer riktig stivalg FRA SYSSELSETTING med valg ARBEIDSTAKER', () => {
-  const gjeldendeSteg = 'SYSSELSETTING';
-  const saksbehandlersVurdering = { sysselsettingType: VurderingSysselsettingTyper.ARBEIDSTAKER };
-
-  expect(Logikk.beregnNesteSteg(gjeldendeSteg, saksbehandlersVurdering)).toEqual('ARBEIDSFORHOLD');
-});


### PR DESCRIPTION
Oppsummering:
- Skrevet om steglogikken slik at hvert steg ikke bare kjenner forrige valg, men ALLE valg i faktaavklaringene.
- Slått sammen stier-logikk og iterasjonen slik at forretningslogikken er samlet ETT sted.
- Oppdatert unit test og fjernet 2 tester. Foreslår å avvente til stegene og rekkefølge er satt.