### PR TITLE
MELOSYS-2010: Konsekvent bruk av "*status"

### DIFF
--- a/src/ducks/fagsaker/selectors.js
+++ b/src/ducks/fagsaker/selectors.js
@@ -279,6 +279,7 @@ export const OppsummeringSelector = createSelector(
     saksnummer: saksdata.saksnummer,
     behandlingID: behandlingsdata.behandlingID,
     sakstype: saksdata.sakstype,
+    saksstatus: saksdata.saksstatus,
     behandlingsstatus: behandlingsdata.behandlingsstatus,
     registrertDato: behandlingsdata.registrertDato,
     sisteOpplysningerHentetDato: behandlingsdata.sisteOpplysningerHentetDato,

--- a/src/ducks/kodeverk/selectors.js
+++ b/src/ducks/kodeverk/selectors.js
@@ -77,14 +77,9 @@ export const brevSelector = createSelector(
   brev => brev || {}
 );
 
-export const dokumentTypeIDSelector = createSelector(
+export const produserbareDokumenterSelector = createSelector(
   state => brevSelector(state),
-  brev => brev.dokumentTypeIder || []
-);
-
-export const dokumentTypeSelector = createSelector(
-  state => brevSelector(state),
-  brev => brev.dokumenttyper || []
+  brev => brev.produserbareDokumenter || []
 );
 
 export const aktoerrollerSelector = createSelector(

--- a/src/felles-komponenter/forside/oppgaveliste/sakEnkeltLinje.js
+++ b/src/felles-komponenter/forside/oppgaveliste/sakEnkeltLinje.js
@@ -76,7 +76,7 @@ const SakEnkeltLinje = ({ sak }) => {
             <Nav.Row>
               <Nav.Column xs="12" md="6">
                 <dl className="sakEnkeltLinje__meta">
-                  <dt className="sakEnkeltLinje__meta__term">Status:</dt>
+                  <dt className="sakEnkeltLinje__meta__term">Behandlingsstatus:</dt>
                   <dd className="sakEnkeltLinje__meta__detalj">{kodeverkObjektTilTerm(behandlingsstatus) || '(ukjent)'}</dd>
                   <dt className="sakEnkeltLinje__meta__term">Frist:</dt>
                   <dd className="sakEnkeltLinje__meta__detalj">{<EnkeltDato dato={aktivTil} /> || '(ukjent)'}</dd>

--- a/src/felles-komponenter/sideDialog/brevBestilling.js
+++ b/src/felles-komponenter/sideDialog/brevBestilling.js
@@ -97,7 +97,7 @@ class BrevBestilling extends Component {
 
   render () {
     const {
-      dokumenttypeIDer,
+      produserbareDokumenter,
       aktoerroller,
       brevbestillingSkjemaVerdier,
       oppsummering,
@@ -120,7 +120,7 @@ class BrevBestilling extends Component {
               {aktoerroller && aktoerroller.map(elem => <option key={elem.kode} value={elem.kode}>{elem.term}</option>)}
             </Skjema.Select>
             <Skjema.Select feltNavn="dokumenttypeKode" bredde="fullbredde" label="Type brev" disabled>
-              {dokumenttypeIDer && dokumenttypeIDer.map(elem => <option key={elem.kode} value={elem.kode}>{elem.term}</option>)}
+              {produserbareDokumenter && produserbareDokumenter.map(elem => <option key={elem.kode} value={elem.kode}>{elem.term}</option>)}
             </Skjema.Select>
             {this.erMangelBrevMedFritekst() && <InfoPanel />}
             {this.erMangelBrevMedFritekst() &&
@@ -145,7 +145,7 @@ BrevBestilling.propTypes = {
   forhandsvisPDF: PT.func.isRequired,
   resetDokument: PT.func.isRequired,
   aktoerroller: PT.arrayOf(MPT.Kodeverk),
-  dokumenttypeIDer: PT.arrayOf(MPT.Kodeverk).isRequired,
+  produserbareDokumenter: PT.arrayOf(MPT.Kodeverk).isRequired,
   brevbestillingSkjemaVerdier: PT.object,
   dokumenter: PT.object,
   oppsummering: MPT.Oppsummering,
@@ -170,7 +170,7 @@ const mapStateToProps = state => ({
   brevbestillingSkjemaVerdier: formSelectors.BrevBestillingFormSelector(state).values,
   dokumenter: dokumenterSelectors.dokumenterSelector(state),
   oppsummering: fagsakSelectors.OppsummeringSelector(state),
-  dokumenttypeIDer: KodeverkSelectors.dokumentTypeIDSelector(state),
+  produserbareDokumenter: KodeverkSelectors.produserbareDokumenterSelector(state),
   aktoerroller: KodeverkSelectors.aktoerrollerSelector(state),
   initialValues: {
     dokumenttypeKode: 'MELDING_MANGLENDE_OPPLYSNINGER',

--- a/src/felles-komponenter/sideOppsummering.js
+++ b/src/felles-komponenter/sideOppsummering.js
@@ -62,6 +62,7 @@ class SideOppsummering extends Component {
     const {
       saksnummer,
       sakstype,
+      saksstatus,
       behandlingsstatus,
       registrertDato,
       sisteOpplysningerHentetDato,
@@ -116,6 +117,8 @@ class SideOppsummering extends Component {
                 <dd>{fnr}</dd>
                 <dt>Saksnummer:</dt>
                 <dd>{saksnummer || '-'}</dd>
+                <dt>Saksstatus:</dt>
+                <dd>{kodeverkObjektTilTerm(saksstatus)}</dd>
                 <dt>Behandlingsstatus:</dt>
                 <dd>{kodeverkObjektTilTerm(behandlingsstatus)}</dd>
                 <dt>Oppholdsland:</dt>


### PR DESCRIPTION
ProduserbareDokumenter og status:
-Oppdatert "status" til korrekt "saksstatus".
-Fjernet dokumenttype.
-Refactor dokumenttypeIDer til produserbareDokumenter.