### PR TITLE
MELOSYS-1059: Feil i inntektsgruppering

### DIFF
--- a/src/ducks/fagsaker/selectors.js
+++ b/src/ducks/fagsaker/selectors.js
@@ -220,17 +220,29 @@ const byggNyArbeidsforholdGruppe = (arbeidsforholdet, organisasjoner, inntekter,
   }
 );
 
+/** Denne funksjonen gjør følgende:
+ * 1. Itererer alle arbeidsforhold og grupperer de inn etter opplysningspliktigID (dvs juridisk arbeidsgiver)
+ * 2. Dersom en gruppe av opplysningspliktigID ikke eksisterer fra før, lages den via byggNyArbeidsforholdGruppe
+ *
+ * Etterpå returneres hele arrayen med sub-arrays som hver inneholder grupperinger av
+ *  - organisasjon (juridisk arbeidsgiver)
+ *  - arbeidsforholdene (virksomhetene)
+ *  - inntekt
+ */
 export const ArbeidsgivereNorgeSelector = createSelector(
   state => OrganisasjonerSelector(state),
   state => ArbeidsforholdeneSelector(state),
   state => InntektSelector(state),
   state => faktaavklaringSelectors.FaktaavklaringOppholdPeriodeSelector(state),
   (organisasjoner, arbeidsforholdene, inntekter, periode) => {
+    // Det er inntekter 6 måneder pri SØKNADSDATO som er interessant.
+    // Finn derfor startDato hvor vi senere teller 6 måneder tilbake når inntektslisten settes sammen.
     const { fom: startDato = moment().format('YYYY-MM-DD') } = periode;
 
     const arbeidsgivere = arbeidsforholdene.reduce((samling, arbeidsforholdet) => {
       const tmpSamling = [...samling];
 
+      // Sjekk om det allerede er laget en gruppe for den aktuelle opplysningspliktigID.
       const arbeidsforholdEksistererVedIndeks = samling
         .findIndex(enkelt =>
           enkelt.arbeidsforholdene.some(enkeltforhold =>

--- a/src/ducks/fagsaker/selectors.js
+++ b/src/ducks/fagsaker/selectors.js
@@ -209,14 +209,14 @@ export const ArbeidsgivereNorgeSelectorOld = createSelector(
  * @param arbeidsforholdet
  * @param organisasjoner
  * @param inntekter
- * @param startDato
+ * @param soknadStartDato
  * @returns {{arbeidsforholdene: *[], organisasjon: *, inntekter: any[]}}
  */
-const byggNyArbeidsforholdGruppe = (arbeidsforholdet, organisasjoner, inntekter, startDato) => (
+const byggNyArbeidsforholdGruppe = (arbeidsforholdet, organisasjoner, inntekter, soknadStartDato) => (
   {
     arbeidsforholdene: [arbeidsforholdet],
     organisasjon: organisasjoner.find(org => org.orgnr === arbeidsforholdet.opplysningspliktigID),
-    inntektListe: filtrerOgSpreInntekt(startDato, arbeidsforholdet.opplysningspliktigID, inntekter),
+    inntektListe: filtrerOgSpreInntekt(soknadStartDato, arbeidsforholdet.opplysningspliktigID, inntekter),
   }
 );
 

--- a/src/ducks/fagsaker/selectors.js
+++ b/src/ducks/fagsaker/selectors.js
@@ -90,15 +90,18 @@ const summerInntektsTyperFraSammeOpplysningspliktig = flatInntektListe => (
 const filtrerOgSpreInntekt = (startDato, orgnr, inntekter) => {
   const filtrerteInntekterFraOpplysningspliktig = inntekter.filter(inntekt => inntekt.opplysningspliktigID === orgnr);
 
-  return Array(6).fill({}).map((verdi, index) => {
-    const aarMaaned = moment(startDato).subtract(index, 'months').format('YYYY-MM');
-    const eksisterendeInntektFunnetVedIndeks = filtrerteInntekterFraOpplysningspliktig.findIndex(enkeltInntekt => enkeltInntekt.aarMaaned === aarMaaned);
-    return eksisterendeInntektFunnetVedIndeks > -1
-      ?
-      filtrerteInntekterFraOpplysningspliktig[eksisterendeInntektFunnetVedIndeks]
-      :
-      { aarMaaned, beloep: 0, opplysningspliktigID: orgnr };
-  });
+  return filtrerteInntekterFraOpplysningspliktig.length === 0 ?
+    filtrerteInntekterFraOpplysningspliktig
+    :
+    Array(6).fill({}).map((verdi, index) => {
+      const aarMaaned = moment(startDato).subtract(index, 'months').format('YYYY-MM');
+      const eksisterendeInntektFunnetVedIndeks = filtrerteInntekterFraOpplysningspliktig.findIndex(enkeltInntekt => enkeltInntekt.aarMaaned === aarMaaned);
+      return eksisterendeInntektFunnetVedIndeks > -1
+        ?
+        filtrerteInntekterFraOpplysningspliktig[eksisterendeInntektFunnetVedIndeks]
+        :
+        { aarMaaned, beloep: 0, opplysningspliktigID: orgnr };
+    });
 };
 
 export const InntektSelector = createSelector(
@@ -182,7 +185,7 @@ export const OrganisasjonSelector = createSelector(
   }
 );
 
-export const ArbeidsgivereNorgeSelector = createSelector(
+export const ArbeidsgivereNorgeSelectorOld = createSelector(
   state => OrganisasjonerSelector(state),
   state => ArbeidsforholdeneSelector(state),
   state => InntektSelector(state),
@@ -195,6 +198,52 @@ export const ArbeidsgivereNorgeSelector = createSelector(
       return ([...samling, { organisasjon, arbeidsforholdene: filtrerteArbeidsforholdene, inntektListe: filtrerteInntekter }]);
     }, [])
       .filter(arbeidsgiver => arbeidsgiver.arbeidsforholdene.length > 0 || arbeidsgiver.inntektListe.length > 0);
+    return arbeidsgivere;
+  }
+);
+
+/** Hjelpefunksjon for ArbeidsgivereNorgeSelector. Funksjonen bygger en ny gruppe av et arbeidsforhold
+ * med arbeidsforholdene (array), inntekter (array) og organisasjonen (objekt)
+ * @param arbeidsforholdet
+ * @param organisasjoner
+ * @param inntekter
+ * @param startDato
+ * @returns {{arbeidsforholdene: *[], organisasjon: *, inntekter: any[]}}
+ */
+const byggNyArbeidsforholdGruppe = (arbeidsforholdet, organisasjoner, inntekter, startDato) => (
+  {
+    arbeidsforholdene: [arbeidsforholdet],
+    organisasjon: organisasjoner.find(org => org.orgnr === arbeidsforholdet.opplysningspliktigID),
+    inntekter: filtrerOgSpreInntekt(startDato, arbeidsforholdet.opplysningspliktigID, inntekter),
+  }
+);
+
+export const ArbeidsgivereNorgeSelector = createSelector(
+  state => OrganisasjonerSelector(state),
+  state => ArbeidsforholdeneSelector(state),
+  state => InntektSelector(state),
+  state => faktaavklaringSelectors.FaktaavklaringOppholdPeriodeSelector(state),
+  (organisasjoner, arbeidsforholdene, inntekter, periode) => {
+    const { fom: startDato = moment().format('YYYY-MM-DD') } = periode;
+
+    const arbeidsgivere = arbeidsforholdene.reduce((samling, arbeidsforholdet) => {
+      const tmpSamling = [...samling];
+
+      const arbeidsforholdEksistererVedIndeks = samling
+        .findIndex(enkelt =>
+          enkelt.arbeidsforholdene.some(enkeltforhold =>
+            enkeltforhold.opplysningspliktigID === arbeidsforholdet.opplysningspliktigID));
+
+      if (arbeidsforholdEksistererVedIndeks > -1) {
+        tmpSamling[arbeidsforholdEksistererVedIndeks].arbeidsforholdene.push(arbeidsforholdet);
+      } else {
+        tmpSamling.push(byggNyArbeidsforholdGruppe(arbeidsforholdet, organisasjoner, inntekter, startDato));
+      }
+
+      return tmpSamling;
+    }, []);
+
+    console.log(arbeidsgivere)
     return arbeidsgivere;
   }
 );

--- a/src/ducks/fagsaker/selectors.js
+++ b/src/ducks/fagsaker/selectors.js
@@ -95,7 +95,9 @@ const filtrerOgSpreInntekt = (startDato, orgnr, inntekter) => {
     :
     Array(6).fill({}).map((verdi, index) => {
       const aarMaaned = moment(startDato).subtract(index, 'months').format('YYYY-MM');
+
       const eksisterendeInntektFunnetVedIndeks = filtrerteInntekterFraOpplysningspliktig.findIndex(enkeltInntekt => enkeltInntekt.aarMaaned === aarMaaned);
+
       return eksisterendeInntektFunnetVedIndeks > -1
         ?
         filtrerteInntekterFraOpplysningspliktig[eksisterendeInntektFunnetVedIndeks]
@@ -214,7 +216,7 @@ const byggNyArbeidsforholdGruppe = (arbeidsforholdet, organisasjoner, inntekter,
   {
     arbeidsforholdene: [arbeidsforholdet],
     organisasjon: organisasjoner.find(org => org.orgnr === arbeidsforholdet.opplysningspliktigID),
-    inntekter: filtrerOgSpreInntekt(startDato, arbeidsforholdet.opplysningspliktigID, inntekter),
+    inntektListe: filtrerOgSpreInntekt(startDato, arbeidsforholdet.opplysningspliktigID, inntekter),
   }
 );
 
@@ -243,7 +245,6 @@ export const ArbeidsgivereNorgeSelector = createSelector(
       return tmpSamling;
     }, []);
 
-    console.log(arbeidsgivere)
     return arbeidsgivere;
   }
 );

--- a/src/felles-komponenter/arbeidsgiver/inntekt.js
+++ b/src/felles-komponenter/arbeidsgiver/inntekt.js
@@ -96,7 +96,7 @@ class Inntekt extends Component {
 
     const harMinstEnInntekt = inntektListe.some(inntekt => inntekt.beloep > 0);
 
-    const inntektInnhold = harMinstEnInntekt ? (
+    const inntektInnhold = harMinstEnInntekt && (
       <div className="inntekt">
         <div className="inntekt__graf">
           <ReactHighcharts config={grafConfig} />
@@ -105,14 +105,15 @@ class Inntekt extends Component {
           </Nav.Knapp>
         </div>
         {uuTabell}
-      </div>)
-      :
-      <div>Finner ingen inntekt registrert i arbeidsforholdet 6 måneder forut for søknadsperioden.</div>;
+      </div>
+    );
+
+    const manglerInntektTekst = !harMinstEnInntekt && 'Ingen inntekt i arbeidsforholdet 6 måneder forut for søknadsperioden.';
 
     return (
       <div className="inntekt panelSeksjon">
         <Nav.EkspanderbartpanelBase
-          heading={<PanelHeader tittel="Inntekt" undertittel="" ikon={Ikoner.Inntekt} />}
+          heading={<PanelHeader tittel="Inntekt" undertittel={manglerInntektTekst} ikon={Ikoner.Inntekt} />}
           ariaTittel="Panel for inntekt">
           { inntektInnhold }
         </Nav.EkspanderbartpanelBase>

--- a/src/felles-komponenter/arbeidsgiver/organisasjon.js
+++ b/src/felles-komponenter/arbeidsgiver/organisasjon.js
@@ -15,13 +15,12 @@ import './organisasjon.css';
  *
  * @param props Et objekt med det aktuelle arbeidsforholdet.
  */
-const Organisasjon = props => {
+const Organisasjon = ({ organisasjon = {} }) => {
   const {
     orgnr,
     navn,
     forretningsadresse,
-  } = props.organisasjon;
-
+  } = organisasjon;
 
   return (
     <div className="panelSeksjon organisasjon">

--- a/src/felles-komponenter/skjema/input/radio-gruppe.js
+++ b/src/felles-komponenter/skjema/input/radio-gruppe.js
@@ -1,4 +1,3 @@
-/* eslint jsx-a11y/label-has-for:off */
 import React from 'react';
 import PT from 'prop-types';
 import classNames from 'classnames';
@@ -13,15 +12,14 @@ function InnerInputComponent({
       <div className={classNames({ skjema__feilomrade: errorMessage })}>
         <label className="skjemaelement__label" htmlFor={feltNavn}>
           {label}
+          {children}
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="skjemaelement__feilmelding">
+            {errorMessage}
+          </div>
         </label>
-        {children}
-        <div
-          role="alert"
-          aria-live="assertive"
-          className="skjemaelement__feilmelding"
-        >
-          {errorMessage}
-        </div>
       </div>
     </div>
   );

--- a/src/felles-komponenter/skjema/input/radio-gruppe.js
+++ b/src/felles-komponenter/skjema/input/radio-gruppe.js
@@ -1,3 +1,4 @@
+/* eslint jsx-a11y/label-has-for:off */
 import React from 'react';
 import PT from 'prop-types';
 import classNames from 'classnames';

--- a/src/felles-komponenter/skjema/listevelger/listevelgerGruppe.js
+++ b/src/felles-komponenter/skjema/listevelger/listevelgerGruppe.js
@@ -1,4 +1,4 @@
-/* eslint react/no-array-index-key:off, jsx-a11y/label-has-for:off */
+/* eslint react/no-array-index-key:off */
 import React, { Component } from 'react';
 import PT from 'prop-types';
 import * as Nav from '../../../utils/navFrontend';
@@ -81,34 +81,35 @@ class ListevelgerGruppe extends Component {
 
     return (
       <div>
-        <label htmlFor={`listevelger-${fields.name}`}>{label}</label>
-        {
-          alleFelter.map((verdi, index) => <ListevelgerValgtElement
-            key={index}
-            label={verdi}
-            slettElement={() => this.slettElement(index)}
-            oppdaterElement={event => this.oppdaterElement(event.target.value, index)}
-          />)
-        }
-        <div className="listevelger__linje">
-          <Nav.Input
-            id={`listevelger-${fields.name}`}
-            label=""
-            feil={feil}
-            placeholder={placeholder}
-            onBlur={this.onBlur}
-            onFocus={this.onFocus}
-            onChange={this.onChange}
-            onKeyDown={this.onKeyDown}
-            value={this.state.inputVerdi}
-            list={`dataliste-${fields.name}`}
-            className="listevelger__linje__input"
-          />
-          <button
-            className="listevelger__linje__knapp listevelger__linje__knapp--leggtil"
-            onClick={this.leggTilListeHandler}>+
-          </button>
-        </div>
+        <label htmlFor={`listevelger-${fields.name}`}>{label}
+          {
+            alleFelter.map((verdi, index) => <ListevelgerValgtElement
+              key={index}
+              label={verdi}
+              slettElement={() => this.slettElement(index)}
+              oppdaterElement={event => this.oppdaterElement(event.target.value, index)}
+            />)
+          }
+          <div className="listevelger__linje">
+            <Nav.Input
+              id={`listevelger-${fields.name}`}
+              label=""
+              feil={feil}
+              placeholder={placeholder}
+              onBlur={this.onBlur}
+              onFocus={this.onFocus}
+              onChange={this.onChange}
+              onKeyDown={this.onKeyDown}
+              value={this.state.inputVerdi}
+              list={`dataliste-${fields.name}`}
+              className="listevelger__linje__input"
+            />
+            <button
+              className="listevelger__linje__knapp listevelger__linje__knapp--leggtil"
+              onClick={this.leggTilListeHandler}>+
+            </button>
+          </div>
+        </label>
         <datalist id={`dataliste-${fields.name}`}>
           {muligeValg.map(valg => <option key={uuid()} value={valg.term} />)}
         </datalist>

--- a/src/felles-komponenter/skjema/listevelger/listevelgerGruppe.js
+++ b/src/felles-komponenter/skjema/listevelger/listevelgerGruppe.js
@@ -1,4 +1,4 @@
-/* eslint react/no-array-index-key:off */
+/* eslint react/no-array-index-key:off, jsx-a11y/label-has-for:off */
 import React, { Component } from 'react';
 import PT from 'prop-types';
 import * as Nav from '../../../utils/navFrontend';


### PR DESCRIPTION
Skrevet om gruppering og reducing av inntekt slik at denne er litt mer robust. Den tar ikke hensyn til inntekter utenfor et ordinært arbeidsforhold (feks freelance). Dette kommer som en story senere.

I tillegg disablet feilaktig eslinting fra jsx-a1lly. Permanent fiks kommer senere.
Satt inn default dersom organisasjon mangler (exception).