### PR TITLE
PATCH: Kall beOmVurdering() først når man klikker "fatt vedtak".

### DIFF
--- a/src/felles-komponenter/vilkarsveileder/vilkarsveileder.js
+++ b/src/felles-komponenter/vilkarsveileder/vilkarsveileder.js
@@ -135,7 +135,7 @@ class Vilkarsveileder extends Component {
           komponent: VurderingVirksomhet,
           dataHenter: () => ({}),
           handlers: {
-            bekreftOgFortsett: this.beOmVurdering,
+            bekreftOgFortsett: this.bekreftOgFortsett,
           },
           status: FANE_STATUS.OK,
         },
@@ -144,7 +144,7 @@ class Vilkarsveileder extends Component {
           komponent: VurderingVedtak,
           dataHenter: () => ({}),
           handlers: {
-            fattVedtakHandler: this.fattVedtak,
+            fattVedtakHandler: () => { this.fattVedtak(); this.beOmVurdering(); },
           },
           status: FANE_STATUS.OK,
         },


### PR DESCRIPTION
Siden løsningen krasjer på autentisering (timeout?) når man kaller /vurdering/:behandlingID, må vi flytte denne sammen med fattVedtak. Dette skal uansett revurderes i MELOSYS-952, men denne fiksen unngår at løsningen krasjer før stegvelgeren har gått ferdig.