### PR TITLE
HOTFIX-MELOSYS-3013 - Fiks bug hvor art.12.1 er i overskriften i vedtaksteget for alle hjemler

### DIFF
--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingVedtak.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingVedtak.js
@@ -52,7 +52,7 @@ const VurderingVedtak = ({
 
   return (
     <div className="vedtak">
-      <Nav.Undertittel>Omfattet av norsk trygdelovgivning etter Fo 883/2004, artikkel 12 nr. 1</Nav.Undertittel>
+      <Nav.Undertittel>Omfattet av norsk trygdelovgivning etter { KV.objektTilTerm(lovvalgSomKodeTerm) }</Nav.Undertittel>
       <div>
         <Nav.Row className="lovvalgsperiode">
           <Nav.Column xs="6">


### PR DESCRIPTION
Vedtaksteget brukes i flere flyter, derfor ble det feil å hardkode det til art.12.1.