### PR TITLE
Melosys-3384 - Filtrer begrunnelse fra kodeverk

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash": "^4.17.15",
     "lodash.throttle": "^4.1.1",
     "melosys-ikoner-assets": "^1.0.1",
-    "melosys-kodeverk": "5.14.12",
+    "melosys-kodeverk": "5.14.16",
     "moment": "^2.24.0",
     "moment-duration-format": "^2.3.2",
     "nav-frontend-alertstriper": "^3.0.7",

--- a/src/ducks/anmodningsperioder/operations.js
+++ b/src/ducks/anmodningsperioder/operations.js
@@ -6,7 +6,7 @@
  * når det asynkrone kallet, feks fra API'et er ferdigkjørt.
  *
  */
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../melosyskodeverk';
 
 import * as Api from '../../services/api';
 import { doThenDispatch } from '../../services/utils';

--- a/src/ducks/avklartefakta/reducers.js
+++ b/src/ducks/avklartefakta/reducers.js
@@ -4,7 +4,7 @@
  * Dette er Redux-reducere som håndterer state-manipulasjon direkte, basert på
  * action types som sendes inn sammen med dataene.
  */
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../melosyskodeverk';
 
 import { STATUS } from '../../services/utils';
 import * as Utils from '../../utils';

--- a/src/ducks/avklartefakta/selectors.js
+++ b/src/ducks/avklartefakta/selectors.js
@@ -7,7 +7,8 @@
  */
 
 import { createSelector } from 'reselect';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 import * as KV from '../../kodeverk';
 

--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -7,8 +7,8 @@
 
 import { createSelector } from 'reselect';
 import moment from 'moment/moment';
-import * as MKV from 'melosys-kodeverk';
 
+import MKV from '../../melosyskodeverk';
 import { datoDiff } from '../../utils/dato';
 import * as KV from '../../kodeverk';
 import * as soknadSelectors from '../soknad/selectors';

--- a/src/ducks/lovvalgsperioder/operations.js
+++ b/src/ducks/lovvalgsperioder/operations.js
@@ -6,7 +6,7 @@
  * når det asynkrone kallet, feks fra API'et er ferdigkjørt.
  *
  */
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../melosyskodeverk';
 
 import * as Api from '../../services/api';
 import { doThenDispatch } from '../../services/utils';

--- a/src/ducks/lovvalgsperioder/operations.test.js
+++ b/src/ducks/lovvalgsperioder/operations.test.js
@@ -1,6 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 import * as types from './types';
 import * as operations from './operations';

--- a/src/ducks/oppgaver/operations.js
+++ b/src/ducks/oppgaver/operations.js
@@ -7,7 +7,7 @@
  *
  */
 
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../melosyskodeverk';
 
 import { doThenDispatch } from '../../services/utils';
 import * as Api from '../../services/api';

--- a/src/ducks/redigerbart/selectors.js
+++ b/src/ducks/redigerbart/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../melosyskodeverk';
 
 import { avklartefaktaSelectors } from '../avklartefakta';
 import { behandlingerSelectors } from '../behandlinger';

--- a/src/ducks/vilkar/reducers.js
+++ b/src/ducks/vilkar/reducers.js
@@ -4,7 +4,7 @@
  * Dette er Redux-reducere som håndterer state-manipulasjon direkte, basert på
  * action types som sendes inn sammen med dataene.
  */
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../melosyskodeverk';
 
 import { STATUS } from '../../services/utils';
 

