### PR TITLE
MELOSYS-3276 - ØVRIG_SED og VURDER_TRYGDETID land ikke påkrevd

### DIFF
--- a/src/felleskomponenter/skjema/validering/skjemaer/journalforing.js
+++ b/src/felleskomponenter/skjema/validering/skjemaer/journalforing.js
@@ -22,7 +22,14 @@ const VELG_MINST_ETT_LAND = { melding: 'Velg minst ett land.' };
 const VELG_ETT_LAND = { melding: 'Velg ett land.' };
 const VELG_EN_BESTEMMELSE = 'Velg en bestemmelse.';
 
+const kreverPeriodeOgLand = (journalforingHensikt, behandlingstype) =>
+  journalforingHensikt === Konstanter.JOURNALFORING_HENSIKT.OPPRETT && ![
+    MKV.Koder.behandlinger.behandlingstyper.ØVRIGE_SED,
+    MKV.Koder.behandlinger.behandlingstyper.VURDER_TRYGDETID,
+  ].includes(behandlingstype);
+
 const anmodningOmUnntak = (journalforingHensikt, behandlingstype) =>
+  kreverPeriodeOgLand(journalforingHensikt, behandlingstype) &&
   journalforingHensikt === Konstanter.JOURNALFORING_HENSIKT.OPPRETT &&
   behandlingstype === MKV.Koder.behandlinger.behandlingstyper.ANMODNING_OM_UNNTAK_HOVEDREGEL;
 
@@ -78,23 +85,23 @@ const journalforing = object().shape({
         .required(VELG_HVILKEN_SAK_DU_ONSKER_A_KNYTTE_JOURNALFORINGEN_MOT),
     }),
   journalforingPeriodeFraOgMed: string()
