### PR TITLE
MELOSYS-2898 & MELOSYS-2901 - Validere personopplysningspanel

### DIFF
--- a/src/felleskomponenter/skjema/input/input.js
+++ b/src/felleskomponenter/skjema/input/input.js
@@ -1,14 +1,11 @@
 import React from 'react';
 import PT from 'prop-types';
 import { Field } from 'redux-form';
-import { connect } from 'react-redux';
 
 import * as Nav from '../../../utils/navFrontend';
 import * as Utils from '../../../utils';
 
 import { normaliserInputDato } from '../../../utils/dato';
-
-import { formSelectors } from '../../../ducks/form';
 
 import '../skjema.css';
 
@@ -16,20 +13,13 @@ import '../skjema.css';
  * objekt som NAV-Input-komponenten forventer. Før den settes inn i Nav.Input.
  */
 function InnerInputComponent({
-  input, label, feltFeil, /* eslint-disable */feltNavn/* eslint-enable */, ...rest
+  input, label, ...rest
 }) {
   const { meta: { error, touched, active } } = rest;
 
-  let feil = (error && touched && !active) ? { feilmelding: rest.meta.error } : undefined;
+  const feil = (error && touched && !active) ? { feilmelding: rest.meta.error } : undefined;
   /* Vi forventer at meta.error er en string eller et objekt */
   if (feil && Utils._isObject(feil.feilmelding)) feil.feilmelding = feil.feilmelding.melding;
-
-  /* Fikser feil hvor redux-form ikke sender inn noe meta.error-objekt. */
-  if (!feil) {
-    const feltFeilmelding = feltFeil ? feltFeil.melding : null;
-
-    if (feltFeilmelding && touched && !active) feil = { feilmelding: feltFeilmelding };
-  }
 
   const inputProps = { ...input, ...rest };
 
@@ -41,7 +31,6 @@ InnerInputComponent.propTypes = {
   bredde: PT.string,
   meta: PT.object,
   input: PT.object,
-  feltFeil: PT.object,
 };
 
 InnerInputComponent.defaultProps = {
@@ -51,11 +40,6 @@ InnerInputComponent.defaultProps = {
   feltFeil: {},
 };
 
-const mapStateToProps = (state, ownProps) => ({
-  feltFeil: formSelectors.FormSelector(state)[ownProps.meta.form].syncErrors ? formSelectors.FormSelector(state)[ownProps.meta.form].syncErrors[ownProps.feltNavn] : null,
-});
-
-const ConnectedInnerInputComponent = connect(mapStateToProps, () => ({}))(InnerInputComponent);
 
 function Input({
   feltNavn, bredde, datoFelt, ...rest
@@ -68,9 +52,9 @@ function Input({
       bredde={bredde}
       name={feltNavn}
       normalize={normaliserDatoFunksjon}
-      component={ConnectedInnerInputComponent}
+      component={InnerInputComponent}
       placeholder={placeholderTekst}
-      props={{ ...rest, feltNavn }}
+      props={{ ...rest }}
     />
   );
 }

--- a/src/felleskomponenter/skjema/input/input.js
+++ b/src/felleskomponenter/skjema/input/input.js
@@ -37,7 +37,6 @@ InnerInputComponent.defaultProps = {
   bredde: undefined,
   meta: undefined,
   input: undefined,
-  feltFeil: {},
 };
 
 

--- a/src/felleskomponenter/skjema/input/input.test.js
+++ b/src/felleskomponenter/skjema/input/input.test.js
@@ -64,8 +64,6 @@ describe('InnerInputComponent', () => {
         active: true,
       },
       input: {},
-      feltFeil: {},
-      feltNavn: 'navn',
     };
   });
 

--- a/src/felleskomponenter/skjema/landvelger/enkeltLand.js
+++ b/src/felleskomponenter/skjema/landvelger/enkeltLand.js
@@ -1,15 +1,12 @@
 import React, { Component } from 'react';
 import PT from 'prop-types';
 import { Field } from 'redux-form';
-import { connect } from 'react-redux';
 
 import * as Utils from '../../../utils';
 import * as Nav from '../../../utils/navFrontend';
 import * as MPT from '../../../proptypes';
 
 import { kodeTilObjekt, landTekstFormat } from './LandVelger';
-
-import { formSelectors } from '../../../ducks/form';
 
 import './landvelger.css';
 
@@ -115,7 +112,7 @@ export class EnkeltLand extends Component {
     } = this;
 
     const {
-      label, meta, dataListID, disabled, bredde, feltFeil,
+      label, meta, dataListID, disabled, bredde,
     } = this.props;
 
     const { inputVerdi } = this.state;
@@ -124,14 +121,7 @@ export class EnkeltLand extends Component {
     /* Vi forventer at meta.error er en string eller et objekt */
     if (Utils._isObject(skjemaError)) skjemaError = skjemaError.melding;
     const { error: landError = '' } = this.state;
-    let feilObjekt = skjemaError || landError ? { feilmelding: `${skjemaError || ''} ${landError || ''}` } : null;
-
-    /* Fikser feil hvor redux-form ikke sender inn noe meta.error-objekt. */
-    if (!feilObjekt) {
-      const feltFeilmelding = feltFeil ? feltFeil.melding : null;
-
-      if (feltFeilmelding) feilObjekt = { feilmelding: feltFeilmelding };
-    }
+    const feilObjekt = skjemaError || landError ? { feilmelding: `${skjemaError || ''} ${landError || ''}` } : null;
 
     return (
       <div>
@@ -162,7 +152,6 @@ EnkeltLand.propTypes = {
   input: PT.object.isRequired,
   disabled: PT.bool,
   bredde: PT.string,
-  feltFeil: PT.object.isRequired,
   onChange: PT.func,
 };
 
@@ -174,13 +163,7 @@ EnkeltLand.defaultProps = {
   onChange: null,
 };
 
-const mapStateToProps = (state, ownProps) => ({
-  feltFeil: formSelectors.FormSelector(state)[ownProps.meta.form].syncErrors ? formSelectors.FormSelector(state)[ownProps.meta.form].syncErrors[ownProps.feltNavn] : null,
-});
-
-const ConnectedEnkeltLand = connect(mapStateToProps)(EnkeltLand);
-
-const EnkeltLandWrapper = props => (<Field name={props.feltNavn} component={ConnectedEnkeltLand} props={props} />);
+const EnkeltLandWrapper = props => (<Field name={props.feltNavn} component={EnkeltLand} props={props} />);
 
 EnkeltLandWrapper.propTypes = {
   feltNavn: PT.string.isRequired,

--- a/src/felleskomponenter/skjema/landvelger/enkeltLand.js
+++ b/src/felleskomponenter/skjema/landvelger/enkeltLand.js
@@ -124,7 +124,7 @@ export class EnkeltLand extends Component {
     /* Vi forventer at meta.error er en string eller et objekt */
     if (Utils._isObject(skjemaError)) skjemaError = skjemaError.melding;
     const { error: landError = '' } = this.state;
-    let feilObjekt = skjemaError || landError ? { feilmelding: `${skjemaError} ${landError}` } : null;
+    let feilObjekt = skjemaError || landError ? { feilmelding: `${skjemaError || ''} ${landError || ''}` } : null;
 
     /* Fikser feil hvor redux-form ikke sender inn noe meta.error-objekt. */
     if (!feilObjekt) {

--- a/src/felleskomponenter/skjema/landvelger/enkeltLand.test.js
+++ b/src/felleskomponenter/skjema/landvelger/enkeltLand.test.js
@@ -13,8 +13,6 @@ describe('EnkeltLand', () => {
       feil: undefined,
       input: { onChange: () => null },
       disabled: false,
-      feltFeil: {},
-      feltNavn: 'navn',
     };
   });
 

--- a/src/felleskomponenter/skjema/validering/skjemaer/createValidator.js
+++ b/src/felleskomponenter/skjema/validering/skjemaer/createValidator.js
@@ -1,13 +1,18 @@
+import * as Utils from '../../../../utils';
+
 const createValidator = (schema, settings) => values => {
+  const formErrors = {};
+
   try {
     schema.validateSync(values, { abortEarly: false, ...settings });
     return {};
-  } catch (e) {
-    return e.inner.reduce((errors, err) => ({
-      ...errors,
-      [err.path]: err.message,
-    }), {});
+  } catch (errors) {
+    errors.inner.forEach(error => {
+      Utils._set(formErrors, error.path, error.message);
+    });
   }
+
+  return formErrors;
 };
 
 export { createValidator };

--- a/src/felleskomponenter/skjema/validering/skjemaer/saksopplysninger.js
+++ b/src/felleskomponenter/skjema/validering/skjemaer/saksopplysninger.js
@@ -17,6 +17,10 @@ const saksopplysninger = object().shape({
   maritimtArbeid: array().of(object().shape({
     navn: string().required({ melding: 'Navn kreves', panel: KV.Paneltitler.maritimtArbeid }),
   }).uniqueProperty('navn', { melding: 'Navn må være unikt', panel: KV.Paneltitler.maritimtArbeid })),
+  oppgittAdresseGatenavn: string().required({ melding: 'Gatenavn kreves', panel: KV.Paneltitler.personopplysningspanel }),
+  oppgittAdressePostnummer: string().required({ melding: 'Postnummer kreves', panel: KV.Paneltitler.personopplysningspanel }),
+  oppgittAdressePoststed: string().required({ melding: 'Poststed kreves', panel: KV.Paneltitler.personopplysningspanel }),
+  oppgittAdresseLand: string().required({ melding: 'Land kreves', panel: KV.Paneltitler.personopplysningspanel }),
 });
 
 export { saksopplysninger };

--- a/src/kodeverk/paneltitler.js
+++ b/src/kodeverk/paneltitler.js
@@ -9,3 +9,4 @@ export const medlemskap = 'Medlemskap';
 export const inntektUnderOpphold = 'Inntekt under oppholdet';
 export const arbeidsgiverINorge = navn => `Arbeidsgiver i Norge: ${navn}`;
 export const kontantytelser = 'Kontantytelser fra NAV';
+export const personopplysningspanel = 'Personopplysningspanel';

--- a/src/sider/saksbehandling/komponenter/personopplysninger.js
+++ b/src/sider/saksbehandling/komponenter/personopplysninger.js
@@ -96,7 +96,7 @@ AdresseHeader.propTypes = {
   adresseTittel: PT.string.isRequired,
 };
 
-export const ExpandableList = props => {
+export const ExpandableTable = props => {
   const {
     renderElement, elements, header, defaultMax, altMax, btnTextExpanded, btnTextCollapsed, chevron, expandable,
   } = props;
@@ -133,7 +133,7 @@ export const ExpandableList = props => {
   );
 };
 
-ExpandableList.propTypes = {
+ExpandableTable.propTypes = {
   renderElement: PT.func.isRequired,
   header: PT.node.isRequired,
   elements: PT.array.isRequired,
@@ -145,7 +145,7 @@ ExpandableList.propTypes = {
   expandable: PT.bool,
 };
 
-ExpandableList.defaultProps = {
+ExpandableTable.defaultProps = {
   chevron: false,
   expandable: true,
 };
@@ -209,7 +209,7 @@ class Personopplysninger extends Component {
             </Nav.Row>
             <Nav.Row className="person__seksjon">
               <Nav.Column xs="12">
-                <ExpandableList
+                <ExpandableTable
                   defaultMax={1}
                   altMax={100}
                   btnTextExpanded="Vis mindre"
@@ -222,7 +222,7 @@ class Personopplysninger extends Component {
                     <AdresseRad key={uuid()} adresseKomponent={<GeneriskAdresse adresse={element.bostedsadresse} />} periode={element.periode} />
                   )}
                 />
-                <ExpandableList
+                <ExpandableTable
                   defaultMax={1}
                   altMax={100}
                   btnTextExpanded="Vis mindre"
@@ -235,7 +235,7 @@ class Personopplysninger extends Component {
                     <AdresseRad key={uuid()} adresseKomponent={<UstrukturertAdresse adresse={element.postadresse} />} periode={element.periode} />
                   )}
                 />
-                <ExpandableList
+                <ExpandableTable
                   defaultMax={1}
                   altMax={100}
                   btnTextExpanded="Vis mindre"

--- a/src/sider/saksbehandling/komponenter/personopplysninger.test.js
+++ b/src/sider/saksbehandling/komponenter/personopplysninger.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AdresseHeader, AdresseRad, ExpandableList } from './personopplysninger';
+import { AdresseHeader, AdresseRad, ExpandableTable } from './personopplysninger';
 
 describe('AdresseRad', () => {
   const props = {
@@ -43,7 +43,7 @@ describe('AdresseHeader', () => {
   });
 });
 
-describe('ExpandableList', () => {
+describe('ExpandableTable', () => {
   let props = null;
 
   beforeEach(() => {
@@ -61,13 +61,13 @@ describe('ExpandableList', () => {
   });
 
   it('viser elementer', () => {
-    shallow(<ExpandableList {...props} />);
+    shallow(<ExpandableTable {...props} />);
 
     expect(props.renderElement).toHaveBeenCalledTimes(props.elements.length);
   });
 
   it('viser en knapp med tekst og chevron', () => {
-    const expandableList = shallow(<ExpandableList {...props} />);
+    const expandableList = shallow(<ExpandableTable {...props} />);
 
     expect(expandableList.exists('button')).toBe(true);
     expect(expandableList.find('button').contains(props.btnTextCollapsed)).toBe(true);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,4 @@
-import { isFunction, isNil, isUndefined, isString, isEmpty, isObject, isBoolean, toInteger, round } from 'lodash';
+import { isFunction, isNil, isUndefined, isString, isEmpty, isObject, isBoolean, toInteger, round, set } from 'lodash';
 
 import throttle from 'lodash.throttle';
 
@@ -30,4 +30,5 @@ export {
   isBoolean as _isBoolean,
   toInteger as _toInteger,
   round as _round,
+  set as _set,
 };


### PR DESCRIPTION
- Legger til validering av postnr, poststed, gatenavn og land i personopplysningspanelet.
- Fikser en bug hvor meta.error var undefined i tilfeller hvor en error eksisterte(hovedsakelig i skjema-komponenter). Dette skjedde på grunn av feil mapping fra yup-error til redux-form-error(se createValidator.js).