### PR TITLE
MELOSYS-2825 - Vis flere valg i behandlingsmenyen ved endring av periode.

### DIFF
--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -25,10 +25,14 @@ export const OppsummeringSelector = createSelector(
   state => BehandlingerSelector(state).oppsummering || {},
   oppsummering => oppsummering
 );
+export const BehandlingstypeKodeSelector = createSelector(
+  OppsummeringSelector,
+  oppsummering => (oppsummering.behandlingstype ? oppsummering.behandlingstype.kode : '')
+);
 export const RedigerbartSelector = createSelector(
   state => BehandlingerSelector(state).redigerbart || false,
-  state => OppsummeringSelector(state),
-  (redigerbart, oppsummering) => redigerbart && oppsummering.behandlingstype.kode !== MKV.Koder.behandlinger.typer.ENDRET_PERIODE
+  BehandlingstypeKodeSelector,
+  (redigerbart, behandlingstypeKode) => redigerbart && behandlingstypeKode !== MKV.Koder.behandlinger.typer.ENDRET_PERIODE
 );
 export const EndreLovvalgsPeriodeRedigerbartSelector = createSelector(
   state => BehandlingerSelector(state).redigerbart || false,

--- a/src/soknad-komponenter/behandlingsmeny.js
+++ b/src/soknad-komponenter/behandlingsmeny.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PT from 'prop-types';
+
+import * as Nav from '../utils/navFrontend';
+
+const Behandlingsmeny = props => {
+  const {
+    redigerbart, lagreOgLukkHandle, tilbakeleggeHandle, oppfriskSaksopplysningerHandle, visHenleggDialogHandle, apneTidligereBehandlinger, avsluttSakSomBortfalt, visHenleggSak,
+  } = props;
+
+  return (
+    <Nav.EkspanderbartpanelBase ariaTittel="Behandlingsmeny" className="oppsummering__meny" heading={<div className="behandlingsmeny_title">Behandlingsmeny</div>}>
+      <div className="meny__innhold">
+        { redigerbart && <Nav.Knapp type="hoved" mini className="innhold__element" onClick={lagreOgLukkHandle}>Lagre og lukk</Nav.Knapp> }
+        <Nav.Knapp disabled={!redigerbart} type="hoved" mini className="innhold__element" onClick={tilbakeleggeHandle}>Legg tilbake i kø</Nav.Knapp>
+        <Nav.Knapp disabled={!redigerbart} type="hoved" mini className="innhold__element" onClick={oppfriskSaksopplysningerHandle}>Oppdater saksopplysninger</Nav.Knapp>
+        { redigerbart && visHenleggSak && <Nav.Knapp type="hoved" mini className="innhold__element" onClick={visHenleggDialogHandle}>Henlegg sak</Nav.Knapp> }
+        { redigerbart && <Nav.Knapp type="hoved" mini className="innhold__element" onClick={avsluttSakSomBortfalt}>Avslutt sak som bortfalt</Nav.Knapp>}
+        { <Nav.Knapp type="hoved" mini className="innhold__element" onClick={apneTidligereBehandlinger}>Vis tidligere behandlinger</Nav.Knapp> }
+      </div>
+    </Nav.EkspanderbartpanelBase>
+  );
+};
+
+Behandlingsmeny.propTypes = {
+  lagreOgLukkHandle: PT.func.isRequired,
+  tilbakeleggeHandle: PT.func.isRequired,
+  oppfriskSaksopplysningerHandle: PT.func.isRequired,
+  visHenleggDialogHandle: PT.func.isRequired,
+  avsluttSakSomBortfalt: PT.func.isRequired,
+  apneTidligereBehandlinger: PT.func.isRequired,
+  redigerbart: PT.bool.isRequired,
+  visHenleggSak: PT.bool.isRequired,
+};
+
+export default Behandlingsmeny;

--- a/src/soknad-komponenter/behandlingsmeny.test.js
+++ b/src/soknad-komponenter/behandlingsmeny.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import Behandlingsmeny from './behandlingsmeny';
+import * as Nav from '../utils/navFrontend';
+
+describe('behandlingsmeny', () => {
+  let props = null;
+
+  beforeEach(() => {
+    props = {
+      lagreOgLukkHandle: jest.fn(),
+      tilbakeleggeHandle: jest.fn(),
+      oppfriskSaksopplysningerHandle: jest.fn(),
+      visHenleggDialogHandle: jest.fn(),
+      avsluttSakSomBortfalt: jest.fn(),
+      apneTidligereBehandlinger: jest.fn(),
+      redigerbart: true,
+      visHenleggSak: true,
+    };
+  });
+
+  it('viser en NavEkspanderbartPanelBase', () => {
+    const behandlingsmeny = shallow(<Behandlingsmeny {...props} />);
+
+    expect(behandlingsmeny.find(Nav.EkspanderbartpanelBase)).toHaveLength(1);
+  });
+
+  it('kaller handlere ved klikk på knapper', () => {
+    const behandlingsmeny = shallow(<Behandlingsmeny {...props} />);
+
+    const knapper = behandlingsmeny.find('Knapp');
+    knapper.forEach(knapp => knapp.simulate('click'));
+
+    expect(props.lagreOgLukkHandle).toHaveBeenCalledTimes(1);
+    expect(props.tilbakeleggeHandle).toHaveBeenCalledTimes(1);
+    expect(props.oppfriskSaksopplysningerHandle).toHaveBeenCalledTimes(1);
+    expect(props.visHenleggDialogHandle).toHaveBeenCalledTimes(1);
+    expect(props.avsluttSakSomBortfalt).toHaveBeenCalledTimes(1);
+    expect(props.apneTidligereBehandlinger).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/soknad-komponenter/sideOppsummering.js
+++ b/src/soknad-komponenter/sideOppsummering.js
@@ -17,6 +17,7 @@ import { fagsakSelectors } from '../ducks/fagsaker/';
 import { behandlingerOperations, behandlingerSelectors } from '../ducks/behandlinger/';
 import { avklartefaktaSelectors } from '../ducks/avklartefakta';
 import { KodeTermSelect } from './kodeTermSelect';
+import Behandlingsmeny from './behandlingsmeny';
 
 import './sideOppsummering.css';
 
@@ -99,6 +100,7 @@ class SideOppsummering extends Component {
       person,
       soknadsperiodeFom,
       soknadsperiodeTom,
+      behandlingstype,
     } = this.props;
 
     if (!oppsummering) return <div />;
@@ -127,6 +129,7 @@ class SideOppsummering extends Component {
       visHenleggDialogHandle,
       arbeidsland,
       avsluttSakSomBortfalt,
+      endreLovvalgsperiodeRedigerbart,
     } = this.props;
 
     const arbeidslandSetning = Utils.streng.arrayTilKonjunksjon(arbeidsland.map(land => land.term));
@@ -136,24 +139,22 @@ class SideOppsummering extends Component {
     return (
       <section aria-label="oppsummeringer" className="sideOppsummering panelSeksjon">
         <Nav.Panel className="saksbehandling__soknadSammendrag">
-          {/* START BEHANDLINGSMENY */}
           <Nav.Row>
             <Nav.Column xs="12" md="12">
               <div className="oppsummering__menylinje">
-                <Nav.EkspanderbartpanelBase ariaTittel="Behandlingsmeny" className="oppsummering__meny" heading={<div className="behandlingsmeny_title">Behandlingsmeny</div>}>
-                  <div className="meny__innhold">
-                    { redigerbart && <Nav.Knapp type="hoved" mini className="innhold__element" onClick={lagreOgLukkHandle}>Lagre og lukk</Nav.Knapp> }
-                    <Nav.Knapp disabled={!redigerbart} type="hoved" mini className="innhold__element" onClick={tilbakeleggeHandle}>Legg tilbake i kø</Nav.Knapp>
-                    <Nav.Knapp disabled={!redigerbart} type="hoved" mini className="innhold__element" onClick={oppfriskSaksopplysningerHandle}>Oppdater saksopplysninger</Nav.Knapp>
-                    { redigerbart && <Nav.Knapp type="hoved" mini className="innhold__element" onClick={visHenleggDialogHandle}>Henlegg sak</Nav.Knapp> }
-                    { redigerbart && <Nav.Knapp type="hoved" mini className="innhold_element" onClick={avsluttSakSomBortfalt}>Avslutt sak som bortfalt</Nav.Knapp>}
-                    { <Nav.Knapp type="hoved" mini className="innhold__element" onClick={this.apneTidligereBehandlinger}>Vis tidligere behandlinger</Nav.Knapp> }
-                  </div>
-                </Nav.EkspanderbartpanelBase>
+                <Behandlingsmeny
+                  lagreOgLukkHandle={lagreOgLukkHandle}
+                  tilbakeleggeHandle={tilbakeleggeHandle}
+                  oppfriskSaksopplysningerHandle={oppfriskSaksopplysningerHandle}
+                  visHenleggDialogHandle={visHenleggDialogHandle}
+                  avsluttSakSomBortfalt={avsluttSakSomBortfalt}
+                  apneTidligereBehandlinger={this.apneTidligereBehandlinger}
+                  redigerbart={endreLovvalgsperiodeRedigerbart}
+                  visHenleggSak={behandlingstype !== MKV.Koder.behandlinger.typer.ENDRET_PERIODE}
+                />
               </div>
             </Nav.Column>
           </Nav.Row>
-          {/* END BEHANDLINGSMENY */}
           <Nav.Row>
             <Nav.Column xs="12" md="6">
               <Nav.Undertittel className="soknadSammendrag__header">Søknad</Nav.Undertittel>
@@ -214,7 +215,9 @@ class SideOppsummering extends Component {
 
 SideOppsummering.propTypes = {
   behandlingID: PT.number.isRequired,
+  behandlingstype: PT.string.isRequired,
   redigerbart: PT.bool,
+  endreLovvalgsperiodeRedigerbart: PT.bool.isRequired,
   fagsak: MPT.Fagsak,
   oppsummering: MPT.Behandlinger.Oppsummering,
   avsluttSakSomBortfalt: PT.func.isRequired,
@@ -240,6 +243,8 @@ const mapStateToProps = state => ({
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   person: behandlingerSelectors.PersonSelector(state),
   redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  endreLovvalgsperiodeRedigerbart: behandlingerSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
+  behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
   soknadsperiodeFom: formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).fom),
   soknadsperiodeTom: formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).tom),
   arbeidsland: avklartefaktaSelectors.ArbeidslandKTSelector(state),


### PR DESCRIPTION
Behandlingsmenyen ved endring av lovvalgsperiode var tidligere lik som ved en behandling i "read-only"-modus. Denne endringen viser hele behandlingsmenyen ved endring av lovvalgsperiode, bortsett fra "henlegg-sak"-knappen.