### PR TITLE
MELOSYS-1207_pdf_ma_ikke_rerendre_ved_hver_oppdatering

### DIFF
--- a/src/felles-komponenter/journalforing/pdfdokument.js
+++ b/src/felles-komponenter/journalforing/pdfdokument.js
@@ -62,20 +62,28 @@ class PDFDokument extends Component {
 
   componentDidMount () {
     this.setDivSize();
-    window.addEventListener('resize', throttle(this.setDivSize, 500));
+    window.addEventListener('resize', this.setDivSizeThrottled);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const { journalpostID, dokumentID } = this.props;
+    const { width } = this.state;
+    return ((journalpostID !== nextProps.journalpostID) || (dokumentID !== nextProps.dokumentID) || (width !== nextState.width));
   }
 
   componentWillUnmount () {
-    window.removeEventListener('resize', throttle(this.setDivSize, 500));
+    window.removeEventListener('resize', this.setDivSizeThrottled);
   }
 
   setDivSize = () => {
     const width = this.pdfWrapper && this.pdfWrapper.getBoundingClientRect().width;
-    return width && this.setState({ width: this.pdfWrapper.getBoundingClientRect().width });
+    this.setState({ width });
   };
 
+  setDivSizeThrottled = throttle(this.setDivSize, 500);
+
   render() {
-    const { journalpostID, dokumentID = 'did' } = this.props;
+    const { journalpostID, dokumentID } = this.props;
     const pdfDokumentURI = Api.PDFDokumentURI(journalpostID, dokumentID);
     return (
       <div

--- a/src/sider/journalforing.js
+++ b/src/sider/journalforing.js
@@ -149,7 +149,11 @@ class Journalforing extends Component {
   knyttTilEksisterendeSak = () => {
     const { journalforingSkjemaVerdier: { saksnummer } } = this.props;
 
+    // TODO validate response before redirect
+    /* eslint-disable */
+    console.log(response);
     alert('Denne er ikke avklart / implementert.');
+    /* eslint-enable */
 
     return saksnummer !== undefined;
   };


### PR DESCRIPTION
Optimalisering av PDF-visning++
- Event listener slettes korrekt ved unmount
- Oppdatering av komponent kanselleres dersom ingenting viktig har skjedd.
- Lagt på eslint-disable på dead-end i journalforing for å unngå lint-warning.