### PR TITLE
MELOSYS-3339 - History bugfiks ved korrigering av vedtak

### DIFF
--- a/src/routing.js
+++ b/src/routing.js
@@ -147,7 +147,7 @@ const Routing = ({
       const res = await Api.Saksflyt.Vedtak.revurder(behandlingID);
       const { behandlingID: nyBehandlingID } = res;
 
-      history.push(`${location.pathname}?${stringify({ behandlingID: nyBehandlingID })}`);
+      history.replace(`${location.pathname}?${stringify({ behandlingID: nyBehandlingID })}`);
       lastInnSaksopplysninger(saksnummer, nyBehandlingID);
     } catch (e) {
       Utils.logger.error(e);


### PR DESCRIPTION
- Det var mulig å bruke tilbakeknappen i browseren for å gå tilbake til behandlingen man valgte å revurdere. Denne behandlingen var da redigerbar, selv om den egentlig skulle vært i innsynsmodus. Tenker dette er den enkleste løsningen.