### PR TITLE
MELOSYS-2961 - Deaktivere funksjonalitet art13

### DIFF
--- a/src/ducks/avklartefakta/selectors.js
+++ b/src/ducks/avklartefakta/selectors.js
@@ -264,6 +264,10 @@ export const AvklarteVirksomheterSelector = createSelector(
   }
 );
 
+export const EnVirksomhetErAvklartSelector = createSelector(
+  AvklarteVirksomheterSelector,
+  avklarteVirksomheter => avklarteVirksomheter.length === 1
+);
 
 export const AvklartefaktaVurderingSelector = createSelector(
   state => AvklartefaktaSelector(state).vurdering,
@@ -278,4 +282,11 @@ export const BostedslandSelector = createSelector(
     const bostedslandkode = hentFaktaVerdi(avklartFakta);
     return MKV.KTObjects.landkoder.find(enkeltLand => enkeltLand.kode === bostedslandkode);
   }
+);
+
+export const ErIArtikkel13_1FlytSelector = createSelector(
+  AvklartefaktaSelector,
+  avklarteFakta => (
+    avklarteFakta.some(avklartFakta => avklartFakta.fakta.includes(KV.Koder.VurderingYrkesaktivitetAntallLandTyper.TO_ELLER_FLERE_LAND))
+  )
 );

--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -50,11 +50,6 @@ export const GeneriskStegRedigerbartSelector = createSelector(
   ErArtikkel16AnmodningSendtSelector,
   (redigerbart, erArtikkel16AnmodningSendt) => redigerbart && !erArtikkel16AnmodningSendt
 );
