### PR TITLE
BUGFIX_kodeverk_sti_dialogboksHenlegg

### DIFF
--- a/src/soknad-komponenter/dialogboks/dialogboksHenlegg.js
+++ b/src/soknad-komponenter/dialogboks/dialogboksHenlegg.js
@@ -50,7 +50,7 @@ export class DialogboksHenleggSak extends Component {
     return fritekstValideringPassert;
   };
 
-  fritekstValgt = () => this.state.begrunnelseKode === MKV.Koder.henleggelsesgrunner.ANNET;
+  fritekstValgt = () => this.state.begrunnelseKode === MKV.Koder.begrunnelser.henleggelsesgrunner.ANNET;
 
   fritekstTom = () => this.state.fritekst === '';
 

--- a/src/soknad-komponenter/dialogboks/dialogboksHenlegg.js
+++ b/src/soknad-komponenter/dialogboks/dialogboksHenlegg.js
@@ -108,8 +108,7 @@ export class DialogboksHenleggSak extends Component {
       data,
     }];
 
-    const visTekstFelt = begrunnelseKode === MKV.Koder.henleggelsesgrunner.ANNET;
-
+    const visTekstFelt = begrunnelseKode === MKV.Koder.begrunnelser.henleggelsesgrunner.ANNET;
     return (
       <Nav.Modal
         className="dialogboksHenlegg"
@@ -126,7 +125,7 @@ export class DialogboksHenleggSak extends Component {
             onChange={this.velgBegrunnelseHandle}
             label="Begrunnelse"
             value={begrunnelseKode}
-            koder={MKV.KTObjects.henleggelsesgrunner}
+            koder={MKV.KTObjects.begrunnelser.henleggelsesgrunner}
             disableForsteValg={erBegrunnelseValgt()}
             redigerbar={redigerbart}
           />

--- a/src/soknad-komponenter/dialogboks/dialogboksHenlegg.test.js
+++ b/src/soknad-komponenter/dialogboks/dialogboksHenlegg.test.js
@@ -11,7 +11,7 @@ describe('Dialogbokshenlegg', () => {
   beforeEach(() => {
     props = {
       avbryt,
-      oppsummering: { behandlingID: 1 },
+      behandlingID: 1,
       redigerbart: true,
       henleggHandle,
       ariaHideApp: false,


### PR DESCRIPTION
MKV.henleggelsesgrunner flyttet => MKV.begrunnelser.henleggelsesgrunner.
behandlingID; flyttet fra oppsummering: {behandlingID: 1} => behandlingID: 1