### PR TITLE
MELOSYS-2527 - Maritimt arbeid feiler

### DIFF
--- a/src/ducks/avklartefakta/reducers.js
+++ b/src/ducks/avklartefakta/reducers.js
@@ -59,24 +59,27 @@ const lagAvklartfaktaObjektMedReferanse = (avklarteFakta, referanse, avklartefak
   };
 };
 
-const lagSokkelEllerSkipObjekt = (avklarteFakta, referanse, avklartefaktaKode, maritimtArbeid) => {
-  if (!avklarteFakta) { return []; }
-
-  return avklarteFakta.reduce((samling, enkeltAvklaring, index) => {
-    const installasjon = maritimtArbeid[index] || {};
+const lagSokkelEllerSkipObjekt = (referanse, avklartefaktaKode, maritimtArbeid) => (
+  maritimtArbeid.reduce((samling, installasjon = {}) => {
     const installasjonsNavn = installasjon.navn || Types.NULL;
-    const begrunnelseKoder = enkeltAvklaring.installasjonsTypeBegrunnelse ? [enkeltAvklaring.installasjonsTypeBegrunnelse] : Types.NULL;
 
-    return enkeltAvklaring.installasjonsType ? [...samling, {
-      ...avklartfaktaMal,
-      avklartefaktaKode,
-      referanse,
-      subjektID: installasjonsNavn,
-      begrunnelseKoder,
-      fakta: [enkeltAvklaring.installasjonsType],
-    }] : [...samling];
-  }, []);
-};
+    const { sokkelEllerSkip } = installasjon;
+    const installasjonsType = sokkelEllerSkip ? sokkelEllerSkip.installasjonsType : Types.NULL;
+    const begrunnelseKoder = sokkelEllerSkip ? [sokkelEllerSkip.installasjonsTypeBegrunnelse] : Types.NULL;
+
+    return installasjonsType ? [
+      ...samling,
+      {
+        ...avklartfaktaMal,
+        avklartefaktaKode,
+        referanse,
+        subjektID: installasjonsNavn,
+        begrunnelseKoder,
+        fakta: [installasjonsType],
+      },
+    ] : [...samling];
+  }, [])
+);
 
 const avklarEllerUtledBostedsland = (bostedsland, bosattINorge) => {
   if (bosattINorge) {
@@ -85,22 +88,23 @@ const avklarEllerUtledBostedsland = (bostedsland, bosattINorge) => {
   return lagAvklartfaktaObjektMedReferanse(bostedsland, 'BOSTEDSLAND', 'BOSTEDSLAND');
 };
 
-const lagFlagglandObjekt = (avklarteFakta, referanse, avklartefaktaKode, maritimtArbeid) => {
-  if (!avklarteFakta) { return []; }
-
-  return avklarteFakta.reduce((samling, enkeltAvklaring, index) => {
-    const installasjon = maritimtArbeid[index] || {};
+const lagFlagglandObjekt = (referanse, avklartefaktaKode, maritimtArbeid) => (
+  maritimtArbeid.reduce((samling, installasjon = {}) => {
     const installasjonsNavn = installasjon.navn || Types.NULL;
 
-    return enkeltAvklaring.installasjonsType ? [...samling, {
+    const { sokkelEllerSkip } = installasjon;
+    const installasjonsType = sokkelEllerSkip ? sokkelEllerSkip.installasjonsType : Types.NULL;
+    const arbeidsland = sokkelEllerSkip ? sokkelEllerSkip.arbeidsland : Types.NULL;
+
+    return installasjonsType ? [...samling, {
       ...avklartfaktaMal,
       avklartefaktaKode,
       referanse,
       subjektID: installasjonsNavn,
-      fakta: [enkeltAvklaring.arbeidsland],
+      fakta: [arbeidsland],
     }] : [...samling];
-  }, []);
-};
+  }, [])
+);
 
 // Reducer
 export default function reducer(state = initialState, action) {
@@ -119,6 +123,7 @@ export default function reducer(state = initialState, action) {
       return { ...initialState };
     case Types.OPPDATER_AVKLARTEFAKTA: {
       const { dokument } = action;
+
       const avklartefakta = [
         ...dokument.avklartefakta.soknadsland,
         ...dokument.avklartefakta.virksomheter,
@@ -126,8 +131,8 @@ export default function reducer(state = initialState, action) {
         lagAvklartStateObjekt(dokument.avklartefakta.yrkesaktivitetAntallLand, 'YRKESAKTIVITET_ANTALL_LAND'),
         lagAvklartStateObjekt(dokument.avklartefakta.yrkesaktivitet, 'YRKESAKTIVITET'),
         avklarEllerUtledBostedsland(dokument.avklartefakta.bostedsland, dokument.vilkar.bosattINorge),
-        ...lagSokkelEllerSkipObjekt(dokument.avklartefakta.sokkelEllerSkip, 'SOKKEL_ELLER_SKIP', 'SOKKEL_ELLER_SKIP', dokument.maritimtArbeid),
-        ...lagFlagglandObjekt(dokument.avklartefakta.sokkelEllerSkip, 'INSTALLASJON_ARBEIDSLAND', 'ARBEIDSLAND', dokument.maritimtArbeid),
+        ...lagSokkelEllerSkipObjekt('SOKKEL_ELLER_SKIP', 'SOKKEL_ELLER_SKIP', dokument.maritimtArbeid),
+        ...lagFlagglandObjekt('INSTALLASJON_ARBEIDSLAND', 'ARBEIDSLAND', dokument.maritimtArbeid),
         lagAvklartfaktaObjekt(dokument.avklartefakta.sokkelSkipKonklusjon, 'ARBEID_SOKKEL_SKIP'),
       ].filter(fakta => fakta !== Types.NULL);
 

--- a/src/ducks/form/selectors.js
+++ b/src/ducks/form/selectors.js
@@ -67,6 +67,11 @@ export const Art16BegrunnelseFritekstSelector = createSelector(
   skjemaverdier => skjemaverdier.vilkar.art16_1_begrunnelser_fritekst
 );
 
+export const MaritimtArbeidSelector = createSelector(
+  state => SoknadenFormSelector(state).values,
+  skjemaverdier => skjemaverdier.maritimtArbeid
+);
+
 export const SokkelEllerSkipSelector = createSelector(
   state => SoknadenFormSelector(state).values,
   skjemaverdier => skjemaverdier.avklartefakta.sokkelEllerSkip

--- a/src/ducks/soknad/reducers.js
+++ b/src/ducks/soknad/reducers.js
@@ -140,7 +140,7 @@ export default function reducer(state = initialState, action) {
           fartsomradeKode: maritimtArbeid.fartsomradeKode,
           flaggLandkode: maritimtArbeid.flaggLandkode,
           installasjonsLandkode: maritimtArbeid.installasjonsLandkode,
-          territorialfarvann: maritimtArbeid.territorialfarvann ? maritimtArbeid.territorialfarvann : null,
+          territorialfarvann: maritimtArbeid.territorialfarvann || null,
         })),
         soeknadsland: {
           landkoder: dokument.soknadsland,

--- a/src/ducks/soknad/reducers.js
+++ b/src/ducks/soknad/reducers.js
@@ -136,7 +136,10 @@ export default function reducer(state = initialState, action) {
         maritimtArbeid: dokument.maritimtArbeid.filter(maritimtArbeid => (
           maritimtArbeid.navn && maritimtArbeid.fartsomradeKode && maritimtArbeid.flaggLandkode && maritimtArbeid.installasjonsLandkode
         )).map(maritimtArbeid => ({
-          ...maritimtArbeid,
+          navn: maritimtArbeid.navn,
+          fartsomradeKode: maritimtArbeid.fartsomradeKode,
+          flaggLandkode: maritimtArbeid.flaggLandkode,
+          installasjonsLandkode: maritimtArbeid.installasjonsLandkode,
           territorialfarvann: maritimtArbeid.territorialfarvann ? maritimtArbeid.territorialfarvann : null,
         })),
         soeknadsland: {

--- a/src/sider/saksopplysninger/saksopplysninger.js
+++ b/src/sider/saksopplysninger/saksopplysninger.js
@@ -266,7 +266,6 @@ const mapStateToProps = state => ({
       yrkesaktivitetAntallLand: avklartefaktaSelectors.YrkesaktivitetAntallLand(state),
       yrkesaktivitet: avklartefaktaSelectors.Yrkesaktivitet(state),
       virksomheter: avklartefaktaSelectors.VirksomhetSelector(state),
-      sokkelEllerSkip: avklartefaktaSelectors.SokkelEllerSkipSelector(state),
       sokkelSkipKonklusjon: avklartefaktaSelectors.ArbeidSokkelSkipSelector(state),
     },
     vilkar: {

--- a/src/soknad-komponenter/stegvelger/stegKomponenter/vurderingSokkelSkip.js
+++ b/src/soknad-komponenter/stegvelger/stegKomponenter/vurderingSokkelSkip.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PT from 'prop-types';
-import { connect } from 'react-redux';
 
 import * as Nav from '../../../utils/navFrontend';
 import * as Skjema from '../../skjema';
@@ -10,7 +9,6 @@ import * as MPT from '../../../proptypes';
 import LandVelger from '../../skjema/landvelger';
 
 import './vurderingSokkelSkip.css';
-import { SokkelEllerSkipSelector } from '../../../ducks/form/selectors';
 
 const SokkelSkipEnkelt = props => {
   const {
@@ -18,10 +16,11 @@ const SokkelSkipEnkelt = props => {
     begrunnelser,
     index,
     redigerbart,
-    installasjonsType,
   } = props;
 
-  const { navn } = sokkelSkipInfo;
+  const { navn, sokkelEllerSkip } = sokkelSkipInfo;
+
+  const { installasjonsType } = sokkelEllerSkip || {};
 
   const { SOKKEL, SKIP } = KV.Koder;
 
@@ -29,19 +28,19 @@ const SokkelSkipEnkelt = props => {
     <Nav.Row className="sokkelSkip__liste__rad">
       <Nav.Column xs="4" className="rad__navn">{navn}</Nav.Column>
       <Nav.Column xs="2" className="rad__sokkel">
-        <Skjema.Radio disabled={!redigerbart} feltNavn={`avklartefakta.sokkelEllerSkip[${index}].installasjonsType`} value={SOKKEL} label="Sokkel" />
-        <Skjema.Radio disabled={!redigerbart} feltNavn={`avklartefakta.sokkelEllerSkip[${index}].installasjonsType`} value={SKIP} label="Skip" />
+        <Skjema.Radio disabled={!redigerbart} feltNavn={`maritimtArbeid[${index}].sokkelEllerSkip.installasjonsType`} value={SOKKEL} label="Sokkel" />
+        <Skjema.Radio disabled={!redigerbart} feltNavn={`maritimtArbeid[${index}].sokkelEllerSkip.installasjonsType`} value={SKIP} label="Skip" />
       </Nav.Column>
       {
         installasjonsType === SOKKEL &&
         <Nav.Column xs="3" className="rad__begrunnelse">
-          <Skjema.Select disabled={!redigerbart} feltNavn={`avklartefakta.sokkelEllerSkip[${index}].installasjonsTypeBegrunnelse`} label="Begrunnelse hvis sokkel">
+          <Skjema.Select disabled={!redigerbart} feltNavn={`maritimtArbeid[${index}].sokkelEllerSkip.installasjonsTypeBegrunnelse`} label="Begrunnelse hvis sokkel">
             {begrunnelser.map(enkelt => <option key={enkelt.kode} value={enkelt.kode}>{enkelt.term}</option>)}
           </Skjema.Select>
         </Nav.Column>
       }
       <Nav.Column xs="3" className="rad__land">
-        <LandVelger disabled={!redigerbart} feltNavn={`avklartefakta.sokkelEllerSkip[${index}].arbeidsland`} multiLand={false} label="Arbeidsland" />
+        <LandVelger disabled={!redigerbart} feltNavn={`maritimtArbeid[${index}].sokkelEllerSkip.arbeidsland`} multiLand={false} label="Arbeidsland" />
       </Nav.Column>
     </Nav.Row>
   );
@@ -52,18 +51,7 @@ SokkelSkipEnkelt.propTypes = {
   sokkelSkipInfo: PT.object.isRequired,
   begrunnelser: PT.arrayOf(MPT.Kodeverk).isRequired,
   redigerbart: PT.bool.isRequired,
-  installasjonsType: PT.string,
 };
-
-SokkelSkipEnkelt.defaultProps = {
-  installasjonsType: '',
-};
-
-const mapStateToProps = (state, ownProps) => ({
-  installasjonsType: SokkelEllerSkipSelector(state)[ownProps.index].installasjonsType,
-});
-
-const SokkelSkipEnkeltConnected = connect(mapStateToProps)(SokkelSkipEnkelt);
 
 const SokkelSkipListe = props => {
   const { alleSokkelSkip, begrunnelser, redigerbart } = props;
@@ -71,7 +59,7 @@ const SokkelSkipListe = props => {
   return (
     <div className="sokkelSkip__liste">
       { alleSokkelSkip.map((enkelt, index) => (
-        <SokkelSkipEnkeltConnected
+        <SokkelSkipEnkelt
           key={JSON.stringify(enkelt)}
           sokkelSkipInfo={enkelt}
           index={index}

--- a/src/soknad-komponenter/stegvelger/stegKomponenter/vurderingSokkelSkip.js
+++ b/src/soknad-komponenter/stegvelger/stegKomponenter/vurderingSokkelSkip.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PT from 'prop-types';
+import uuid from 'uuid';
 
 import * as Nav from '../../../utils/navFrontend';
 import * as Skjema from '../../skjema';
@@ -60,7 +61,7 @@ const SokkelSkipListe = props => {
     <div className="sokkelSkip__liste">
       { alleSokkelSkip.map((enkelt, index) => (
         <SokkelSkipEnkelt
-          key={JSON.stringify(enkelt)}
+          key={uuid()}
           sokkelSkipInfo={enkelt}
           index={index}
           begrunnelser={begrunnelser}

--- a/src/soknad-komponenter/stegvelger/stegMotor/kontrollere/sokkel_skip.js
+++ b/src/soknad-komponenter/stegvelger/stegMotor/kontrollere/sokkel_skip.js
@@ -2,6 +2,7 @@ import Steg from '../steg';
 import { FANE_STATUS, STEG } from '../typer';
 import VurderingSokkelSkip from '../../stegKomponenter/vurderingSokkelSkip';
 import * as KV from '../../../../kodeverk';
+import * as Utils from '../../../../utils';
 
 class SokkelSkip extends Steg {
   constructor(propsLight, stegPosisjon) {
@@ -38,7 +39,10 @@ class SokkelSkip extends Steg {
       redigerbart: _propsLight.redigerbart,
     });
     this.beregnRelevantUI = _propsLight => {
-      const { sokkelEllerSkip = [], sokkelSkipKonklusjon } = _propsLight.skjema.avklartefakta;
+      const { sokkelSkipKonklusjon } = _propsLight.skjema.avklartefakta;
+      const sokkelEllerSkip = _propsLight.skjema.maritimtArbeid.map(maritimtArbeid => (
+        Utils._isEmpty(maritimtArbeid.sokkelEllerSkip) ? {} : maritimtArbeid.sokkelEllerSkip
+      ));
 
       return ({
         harAvklaring: SokkelSkip.alleErAvklart(sokkelEllerSkip, sokkelSkipKonklusjon),
@@ -60,7 +64,7 @@ class SokkelSkip extends Steg {
 
   // Hvis SKIP er valgt som vurdering, så skal det ikke legges inn
   // en begrunnelse.
-  static alleErAvklart = (sokkelEllerSkip, sokkelSkipKonklusjon) => {
+  static alleErAvklart = (sokkelEllerSkip = [], sokkelSkipKonklusjon) => {
     const avklartSokkelEllerSkip = sokkelEllerSkip.length > 0 && sokkelEllerSkip
       .map(enkelt => {
         if (enkelt.installasjonsType === KV.Koder.SOKKEL && enkelt.installasjonsTypeBegrunnelse && enkelt.arbeidsland) { return true; }


### PR DESCRIPTION
Hindrer krasj dersom man legger til maritimt arbeid og står i sokkel/skip-steget samtidig.

Endrer på form-struktur for sokkel/skip, og endrer dermed også på oppbygningen av avklartefakta for sokkel/skip.