### PR TITLE
MELOSYS-1467: Inntekt vises ikke i søknadperiden (bug)

### DIFF
--- a/src/ducks/fagsaker/selectors.js
+++ b/src/ducks/fagsaker/selectors.js
@@ -4,6 +4,7 @@ import moment from 'moment/moment';
 
 import { faktaavklaringSelectors } from '../faktaavklaring/';
 import { kodeverkObjektTilKode } from '../../utils/kodeverk';
+import { datoDiff } from '../../utils/dato';
 
 export const PersonSelector = createSelector(
   state => (state.fagsaker.data.behandlinger ? state.fagsaker.data.behandlinger[0].saksopplysninger.person : state.fagsaker.data),
@@ -30,8 +31,8 @@ export const FagsakSokSelector = createSelector(
  */
 
 /**
- * Inntekt er nøstet inn i måned og deretter en blanding av flere typer fra samme
- * opplysningspliktigID og forskjellige opplysningspliktigID. I tillegg er det mye data
+ * Inntekt er nøstet inn i måned og deretter en blanding av flere inntektstyper fra enten samme
+ * opplysningspliktigID eller forskjellige opplysningspliktigID. I tillegg er det mye data
  * som vi ikke har behov for. For å kunne gjøre fremtidige filtreringer ønsker vi å omforme
  * den opprinnelige modellen til en flatere modell:
  *
@@ -81,32 +82,33 @@ const summerInntektsTyperFraSammeOpplysningspliktig = flatInntektListe => (
   }, [])
 );
 
-/** Denne funksjonen filtrerer inntekten på siste 6 måneder fra startdato og
- * sprer den over tilsvarende måneder slik at evt manglende inntektsdata vises som beloep:0 for den
- * aktuelle måneden.
+/** Denne funksjonen filtrerer inntekten som finnes innenfor den relevante perioden (søknadsdato minus 6 måneder)
+ * Dersom det ikke finnes inntekt, vil den sette inntekten til 0 slik at denne måneden fortsatt kommer med
+ * i den grafiske fremstillingen.
  *
- * @param startDato Startdatoen for når vi teller bakover.
+ * @param relevantPeriode Den relevante perioden som det skal vises inntekt på.
  * @param orgnr Organisasjonsnummmeret som det filtreres på.
  * @param inntekter Listen over ufiltrerte inntekter.
  * @returns {any[]}
  */
-const filtrerOgSpreInntekt = (startDato, orgnr, inntekter) => {
+const filtrerOgSpreInntekt = (relevantPeriode, orgnr, inntekter) => {
   const filtrerteInntekterFraOpplysningspliktig = inntekter.filter(inntekt => inntekt.opplysningspliktigID === orgnr);
+  if (filtrerteInntekterFraOpplysningspliktig.length === 0) { return []; }
 
-  return filtrerteInntekterFraOpplysningspliktig.length === 0 ?
-    filtrerteInntekterFraOpplysningspliktig
-    :
-    Array(6).fill({}).map((verdi, index) => {
-      const aarMaaned = moment(startDato).subtract(index, 'months').format('YYYY-MM');
+  const startDato = relevantPeriode.fom;
+  const antallMaaneder = parseInt(datoDiff(relevantPeriode.fom, relevantPeriode.tom, 'months'), 10) + 1;
 
-      const eksisterendeInntektFunnetVedIndeks = filtrerteInntekterFraOpplysningspliktig.findIndex(enkeltInntekt => enkeltInntekt.aarMaaned === aarMaaned);
+  return Array(antallMaaneder).fill({}).map((verdi, index) => {
+    const aarMaaned = moment(startDato).add(index, 'months').format('YYYY-MM');
 
-      return eksisterendeInntektFunnetVedIndeks > -1
-        ?
-        filtrerteInntekterFraOpplysningspliktig[eksisterendeInntektFunnetVedIndeks]
-        :
-        { aarMaaned, beloep: 0, opplysningspliktigID: orgnr };
-    });
+    const eksisterendeInntektFunnetVedIndeks = filtrerteInntekterFraOpplysningspliktig.findIndex(enkeltInntekt => enkeltInntekt.aarMaaned === aarMaaned);
+
+    return eksisterendeInntektFunnetVedIndeks > -1
+      ?
+      filtrerteInntekterFraOpplysningspliktig[eksisterendeInntektFunnetVedIndeks]
+      :
+      { aarMaaned, beloep: 0, opplysningspliktigID: orgnr };
+  });
 };
 
 export const InntektSelector = createSelector(
@@ -192,23 +194,6 @@ export const OrganisasjonSelector = createSelector(
   }
 );
 
-export const ArbeidsgivereNorgeSelectorOld = createSelector(
-  state => OrganisasjonerSelector(state),
-  state => ArbeidsforholdeneSelector(state),
-  state => InntektSelector(state),
-  state => faktaavklaringSelectors.FaktaavklaringOppholdPeriodeSelector(state),
-  (organisasjoner, arbeidsforholdene, inntekter, periode) => {
-    const { fom: startDato = moment().format('YYYY-MM-DD') } = periode;
-    const arbeidsgivere = organisasjoner.reduce((samling, organisasjon) => {
-      const filtrerteArbeidsforholdene = arbeidsforholdene.filter(arbeidsforholdet => arbeidsforholdet.opplysningspliktigID === organisasjon.orgnr);
-      const filtrerteInntekter = filtrerOgSpreInntekt(startDato, organisasjon.orgnr, inntekter);
-      return ([...samling, { organisasjon, arbeidsforholdene: filtrerteArbeidsforholdene, inntektListe: filtrerteInntekter }]);
-    }, [])
-      .filter(arbeidsgiver => arbeidsgiver.arbeidsforholdene.length > 0 || arbeidsgiver.inntektListe.length > 0);
-    return arbeidsgivere;
-  }
-);
-
 /** Hjelpefunksjon for ArbeidsgivereNorgeSelector. Funksjonen bygger en ny gruppe av et arbeidsforhold
  * med arbeidsforholdene (array), inntekter (array) og organisasjonen (objekt)
  * @param arbeidsforholdet
@@ -217,11 +202,11 @@ export const ArbeidsgivereNorgeSelectorOld = createSelector(
  * @param soknadStartDato
  * @returns {{arbeidsforholdene: *[], organisasjon: *, inntekter: any[]}}
  */
-const byggNyArbeidsforholdGruppe = (arbeidsforholdet, organisasjoner, inntekter, soknadStartDato) => (
+const byggNyArbeidsforholdGruppe = (arbeidsforholdet, organisasjoner, inntekter, relevantPeriode) => (
   {
     arbeidsforholdene: [arbeidsforholdet],
     organisasjon: organisasjoner.find(org => org.orgnr === arbeidsforholdet.opplysningspliktigID),
-    inntektListe: filtrerOgSpreInntekt(soknadStartDato, arbeidsforholdet.opplysningspliktigID, inntekter),
+    inntektListe: filtrerOgSpreInntekt(relevantPeriode, arbeidsforholdet.opplysningspliktigID, inntekter),
   }
 );
 
@@ -240,9 +225,22 @@ export const ArbeidsgivereNorgeSelector = createSelector(
   state => InntektSelector(state),
   state => faktaavklaringSelectors.FaktaavklaringOppholdPeriodeSelector(state),
   (organisasjoner, arbeidsforholdene, inntekter, periode) => {
-    // Det er inntekter 6 måneder pri SØKNADSDATO som er interessant.
-    // Finn derfor startDato hvor vi senere teller 6 måneder tilbake når inntektslisten settes sammen.
-    const { fom: startDato = moment().format('YYYY-MM-DD') } = periode;
+    // Inntekten skal vises 6 måneder forut for startdato. Dersom søknaden gjelder en periode
+    // tilbake i tid, skal også inntekt i selve perioden vises.
+
+    const { fom: soknadPeriodeStart, tom: soknadPeriodeSlutt } = periode;
+    if (!soknadPeriodeStart && !soknadPeriodeSlutt) { return []; }
+
+    const relevantPeriodeStart = moment(soknadPeriodeStart, 'YYYY-MM-DD')
+      .subtract(6, 'months')
+      .format('YYYY-MM-DD');
+
+    const relevantPeriodeSlutt = moment(soknadPeriodeSlutt, 'YYYY-MM-DD') < moment() ? soknadPeriodeSlutt : moment().format('YYYY-MM-DD');
+
+    const relevantPeriode = {
+      fom: relevantPeriodeStart,
+      tom: relevantPeriodeSlutt,
+    };
 
     const arbeidsgivere = arbeidsforholdene.reduce((samling, arbeidsforholdet) => {
       const tmpSamling = [...samling];
@@ -256,7 +254,7 @@ export const ArbeidsgivereNorgeSelector = createSelector(
       if (arbeidsforholdEksistererVedIndeks > -1) {
         tmpSamling[arbeidsforholdEksistererVedIndeks].arbeidsforholdene.push(arbeidsforholdet);
       } else {
-        tmpSamling.push(byggNyArbeidsforholdGruppe(arbeidsforholdet, organisasjoner, inntekter, startDato));
+        tmpSamling.push(byggNyArbeidsforholdGruppe(arbeidsforholdet, organisasjoner, inntekter, relevantPeriode));
       }
 
       return tmpSamling;

--- a/src/felles-komponenter/arbeidsgiver/inntekt.js
+++ b/src/felles-komponenter/arbeidsgiver/inntekt.js
@@ -26,7 +26,7 @@ class Inntekt extends Component {
 
     if (!inntektListe) return null;
 
-    const omvendtInntektListe = [...inntektListe].sort((a, b) => a.aarMaaned > b.aarMaaned);
+    const omvendtInntektListe = [...inntektListe].reverse();
 
     const grafConfig = {
       rangeSelector: {
@@ -50,7 +50,7 @@ class Inntekt extends Component {
         labels: { style: { fontSize: '13px', fontWeight: 'bold' } },
       },
       xAxis: {
-        categories: omvendtInntektListe.map(linje => formatterKortDatoTilNorsk(linje.aarMaaned)),
+        categories: inntektListe.map(linje => formatterKortDatoTilNorsk(linje.aarMaaned)),
         crosshair: true,
         description: 'Perioder med inntekt.',
         labels: { style: { fontSize: '13px', fontWeight: 'bold' } },
@@ -63,7 +63,7 @@ class Inntekt extends Component {
       series: [
         {
           name: 'Samlet  i én periode',
-          data: omvendtInntektListe.map(linje => linje.beloep),
+          data: inntektListe.map(linje => linje.beloep),
           color: '#0067c5',
           description: 'Inntekt',
         },
@@ -78,7 +78,7 @@ class Inntekt extends Component {
      * All formattering eller komponent-innsett må derfor gjøres her og returnere
      * en ny ferdigtygget array.
      */
-    const inntektArrayed = inntektListe
+    const inntektArrayed = omvendtInntektListe
       .map(linje => (
         [
           formatterKortDatoTilNorsk(linje.aarMaaned),


### PR DESCRIPTION
- Skrevet om selectors for å hensynta selve søknadsperioden.
- Innført begrepet "relevantPeriode" for inntekt som innebærer selve søknadsperioden i tillegg til 6 måneder tilbake i tid.
- Oppdatert enkelte kodekommentarer.