### PR TITLE
MELOSYS-1122: Avviste medlemskap vises fortsatt

### DIFF
--- a/src/ducks/fagsaker/selectors.js
+++ b/src/ducks/fagsaker/selectors.js
@@ -131,11 +131,12 @@ export const MedlemskapSelector = createSelector(
     const PERIODE_UTEN_MEDLEMSKAP = 'PUMEDSKP';
     const GYLDIG_MEDLEMSKAP = 'GYLD';
     const UAVKLART_MEDLEMSKAP = 'UAVK';
+    const AVVIST_MEDLEMSKAP = 'AVST';
 
     const { medlemsperiode = [] } = medlemskap;
     return {
       perioderMed: medlemsperiode.filter(periode => periode.type.kode === PERIODE_MED_MEDLEMSKAP && periode.status.kode === GYLDIG_MEDLEMSKAP),
-      perioderUten: medlemsperiode.filter(periode => periode.type.kode === PERIODE_UTEN_MEDLEMSKAP),
+      perioderUten: medlemsperiode.filter(periode => periode.type.kode === PERIODE_UTEN_MEDLEMSKAP && periode.status.kode !== AVVIST_MEDLEMSKAP),
       perioderUavklart: medlemsperiode.filter(periode => periode.status.kode === UAVKLART_MEDLEMSKAP),
     };
   }


### PR DESCRIPTION
Avviste medlemskap skal ikke vises feilaktig i gruppen "Perioder uten medlemskap". Avviste medlemskap skal aldri vises i noen av gruppene.