### PR TITLE
MELOSYS-2616 - land kan være null

### DIFF
--- a/src/soknad-komponenter/journalforing/eksisterendeSaker.js
+++ b/src/soknad-komponenter/journalforing/eksisterendeSaker.js
@@ -40,7 +40,7 @@ const EnkeltSak = props => {
         <dd>{<EnkeltDato dato={opprettetDato} />}</dd>
         <DatoOmradeDescription tekst="Søknadsperiode: " periode={soknadsperiode} />
         <dt>Land:</dt>
-        <dd>{land.join(', ')}</dd>
+        <dd>{land ? land.join(', ') : '(ukjent)'}</dd>
       </dl>
     </div>
   );


### PR DESCRIPTION
Noen av behandlingene vi får inn inneholder land = null. Det er en sjekk for det i `fagsak.js`, men ikke i `eksisterendeSaker.js`. Har nå lagt til sjekk i sistnevnte