### PR TITLE
MELOSYS-2794 - Send oppgavetype ved behandling-plukk

### DIFF
--- a/src/ducks/oppgaver/operations.js
+++ b/src/ducks/oppgaver/operations.js
@@ -42,7 +42,7 @@ export const sendBehandlingsOppgave = async checkboxliste => {
   const behandlingstyper = Object.keys(behandlingstyperListe).filter(behandlingstype => behandlingstyperListe[behandlingstype]);
 
   const oppgave = {
-    oppgavetype: MKV.Koder.oppgavetyper.BEH_SAK_MK,
+    oppgavetype: null,
     sakstyper,
     behandlingstyper,
   };
@@ -54,11 +54,12 @@ export const sendBehandlingsOppgave = async checkboxliste => {
 };
 
 export const sendJournalOppgave = async fagomrade => {
+  const behandlingstyper = fagomrade === 'MED' ? [] : [fagomrade];
+
   const oppgave = {
     oppgavetype: MKV.Koder.oppgavetyper.JFR,
     sakstyper: [],
-    behandlingstyper: [],
-    fagomrade, // 'UFM' || 'MDL'
+    behandlingstyper,
   };
   const response = await Api.Oppgaver.send(oppgave);
   const { oppgaveID, journalpostID } = response;

--- a/src/forside-komponenter/behandling.js
+++ b/src/forside-komponenter/behandling.js
@@ -46,8 +46,11 @@ class Behandling extends Component {
             <Nav.Column xs="8">
               <Nav.Fieldset legend="Behandlingstype">
                 {MKV.KTObjects.behandlinger.typer.map(type => {
-                  const isDisabled = type.kode !== MKV.Koder.behandlinger.typer.SOEKNAD;
-                  return (<Skjema.Checkbox key={uuid()} label={type.term} disabled={isDisabled} feltNavn={`behandlingstyper.${type.kode}`} />);
+                  const isDisabled = ![
+                    MKV.Koder.behandlinger.typer.SOEKNAD,
+                    MKV.Koder.behandlinger.typer.ENDRET_PERIODE,
+                  ].includes(type.kode);
+                  return (<Skjema.Checkbox key={type.kode} label={type.term} disabled={isDisabled} feltNavn={`behandlingstyper.${type.kode}`} />);
                 })}
               </Nav.Fieldset>
             </Nav.Column>


### PR DESCRIPTION
Send oppgavetype null ved behandling-plukk(Oppgavetype brukes ikke per dags dato ved plukk av behandling. Behandlingstyper brukes i stedet).

Ikke send fagomrade ved JF-plukk(behandlingstyper brukes for å plukke journalføringsoppgave i stedet).