### PR TITLE
Fix: Lagt inn debug link til /spark

### DIFF
--- a/src/sider/sok.js
+++ b/src/sider/sok.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import PT from 'prop-types';
 
 import withErrorHandling from '../hoc/withErrorHandling';
@@ -69,6 +69,7 @@ class Sok extends Component {
             */}
           </Nav.Row>
         </Nav.Container>
+        <Link to="/spark" className="sok__sparklink">Debug</Link>
       </div>
     );
   }

--- a/src/sider/sok.less
+++ b/src/sider/sok.less
@@ -1,4 +1,15 @@
 .sok {
   width:100%;
   margin:2em 0;
+
+  .sok__sparklink {
+    position: absolute;
+    bottom: 0;
+    margin: 1em;
+    font-size:12px;
+
+    &:link, &:visited {
+      color: #3e3832;
+    }
+  }
 }


### PR DESCRIPTION
Lagt inn link til "/spark". Kalt den Debug, så slipper vi å forklare hele tiden.

<img width="960" alt="debuglink" src="https://user-images.githubusercontent.com/1443997/36721540-7b750856-1bab-11e8-8f8e-cb4d5f8a9968.png">
