### PR TITLE
MELOSYS-3444 - Panelinfo forsvinner

### DIFF
--- a/src/ducks/soknad/reducers.js
+++ b/src/ducks/soknad/reducers.js
@@ -100,7 +100,19 @@ export default function reducer(state = initialState, action) {
           fullmektigRegion: dokument.fullmektigRegion,
           fullmektigLandkode: dokument.fullmektigLand,
         },
-        arbeidUtland: dokument.arbeidUtland,
+        arbeidUtland: dokument.arbeidUtland.map(arbeidUtland => ({
+          adresse: {
+            gatenavn: arbeidUtland.adresse.gatenavn,
+            husnummer: arbeidUtland.adresse.husnummer || null,
+            landkode: arbeidUtland.adresse.landkode,
+            postnummer: arbeidUtland.adresse.postnummer,
+            poststed: arbeidUtland.adresse.poststed,
+            region: arbeidUtland.adresse.region || null,
+          },
+          foretakNavn: arbeidUtland.foretakNavn || null,
+          foretakOrgnr: arbeidUtland.foretakOrgnr || null,
+          arbeidUtlandHjemmekontor: arbeidUtland.arbeidUtlandHjemmekontor || null,
+        })),
         juridiskArbeidsgiverNorge: {
           antallAnsatte: dokument.antallAnsatte ? strengTilInt(dokument.antallAnsatte) : null,
           utsendteNeste12Mnd: dokument.utsendteNeste12Mnd ? strengTilInt(dokument.utsendteNeste12Mnd) : null,

--- a/src/felleskomponenter/skjema/validering/skjemaer/saksopplysninger.js
+++ b/src/felleskomponenter/skjema/validering/skjemaer/saksopplysninger.js
@@ -12,6 +12,7 @@ const saksopplysninger = object().shape({
       postnummer: string().nullable().required({ melding: 'Postnummer kreves', panel: KV.Paneltitler.arbeidUtland }),
       landkode: string().nullable().required({ melding: 'Land kreves', panel: KV.Paneltitler.arbeidUtland }),
       poststed: string().nullable().required({ melding: 'Poststed kreves', panel: KV.Paneltitler.arbeidUtland }),
+      gatenavn: string().nullable().required({ melding: 'Gatenavn kreves' }),
     }),
   })),
   maritimtArbeid: array().of(object().shape({

--- a/src/sider/saksbehandling/komponenter/arbeidutland/arbeidUtlandWrapper.js
+++ b/src/sider/saksbehandling/komponenter/arbeidutland/arbeidUtlandWrapper.js
@@ -15,7 +15,19 @@ import './arbeidUtland.css';
 
 class ArbeidUtlandWrapper extends Component {
   leggTilArbeidHandler = () => {
-    this.props.fields.push({});
+    this.props.fields.push({
+      adresse: {
+        gatenavn: '',
+        husnummer: '',
+        landkode: '',
+        postnummer: '',
+        poststed: '',
+        region: '',
+      },
+      foretakNavn: '',
+      foretakOrgnr: '',
+      arbeidUtlandHjemmekontor: '',
+    });
   };
 
   slettArbeidHandler = indeks => {

--- a/src/sider/saksbehandling/komponenter/saksopplysninger/saksopplysninger.js
+++ b/src/sider/saksbehandling/komponenter/saksopplysninger/saksopplysninger.js
@@ -43,15 +43,6 @@ import { formatterDatoTilNorsk } from '../../../../utils/dato';
 
 
 const Saksopplysninger = props => {
-  const lagreSoknadHandler = async () => {
-    const {
-      behandlingID, valid, sendSoknad, soknad,
-    } = props;
-    if (valid) {
-      await sendSoknad(behandlingID, soknad);
-    }
-  };
-
   const overstyrSubmit = event => {
     event.preventDefault();
   };
@@ -112,7 +103,6 @@ const Saksopplysninger = props => {
         lagreAnmodningsperioderHandler={props.lagreAnmodningsperioderHandler}
         oppdaterOgLagreBehandlingerHandler={props.oppdaterOgLagreBehandlingerHandler}
         lagreAllData={props.lagreAllData}
-        lagreSoknadHandler={lagreSoknadHandler}
         oppdaterLokalSoknadHandler={oppdaterLokalSoknadHandler}
         begrunnelser={MKV.KTObjects.begrunnelser}
         landkoder={MKV.KTObjects.landkoder}

--- a/src/sider/saksbehandling/komponenter/stegvelger/Stegvelger.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/Stegvelger.js
@@ -25,6 +25,7 @@ import { vilkarOperations, vilkarSelectors } from '../../../../ducks/vilkar';
 import { redigerbartSelectors } from '../../../../ducks/redigerbart';
 import { vedtakOperations } from '../../../../ducks/vedtak';
 import { formSelectors } from '../../../../ducks/form';
+import { soknadOperations } from '../../../../ducks/soknad';
 
 import { SoknadFeilmeldinger } from '../soknadFeilmeldinger';
 import { AvklartefaktaStore, VilkaarStore, EnkelDataStore } from './StegState';
@@ -138,19 +139,17 @@ class Stegvelger extends Component {
       unntakfrabestemmelse,
     } = stegStores;
 
+    const bestemmelser = {
+      lovvalgsbestemmelse: lovvalgsbestemmelse.hent(),
+      tilleggbestemmelse: tilleggbestemmelse.hent(),
+      unntakfrabestemmelse: unntakfrabestemmelse.hent(),
+    };
+
     await Promise.all([
       this.props.oppdaterVilkaar(vilkaar.hent()),
       this.props.oppdaterAvklartefakta(avklartefakta.hent()),
-      this.props.oppdaterLovvalgperioder({
-        lovvalgsbestemmelse: lovvalgsbestemmelse.hent(),
-        tilleggbestemmelse: tilleggbestemmelse.hent(),
-        unntakfrabestemmelse: unntakfrabestemmelse.hent(),
-      }),
-      this.props.oppdaterAnmodningsPerioder({
-        lovvalgsbestemmelse: lovvalgsbestemmelse.hent(),
-        tilleggbestemmelse: tilleggbestemmelse.hent(),
-        unntakfrabestemmelse: unntakfrabestemmelse.hent(),
-      }),
+      this.props.oppdaterLovvalgperioder(bestemmelser),
+      this.props.oppdaterAnmodningsPerioder(bestemmelser),
       this.props.oppdaterAnmodningsperiodesvar(anmodningsperiodesvar.hent()),
     ]);
 
@@ -348,7 +347,6 @@ class Stegvelger extends Component {
       artikkel16_anmodning_skjema,
       soknad_skjema,
       oppdaterPerioderState,
-      oppdaterLokalSoknadHandler,
       lagreSoknadHandler,
       redigerbart,
       lagreVilkarHandler,
@@ -360,7 +358,6 @@ class Stegvelger extends Component {
     this.setState({ aktivtStegNummer: nyttStegNummer });
 
     if (redigerbart) {
-      await oppdaterLokalSoknadHandler();
       await oppdaterPerioderState({ ...soknad_skjema, ...artikkel16_anmodning_skjema });
       await lagreAvklartefaktaHandler();
       await lagreVilkarHandler();
@@ -500,6 +497,7 @@ const mapDispatchToProps = dispatch => ({
   hentAnmodningsperioder: behandlingID => dispatch(anmodningsperioderOperations.hent(behandlingID)),
   oppdaterAnmodningsPerioder: lovvalgsbestemmelse => dispatch(anmodningsperioderOperations.oppdaterAnmodningsperioderState(lovvalgsbestemmelse)),
   oppdaterAnmodningsperiodesvar: anmodningsperiodesvar => dispatch(anmodningsperiodesvarOperations.oppdaterAnmodningsperiodesvarState(anmodningsperiodesvar)),
+  lagreSoknadHandler: () => dispatch(soknadOperations.lagre()),
 });
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Stegvelger));


### PR DESCRIPTION
Fiks bug hvor informasjon om fysisk arbeidsted slettes hvis det første man gjør etter å ha åpnet en helt ny behandling, er:
- Fyll ut panel for "Informasjon om fysisk arbeidsted"
- Trykk "Bekreft og fortsett" i stegvelger"

Dette skjedde fordi lagreSoknadHandler fra saksopplysninger.js ble brukt. Fiksen var å bruke soknadOperations.lagre() i stedet.


Andre endringer:
- Setter default verdier for soeknad.arbeidUtland payload
- Hindrer arbeidUtland.adresse i å være undefined ved å sette default verdier hver gang man legger til et nytt arbeidUtland-element. Dette var et problem i soeknad reduceren, hvor man for eksempel brukte arbeidUtland.adresse.gatenavn.
- Validerer gatenavn, da schema krever at det er en string med lengde større enn 1