### PR TITLE
Melosys-3310 - Tester

### DIFF
--- a/src/ducks/anmodningsperioder/operations.js
+++ b/src/ducks/anmodningsperioder/operations.js
@@ -41,10 +41,10 @@ export function lagre() {
     const bid = behandlingerSelectors.BehandlingIDSelector(getState());
     const anmodningsperioderErSendtUtlandet = anmodningsperioderSelectors.AnmodningsperioderErSendtUtlandetSelector(getState());
 
-    if (anmodningsperioderErSendtUtlandet) return;
+    if (anmodningsperioderErSendtUtlandet) return null;
 
     /* eslint-disable-next-line no-unused-vars */
-    dispatch(send(bid, { anmodningsperioder: anmodningsperioder.map(({ sendtUtland, ...beholdProperties }) => beholdProperties) }));
+    return dispatch(send(bid, { anmodningsperioder: anmodningsperioder.map(({ sendtUtland, ...beholdProperties }) => beholdProperties) }));
   };
 }
 

--- a/src/ducks/anmodningsperioder/operations.test.js
+++ b/src/ducks/anmodningsperioder/operations.test.js
@@ -1,0 +1,76 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import * as types from './types';
+import * as operations from './operations';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('Anmodningsperioder operations', () => {
+  let initialState = null;
+
+  beforeEach(() => {
+    fetch.resetMocks();
+    fetch.mockResponse(JSON.stringify({}));
+
+    initialState = {
+      behandlinger: {
+        data: [
+          {
+            behandlingID: 4,
+          },
+        ],
+      },
+      anmodningsperioder: {
+        data: [
+          { sendtUtland: false },
+        ],
+      },
+    };
+  });
+
+  describe('lagre', () => {
+    it('lager PENDING og OK ved normal tilstand', async () => {
+      const expectedActions = [
+        { type: types.PENDING },
+        { type: types.OK, data: {} },
+      ];
+
+      const store = mockStore(initialState);
+
+      await store.dispatch(operations.lagre());
+
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+
+    it('lager FEILET ved feil i api-kall', async () => {
+      const error = new Error('feil ved kall til Api');
+      fetch.resetMocks();
+      fetch.mockReject(error);
+
+      const expectedActions = [
+        { type: types.PENDING },
+        { type: types.FEILET, data: error.toString() },
+      ];
+
+      const store = mockStore(initialState);
+
+      await store.dispatch(operations.lagre());
+
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+
+    it('lager ingen actions dersom anmodning er sendt til utlandet', async () => {
+      initialState.anmodningsperioder.data = initialState.anmodningsperioder.data.map(anmodningsperiode => ({ ...anmodningsperiode, sendtUtland: true }));
+
+      const expectedActions = [];
+
+      const store = mockStore(initialState);
+
+      await store.dispatch(operations.lagre());
+
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});

--- a/src/ducks/lovvalgsperioder/operations.js
+++ b/src/ducks/lovvalgsperioder/operations.js
@@ -235,9 +235,9 @@ export function lagre() {
     const bid = behandlingerSelectors.BehandlingIDSelector(getState());
     const anmodningsperioderErSendtUtlandet = AnmodningsperioderErSendtUtlandetSelector(getState());
 
-    if (anmodningsperioderErSendtUtlandet) return;
+    if (anmodningsperioderErSendtUtlandet) return null;
 
-    dispatch(send(bid, lovvalgsperioder));
+    return dispatch(send(bid, lovvalgsperioder));
   };
 }
 

--- a/src/ducks/lovvalgsperioder/operations.test.js
+++ b/src/ducks/lovvalgsperioder/operations.test.js
@@ -9,38 +9,101 @@ import * as KV from '../../kodeverk';
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
-const initialState = {
-  form: {
-    [KV.Form.ARTIKKEL_16_ANMODNING]: {
-      values: {
-        unntakFraBestemmelse: 'Test',
+describe('Lovvalgsperioder operations', () => {
+  let initialState = null;
+
+  beforeEach(() => {
+    fetch.resetMocks();
+    fetch.mockResponse(JSON.stringify({}));
+
+    initialState = {
+      behandlinger: {
+        data: [
+          {
+            behandlingID: 4,
+          },
+        ],
       },
-    },
-  },
-  lovvalgsperioder: {
-    data: [
-      { medlemskapsperiodeID: '123' },
-    ],
-  },
-  vilkar: {
-    data: [],
-  },
-  soknad: {
-    data: {
-      soeknadDokument: {
-        periode: { fom: '1234', tom: '4321' },
-        soeknadsland: {
-          landkoder: [
-            'NO',
-            'DK',
-          ],
+      form: {
+        [KV.Form.ARTIKKEL_16_ANMODNING]: {
+          values: {
+            unntakFraBestemmelse: 'Test',
+          },
         },
       },
-    },
-  },
-};
+      anmodningsperioder: {
+        data: [
+          { sendtUtland: false },
+        ],
+      },
+      lovvalgsperioder: {
+        data: [
+          { medlemskapsperiodeID: '123' },
+        ],
+      },
+      vilkar: {
+        data: [],
+      },
+      soknad: {
+        data: {
+          soeknadDokument: {
+            periode: { fom: '1234', tom: '4321' },
+            soeknadsland: {
+              landkoder: [
+                'NO',
+                'DK',
+              ],
+            },
+          },
+        },
+      },
+    };
+  });
 
-describe('Lovvalgsperioder operations', () => {
+  describe('lagre', () => {
+    it('lager PENDING og OK ved normal tilstand', async () => {
+      const expectedActions = [
+        { type: types.PENDING },
+        { type: types.OK, data: {} },
+      ];
+
+      const store = mockStore(initialState);
+
+      await store.dispatch(operations.lagre());
+
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+
+    it('lager FEILET ved feil i api-kall', async () => {
+      const error = new Error('feil ved kall til Api');
+      fetch.resetMocks();
+      fetch.mockReject(error);
+
+      const expectedActions = [
+        { type: types.PENDING },
+        { type: types.FEILET, data: error.toString() },
+      ];
+
+      const store = mockStore(initialState);
+
+      await store.dispatch(operations.lagre());
+
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+
+    it('lager ingen actions dersom anmodning er sendt til utlandet', async () => {
+      initialState.anmodningsperioder.data = initialState.anmodningsperioder.data.map(anmodningsperiode => ({ ...anmodningsperiode, sendtUtland: true }));
+
+      const expectedActions = [];
+
+      const store = mockStore(initialState);
+
+      await store.dispatch(operations.lagre());
+
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
   describe('oppdaterLovvalgsperioderState', () => {
     it('lager RESET dersom ingen lovvalgsvilkar, lovvalgsbestemmelse eller tilleggbestemmelse er valgt', () => {
       const expectedActions = [

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -38,7 +38,6 @@ export const sendResultatTilDispatch = (dispatch, action, validering) => (...dat
 export const handterFeil = (dispatch, action) => async error => {
   if (error.response) {
     const data = await error.response.text();
-    console.error(error, error.stack, data); // eslint-disable-line no-console
 
     window.frontendlogger.error({
       error,
@@ -51,8 +50,6 @@ export const handterFeil = (dispatch, action) => async error => {
       data: { response: error.response, data },
     });
   } else {
-    console.error(error, error.stack); // eslint-disable-line no-console
-
     window.frontendlogger.error({
       error,
       stack: error.stack,

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -11,5 +11,10 @@ Enzyme.configure({ adapter: new Adapter() });
 
 global.shallow = shallow;
 global.mount = mount;
-
 global.each = each;
+
+// Mocker frontendlogger
+global.frontendlogger = {};
+global.frontendlogger.info = () => {};
+global.frontendlogger.warn = () => {};
+global.frontendlogger.error = () => {};


### PR DESCRIPTION
Legger til tester for å unngå at melosys-3310 skjer igjen (en tom array ble lagret som lovvalgsperiode ved art16 vedtak, etter at utlandet hadde svart).

Tester dispatch av actions ved lagring av lovvalgsperiode og anmodningsperiode.