-export const PanelerRedigerbartSelector = createSelector(
-  RedigerbartSelector,
-  ErArtikkel16AnmodningSendtSelector,
-  (redigerbart, erArtikkel16AnmodningSendt) => redigerbart && !erArtikkel16AnmodningSendt
-);
 export const SaksopplysningerSelector = createSelector(
   state => BehandlingerSelector(state).saksopplysninger || {},
   saksopplysninger => saksopplysninger

--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -55,12 +55,6 @@ export const PanelerRedigerbartSelector = createSelector(
   ErArtikkel16AnmodningSendtSelector,
   (redigerbart, erArtikkel16AnmodningSendt) => redigerbart && !erArtikkel16AnmodningSendt
 );
-export const SidedialogRedigerbartSelector = createSelector(
-  RedigerbartSelector,
-  ErArtikkel16AnmodningSendtSelector,
-  (redigerbart, erArtikkel16AnmodningSendt) => redigerbart && !erArtikkel16AnmodningSendt
-);
-
 export const SaksopplysningerSelector = createSelector(
   state => BehandlingerSelector(state).saksopplysninger || {},
   saksopplysninger => saksopplysninger

--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -4,7 +4,6 @@
  * Målet med selectorer er å samle funksjonalitet som behandler, itererer og omformer
  * data slik at denne logikken kan benyttes flere steder i applikasjonen - ikke bare ett sted.
  */
-import * as MKV from 'melosys-kodeverk';
 
 import { createSelector } from 'reselect';
 import moment from 'moment/moment';
@@ -36,11 +35,6 @@ export const ErArtikkel16AnmodningSendtSelector = createSelector(
   anmodningsperioderSendtUtland => anmodningsperioderSendtUtland
 );
 
-export const RedigerbartSelector = createSelector(
-  state => BehandlingerSelector(state).redigerbart || false,
-  BehandlingstypeKodeSelector,
-  (redigerbart, behandlingstypeKode) => redigerbart && behandlingstypeKode !== MKV.Koder.behandlinger.typer.ENDRET_PERIODE
-);
 export const SaksopplysningerSelector = createSelector(
   state => BehandlingerSelector(state).saksopplysninger || {},
   saksopplysninger => saksopplysninger

--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -41,10 +41,6 @@ export const RedigerbartSelector = createSelector(
   BehandlingstypeKodeSelector,
   (redigerbart, behandlingstypeKode) => redigerbart && behandlingstypeKode !== MKV.Koder.behandlinger.typer.ENDRET_PERIODE
 );
-export const EndreLovvalgsPeriodeRedigerbartSelector = createSelector(
-  state => BehandlingerSelector(state).redigerbart || false,
-  redigerbart => redigerbart
-);
 export const SaksopplysningerSelector = createSelector(
   state => BehandlingerSelector(state).saksopplysninger || {},
   saksopplysninger => saksopplysninger

--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -45,11 +45,6 @@ export const EndreLovvalgsPeriodeRedigerbartSelector = createSelector(
   state => BehandlingerSelector(state).redigerbart || false,
   redigerbart => redigerbart
 );
-export const GeneriskStegRedigerbartSelector = createSelector(
-  RedigerbartSelector,
-  ErArtikkel16AnmodningSendtSelector,
-  (redigerbart, erArtikkel16AnmodningSendt) => redigerbart && !erArtikkel16AnmodningSendt
-);
 export const SaksopplysningerSelector = createSelector(
   state => BehandlingerSelector(state).saksopplysninger || {},
   saksopplysninger => saksopplysninger

--- a/src/ducks/redigerbart/index.js
+++ b/src/ducks/redigerbart/index.js
@@ -1,0 +1,3 @@
+import * as redigerbartSelectors from './selectors';
+
+export { redigerbartSelectors };

--- a/src/ducks/redigerbart/selectors.js
+++ b/src/ducks/redigerbart/selectors.js
@@ -4,6 +4,7 @@ import * as MKV from 'melosys-kodeverk';
 
 import { avklartefaktaSelectors } from '../avklartefakta';
 import { behandlingerSelectors } from '../behandlinger';
+import { formSelectors } from '../form';
 
 export const RedigerbartSelector = createSelector(
   state => behandlingerSelectors.BehandlingerSelector(state).redigerbart || false,
@@ -29,15 +30,21 @@ export const SidedialogRedigerbartSelector = createSelector(
   behandlingerSelectors.ErArtikkel16AnmodningSendtSelector,
   (redigerbart, erArtikkel16AnmodningSendt) => redigerbart && !erArtikkel16AnmodningSendt
 );
-export const ErIArtikkel13_1FlytSelector = () => false;
 export const BrevBestillingRedigerbartSelector = createSelector(
   SidedialogRedigerbartSelector,
-  ErIArtikkel13_1FlytSelector,
-  avklartefaktaSelectors.AvklarteVirksomheterSelector,
-  (sideDialogRedigerbart, erIArtikkel13_1Flyt, avklarteVirksomheter) => sideDialogRedigerbart && !erIArtikkel13_1Flyt && avklarteVirksomheter.length === 1
+  sideDialogRedigerbart => sideDialogRedigerbart
 );
 export const SedBestillingRedigerbartSelector = createSelector(
   SidedialogRedigerbartSelector,
-  ErIArtikkel13_1FlytSelector,
   sideDialogRedigerbart => sideDialogRedigerbart
+);
+export const BrevBestillingRedigerbartIArtikkel13Selector = createSelector(
+  avklartefaktaSelectors.ErIArtikkel13_1FlytSelector,
+  avklartefaktaSelectors.EnVirksomhetErAvklartSelector,
+  formSelectors.BrevBestillingFormSelector,
+  (erIArtikkel13_1Flyt, enVirksomhetErAvklart, brevBestillingForm) => {
+    const { values: { mottaker } = {} } = brevBestillingForm;
+
+    return !erIArtikkel13_1Flyt || enVirksomhetErAvklart || mottaker !== MKV.Koder.aktoersroller.ARBEIDSGIVER;
+  }
 );

--- a/src/ducks/redigerbart/selectors.js
+++ b/src/ducks/redigerbart/selectors.js
@@ -1,0 +1,43 @@
+import { createSelector } from 'reselect';
+
+import * as MKV from 'melosys-kodeverk';
+
+import { avklartefaktaSelectors } from '../avklartefakta';
+import { behandlingerSelectors } from '../behandlinger';
+
+export const RedigerbartSelector = createSelector(
+  state => behandlingerSelectors.BehandlingerSelector(state).redigerbart || false,
+  behandlingerSelectors.BehandlingstypeKodeSelector,
+  (redigerbart, behandlingstypeKode) => redigerbart && behandlingstypeKode !== MKV.Koder.behandlinger.typer.ENDRET_PERIODE
+);
+export const EndreLovvalgsPeriodeRedigerbartSelector = createSelector(
+  state => behandlingerSelectors.BehandlingerSelector(state).redigerbart || false,
+  redigerbart => redigerbart
+);
+export const GeneriskStegRedigerbartSelector = createSelector(
+  RedigerbartSelector,
+  behandlingerSelectors.ErArtikkel16AnmodningSendtSelector,
+  (redigerbart, erArtikkel16AnmodningSendt) => redigerbart && !erArtikkel16AnmodningSendt
+);
+export const PanelerRedigerbartSelector = createSelector(
+  RedigerbartSelector,
+  behandlingerSelectors.ErArtikkel16AnmodningSendtSelector,
+  (redigerbart, erArtikkel16AnmodningSendt) => redigerbart && !erArtikkel16AnmodningSendt
+);
+export const SidedialogRedigerbartSelector = createSelector(
+  RedigerbartSelector,
+  behandlingerSelectors.ErArtikkel16AnmodningSendtSelector,
+  (redigerbart, erArtikkel16AnmodningSendt) => redigerbart && !erArtikkel16AnmodningSendt
+);
+export const ErIArtikkel13_1FlytSelector = () => false;
+export const BrevBestillingRedigerbartSelector = createSelector(
+  SidedialogRedigerbartSelector,
+  ErIArtikkel13_1FlytSelector,
+  avklartefaktaSelectors.AvklarteVirksomheterSelector,
+  (sideDialogRedigerbart, erIArtikkel13_1Flyt, avklarteVirksomheter) => sideDialogRedigerbart && !erIArtikkel13_1Flyt && avklarteVirksomheter.length === 1
+);
+export const SedBestillingRedigerbartSelector = createSelector(
+  SidedialogRedigerbartSelector,
+  ErIArtikkel13_1FlytSelector,
+  sideDialogRedigerbart => sideDialogRedigerbart
+);

--- a/src/felleskomponenter/dialogboks/dialogboksAvslagSoknad.js
+++ b/src/felleskomponenter/dialogboks/dialogboksAvslagSoknad.js
@@ -10,6 +10,7 @@ import PdfLenkeListe from '../pdfLenkeListe';
 import Knapperad from '../knapperad';
 
 import { behandlingerSelectors } from '../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../ducks/redigerbart';
 
 import './dialogboksAvslagSoknad.css';
 
@@ -79,7 +80,7 @@ DialogboksAvslagSoknad.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
 });
 

--- a/src/felleskomponenter/dialogboks/dialogboksAvsluttSakSomBortfalt.js
+++ b/src/felleskomponenter/dialogboks/dialogboksAvsluttSakSomBortfalt.js
@@ -6,7 +6,7 @@ import * as Nav from '../../utils/navFrontend';
 
 import Knapperad from '../knapperad';
 
-import { behandlingerSelectors } from '../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../ducks/redigerbart';
 
 import './dialogboksAvsluttSakSomBortfalt.css';
 
@@ -44,7 +44,7 @@ DialogboksAvsluttSakSomBortfalt.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
 });
 
 export default connect(mapStateToProps)(DialogboksAvsluttSakSomBortfalt);

--- a/src/felleskomponenter/dialogboks/dialogboksHenlegg.js
+++ b/src/felleskomponenter/dialogboks/dialogboksHenlegg.js
@@ -10,9 +10,9 @@ import { KodeTermSelect } from '../ui/kodeTermSelect';
 import Knapperad from '../knapperad';
 
 import { behandlingerSelectors } from '../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../ducks/redigerbart';
 
 import './dialogboksHenlegg.css';
-
 
 export class DialogboksHenleggSak extends Component {
   state = {
@@ -166,7 +166,7 @@ DialogboksHenleggSak.defaultProps = {
 
 const mapStateToProps = state => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
 });
 
 export default connect(mapStateToProps, null)(DialogboksHenleggSak);

--- a/src/felleskomponenter/sideDialog/brevBestilling.js
+++ b/src/felleskomponenter/sideDialog/brevBestilling.js
@@ -103,6 +103,7 @@ class BrevBestilling extends Component {
       behandlingID,
       brevbestillingSkjemaVerdier,
       redigerbart,
+      brevBestillingRedigerbartIArtikkel13,
     } = this.props;
     const { fritekst, mottaker, dokumenttypeKode } = brevbestillingSkjemaVerdier;
 
@@ -118,6 +119,8 @@ class BrevBestilling extends Component {
 
     const placeholder = 'F.eks.: \u00ABOpplysninger om antall utsendte ansatte i perioden\u00BB, \u00ABOpplysninger om den ansatte erstatter en annen utsendt ansatt\u00BB.';
 
+    const disabled = !redigerbart || !brevBestillingRedigerbartIArtikkel13;
+
     return (
       <div className="brevBestilling">
         <form onSubmit={this.overstyrSubmit}>
@@ -130,12 +133,12 @@ class BrevBestilling extends Component {
             </Skjema.Select>
             {this.erMangelBrevMedFritekst() && <InfoPanel />}
             {this.erMangelBrevMedFritekst() &&
-            <Skjema.Textarea disabled={!redigerbart} feltNavn="fritekst" label="Hva skal søker sende inn?" placeholder={placeholder} feil={undefined} />}
-            { behandlingID && redigerbart &&
+            <Skjema.Textarea disabled={disabled} feltNavn="fritekst" label="Hva skal søker sende inn?" placeholder={placeholder} feil={undefined} />}
+            { behandlingID && !disabled &&
               <PdfLenkeListe behandlingID={behandlingID} dokumenter={ForhandsvistePdfDokumenter} vedKlikk={this.validerBrev} />
             }
-            <Nav.Hovedknapp htmlType="submit" disabled={!redigerbart} onClick={this.sendBrev}>Send brev</Nav.Hovedknapp>&nbsp;
-            <Nav.Knapp htmlType="reset" type="standard" disabled={!redigerbart} onClick={this.forkastBrev}>Forkast Brev</Nav.Knapp>
+            <Nav.Hovedknapp htmlType="submit" disabled={disabled} onClick={this.sendBrev}>Send brev</Nav.Hovedknapp>&nbsp;
+            <Nav.Knapp htmlType="reset" type="standard" disabled={disabled} onClick={this.forkastBrev}>Forkast Brev</Nav.Knapp>
             { this.state.erBrevSendt && <Nav.AlertStripe type="suksess" className="varsel">Brevet er sendt. Det kan ta noe tid før brevet vises i dokumentlisten.</Nav.AlertStripe> }
             { this.state.feilmelding && <Nav.AlertStripe type="advarsel" className="varsel">{this.state.feilmelding}</Nav.AlertStripe> }
           </Nav.Fieldset>
@@ -154,6 +157,7 @@ BrevBestilling.propTypes = {
   brevbestillingSkjemaVerdier: PT.object,
   dokumenter: PT.object,
   redigerbart: PT.bool.isRequired,
+  brevBestillingRedigerbartIArtikkel13: PT.bool.isRequired,
 };
 BrevBestilling.defaultProps = {
   brevbestillingSkjemaVerdier: {},
@@ -162,7 +166,6 @@ BrevBestilling.defaultProps = {
 
 const form = {
   form: KV.Form.BREV_BESTILLING,
-  enableReinitialize: true,
   destroyOnUnmount: false,
   updateUnregisteredFields: true,
   validate: brevbestillingValidering,

--- a/src/felleskomponenter/sideDialog/sideDialog.js
+++ b/src/felleskomponenter/sideDialog/sideDialog.js
@@ -10,8 +10,9 @@ import SideDialogBrevBestilling from './brevBestilling';
 import SideDialogSedBestilling from './sedBestilling';
 import SideDialogBesvarSed from './sideDialogBesvarSed';
 
-import './sideDialog.css';
 import { redigerbartSelectors } from '../../ducks/redigerbart';
+
+import './sideDialog.css';
 
 const uuid = require('uuid/v4');
 
@@ -21,6 +22,7 @@ class SideDialog extends Component {
     behandlingID: PT.number.isRequired,
     brevBestillingRedigerbart: PT.bool.isRequired,
     sedBestillingRedigerbart: PT.bool.isRequired,
+    BrevBestillingRedigerbartIArtikkel13: PT.bool.isRequired,
   };
 
   static defaultProps = {
@@ -47,12 +49,12 @@ class SideDialog extends Component {
   }
 
   getFaneKomponent = (navn, behandlingID) => {
-    const { brevBestillingRedigerbart, sedBestillingRedigerbart } = this.props;
+    const { brevBestillingRedigerbart, sedBestillingRedigerbart, BrevBestillingRedigerbartIArtikkel13 } = this.props;
 
     if (navn === 'dokumenter') {
       return <SideDialogDokumenter key={uuid()} />;
     } else if (navn === 'brevbestilling') {
-      return <SideDialogBrevBestilling key={uuid()} behandlingID={behandlingID} redigerbart={brevBestillingRedigerbart} />;
+      return <SideDialogBrevBestilling key={uuid()} behandlingID={behandlingID} redigerbart={brevBestillingRedigerbart} brevBestillingRedigerbartIArtikkel13={BrevBestillingRedigerbartIArtikkel13} />;
     } else if (navn === 'sedbestilling') {
       return <SideDialogSedBestilling key={uuid()} behandlingID={behandlingID} redigerbart={sedBestillingRedigerbart} />;
     } else if (navn === 'besvarsed') {
@@ -100,6 +102,7 @@ class SideDialog extends Component {
 const mapStateToProps = state => ({
   brevBestillingRedigerbart: redigerbartSelectors.BrevBestillingRedigerbartSelector(state),
   sedBestillingRedigerbart: redigerbartSelectors.SedBestillingRedigerbartSelector(state),
+  BrevBestillingRedigerbartIArtikkel13: redigerbartSelectors.BrevBestillingRedigerbartIArtikkel13Selector(state),
 });
 
 const mapDispatchToProps = () => ({});

--- a/src/felleskomponenter/sideDialog/sideDialog.js
+++ b/src/felleskomponenter/sideDialog/sideDialog.js
@@ -11,6 +11,7 @@ import SideDialogSedBestilling from './sedBestilling';
 import SideDialogBesvarSed from './sideDialogBesvarSed';
 
 import './sideDialog.css';
+import { redigerbartSelectors } from '../../ducks/redigerbart';
 
 const uuid = require('uuid/v4');
 
@@ -18,7 +19,8 @@ class SideDialog extends Component {
   static propTypes = {
     faner: PT.array,
     behandlingID: PT.number.isRequired,
-    redigerbart: PT.bool.isRequired,
+    brevBestillingRedigerbart: PT.bool.isRequired,
+    sedBestillingRedigerbart: PT.bool.isRequired,
   };
 
   static defaultProps = {
@@ -44,13 +46,15 @@ class SideDialog extends Component {
       });
   }
 
-  getFaneKomponent = (navn, behandlingID, redigerbart) => {
+  getFaneKomponent = (navn, behandlingID) => {
+    const { brevBestillingRedigerbart, sedBestillingRedigerbart } = this.props;
+
     if (navn === 'dokumenter') {
       return <SideDialogDokumenter key={uuid()} />;
     } else if (navn === 'brevbestilling') {
-      return <SideDialogBrevBestilling key={uuid()} behandlingID={behandlingID} redigerbart={redigerbart} />;
+      return <SideDialogBrevBestilling key={uuid()} behandlingID={behandlingID} redigerbart={brevBestillingRedigerbart} />;
     } else if (navn === 'sedbestilling') {
-      return <SideDialogSedBestilling key={uuid()} behandlingID={behandlingID} redigerbart={redigerbart} />;
+      return <SideDialogSedBestilling key={uuid()} behandlingID={behandlingID} redigerbart={sedBestillingRedigerbart} />;
     } else if (navn === 'besvarsed') {
       return <SideDialogBesvarSed key={uuid()} behandlingID={behandlingID} />;
     }
@@ -71,7 +75,7 @@ class SideDialog extends Component {
   };
 
   render() {
-    const { behandlingID, redigerbart } = this.props;
+    const { behandlingID } = this.props;
     const { navn } = this.state.faner.find(item => item.navn === this.state.aktivFane);
     return (
       <div className="dialog panelSeksjon">
@@ -85,7 +89,7 @@ class SideDialog extends Component {
               </button>))}
           </div>
           <div>
-            { this.getFaneKomponent(navn, behandlingID, redigerbart)}
+            { this.getFaneKomponent(navn, behandlingID)}
           </div>
         </Panel>
       </div>
@@ -93,7 +97,10 @@ class SideDialog extends Component {
   }
 }
 
-const mapStateToProps = () => ({});
+const mapStateToProps = state => ({
+  brevBestillingRedigerbart: redigerbartSelectors.BrevBestillingRedigerbartSelector(state),
+  sedBestillingRedigerbart: redigerbartSelectors.SedBestillingRedigerbartSelector(state),
+});
 
 const mapDispatchToProps = () => ({});
 

--- a/src/sider/registrering/komponenter/behandlingsstatus.js
+++ b/src/sider/registrering/komponenter/behandlingsstatus.js
@@ -10,6 +10,7 @@ import * as Nav from '../../../utils/navFrontend';
 
 import * as MPT from '../../../proptypes';
 import { behandlingerOperations, behandlingerSelectors } from '../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
 import { KodeTermSelect } from '../../../felleskomponenter/ui/kodeTermSelect';
 
 import './sideOppsummering.css';
@@ -121,7 +122,7 @@ BehandlingsStatus.defaultProps = {
 const mapStateToProps = state => ({
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   redigerbart: behandlingerSelectors.RedigerbartSelector(state),
-  endreLovvalgsperiodeRedigerbart: behandlingerSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
+  endreLovvalgsperiodeRedigerbart: redigerbartSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/sider/registrering/komponenter/behandlingsstatus.js
+++ b/src/sider/registrering/komponenter/behandlingsstatus.js
@@ -121,7 +121,7 @@ BehandlingsStatus.defaultProps = {
 
 const mapStateToProps = state => ({
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   endreLovvalgsperiodeRedigerbart: redigerbartSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
 });
 

--- a/src/sider/registrering/komponenter/sideOppsummering.js
+++ b/src/sider/registrering/komponenter/sideOppsummering.js
@@ -130,7 +130,7 @@ const mapStateToProps = state => ({
   fagsak: fagsakSelectors.FagsakSelector(state),
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   person: behandlingerSelectors.PersonSelector(state),
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   endreLovvalgsperiodeRedigerbart: redigerbartSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
   behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
   soknadsperiodeFom: formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).fom),

--- a/src/sider/registrering/komponenter/sideOppsummering.js
+++ b/src/sider/registrering/komponenter/sideOppsummering.js
@@ -11,6 +11,7 @@ import { formatterDatoTilNorsk } from '../../../utils/dato';
 import { soknadSelectors } from '../../../ducks/soknad';
 import { fagsakSelectors } from '../../../ducks/fagsaker';
 import { behandlingerOperations, behandlingerSelectors } from '../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
 import { avklartefaktaSelectors } from '../../../ducks/avklartefakta';
 import Behandlingsmeny from './behandlingsmeny';
 import Behandlingsstatus from './behandlingsstatus';
@@ -130,7 +131,7 @@ const mapStateToProps = state => ({
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   person: behandlingerSelectors.PersonSelector(state),
   redigerbart: behandlingerSelectors.RedigerbartSelector(state),
-  endreLovvalgsperiodeRedigerbart: behandlingerSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
+  endreLovvalgsperiodeRedigerbart: redigerbartSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
   behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
   soknadsperiodeFom: formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).fom),
   soknadsperiodeTom: formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).tom),

--- a/src/sider/registrering/registrering.js
+++ b/src/sider/registrering/registrering.js
@@ -11,6 +11,7 @@ import Saksopplysninger from './komponenter/saksopplysninger';
 import SideDialog from '../../felleskomponenter/sideDialog/sideDialog';
 import SideOppsummering from './komponenter/sideOppsummering';
 import { behandlingerOperations, behandlingerSelectors } from '../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../ducks/redigerbart';
 import { fagsakOperations, fagsakSelectors } from '../../ducks/fagsaker';
 import { avklartefaktaOperations, avklartefaktaSelectors } from '../../ducks/avklartefakta';
 
@@ -146,7 +147,7 @@ Registrering.defaultProps = {
   vurderingBegrunnelser: {},
 };
 const mapStateToProps = state => ({
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   avklartefakta: avklartefaktaSelectors.AvklartefaktaSelector(state),
   vurderingBegrunnelser: avklartefaktaSelectors.VurderingUnntakPeriode(state),
   fagsak: fagsakSelectors.FagsakSelector(state),

--- a/src/sider/saksbehandling/komponenter/arbeidsgivereNorge.js
+++ b/src/sider/saksbehandling/komponenter/arbeidsgivereNorge.js
@@ -6,6 +6,7 @@ import PT from 'prop-types';
 import * as MPT from '../../../proptypes';
 
 import { behandlingerSelectors } from '../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
 import { soknadSelectors, soknadOperations } from '../../../ducks/soknad';
 import { OrganisasjonOperations, OrganisasjonSelectors } from '../../../ducks/organisasjoner';
 
@@ -70,7 +71,7 @@ const mapStateToProps = state => ({
   arbeidsgivereNorge: behandlingerSelectors.ArbeidsgivereNorgeSelector(state),
   ekstraArbeidsgivere: soknadSelectors.JuridiskArbeidsgiverNorgeSelector(state).ekstraArbeidsgivere,
   organisasjoner: OrganisasjonSelectors.organisasjonerSelector(state),
-  redigerbart: behandlingerSelectors.PanelerRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/sider/saksbehandling/komponenter/arbeidutland/arbeidUtlandWrapper.js
+++ b/src/sider/saksbehandling/komponenter/arbeidutland/arbeidUtlandWrapper.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
 
-import { behandlingerSelectors } from '../../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../../ducks/redigerbart';
 import ArbeidUtlandEnkelt from './arbeidUtlandEnkelt';
 import * as Nav from '../../../../utils/navFrontend';
 import * as Ikoner from '../../../../resources/images';
@@ -50,7 +50,7 @@ ArbeidUtlandWrapper.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  redigerbart: behandlingerSelectors.PanelerRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
 });
 
 const mapDispatchToProps = () => ({});

--- a/src/sider/saksbehandling/komponenter/behandlingsstatus.js
+++ b/src/sider/saksbehandling/komponenter/behandlingsstatus.js
@@ -125,7 +125,7 @@ BehandlingsStatus.defaultProps = {
 
 const mapStateToProps = state => ({
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   endreLovvalgsperiodeRedigerbart: redigerbartSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
 });
 

--- a/src/sider/saksbehandling/komponenter/behandlingsstatus.js
+++ b/src/sider/saksbehandling/komponenter/behandlingsstatus.js
@@ -10,6 +10,7 @@ import * as Nav from '../../../utils/navFrontend';
 
 import * as MPT from '../../../proptypes';
 import { behandlingerOperations, behandlingerSelectors } from '../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
 import { KodeTermSelect } from '../../../felleskomponenter/ui/kodeTermSelect';
 
 import './sideOppsummering.css';
@@ -125,7 +126,7 @@ BehandlingsStatus.defaultProps = {
 const mapStateToProps = state => ({
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   redigerbart: behandlingerSelectors.RedigerbartSelector(state),
-  endreLovvalgsperiodeRedigerbart: behandlingerSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
+  endreLovvalgsperiodeRedigerbart: redigerbartSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/sider/saksbehandling/komponenter/foretakutland/foretakUtlandWrapper.js
+++ b/src/sider/saksbehandling/komponenter/foretakutland/foretakUtlandWrapper.js
@@ -11,7 +11,7 @@ import EnkeltForetak from './enkeltforetak';
 
 import PanelHeader from '../../../../felleskomponenter/panelHeader/panelHeader';
 
-import { behandlingerSelectors } from '../../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../../ducks/redigerbart';
 
 import './foretakUtland.css';
 
@@ -52,7 +52,7 @@ ForetakUtlandWrapper.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  redigerbart: behandlingerSelectors.PanelerRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
 });
 
 const mapDispatchToProps = () => ({});

--- a/src/sider/saksbehandling/komponenter/fullmektig/fullmektigPanel.js
+++ b/src/sider/saksbehandling/komponenter/fullmektig/fullmektigPanel.js
@@ -13,6 +13,7 @@ import * as MPT from '../../../../proptypes';
 import PanelHeader from '../../../../felleskomponenter/panelHeader/panelHeader';
 import { fagsakSelectors } from '../../../../ducks/fagsaker';
 import { behandlingerSelectors } from '../../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../../ducks/redigerbart';
 
 import Fullmektig from './fullmektig';
 
@@ -148,7 +149,7 @@ FullmektigPanel.propTypes = {
 const mapStateToProps = state => ({
   arbeidsgivereNorge: behandlingerSelectors.ArbeidsgivereNorgeSelector(state),
   fagsak: fagsakSelectors.FagsakSelector(state),
-  redigerbart: behandlingerSelectors.PanelerRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
 });
 
 const hentOrg = orgNr => Api.Organisasjoner.hentOrganisasjon(orgNr);

--- a/src/sider/saksbehandling/komponenter/inntektUtland.js
+++ b/src/sider/saksbehandling/komponenter/inntektUtland.js
@@ -6,13 +6,15 @@ import * as Ikoner from '../../../resources/images';
 import * as Nav from '../../../utils/navFrontend';
 import * as MPT from '../../../proptypes';
 import * as Skjema from '../../../felleskomponenter/skjema';
+import * as Utils from '../../../utils';
 import * as KV from '../../../kodeverk';
 
-import { behandlingerSelectors } from '../../../ducks/behandlinger';
-import PanelHeader from '../../../felleskomponenter/panelHeader/panelHeader';
-import './inntektUtland.css';
-import * as Utils from '../../../utils';
 import { formSelectors } from '../../../ducks/form';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
+
+import PanelHeader from '../../../felleskomponenter/panelHeader/panelHeader';
+
+import './inntektUtland.css';
 
 function Inntekt (props) {
   const { redigerbart, soknadForm: { values } } = props;
@@ -69,7 +71,7 @@ Inntekt.defaultProps = {
 
 const mapStateToProps = state => ({
   soknadForm: formSelectors.SoknadenFormSelector(state),
-  redigerbart: behandlingerSelectors.PanelerRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
 });
 const mapDispatchToProps = () => ({});
 

--- a/src/sider/saksbehandling/komponenter/maritimtArbeid.js
+++ b/src/sider/saksbehandling/komponenter/maritimtArbeid.js
@@ -11,7 +11,7 @@ import * as MPT from '../../../proptypes';
 import * as KV from '../../../kodeverk';
 
 import { formSelectors } from '../../../ducks/form';
-import { behandlingerSelectors } from '../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
 
 import LandVelger from '../../../felleskomponenter/skjema/landvelger';
 import PanelHeader from '../../../felleskomponenter/panelHeader/panelHeader';
@@ -171,7 +171,7 @@ MaritimtArbeid.defaultProps = {
 
 const mapStateToProps = state => ({
   soknadForm: formSelectors.SoknadenFormSelector(state),
-  redigerbart: behandlingerSelectors.PanelerRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
 });
 
 export default connect(mapStateToProps)(MaritimtArbeid);

--- a/src/sider/saksbehandling/komponenter/personopplysninger.js
+++ b/src/sider/saksbehandling/komponenter/personopplysninger.js
@@ -25,6 +25,7 @@ import { behandlingerSelectors } from '../../../ducks/behandlinger';
 import { PersonSelectors, PersonOperations } from '../../../ducks/personer';
 import { soknadSelectors } from '../../../ducks/soknad';
 import { formSelectors } from '../../../ducks/form';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
 
 const ikonFraKjonn = kjoenn => {
   switch (kjoenn) {
@@ -290,7 +291,7 @@ const mapStateToProps = state => ({
   personOpplysninger: soknadSelectors.PersonOpplysningerSelector(state),
   person: behandlingerSelectors.PersonSelector(state),
   personhistorikk: behandlingerSelectors.PersonhistorikkSelector(state),
-  redigerbart: behandlingerSelectors.PanelerRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
   medfolgendeAndre: soknadSelectors.MedfolgendeAndreSelector(state),
   oppgittAdresseHarVerdier: formSelectors.OppgittAdresseHarVerdierSelector(state),
 });

--- a/src/sider/saksbehandling/komponenter/saksopplysninger/saksopplysninger.js
+++ b/src/sider/saksbehandling/komponenter/saksopplysninger/saksopplysninger.js
@@ -27,6 +27,7 @@ import Kontantytelser from '../kontantytelser';
 import { fagsakSelectors } from '../../../../ducks/fagsaker';
 import { behandlingerSelectors } from '../../../../ducks/behandlinger';
 import { behandlingsperioderSelectors } from '../../../../ducks/behandlingsperioder';
+import { redigerbartSelectors } from '../../../../ducks/redigerbart';
 import { saksopplysningerOperations, saksopplysningerSelectors } from '../../../../ducks/saksopplysninger';
 import {
   soknadOperations,
@@ -180,7 +181,7 @@ Saksopplysninger.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   avklartefakta: avklartefaktaSelectors.AvklartefaktaSelector(state),
   oppfriskning: saksopplysningerSelectors.SaksopplysningerSelector(state),
   fagsakStatusKode: fagsakSelectors.FagsakStatusSelector(state),

--- a/src/sider/saksbehandling/komponenter/selvstendigarbeid/selvstendigArbeid.js
+++ b/src/sider/saksbehandling/komponenter/selvstendigarbeid/selvstendigArbeid.js
@@ -7,7 +7,6 @@ import * as Nav from '../../../../utils/navFrontend';
 import * as Ikoner from '../../../../resources/images';
 import * as Skjema from '../../../../felleskomponenter/skjema';
 import * as formSelectors from '../../../../ducks/form/selectors';
-import { behandlingerSelectors } from '../../../../ducks/behandlinger';
 import * as KV from '../../../../kodeverk';
 
 import SelvstendigeForetak from './selvstendigeforetak';
@@ -16,6 +15,7 @@ import { BOOLSK } from '../../../../constants';
 import PanelHeader from '../../../../felleskomponenter/panelHeader/panelHeader';
 
 import { OrganisasjonSelectors, OrganisasjonOperations } from '../../../../ducks/organisasjoner';
+import { redigerbartSelectors } from '../../../../ducks/redigerbart';
 import { soknadOperations } from '../../../../ducks/soknad';
 
 import './selvstendigArbeid.css';
@@ -78,7 +78,7 @@ SelvstendigArbeid.defaultProps = {
 const mapStateToProps = state => ({
   soknadForm: formSelectors.SoknadenFormSelector(state),
   organisasjoner: OrganisasjonSelectors.organisasjonerSelector(state),
-  redigerbart: behandlingerSelectors.PanelerRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/sider/saksbehandling/komponenter/sideKommentarer.js
+++ b/src/sider/saksbehandling/komponenter/sideKommentarer.js
@@ -6,7 +6,8 @@ import { TextareaControlled } from 'nav-frontend-skjema';
 import { Knapp } from 'nav-frontend-knapper';
 import { Undertittel } from 'nav-frontend-typografi';
 
-import { behandlingerSelectors } from '../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
+
 import './sideKommentarer.css';
 
 const SideKommentarer = props => {
@@ -29,7 +30,7 @@ SideKommentarer.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
 });
 
 const mapDispatchToProps = () => ({});

--- a/src/sider/saksbehandling/komponenter/sideOppsummering.js
+++ b/src/sider/saksbehandling/komponenter/sideOppsummering.js
@@ -11,6 +11,7 @@ import { formatterDatoTilNorsk } from '../../../utils/dato';
 import { soknadSelectors } from '../../../ducks/soknad';
 import { fagsakSelectors } from '../../../ducks/fagsaker';
 import { behandlingerOperations, behandlingerSelectors } from '../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
 import { avklartefaktaSelectors } from '../../../ducks/avklartefakta';
 import Behandlingsmeny from './behandlingsmeny';
 import Behandlingsstatus from './behandlingsstatus';
@@ -132,7 +133,7 @@ const mapStateToProps = state => ({
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   person: behandlingerSelectors.PersonSelector(state),
   redigerbart: behandlingerSelectors.RedigerbartSelector(state),
-  endreLovvalgsperiodeRedigerbart: behandlingerSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
+  endreLovvalgsperiodeRedigerbart: redigerbartSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
   behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
   soknadsperiodeFom: formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).fom),
   soknadsperiodeTom: formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).tom),

--- a/src/sider/saksbehandling/komponenter/sideOppsummering.js
+++ b/src/sider/saksbehandling/komponenter/sideOppsummering.js
@@ -132,7 +132,7 @@ const mapStateToProps = state => ({
   fagsak: fagsakSelectors.FagsakSelector(state),
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   person: behandlingerSelectors.PersonSelector(state),
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   endreLovvalgsperiodeRedigerbart: redigerbartSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
   behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
   soknadsperiodeFom: formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).fom),

--- a/src/sider/saksbehandling/komponenter/soknadsperiode.js
+++ b/src/sider/saksbehandling/komponenter/soknadsperiode.js
@@ -9,7 +9,7 @@ import * as MPT from '../../../proptypes';
 import * as KV from '../../../kodeverk';
 
 import * as Ikoner from '../../../resources/images';
-import { behandlingerSelectors } from '../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
 import { soknadSelectors, soknadOperations } from '../../../ducks/soknad';
 import PanelHeader from '../../../felleskomponenter/panelHeader/panelHeader';
 
@@ -226,7 +226,7 @@ Soknadsperiode.defaultProps = {
 const mapStateToProps = state => ({
   soknadsperiodeFom: Utils.dato.formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).fom),
   soknadsperiodeTom: Utils.dato.formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).tom),
-  redigerbart: behandlingerSelectors.PanelerRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/sider/saksbehandling/komponenter/stegvelger/Stegvelger.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/Stegvelger.js
@@ -43,10 +43,8 @@ class Stegvelger extends Component {
   async componentDidMount() {
     this.aktiv = true;
 
-    const { behandlingID, match } = this.props;
+    const { behandlingID } = this.props;
     const { aktivtStegNummer } = this.state;
-
-    const { snr } = match.params;
 
     await Promise.all([
       this.props.hentMedlemsPerioder(behandlingID),
@@ -357,7 +355,6 @@ Stegvelger.propTypes = {
   fattVedtak: PT.func.isRequired,
   lagreSoknadHandler: PT.func.isRequired,
   lovvalgsperioder: PT.array.isRequired,
-  match: PT.object.isRequired,
   oppdaterPerioderState: PT.func.isRequired,
   oppdaterLokalSoknadHandler: PT.func.isRequired,
   oppsummering: MPT.Behandlinger.Oppsummering,

--- a/src/sider/saksbehandling/komponenter/stegvelger/Stegvelger.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/Stegvelger.js
@@ -20,8 +20,10 @@ import { avklartefaktaOperations, avklartefaktaSelectors } from '../../../../duc
 import { behandlingsperioderSelectors, behandlingsperioderOperations } from '../../../../ducks/behandlingsperioder';
 import { lovvalgsperioderOperations, lovvalgsperioderSelectors } from '../../../../ducks/lovvalgsperioder';
 import { vilkarOperations, vilkarSelectors } from '../../../../ducks/vilkar';
+import { redigerbartSelectors } from '../../../../ducks/redigerbart';
 import { vedtakOperations } from '../../../../ducks/vedtak';
 import { formSelectors } from '../../../../ducks/form';
+
 import { SoknadFeilmeldinger } from '../soknadFeilmeldinger';
 import { AvklartefaktaStore, VilkaarStore, LovvalgsbestemmelseStore, AnmodningsperiodesvarStore } from './StegState';
 
@@ -410,7 +412,7 @@ const mapStateToProps = state => ({
   valgteVirksomheter: avklartefaktaSelectors.AvklarteVirksomheterSelector(state),
   redigerbart: behandlingerSelectors.RedigerbartSelector(state),
   soknadFeilmeldinger: formSelectors.SoknadErrorsSelector(state),
-  generiskStegRedigerbart: behandlingerSelectors.GeneriskStegRedigerbartSelector(state),
+  generiskStegRedigerbart: redigerbartSelectors.GeneriskStegRedigerbartSelector(state),
 });
 
 /* eslint no-alert:off */

--- a/src/sider/saksbehandling/komponenter/stegvelger/Stegvelger.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/Stegvelger.js
@@ -410,7 +410,7 @@ const mapStateToProps = state => ({
   artikkel16_motta_svar_skjema: formSelectors.Artikkel16MottaSvarFormSelector(state).values,
   saksopplysninger: behandlingerSelectors.SaksopplysningerSelector(state),
   valgteVirksomheter: avklartefaktaSelectors.AvklarteVirksomheterSelector(state),
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   soknadFeilmeldinger: formSelectors.SoknadErrorsSelector(state),
   generiskStegRedigerbart: redigerbartSelectors.GeneriskStegRedigerbartSelector(state),
 });

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel13_1_vedtak.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel13_1_vedtak.js
@@ -15,6 +15,7 @@ import PdfLenkeListe from '../../../../../felleskomponenter/pdfLenkeListe';
 
 import { behandlingerSelectors } from '../../../../../ducks/behandlinger';
 import { lovvalgsperioderSelectors, lovvalgsperioderOperations } from '../../../../../ducks/lovvalgsperioder';
+import { redigerbartSelectors } from '../../../../../ducks/redigerbart';
 import { soknadSelectors } from '../../../../../ducks/soknad';
 
 import './vurderingArtikkel13_1_vedtak.css';
@@ -164,7 +165,7 @@ VurderingArtikkel13_1_Vedtak.defaultProps = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
   lovvalgsperiode: lovvalgsperioderSelectors.LovvalgsperiodeSelector(state),
   formIsValid: isValid(KV.Form.ARTIKKEL_13_1_VEDTAK)(state),

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.js
@@ -13,7 +13,7 @@ import PdfLenkeListe from '../../../../../felleskomponenter/pdfLenkeListe';
 import { KodeTermSelect } from '../../../../../felleskomponenter/ui/kodeTermSelect';
 
 import { lovvalgsperioderSelectors } from '../../../../../ducks/lovvalgsperioder';
-import { behandlingerSelectors } from '../../../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../../../ducks/redigerbart';
 import { soknadOperations } from '../../../../../ducks/soknad';
 
 import * as Api from '../../../../../services/api';
@@ -240,12 +240,11 @@ VurderingEndrePeriode.defaultProps = {
 
 const mapStateToProps = state => ({
   lovvalgsPeriode: lovvalgsperioderSelectors.LovvalgsperiodeSelector(state),
-  redigerbart: behandlingerSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({
   oppdaterPeriode: periode => dispatch(soknadOperations.oppdaterPeriode(periode)),
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(VurderingEndrePeriode);

--- a/src/sider/saksbehandling/komponenter/virksomhetNorge.js
+++ b/src/sider/saksbehandling/komponenter/virksomhetNorge.js
@@ -11,8 +11,9 @@ import * as KV from '../../../kodeverk';
 import LandVelger from '../../../felleskomponenter/skjema/landvelger';
 import PanelHeader from '../../../felleskomponenter/panelHeader/panelHeader';
 
-import { behandlingerSelectors } from '../../../ducks/behandlinger';
+import { redigerbartSelectors } from '../../../ducks/redigerbart';
 import { formSelectors } from '../../../ducks/form';
+
 import './virksomhetNorge.css';
 
 function VirksomhetNorge (props) {
@@ -74,7 +75,7 @@ VirksomhetNorge.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  redigerbart: behandlingerSelectors.PanelerRedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
   soknadForm: formSelectors.SoknadenFormSelector(state),
 });
 

--- a/src/sider/saksbehandling/saksbehandling.js
+++ b/src/sider/saksbehandling/saksbehandling.js
@@ -29,6 +29,7 @@ import { avklartefaktaOperations, avklartefaktaSelectors } from '../../ducks/avk
 import { saksopplysningerOperations, saksopplysningerSelectors } from '../../ducks/saksopplysninger';
 import { oppgaverOperations } from '../../ducks/oppgaver';
 import { lovvalgsperioderOperations, lovvalgsperioderSelectors } from '../../ducks/lovvalgsperioder';
+import { redigerbartSelectors } from '../../ducks/redigerbart';
 import { soknadOperations, soknadSelectors } from '../../ducks/soknad';
 import { behandlingsperioderOperations, behandlingsperioderSelectors } from '../../ducks/behandlingsperioder';
 import { formSelectors } from '../../ducks/form';
@@ -449,7 +450,7 @@ Saksbehandling.defaultProps = {
  * @param state
  */
 const mapStateToProps = state => ({
-  redigerbart: behandlingerSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   avklartefakta: avklartefaktaSelectors.AvklartefaktaSelector(state),
   fagsak: fagsakSelectors.FagsakSelector(state),
   oppfriskning: saksopplysningerSelectors.SaksopplysningerSelector(state),

--- a/src/sider/saksbehandling/saksbehandling.js
+++ b/src/sider/saksbehandling/saksbehandling.js
@@ -304,7 +304,7 @@ class Saksbehandling extends Component {
   };
 
   render() {
-    const { redigerbart, sidedialogRedigerbart } = this.props;
+    const { redigerbart } = this.props;
     const { behandlingID } = this.state;
     const { blokkerInnholdMedOppfriskSpinner } = this;
 
@@ -349,7 +349,7 @@ class Saksbehandling extends Component {
                 visAvsluttSakSomBortfaltDialogHandle={this.visAvsluttSakSomBortfaltDialog}
                 tilForsidenHandle={this.navigerTilOversiktSide}
               />
-              <SideDialog behandlingID={behandlingID} redigerbart={sidedialogRedigerbart} />
+              <SideDialog behandlingID={behandlingID} />
             </Nav.Column>
           </Nav.Row>
         </Nav.Container>
@@ -432,7 +432,6 @@ Saksbehandling.propTypes = {
   anmodningsperioder: PT.array,
   sendAnmodningsperioder: PT.func.isRequired,
   fattVedtak: PT.func.isRequired,
-  sidedialogRedigerbart: PT.bool.isRequired,
 };
 
 Saksbehandling.defaultProps = {
@@ -462,7 +461,6 @@ const mapStateToProps = state => ({
   behandlingsPeriode: behandlingsperioderSelectors.behandlingsPerioderSelector(state),
   anmodningsperioder: anmodningsperioderSelectors.AnmodningsperioderSelector(state),
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
-  sidedialogRedigerbart: behandlingerSelectors.SidedialogRedigerbartSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
- Låser dialog for å bestille brev dersom stegvelger er i art13-flyt, flere eller 0 arbeidsgivere er valgt i virksomhet-steg og mottaker er "Arbeidsgiver".
- Lager en ny duck for redigerbart. Fikk problemer med circular dependencies mellom ducks, og det virker naturlig å skille ut redigerbart fra behandlinger-ducken. 