--- a/src/ducks/vilkar/selectors.js
+++ b/src/ducks/vilkar/selectors.js
@@ -6,7 +6,8 @@
  */
 
 import { createSelector } from 'reselect';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 // selector(s)
 export const VilkarSelector = createSelector(

--- a/src/felleskomponenter/behandlingsstatus.js
+++ b/src/felleskomponenter/behandlingsstatus.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import PT from 'prop-types';
 import moment from 'moment/moment';
 
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../melosyskodeverk';
 import * as KV from '../kodeverk';
 import * as Api from '../services/api';
 import * as Nav from '../utils/navFrontend';

--- a/src/felleskomponenter/dialogboks/dialogboksAvslagSoknad.js
+++ b/src/felleskomponenter/dialogboks/dialogboksAvslagSoknad.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PT from 'prop-types';
 import { connect } from 'react-redux';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 import * as Nav from '../../utils/navFrontend';
 import * as Ikon from '../../resources/images';

--- a/src/felleskomponenter/dialogboks/dialogboksHenlegg.js
+++ b/src/felleskomponenter/dialogboks/dialogboksHenlegg.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PT from 'prop-types';
 import { connect } from 'react-redux';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 import * as Nav from '../../utils/navFrontend';
 

--- a/src/felleskomponenter/sideDialog/brevBestilling.js
+++ b/src/felleskomponenter/sideDialog/brevBestilling.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, change, reset, setSubmitFailed } from 'redux-form';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 import * as KV from '../../kodeverk';
 import * as Nav from '../../utils/navFrontend';

--- a/src/felleskomponenter/sideDialog/sideDialogDokumenter.js
+++ b/src/felleskomponenter/sideDialog/sideDialogDokumenter.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 import * as MPT from '../../proptypes';
 import * as API from '../../services/api';

--- a/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.js
+++ b/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import * as EKV from 'eessi-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 import * as Nav from '../../utils/navFrontend';
 import * as Api from '../../services/api';

--- a/src/felleskomponenter/sideOppsummering.js
+++ b/src/felleskomponenter/sideOppsummering.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../melosyskodeverk';
 
 import * as Nav from '../utils/navFrontend';
 import * as MPT from '../proptypes';

--- a/src/felleskomponenter/skjema/landvelger/LandVelger.js
+++ b/src/felleskomponenter/skjema/landvelger/LandVelger.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../melosyskodeverk';
 
 import * as KV from '../../../kodeverk';
 import EnkeltLand from './enkeltLand';

--- a/src/felleskomponenter/skjema/validering/brevbestilling.js
+++ b/src/felleskomponenter/skjema/validering/brevbestilling.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../melosyskodeverk';
 
 const harBlankMelding = (verdi, melding = 'Velg et element i nedtrekkslisten') => ((verdi === '') ? melding : false);
 const harTekstMelding = (tekst, melding = 'Tekstfeltet må fylles ut') => ((tekst && tekst.length > 0) ? false : melding);

--- a/src/felleskomponenter/skjema/validering/skjemaer/artikkel16mottasvar.js
+++ b/src/felleskomponenter/skjema/validering/skjemaer/artikkel16mottasvar.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../melosyskodeverk';
 
 import * as Utils from '../../../../utils';
 

--- a/src/felleskomponenter/skjema/validering/skjemaer/journalforing.js
+++ b/src/felleskomponenter/skjema/validering/skjemaer/journalforing.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../melosyskodeverk';
 import * as Utils from '../../../../utils';
 import * as Konstanter from '../../../../constants';
 

--- a/src/felleskomponenter/ui/checkboxgruppe.test.js
+++ b/src/felleskomponenter/ui/checkboxgruppe.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../melosyskodeverk';
 import * as Nav from '../../utils/navFrontend';
 
 import Checkboxgruppe from './checkboxgruppe';

--- a/src/melosyskodeverk/index.js
+++ b/src/melosyskodeverk/index.js
@@ -2,8 +2,12 @@ import * as MKV from 'melosys-kodeverk';
 
 /* Filtrerer bort koder som vi ikke ønsker at bruker skal kunne oppgi, men som backend har behov for. */
 
