### PR TITLE
MELOSYS-2972 - Ikke vis gatenummer

### DIFF
--- a/src/felleskomponenter/adresser/generiskAdresse.js
+++ b/src/felleskomponenter/adresser/generiskAdresse.js
@@ -18,16 +18,16 @@ const GeneriskAdresse = ({ adresse }) => {
   } = adresse;
 
   const {
-    gatenavn, gatenummer, husnummer, husbokstav,
+    gatenavn, husnummer, husbokstav,
   } = gateadresse;
 
   const landNavn = (typeof land === 'string' ? land : KV.objektTilTermUtenFeilmelding(land));
-  const visGate = gatenavn || gatenummer || husnummer || husbokstav;
+  const visGate = gatenavn || husnummer || husbokstav;
 
-  return (gatenavn || gatenummer || husnummer || husbokstav || land || postnr || poststed) ? (
+  return (gatenavn || husnummer || husbokstav || land || postnr || poststed) ? (
     <address className="generiskadresse">
       { visGate &&
-        <div>{gatenavn} {gatenummer} {husnummer} {husbokstav}</div>
+        <div>{gatenavn} {husnummer} {husbokstav}</div>
       }
       {
         (postnr || poststed) &&


### PR DESCRIPTION
Gatenummer er ikke relevant for saksbehandling og trenger derfor ikke å bli vist.
Med gatenummer blir gater vist som f.eks. "Oslogata **11432** 4C".

schema: https://github.com/navikt/melosys-schema/pull/116