### PR TITLE
PATCH: Dokumentlisten laster ikke på nytt ved remount

### DIFF
--- a/src/felles-komponenter/sideDialog/sideDialogDokumenter.js
+++ b/src/felles-komponenter/sideDialog/sideDialogDokumenter.js
@@ -118,6 +118,13 @@ RenderOversiktRad.defaultProps = {
 class SideDialogDokumenter extends Component {
   state = { oversiktDokumenter: [] };
 
+  async componentDidMount() {
+    const { oppsummering: { saksnummer } } = this.props;
+    if (saksnummer) {
+      await this.hentDokumentOversikt(saksnummer);
+    }
+  }
+
   async componentDidUpdate(prevProps) {
     const { oppsummering: { saksnummer: prevSaksnummer } } = prevProps;
     const { oppsummering: { saksnummer } } = this.props;


### PR DESCRIPTION
Siden komponenten dismounter fullstendig ved klikk på andre faner "send brev", så slettes local state. En forbedring kunne vært å legge dokumenter i redux, men det er det ikke tid til i denne sprinten.