### PR TITLE
En skråstrek for masse i kall mot behandlinger

### DIFF
--- a/src/services/modules/behandlinger.js
+++ b/src/services/modules/behandlinger.js
@@ -2,11 +2,11 @@ import { postAsJson } from '../utils';
 import { API_BASE_URL, BEHANDLINGER } from '../api-constants';
 
 export const oppdaterStatus = (behandlingID, status) => {
-  const URI_BEHANDLINGER_STATUS = `${API_BASE_URL}/${BEHANDLINGER}/${behandlingID}/status`;
+  const URI_BEHANDLINGER_STATUS = `${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/status`;
   return postAsJson(URI_BEHANDLINGER_STATUS, { behandlingsstatus: status });
 };
 export const sendPerioder = (behandlingID, perioder) => {
-  const URI_BEHANDLINGER_PERIODER = `${API_BASE_URL}/${BEHANDLINGER}/${behandlingID}/perioder`;
+  const URI_BEHANDLINGER_PERIODER = `${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/perioder`;
   return postAsJson(URI_BEHANDLINGER_PERIODER, perioder);
 };
 


### PR DESCRIPTION
Kall mot behandlinger hadde en skråstrek for mye. Det gjorde at "Oppdater"-knappen ikke fungerte. Kallene ble gjort mot sti `/api//behandlinger/9/status`, men skulle være `/api/behandlinger/9/status`.