### PR TITLE
MELOSYS-2043: Brev-skjema setter ikke korrekte verdier ved reset.

### DIFF
--- a/src/felles-komponenter/sideDialog/brevBestilling.js
+++ b/src/felles-komponenter/sideDialog/brevBestilling.js
@@ -91,9 +91,9 @@ class BrevBestilling extends Component {
   };
 
   forkastBrev = async () => {
-    const { resetDokument } = this.props;
+    const { resetBrevBestillingForm, resetDokument } = this.props;
     resetDokument();
-    this.props.resetBrevBestillingForm();
+    resetBrevBestillingForm();
     // Quirk: Reset av form oppdaterer tilbake til initValues i form state, men
     // av en eller annen grunn så rendres ikke select til DOM.
     // Quick-fix er å tvinge en update til vi finner ut hva som blocker dette.

--- a/src/felles-komponenter/sideDialog/brevBestilling.js
+++ b/src/felles-komponenter/sideDialog/brevBestilling.js
@@ -18,6 +18,7 @@ import PdfLenkeListe from '../pdfLenkeListe';
 import './brevBestilling.css';
 import * as Utils from '../../utils/utils';
 
+
 const InfoPanel = () => (
   <Nav.Lesmerpanel
     intro="Se hva som skal stå i mangelbrevet:"
@@ -89,10 +90,15 @@ class BrevBestilling extends Component {
     return true;
   };
 
-  forkastBrev = () => {
-    const { resetBrevBestillingForm, resetDokument } = this.props;
-    resetBrevBestillingForm();
+  forkastBrev = async () => {
+    const { resetDokument } = this.props;
     resetDokument();
+    this.props.resetBrevBestillingForm();
+    // Quirk: Reset av form oppdaterer tilbake til initValues i form state, men
+    // av en eller annen grunn så rendres ikke select til DOM.
+    // Quick-fix er å tvinge en update til vi finner ut hva som blocker dette.
+    await Utils.delay(0);
+    this.forceUpdate();
   };
 
   render () {
@@ -109,7 +115,6 @@ class BrevBestilling extends Component {
     const ForhandsvistePdfDokumenter = [
       { navn: 'Vis utkast', type: dokumenttypeKode, data },
     ];
-
 
     const placeholder = 'Feks: "Opplysning om antall utsendet i perioden, "Opplysninger om den ansatt erstatter en annen utsendt ansatt""';
     return (
@@ -175,7 +180,7 @@ const mapStateToProps = state => ({
   initialValues: {
     dokumenttypeKode: 'MELDING_MANGLENDE_OPPLYSNINGER',
     mottaker: 'BRUKER',
-    fritekst: undefined,
+    fritekst: '',
   },
 });
 


### PR DESCRIPTION
Bakgrunn: Det er en quirk et eller annet sted som ikke oppdaterer UI helt ut til browser DOM. Verdiene settes først ved NESTE render-syklus. Jeg greier ikke helt å pinpointe hva som utløser dette, men denne PR'en har en quick-fix for å få dette til å fungere.