### PR TITLE
MELOSYS-2350 - Send begrunnelsekode null ved mangelbrev

### DIFF
--- a/src/soknad-komponenter/sideDialog/brevBestilling.js
+++ b/src/soknad-komponenter/sideDialog/brevBestilling.js
@@ -55,7 +55,7 @@ class BrevBestilling extends Component {
     } = this.props;
     const { behandlingID } = oppsummering;
     const { fritekst, mottaker, dokumenttypeKode } = brevbestillingSkjemaVerdier;
-    const dokument = this.erMangelBrevMedFritekst() ? Object.assign({ fritekst, mottaker }) : {};
+    const dokument = this.erMangelBrevMedFritekst() ? Object.assign({ fritekst, mottaker, begrunnelseKode: null }) : {};
 
     this.setState({ feilmelding: undefined });
 


### PR DESCRIPTION
Det manglet begrunnelsekode i payload når mangelbrev brev ble sendt. Det er foreløpig bare mangelbrev som sendes fra frontend manuelt(utenom vedtak/henleggelse)