### PR TITLE
Fiks: Linting har plutselig slått seg vrang på object-curly-newline

### DIFF
--- a/src/felles-komponenter/skjema/landvelger/index.js
+++ b/src/felles-komponenter/skjema/landvelger/index.js
@@ -7,9 +7,7 @@ import * as Nav from '../../../utils/navFrontend';
 import * as MPT from '../../../proptypes';
 
 import './landvelger.css';
-import {
-  LandkoderSelector,
-} from '../../../ducks/landkoder';
+import { LandkoderSelector } from '../../../ducks/landkoder';
 
 const landTekstFormat = landObjekt => (`${landObjekt.term} (${landObjekt.kode})`);
 
@@ -46,7 +44,7 @@ class CustomLandVelger extends Component {
    * * For å kunne søke på både landkode og land-navnslik det står i listen, feks "Storbrittannia (GB)",
    * brukes 'landTekstFormat' for å sette sammen dette til en string før det søkes i denne stringen.
    *
-   * @param alleLand Array Liste over alle tilgjengelige land, bestående av landobjekt.
+   * @param landkoder Array Liste over alle tilgjengelige land, bestående av landobjekt.
    * @param inputVerdi String Verdien det skal søkes etter.
    * @return Array med landObjekter som matcher.
    */

--- a/src/felles-komponenter/topplinje.js
+++ b/src/felles-komponenter/topplinje.js
@@ -7,9 +7,7 @@ import * as navLogo from '../resources/images/nav.svg';
 import './topplinje.css';
 import * as MPT from '../proptypes/';
 
-import {
-  SaksbehandlerSelector,
-} from '../ducks/saksbehandler';
+import { SaksbehandlerSelector } from '../ducks/saksbehandler';
 
 const Topplinje = props => {
   const { saksbehandler: { navn } } = props;

--- a/src/proptypes/arbeidNorge.js
+++ b/src/proptypes/arbeidNorge.js
@@ -20,6 +20,4 @@ const ArbeidNorgePropType = PT.shape({
   fullmektigAdresse: PT.string,
 });
 
-export {
-  ArbeidNorgePropType as ArbeidNorge,
-};
+export { ArbeidNorgePropType as ArbeidNorge };

--- a/src/proptypes/arbeidsgivereNorge.js
+++ b/src/proptypes/arbeidsgivereNorge.js
@@ -13,6 +13,4 @@ const ArbeidsgivereNorgePropType = PT.arrayOf(PT.shape({
   }),
 }));
 
-export {
-  ArbeidsgivereNorgePropType as ArbeidsgivereNorge,
-};
+export { ArbeidsgivereNorgePropType as ArbeidsgivereNorge };

--- a/src/proptypes/bekreftelser.js
+++ b/src/proptypes/bekreftelser.js
@@ -13,6 +13,4 @@ const BekreftelserPropType = PT.shape({
   }),
 });
 
-export {
-  BekreftelserPropType as Bekreftelser,
-};
+export { BekreftelserPropType as Bekreftelser };

--- a/src/proptypes/bosted.js
+++ b/src/proptypes/bosted.js
@@ -14,6 +14,4 @@ const BostedsAdressePropType = PT.shape({
 });
 
 
-export {
-  BostedsAdressePropType as BostedsAdresse,
-};
+export { BostedsAdressePropType as BostedsAdresse };

--- a/src/proptypes/kodeverk.js
+++ b/src/proptypes/kodeverk.js
@@ -6,6 +6,4 @@ const KodeverkPropType = PT.shape({
   term: PT.string,
 });
 
-export {
-  KodeverkPropType as Kodeverk,
-};
+export { KodeverkPropType as Kodeverk };

--- a/src/proptypes/opphold.js
+++ b/src/proptypes/opphold.js
@@ -7,6 +7,4 @@ const OppholdPropType = PT.shape({
   periode: Periode,
 });
 
-export {
-  OppholdPropType as Opphold,
-};
+export { OppholdPropType as Opphold };

--- a/src/proptypes/oppholdUtland.js
+++ b/src/proptypes/oppholdUtland.js
@@ -12,6 +12,4 @@ const OppholdUtlandPropType = PT.shape({
   studieLand: PT.string,
 });
 
-export {
-  OppholdUtlandPropType as OppholdUtland,
-};
+export { OppholdUtlandPropType as OppholdUtland };

--- a/src/proptypes/oppsummering.js
+++ b/src/proptypes/oppsummering.js
@@ -8,6 +8,4 @@ const OppsummeringPropType = PT.shape({
   registrertDato: PT.string,
 });
 
-export {
-  OppsummeringPropType as Oppsummering,
-};
+export { OppsummeringPropType as Oppsummering };

--- a/src/proptypes/periode.js
+++ b/src/proptypes/periode.js
@@ -6,6 +6,4 @@ const PeriodePropType = PT.shape({
   tom: PT.string,
 });
 
-export {
-  PeriodePropType as Periode,
-};
+export { PeriodePropType as Periode };

--- a/src/proptypes/person.js
+++ b/src/proptypes/person.js
@@ -13,6 +13,4 @@ const PersonPropType = PT.shape({
   foedselsdato: PT.string,
 });
 
-export {
-  PersonPropType as Person,
-};
+export { PersonPropType as Person };

--- a/src/proptypes/saksbehandler.js
+++ b/src/proptypes/saksbehandler.js
@@ -6,6 +6,4 @@ const SaksbehandlerPropType = PT.shape({
   navn: PT.string,
 });
 
-export {
-  SaksbehandlerPropType as Saksbehandler,
-};
+export { SaksbehandlerPropType as Saksbehandler };

--- a/src/proptypes/soknadForm.js
+++ b/src/proptypes/soknadForm.js
@@ -6,6 +6,4 @@ const SoknadFormPropType = PT.shape({
   term: PT.string,
 });
 
-export {
-  SoknadFormPropType as SoknadForm,
-};
+export { SoknadFormPropType as SoknadForm };

--- a/src/proptypes/sysselsetting.js
+++ b/src/proptypes/sysselsetting.js
@@ -5,7 +5,5 @@ const SysselsettingPropType = PT.shape({
   SysselsettingType: PT.string,
 });
 
-export {
-  SysselsettingPropType as Sysselsetting,
-};
+export { SysselsettingPropType as Sysselsetting };
 

--- a/src/sider/saksbehandling.js
+++ b/src/sider/saksbehandling.js
@@ -76,9 +76,7 @@ import {
 import { boolTilStreng } from '../utils/utils';
 import { formatterDatoTilNorsk } from '../utils/dato';
 
-import {
-  SoknadenFormSelector,
-} from '../ducks/form';
+import { SoknadenFormSelector } from '../ducks/form';
 
 import './saksbehandling.css';
 import '../felles-komponenter/skjema/skjema.css';


### PR DESCRIPTION
Linting på filer som ikke har vært endret på lenge har plutselig blitt oppdaget. Lintingen er korrekt og påpeker feil som faktisk er korrekte, så jeg er usikker på hvorfor dette ikke har blitt fanget opp tidligere.

I tillegg fikset 2 warnings på feil i jsdoc.

Ref https://eslint.org/docs/rules/object-curly-newline