### PR TITLE
Bugfiks - Stegvelger yrkessituasjon

### DIFF
--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/yrkesgruppe.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/yrkesgruppe.js
@@ -27,7 +27,7 @@ class Yrkesgruppe extends Steg {
       },
       {
         beskrivelse: '',
-        exec: () => avklartefakta => Yrkesgruppe.finnAvklaring(avklartefakta, KV.Koder.VurderingYrkesgruppeTyper.YRKESAKTIV_DIREKTE_TIL_ARTIKKEL_16),
+        exec: avklartefakta => Yrkesgruppe.finnAvklaring(avklartefakta, KV.Koder.VurderingYrkesgruppeTyper.YRKESAKTIV_DIREKTE_TIL_ARTIKKEL_16),
         nesteSteg: STEG.VIRKSOMHETER,
       },
       {


### PR DESCRIPTION
Fiks bug hvor virksomhet-steg er åpent i det man åpner yrkessituasjon-steget. Det burde være lukket til en yrkessituasjon er valgt.