### PR TITLE
MELOSYS-1208: Stylet inn bedre visuelt skille mellom hver PDF.

### DIFF
--- a/src/felles-komponenter/journalforing/pdfdokument.js
+++ b/src/felles-komponenter/journalforing/pdfdokument.js
@@ -33,8 +33,9 @@ class PDFViser extends Component {
           onLoadSuccess={this.onLoadSuccess}
         >
           { pageArray.map((item, index) => (
-            <div key={uuid()} id={`section-${index + 1}`}>
+            <div key={uuid()} id={`section-${index + 1}`} className="pdfviser__side">
               <Page width={this.props.wrapperDivSize} pageNumber={index + 1} />
+              <div className="pdfviser__sideinfo">side {index + 1} av { pageArray.length}</div>
             </div>
           ))}
         </Document>

--- a/src/felles-komponenter/journalforing/pdfdokument.less
+++ b/src/felles-komponenter/journalforing/pdfdokument.less
@@ -14,12 +14,16 @@
   display: block;
   position: relative;
 
-  .pdfviser__paginering {
-    position: sticky;
-    top: 20px;
-    background-color: @gray;
-    padding: 0.5em;
-    border-radius: 3px;
-    z-index: 2000;
+  .pdfviser__side {
+    border-bottom: 4px dotted @gray-dark;
+  }
+
+  .pdfviser__side:last-of-type {
+    border-bottom: 0px;
+  }
+
+  .pdfviser__sideinfo {
+    text-align:center;
+    margin: 0 0 1em 0;
   }
 }


### PR DESCRIPTION
<img width="799" alt="skillelinjepdf" src="https://user-images.githubusercontent.com/1443997/39627138-1acf8822-4fa5-11e8-951b-ea33a67e75ce.png">

Merk: Usikkert på om endelig PDF vil ha egne sidenr. I såfall blir det dobbelt opp og denne må fjernes.