### PR TITLE
MELOSYS-2350 - Oppdater react-router-dom til v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-motion": "^0.5.2",
     "react-pdf": "^3.0.6",
     "react-redux": "^5.1.1",
-    "react-router-dom": "^4.3.1",
+    "react-router-dom": "^5.0.0",
     "react-router-redux": "^4.0.8",
     "react-scripts": "^1.1.5",
     "redux": "^4.0.1",


### PR DESCRIPTION
Just a note on the version bump: This was necessary because of how we specified versions in 4.x. In react-router-dom, we asked for react-router with the selector ^4.3.1. That was matching the temporary 4.4.0 release, for users of 4.3.1 and lower. Those versions are incompatible with each other directly; you should always have the same versions of react-router and react-router-dom. So, in order to fix this, we've bumped up the major version.

Despite the major bump, this is actually a minor release. It is fully backwards compatible with any project coming from 4.x. Sorry for the convenience.