-    .when('journalforingHensikt', {
-      is: Konstanter.JOURNALFORING_HENSIKT.OPPRETT,
+    .when(['journalforingHensikt', 'opprettnysak_behandlingstype'], {
+      is: kreverPeriodeOgLand,
       then: string()
         .required(TAST_INN_DATO)
         .erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO),
     }),
   journalforingPeriodeTilOgMed: string()
-    .when('journalforingHensikt', {
-      is: Konstanter.JOURNALFORING_HENSIKT.OPPRETT,
+    .when(['journalforingHensikt', 'opprettnysak_behandlingstype'], {
+      is: kreverPeriodeOgLand,
       then: string()
         .required(TAST_INN_DATO)
         .erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO),
     }),
   journalforingSoknadsland: array().of(string())
     .ensure()
-    .when('journalforingHensikt', {
-      is: Konstanter.JOURNALFORING_HENSIKT.OPPRETT,
+    .when(['journalforingHensikt', 'opprettnysak_behandlingstype'], {
+      is: kreverPeriodeOgLand,
       then: array().of(string())
         .min(1, { _error: VELG_MINST_ETT_LAND }),
     }),

--- a/src/sider/journalforing/journalforing.js
+++ b/src/sider/journalforing/journalforing.js
@@ -206,13 +206,15 @@ class Journalforing extends Component {
       return false;
     }
 
+    const fom = journalforingPeriodeFraOgMed ? Utils.dato.formatterDatoTilISO(journalforingPeriodeFraOgMed) : null;
+    const tom = journalforingPeriodeTilOgMed ? Utils.dato.formatterDatoTilISO(journalforingPeriodeTilOgMed) : null;
     const fagsak = {
       sakstype: MKV.Koder.sakstyper.EU_EOS,
       soknadsperiode: {
-        fom: Utils.dato.formatterDatoTilISO(journalforingPeriodeFraOgMed),
-        tom: Utils.dato.formatterDatoTilISO(journalforingPeriodeTilOgMed),
+        fom,
+        tom,
       },
-      land: journalforingSoknadsland,
+      land: journalforingSoknadsland || [],
     };
 
     const anmodningOmUnntak = {

--- a/src/sider/journalforing/komponenter/opprettnyfagsak.js
+++ b/src/sider/journalforing/komponenter/opprettnyfagsak.js
@@ -45,6 +45,11 @@ class OpprettNyFagSak extends Component {
     if (opprinneligFeltID === 'representantID') { await this.sjekkArbeidsgiver(value); }
   };
 
+  skalViseSoknadsperiodeOgLand = behandlingstype => ![
+    MKV.Koder.behandlinger.behandlingstyper.ØVRIGE_SED,
+    MKV.Koder.behandlinger.behandlingstyper.VURDER_TRYGDETID,
+  ].includes(behandlingstype);
+
   alleLovvalg = [
     ...MKV.KTObjects.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004,
     ...MKV.KTObjects.lovvalgsbestemmelser.lovvalgbestemmelser_987_2009,
@@ -90,59 +95,63 @@ class OpprettNyFagSak extends Component {
             </Skjema.Select>
           </Nav.Column>
         </Nav.Row>
-        <Nav.Row>
-          <Nav.Column xs="6">
-            <Skjema.Input feltNavn="representantID" label="Fullmektigens organisasjonsnummer" onKeyUp={this.IDFeltTastOppHandler} />
-            <Skjema.Input feltNavn="representantNavn" label="Organisasjonsnavn" disabled />
-            <Skjema.Input feltNavn="representantKontaktPerson" label="Kontaktperson hos fullmektig" />
-            { visArbeidsgiverSpinner && <Nav.NavFrontendSpinner className="sok__spinner" /> }
-          </Nav.Column>
-        </Nav.Row>
-        <Nav.Fieldset legend="Soknadperiode:" className="opprettnysak__soknadsperiode">
+        { this.skalViseSoknadsperiodeOgLand(valgtBehandlingstype) &&
+        <Fragment>
           <Nav.Row>
             <Nav.Column xs="6">
-              <Skjema.Input datoFelt label="Fra" feltNavn="journalforingPeriodeFraOgMed" />
-            </Nav.Column>
-            <Nav.Column xs="6">
-              <Skjema.Input datoFelt label="Til" feltNavn="journalforingPeriodeTilOgMed" />
-            </Nav.Column>
-          </Nav.Row>
-        </Nav.Fieldset>
-        <Nav.Fieldset legend="Land:">
-          <Nav.Row>
-            <Nav.Column xs="12">
-              <LandVelger feltNavn="journalforingSoknadsland" multiLand />
+              <Skjema.Input feltNavn="representantID" label="Fullmektigens organisasjonsnummer" onKeyUp={this.IDFeltTastOppHandler} />
+              <Skjema.Input feltNavn="representantNavn" label="Organisasjonsnavn" disabled />
+              <Skjema.Input feltNavn="representantKontaktPerson" label="Kontaktperson hos fullmektig" />
+              { visArbeidsgiverSpinner && <Nav.NavFrontendSpinner className="sok__spinner" /> }
             </Nav.Column>
           </Nav.Row>
-        </Nav.Fieldset>
-        { valgtBehandlingstype === MKV.Koder.behandlinger.behandlingstyper.ANMODNING_OM_UNNTAK_HOVEDREGEL &&
-          <Fragment>
-            <Nav.Fieldset legend="Unntak fra lovvalgsland:">
-              <Nav.Row>
-                <Nav.Column xs="12">
-                  <LandVelger label="Velg ett land:" feltNavn="journalforingUnntakFraLovvalgsland" multiLand={false} />
-                </Nav.Column>
-              </Nav.Row>
-            </Nav.Fieldset>
-            <Nav.Fieldset legend="Lovvalgsbestemmelse">
-              <Nav.Row>
-                <Nav.Column xs="12">
-                  <Skjema.Select label="Artikkelen det gjelder:" feltNavn="journalforingLovvalgsbestemmelse">
-                    { this.art16.map(kodeObjekt => <option key={uuid()} value={kodeObjekt.kode}>{kodeObjekt.term}</option>)}
-                  </Skjema.Select>
-                </Nav.Column>
-              </Nav.Row>
-            </Nav.Fieldset>
-            <Nav.Fieldset legend="Unntak fra lovvalgsbestemmelse">
-              <Nav.Row>
-                <Nav.Column xs="12">
-                  <Skjema.Select label="Artikkelen det søkes unntak fra:" feltNavn="journalforingUnntakFraLovvalgsbestemmelse">
-                    { this.alleLovvalg.map(kodeObjekt => <option key={uuid()} value={kodeObjekt.kode}>{kodeObjekt.term}</option>)}
-                  </Skjema.Select>
-                </Nav.Column>
-              </Nav.Row>
-            </Nav.Fieldset>
-          </Fragment>
+          <Nav.Fieldset legend="Soknadperiode:" className="opprettnysak__soknadsperiode">
+            <Nav.Row>
+              <Nav.Column xs="6">
+                <Skjema.Input datoFelt label="Fra" feltNavn="journalforingPeriodeFraOgMed" />
+              </Nav.Column>
+              <Nav.Column xs="6">
+                <Skjema.Input datoFelt label="Til" feltNavn="journalforingPeriodeTilOgMed" />
+              </Nav.Column>
+            </Nav.Row>
+          </Nav.Fieldset>
+          <Nav.Fieldset legend="Land:">
+            <Nav.Row>
+              <Nav.Column xs="12">
+                <LandVelger feltNavn="journalforingSoknadsland" multiLand />
+              </Nav.Column>
+            </Nav.Row>
+          </Nav.Fieldset>
+          { valgtBehandlingstype === MKV.Koder.behandlinger.behandlingstyper.ANMODNING_OM_UNNTAK_HOVEDREGEL &&
+            <Fragment>
+              <Nav.Fieldset legend="Unntak fra lovvalgsland:">
+                <Nav.Row>
+                  <Nav.Column xs="12">
+                    <LandVelger label="Velg ett land:" feltNavn="journalforingUnntakFraLovvalgsland" multiLand={false} />
+                  </Nav.Column>
+                </Nav.Row>
+              </Nav.Fieldset>
+              <Nav.Fieldset legend="Lovvalgsbestemmelse">
+                <Nav.Row>
+                  <Nav.Column xs="12">
+                    <Skjema.Select label="Artikkelen det gjelder:" feltNavn="journalforingLovvalgsbestemmelse">
+                      { this.art16.map(kodeObjekt => <option key={uuid()} value={kodeObjekt.kode}>{kodeObjekt.term}</option>)}
+                    </Skjema.Select>
+                  </Nav.Column>
+                </Nav.Row>
+              </Nav.Fieldset>
+              <Nav.Fieldset legend="Unntak fra lovvalgsbestemmelse">
+                <Nav.Row>
+                  <Nav.Column xs="12">
+                    <Skjema.Select label="Artikkelen det søkes unntak fra:" feltNavn="journalforingUnntakFraLovvalgsbestemmelse">
+                      { this.alleLovvalg.map(kodeObjekt => <option key={uuid()} value={kodeObjekt.kode}>{kodeObjekt.term}</option>)}
+                    </Skjema.Select>
+                  </Nav.Column>
+                </Nav.Row>
+              </Nav.Fieldset>
+            </Fragment>
+          }
+        </Fragment>
         }
         <Skjema.Checkbox feltNavn="ikkeSendForvaltingsmelding" label="Jeg ønsker ikke å sende forvaltningsmelding" />
         <Skjema.Checkbox feltNavn="skalTilordnes" label="Legg til behandlingen i mine oppgaver" />


### PR DESCRIPTION
Land og søknadsperiode er ikke relevant ved journalføring med behandlingstype ØVRIG_SED eller VURDER_TRYGDETID. Skjuler derfor de feltene, samt felter for fullmektig som heller ikke er relevant.
schema: https://github.com/navikt/melosys-schema/pull/102