-MKV.KTObjects.begrunnelser.art12_1_vesentlig_virksomhet = MKV.KTObjects.begrunnelser.art12_1_vesentlig_virksomhet.filter(({ kode }) => (
+const filtrertMKV = { ...MKV };
+
+filtrertMKV.KTObjects.begrunnelser.art12_1_vesentlig_virksomhet = MKV.KTObjects.begrunnelser.art12_1_vesentlig_virksomhet.filter(({ kode }) => (
   kode !== MKV.Koder.begrunnelser.art12_1_vesentlig_virksomhet.KONTRAKTER_IKKE_NORSK_LOV
 ));
+delete filtrertMKV.Koder.begrunnelser.art12_1_vesentlig_virksomhet.KONTRAKTER_IKKE_NORSK_LOV;
+delete filtrertMKV.Terms.begrunnelser.art12_1_vesentlig_virksomhet.KONTRAKTER_IKKE_NORSK_LOV;
 
-export default MKV;
+export default filtrertMKV;

--- a/src/melosyskodeverk/index.js
+++ b/src/melosyskodeverk/index.js
@@ -1,0 +1,9 @@
+import * as MKV from 'melosys-kodeverk';
+
+/* Filtrerer bort koder som vi ikke ønsker at bruker skal kunne oppgi, men som backend har behov for. */
+
+MKV.KTObjects.begrunnelser.art12_1_vesentlig_virksomhet = MKV.KTObjects.begrunnelser.art12_1_vesentlig_virksomhet.filter(({ kode }) => (
+  kode !== MKV.Koder.begrunnelser.art12_1_vesentlig_virksomhet.KONTRAKTER_IKKE_NORSK_LOV
+));
+
+export default MKV;

--- a/src/routing.js
+++ b/src/routing.js
@@ -3,8 +3,8 @@ import { Route, Switch, withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import loadable from '@loadable/component';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 
+import MKV from './melosyskodeverk';
 import * as Utils from './utils';
 import * as Api from './services/api';
 

--- a/src/sider/forside/komponenter/behandling.js
+++ b/src/sider/forside/komponenter/behandling.js
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import { reduxForm } from 'redux-form';
 import { withRouter } from 'react-router-dom';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../melosyskodeverk';
 
 import * as KV from '../../../kodeverk';
 import * as Nav from '../../../utils/navFrontend';

--- a/src/sider/journalforing/journalforing.js
+++ b/src/sider/journalforing/journalforing.js
@@ -4,7 +4,8 @@ import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { autofill, setSubmitFailed, change, getFormSyncErrors, touch, isValid, getFormValues } from 'redux-form';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 import * as KV from '../../kodeverk';
 import * as Utils from '../../utils';

--- a/src/sider/journalforing/komponenter/avsendervelger.js
+++ b/src/sider/journalforing/komponenter/avsendervelger.js
@@ -2,7 +2,7 @@ import React, { Fragment, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { getFormValues } from 'redux-form';
 import PT from 'prop-types';
-import MKV from 'melosys-kodeverk';
+import MKV from '../../../melosyskodeverk';
 
 import * as Skjema from '../../../felleskomponenter/skjema/';
 import * as Nav from '../../../utils/navFrontend';

--- a/src/sider/journalforing/komponenter/eksisterendeSaker.js
+++ b/src/sider/journalforing/komponenter/eksisterendeSaker.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../melosyskodeverk';
 
 import * as KV from '../../../kodeverk';
 import EnkeltDato from '../../../felleskomponenter/datoOmrade/enkeltDato';

--- a/src/sider/journalforing/komponenter/journalforingform.js
+++ b/src/sider/journalforing/komponenter/journalforingform.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PT from 'prop-types';
 import { connect } from 'react-redux';
 import { reduxForm, getFormValues } from 'redux-form';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../melosyskodeverk';
 
 import * as KV from '../../../kodeverk';
 import * as Validering from '../../../felleskomponenter/skjema/validering';

--- a/src/sider/journalforing/komponenter/opprettnyfagsak.js
+++ b/src/sider/journalforing/komponenter/opprettnyfagsak.js
@@ -2,7 +2,8 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { change } from 'redux-form';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../melosyskodeverk';
 
 import * as Skjema from '../../../felleskomponenter/skjema/';
 import * as Nav from '../../../utils/navFrontend';

--- a/src/sider/registrering/anmodningunntak/saksopplysninger.js
+++ b/src/sider/registrering/anmodningunntak/saksopplysninger.js
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, Fragment } from 'react';
 import { withRouter } from 'react-router-dom';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import * as EKV from 'eessi-kodeverk';
+
+import MKV from '../../../melosyskodeverk';
 
 import * as KV from '../../../kodeverk';
 import * as Utils from '../../../utils';

--- a/src/sider/registrering/komponenter/registerkontrollTreff.js
+++ b/src/sider/registrering/komponenter/registerkontrollTreff.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../melosyskodeverk';
 
 import * as KV from '../../../kodeverk';
 import * as Nav from '../../../utils/navFrontend';

--- a/src/sider/registrering/registrering.js
+++ b/src/sider/registrering/registrering.js
@@ -1,7 +1,8 @@
 /* eslint no-alert:off, consistent-return:off */
 import React from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 import * as Utils from '../../utils/';
 import * as Nav from '../../utils/navFrontend';

--- a/src/sider/registrering/unntaksperioder/komponenter/endrePeriode.js
+++ b/src/sider/registrering/unntaksperioder/komponenter/endrePeriode.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PT from 'prop-types';
 
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../melosyskodeverk';
 
 import * as Utils from '../../../../utils';
 import * as Nav from '../../../../utils/navFrontend';

--- a/src/sider/registrering/unntaksperioder/saksopplysninger.js
+++ b/src/sider/registrering/unntaksperioder/saksopplysninger.js
@@ -1,7 +1,8 @@
 import React, { Fragment } from 'react';
 import { withRouter } from 'react-router-dom';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../melosyskodeverk';
 
 import * as KV from '../../../kodeverk';
 import * as Utils from '../../../utils';

--- a/src/sider/saksbehandling/komponenter/fullmektig/fullmektig.js
+++ b/src/sider/saksbehandling/komponenter/fullmektig/fullmektig.js
@@ -1,6 +1,7 @@
 import React, { Fragment, useState, useEffect } from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../melosyskodeverk';
 
 import * as Nav from '../../../../utils/navFrontend';
 import * as Utils from '../../../../utils';

--- a/src/sider/saksbehandling/komponenter/fullmektig/fullmektigPanel.js
+++ b/src/sider/saksbehandling/komponenter/fullmektig/fullmektigPanel.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../melosyskodeverk';
 
 import * as Nav from '../../../../utils/navFrontend';
 import * as Ikoner from '../../../../resources/images';

--- a/src/sider/saksbehandling/komponenter/maritimtArbeid.js
+++ b/src/sider/saksbehandling/komponenter/maritimtArbeid.js
@@ -2,7 +2,8 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { FieldArray, change } from 'redux-form';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../melosyskodeverk';
 
 import * as Nav from '../../../utils/navFrontend';
 import * as Ikoner from '../../../resources/images';

--- a/src/sider/saksbehandling/komponenter/saksopplysninger/saksopplysninger.js
+++ b/src/sider/saksbehandling/komponenter/saksopplysninger/saksopplysninger.js
@@ -3,7 +3,8 @@ import PT from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { reduxForm } from 'redux-form';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../melosyskodeverk';
 import * as Utils from '../../../../utils';
 import * as KV from '../../../../kodeverk';
 import * as Validering from '../../../../felleskomponenter/skjema/validering';

--- a/src/sider/saksbehandling/komponenter/stegErstatter/henlagtSak.js
+++ b/src/sider/saksbehandling/komponenter/stegErstatter/henlagtSak.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../melosyskodeverk';
 
 import * as KV from '../../../../kodeverk';
 import * as MPT from '../../../../proptypes';

--- a/src/sider/saksbehandling/komponenter/stegErstatter/henlagtSak.test.js
+++ b/src/sider/saksbehandling/komponenter/stegErstatter/henlagtSak.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../melosyskodeverk';
 
 import * as KV from '../../../../kodeverk';
 

--- a/src/sider/saksbehandling/komponenter/stegvelger/StegState/VilkaarStore.test.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/StegState/VilkaarStore.test.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../melosyskodeverk';
 import VilkaarStore from './VilkaarStore';
 import { konverterTilStegData, lagBegrunnelse, lagVilkaar } from '../../../../../regler/vilkar';
 

--- a/src/sider/saksbehandling/komponenter/stegvelger/Stegvelger.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/Stegvelger.js
@@ -3,8 +3,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import TrackVisibility from 'react-on-screen';
+
+import MKV from '../../../../melosyskodeverk';
 
 import * as MPT from '../../../../proptypes';
 import * as Api from '../../../../services/api';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/felles/multiVilkaar.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/felles/multiVilkaar.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../../utils/navFrontend';
 import { konverterTilStegData, lagBegrunnelse, lagVilkaar, slettVilkar } from '../../../../../../regler/vilkar';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/inngang/soknadslandListe.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/inngang/soknadslandListe.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { formValueSelector, change } from 'redux-form';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../../utils/navFrontend';
 import * as MPT from '../../../../../../proptypes';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
-import * as MKV from 'melosys-kodeverk';
 import PT from 'prop-types';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as MPT from '../../../../../proptypes';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel11_4.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel11_4.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as MPT from '../../../../../proptypes';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel12_1.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel12_1.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as MPT from '../../../../../proptypes';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel12_2.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel12_2.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as MPT from '../../../../../proptypes';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel13_1_vedtak.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel13_1_vedtak.js
@@ -2,8 +2,9 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, isValid, getFormValues } from 'redux-form';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import * as EKV from 'eessi-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as Utils from '../../../../../utils';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel13_1b_UtpekLand.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel13_1b_UtpekLand.js
@@ -2,8 +2,9 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, isValid, getFormValues } from 'redux-form';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import * as EKV from 'eessi-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as Utils from '../../../../../utils';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
@@ -3,8 +3,9 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { FieldArray, reduxForm } from 'redux-form';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import * as EKV from 'eessi-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as MPT from '../../../../../proptypes';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel16MottaSvar.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel16MottaSvar.js
@@ -1,8 +1,9 @@
 import React, { Fragment, useEffect } from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import { reduxForm, formValueSelector } from 'redux-form';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Skjema from '../../../../../felleskomponenter/skjema';
 import * as Nav from '../../../../../utils/navFrontend';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel16MottaSvar.test.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel16MottaSvar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../melosyskodeverk';
 
 import { VurderingArtikkel16MottaSvar } from './vurderingArtikkel16MottaSvar';
 import { DatoOmradeMedVarighet } from '../../../../../felleskomponenter/datoOmrade/datoOmrade';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel16Vedtak.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel16Vedtak.js
@@ -1,7 +1,7 @@
 import React, { Fragment, useCallback } from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as MPT from '../../../../../proptypes';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel16Vedtak.test.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingArtikkel16Vedtak.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import { VurderingArtikkel16Vedtak, Innvilgelse, DelvisInnvilgelse, Avslag } from './vurderingArtikkel16Vedtak';
 

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingAvslag12_x_og_16.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingAvslag12_x_og_16.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as VilkarSelectors from '../../../../../ducks/vilkar/selectors';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingBostedsland.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingBostedsland.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import classnames from 'classnames';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as KV from '../../../../../kodeverk';
 import * as Nav from '../../../../../utils/navFrontend';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PT from 'prop-types';
 import { connect } from 'react-redux';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Utils from '../../../../../utils';
 import * as Nav from '../../../../../utils/navFrontend';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingForretningssted.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingForretningssted.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PT from 'prop-types';
 
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../melosyskodeverk';
 import * as Nav from '../../../../../utils/navFrontend';
 import * as KV from '../../../../../kodeverk';
 import * as MPT from '../../../../../proptypes';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingSokkelSkip.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingSokkelSkip.js
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import uuid from 'uuid';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as KV from '../../../../../kodeverk';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingVedtak.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingVedtak.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import * as EKV from 'eessi-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as KV from '../../../../../kodeverk';
 import * as Nav from '../../../../../utils/navFrontend';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingVideresend.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingVideresend.js
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
 import * as EKV from 'eessi-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as MPT from '../../../../../proptypes';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingYrkesgruppe.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingYrkesgruppe.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../../../../melosyskodeverk';
 
 import * as Nav from '../../../../../utils/navFrontend';
 import * as KV from '../../../../../kodeverk';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/StegMotor.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/StegMotor.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../melosyskodeverk';
 
 import { STEG } from './typer';
 

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/arbeidsmonster.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/arbeidsmonster.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 import Steg from '../steg';
 import { FANE_STATUS, STEG } from '../typer';
 import * as KV from '../../../../../../kodeverk';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/artikkel11_4.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/artikkel11_4.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 import Steg from '../steg';
 import { FANE_STATUS, STEG } from '../typer';
 import VurderingArtikkel11_4 from '../../stegKomponenter/vurderingArtikkel11_4';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/artikkel12_1.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/artikkel12_1.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 import Steg from '../steg';
 import { FANE_STATUS, STEG } from '../typer';
 import VurderingArtikkel12_1 from '../../stegKomponenter/vurderingArtikkel12_1';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/artikkel12_2.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/artikkel12_2.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 
 import Steg from '../steg';
 import { FANE_STATUS, STEG } from '../typer';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/artikkel16_anmodning.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/artikkel16_anmodning.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 
 import * as KV from '../../../../../../kodeverk';
 

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/artikkel16_motta_svar.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/artikkel16_motta_svar.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 
 import * as Utils from '../../../../../../utils';
 import * as Validering from '../../../../../../felleskomponenter/skjema/validering';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/bostedsland.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/bostedsland.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 import * as KV from '../../../../../../kodeverk';
 import Steg from '../steg';
 import { FANE_STATUS, STEG } from '../typer';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/endre_periode.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/endre_periode.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 
 import Steg from '../steg';
 import { FANE_STATUS, STEG } from '../typer';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/forutgaende_medlemskap.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/forutgaende_medlemskap.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 import Steg from '../steg';
 import { FANE_STATUS, STEG } from '../typer';
 import VurderingForutgaendeMedlemskap from '../../stegKomponenter/vurderingForutgaendeMedlemskap';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/normalt_driver_virksomhet.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/normalt_driver_virksomhet.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 import Steg from '../steg';
 import { FANE_STATUS, STEG } from '../typer';
 import VurderingNormaltDriverVirksomhet from '../../stegKomponenter/vurderingNormaltDriverVirksomhet';

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/vesentlig_virksomhet.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegMotor/kontrollere/vesentlig_virksomhet.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../../../../../melosyskodeverk';
 
 import Steg from '../steg';
 import { FANE_STATUS, STEG } from '../typer';

--- a/src/sider/saksbehandling/saksbehandling.js
+++ b/src/sider/saksbehandling/saksbehandling.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
 import { withRouter } from 'react-router-dom';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../../melosyskodeverk';
 
 import * as Utils from '../../utils';
 import * as Nav from '../../utils/navFrontend';

--- a/src/sider/sedbehandling/sedbehandling.js
+++ b/src/sider/sedbehandling/sedbehandling.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PT from 'prop-types';
 import { connect } from 'react-redux';
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../../melosyskodeverk';
 
 import * as Nav from '../../utils/navFrontend';
 import * as Utils from '../../utils';

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,4 +1,4 @@
-import * as MKV from 'melosys-kodeverk';
+import MKV from '../melosyskodeverk';
 
 export const lagUrl = (saksnummer, behandlingID, behandlingstypeKode) => {
   switch (behandlingstypeKode) {


### PR DESCRIPTION
- Filtrerer bort begrunnelsen KONTRAKTER_IKKE_NORSK_LOV fra vesentlig virksomhet begrunnelser der den brukes
- Eksponerer melosys-kodeverk gjennom et eget directory slik at det er enklere å filtrere bort verdier frontend ikke ønsker å vise