### PR TITLE
MELOSYS-2802 - Fiks "Arbeidsgivers virksomhet i Norge"-panelikon

### DIFF
--- a/src/soknad-komponenter/virksomhetNorge.js
+++ b/src/soknad-komponenter/virksomhetNorge.js
@@ -28,7 +28,7 @@ function VirksomhetNorge (props) {
     values.arbeidstakereRekruttertILand,
     values.oppdragsKontrakterIHovedsakInngaattILand,
   ];
-  const minstEttFeltErUtfylt = felter.some(felt => felt !== '');
+  const minstEttFeltErUtfylt = felter.some(felt => felt !== '' && felt !== null);
   const panelIkon = minstEttFeltErUtfylt ? Ikoner.Ferdig : Ikoner.Ubehandlet;
 
   return (


### PR DESCRIPTION
Vis grått ikon dersom ingen felter er utfylt i "arbeidsgiver virksomhet i norge"-panel.