### PR TITLE
MELOSYS-3178 - Stegvelger avkuttes

### DIFF
--- a/src/sider/saksbehandling/komponenter/stegvelger/felles/stegLinje.less
+++ b/src/sider/saksbehandling/komponenter/stegvelger/felles/stegLinje.less
@@ -1,5 +1,6 @@
 .stegLinje {
   display:flex;
+  flex-wrap: wrap;
   list-style: none;
   flex-direction: row;
   margin: 0;


### PR DESCRIPTION
Fikser visuell bug hvor steg i stegvelgeren ikke vises når det er for mange steg(relevant i art16 flyt). Skjer bare på smale skjermer.