### PR TITLE
Feil proptypes forventet objekt fremforarray.

### DIFF
--- a/src/felles-komponenter/arbeidsforhold/inntekt.js
+++ b/src/felles-komponenter/arbeidsforhold/inntekt.js
@@ -117,7 +117,7 @@ class Inntekt extends Component {
 }
 
 Inntekt.propTypes = {
-  inntekt: MPT.Inntekt,
+  inntekt: MPT.InntektListe,
 };
 
 Inntekt.defaultProps = {

--- a/src/proptypes/arbeidsforhold.js
+++ b/src/proptypes/arbeidsforhold.js
@@ -5,7 +5,7 @@ import { Periode } from './periode';
 import { Permisjoner } from './permisjon';
 import { TimerTimelonnet } from './timerTimelonnet';
 import { Arbeidsavtale } from './arbeidsavtale';
-import { InntektLinje } from './inntekt';
+import { InntektEnkeltLinje } from './inntekt';
 
 const ArbeidsforholdetPropType = PT.shape({
   arbeidsforholdID: PT.string,
@@ -14,7 +14,7 @@ const ArbeidsforholdetPropType = PT.shape({
   arbeidsforholdstype: PT.string,
   permisjonOgPermittering: Permisjoner,
   timerTimelonnet: TimerTimelonnet,
-  inntekt: PT.arrayOf(InntektLinje),
+  inntekt: PT.arrayOf(InntektEnkeltLinje),
   utenlandsopphold: PT.array,
   arbeidsgiverID: PT.string,
   arbeidstakerID: PT.string,

--- a/src/proptypes/index.js
+++ b/src/proptypes/index.js
@@ -1,5 +1,5 @@
 import { Permisjonen, Permisjoner, PermisjonOgPermittering } from './permisjon';
-import { Inntekt, InntektLinje } from './inntekt';
+import { Inntekt, InntektListe, InntektLinje } from './inntekt';
 import { Arbeidsforholdet, Arbeidsforholdene } from './arbeidsforhold';
 import { TimerTimelonnet, TimerTimelonnetLinje } from './timerTimelonnet';
 import { OppholdUtland } from './oppholdUtland';
@@ -42,6 +42,7 @@ export {
   Medlemskap,
   Bekreftelser,
   Inntekt,
+  InntektListe,
   InntektLinje,
   Oppsummering,
   Permisjonen,

--- a/src/proptypes/index.js
+++ b/src/proptypes/index.js
@@ -1,5 +1,5 @@
 import { Permisjonen, Permisjoner, PermisjonOgPermittering } from './permisjon';
-import { Inntekt, InntektListe, InntektLinje } from './inntekt';
+import { Inntekt, InntektListe, InntektEnkeltLinje } from './inntekt';
 import { Arbeidsforholdet, Arbeidsforholdene } from './arbeidsforhold';
 import { TimerTimelonnet, TimerTimelonnetLinje } from './timerTimelonnet';
 import { OppholdUtland } from './oppholdUtland';
@@ -43,7 +43,7 @@ export {
   Bekreftelser,
   Inntekt,
   InntektListe,
-  InntektLinje,
+  InntektEnkeltLinje,
   Oppsummering,
   Permisjonen,
   Permisjoner,

--- a/src/proptypes/inntekt.js
+++ b/src/proptypes/inntekt.js
@@ -18,6 +18,8 @@ const InntektLinjePropType = PT.shape({
   beskrivelse: PT.string,
 });
 
+const InntektListePropType = PT.arrayOf(InntektLinjePropType);
+
 const InntektPropType = PT.shape({
   ident: PT.shape({
     personIdent: PT.string,
@@ -34,5 +36,6 @@ const InntektPropType = PT.shape({
 
 export {
   InntektLinjePropType as InntektLinje,
+  InntektListePropType as InntektListe,
   InntektPropType as Inntekt,
 };

--- a/src/proptypes/inntekt.js
+++ b/src/proptypes/inntekt.js
@@ -1,7 +1,7 @@
 import PT from 'prop-types';
 import { Periode } from './periode';
 
-const InntektLinjePropType = PT.shape({
+const InntektEnkeltLinjePropType = PT.shape({
   beloep: PT.number,
   fordel: PT.string,
   inntektskilde: PT.string,
@@ -18,7 +18,7 @@ const InntektLinjePropType = PT.shape({
   beskrivelse: PT.string,
 });
 
-const InntektListePropType = PT.arrayOf(InntektLinjePropType);
+const InntektListePropType = PT.arrayOf(InntektEnkeltLinjePropType);
 
 const InntektPropType = PT.shape({
   ident: PT.shape({
@@ -28,14 +28,14 @@ const InntektPropType = PT.shape({
     arbeidsInntektMaaned: PT.shape({
       aarMaaned: PT.string,
       arbeidsInntektInformasjon: PT.shape({
-        inntektListe: InntektLinjePropType,
+        inntektListe: InntektEnkeltLinjePropType,
       }),
     }),
   }),
 });
 
 export {
-  InntektLinjePropType as InntektLinje,
+  InntektEnkeltLinjePropType as InntektEnkeltLinje,
   InntektListePropType as InntektListe,
   InntektPropType as Inntekt,
 };


### PR DESCRIPTION
Inntekt-proptype forventer hele treet innenfor inntekt. Komponenten for inntekt får derimot kun selve listen med InntektLinjer. Har opprettet en ny MPT.InntektLister som er en arrayOf(InntektLinje).