### PR TITLE
Patch feil i EnkeltDato

### DIFF
--- a/src/felles-komponenter/arbeidsgiver/arbeidsavtaler.js
+++ b/src/felles-komponenter/arbeidsgiver/arbeidsavtaler.js
@@ -29,7 +29,7 @@ class Arbeidsavtaler extends Component {
       const {
         gyldigTil = '-', yrke, arbeidstidsordning, avtaltArbeidstimerPerUke, stillingsprosent, antallTimerFraGammeltRegister = '-', endringsdatoStillingsprosent,
       } = arbeidsavtale;
-      return [...samling, [gyldigTil, yrke, arbeidstidsordning, avtaltArbeidstimerPerUke, antallTimerFraGammeltRegister, stillingsprosent, EnkeltDato(endringsdatoStillingsprosent)]];
+      return [...samling, [gyldigTil, yrke, arbeidstidsordning, avtaltArbeidstimerPerUke, antallTimerFraGammeltRegister, stillingsprosent, <EnkeltDato dato={endringsdatoStillingsprosent} />]];
     }, []);
 
     // Lag eventuelle elementer som skal rendres ut senere, slik at vi slipper mye logikk i selve return-blokken.


### PR DESCRIPTION
Feil bruk av EnkeltDato gjør at Melosys krasjer dersom endringsdatoStillingsprosent er undefined.