### PR TITLE
MELOSYS-3406 - Test feiler når den kjøres i action

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "melosys-kodeverk": "5.14.16",
     "moment": "^2.24.0",
     "moment-duration-format": "^2.3.2",
+    "moment-timezone": "^0.5.27",
     "nav-frontend-alertstriper": "^3.0.7",
     "nav-frontend-alertstriper-style": "^2.0.6",
     "nav-frontend-chevron": "^1.0.10",

--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import momentTZ from 'moment-timezone';
 
 /**
  * Saksbehandlere har forskjellig måte å taste inn datoer på. Denne funksjonen forsøker å
@@ -76,7 +77,7 @@ function formatterDatoTilNorsk(dato, visTidspunkt) {
   const inputFormat = ['YYYY-MM-DD', 'YYYY-MM-DDTHH:mm:ss', 'DD-MM-YYYY', 'DD-MM-YYYY HH:mm'];
   const momentFormat = visTidspunkt ? 'DD.MM.YYYY HH:mm' : 'DD.MM.YYYY';
   const momentDato = moment.utc(dato, inputFormat);
-  return momentDato.isValid() ? momentDato.local().format(momentFormat) : '';
+  return momentDato.isValid() ? momentTZ(momentDato).tz('Europe/Oslo').format(momentFormat) : '';
 }
 
 /** Forutsatt at datoen er validert korrekt norsk (DD.MM.YYYY HH:mm), formatter den til det maskinlesbare


### PR DESCRIPTION
- Testen `formatterDatoTilNorsk - formatterer datoen riktig til norsk format DD.MM.YYYY HH:mm:ss med klokkeslett` feiler når den kjøres i en action. Det virker som moment.local() baserer seg på tidssone, og ikke locale som er satt til 'nb'.

I og med at funksjonen heter formatterDatoTilNorsk tenker jeg det er riktig at den er låst til å konvertere til norsk tid.