### PR TITLE
Fiks: Avregistrerer serviceworkere for klienter som evt kjører de.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import loadInitialData from './startupDataLoader';
 import createStore from './store';
 import routerHistory from './history';
 import Routing from './routing';
-import registerServiceWorker from './registerServiceWorker';
+import { unregister } from './registerServiceWorker';
 
 const store = createStore(routerHistory);
 loadInitialData(store);
@@ -27,4 +27,4 @@ ReactDOM.render(
   document.getElementById('root')
 );
 
-registerServiceWorker();
+unregister();


### PR DESCRIPTION
Slik jeg ser det trenger vi ikke serviceworkere. De skaper mer bry enn hjelp, spesielt siden vi ikke har SSL. Foreslår å fjerne den, men en stund bør vi gjøre unregister() slik at evt testere osv får avregistrert sine de neste 24 timer.