### PR TITLE
PATCH: Fikset krasj ved pdf resize

### DIFF
--- a/src/felles-komponenter/journalforing/dokument.js
+++ b/src/felles-komponenter/journalforing/dokument.js
@@ -68,7 +68,8 @@ class Dokument extends Component {
   }
 
   setDivSize = () => {
-    this.setState({ width: this.pdfWrapper.getBoundingClientRect().width });
+    const width = this.pdfWrapper && this.pdfWrapper.getBoundingClientRect().width;
+    return width && this.setState({ width: this.pdfWrapper.getBoundingClientRect().width });
   }
 
   render() {


### PR DESCRIPTION
Component unmounter ikke alltid, så event listener kan bli stående og sjekker på resize selv om elementene ikke lenger er tilgjengelig i DOM. Lagt inn sjekk som unngår krasj.