### PR TITLE
MELOSYS-3450 - Skjul fritekstfelt i endre periode skjermbilde

### DIFF
--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.js
@@ -28,7 +28,6 @@ export class VurderingEndrePeriode extends React.Component {
     begrunnelse: hentFaktaVerdi(this.props.tilstand.aarsakEndringPeriodeAvklartfakta) || '',
     begrunnelseFeilmelding: undefined,
     opprinneligLovvalgsperiode: { fom: undefined, tom: undefined },
-    vedtaksbrevFritekst: '',
   };
 
   componentDidMount() {
@@ -44,8 +43,6 @@ export class VurderingEndrePeriode extends React.Component {
   }
 
   settSluttDato = nyTomDato => this.setState({ nyTomDato: Utils.dato.formatterDatoTilNorsk(nyTomDato) });
-
-  settVedtaksbrevFritekst = event => this.setState({ vedtaksbrevFritekst: event.target.value });
 
   hentOpprinneligPeriode = async behandlingID => {
     const opprinneligLovvalgsperiode = await Api.Lovvalgsperioder.hentOpprinnelig(behandlingID).catch(Utils.logger.error);
@@ -102,14 +99,14 @@ export class VurderingEndrePeriode extends React.Component {
   vedKlikkEndrePeriode = async () => {
     const { endreVedtak, tilForsiden } = this.props;
     const { sendEndretLovvalgsPeriode, validerAlt } = this;
-    const { begrunnelse, vedtaksbrevFritekst } = this.state;
+    const { begrunnelse } = this.state;
 
     if (validerAlt()) {
       await sendEndretLovvalgsPeriode();
 
       const data = {
         begrunnelseKode: begrunnelse,
-        fritekst: vedtaksbrevFritekst,
+        fritekst: null,
         behandlingstype: MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE,
       };
       await endreVedtak(data);
@@ -144,7 +141,6 @@ export class VurderingEndrePeriode extends React.Component {
       vedKlikkEndrePeriode,
       vedKlikkPdf,
       lagrePeriodeForForhandsvisning,
-      settVedtaksbrevFritekst,
     } = this;
 
     const {
@@ -153,7 +149,6 @@ export class VurderingEndrePeriode extends React.Component {
       begrunnelse,
       begrunnelseFeilmelding,
       opprinneligLovvalgsperiode: { fom, tom },
-      vedtaksbrevFritekst,
     } = this.state;
 
     const endretPeriodeBegrunnelse = begrunnelse;
@@ -164,7 +159,7 @@ export class VurderingEndrePeriode extends React.Component {
         type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV,
         data: {
           mottaker: MKV.Koder.aktoersroller.BRUKER,
-          fritekst: vedtaksbrevFritekst,
+          fritekst: null,
           begrunnelseKode: endretPeriodeBegrunnelse,
         },
       },
@@ -227,7 +222,12 @@ export class VurderingEndrePeriode extends React.Component {
             />
           </Nav.Column>
         </Nav.Row>
-        <Nav.Row>
+        {
+        /**
+         * Skjuler fritekstfelt inntil fritekst for endret periode støttes i brev.
+         * TODO: Vise når brev er klar.
+         */
+        /* <Nav.Row>
           <Nav.Column xs="6">
             <Nav.Textarea
               label="Fritekst til vedtaksbrev"
@@ -238,7 +238,7 @@ export class VurderingEndrePeriode extends React.Component {
               disabled={!redigerbart}
             />
           </Nav.Column>
-        </Nav.Row>
+        </Nav.Row> */}
         {redigerbart && <PdfLenkeListe behandlingID={behandlingID} dokumenter={pdfDokumenter} vedKlikk={vedKlikkPdf} />}
         <Nav.Hovedknapp disabled={!redigerbart} onClick={vedKlikkEndrePeriode} >Fatt vedtak</Nav.Hovedknapp>
       </div>


### PR DESCRIPTION
- Skjuler fritekstfelt for endre periode

Fritekstfelt for vedtaksbrev støttes ikke for endre periode for øyeblikket. Derfor ønsket fag at dette skulle skjules.