### PR TITLE
MELOSYS-3438 - Ikke vis link for A1 ved sending av sed

### DIFF
--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PT from 'prop-types';
 import { connect } from 'react-redux';
+import * as EKV from 'eessi-kodeverk';
 
 import MKV from '../../../../../melosyskodeverk';
 
@@ -15,7 +16,7 @@ import * as Mui from '../../../../../felleskomponenter/ui';
 
 import { lovvalgsperioderSelectors } from '../../../../../ducks/lovvalgsperioder';
 import { redigerbartSelectors } from '../../../../../ducks/redigerbart';
-import { soknadOperations } from '../../../../../ducks/soknad';
+import { soknadOperations, soknadSelectors } from '../../../../../ducks/soknad';
 
 import * as Api from '../../../../../services/api';
 
@@ -29,11 +30,12 @@ export class VurderingEndrePeriode extends React.Component {
     begrunnelseFeilmelding: undefined,
     opprinneligLovvalgsperiode: { fom: undefined, tom: undefined },
     vedtaksbrevFritekst: '',
+    erEessiReady: false,
   };
 
   componentDidMount() {
     const {
-      behandlingID, redigerbart, lovvalgsPeriode, oppdaterData, tilstand: { aarsakEndringPeriodeAvklartfakta },
+      behandlingID, redigerbart, lovvalgsPeriode, oppdaterData, tilstand: { aarsakEndringPeriodeAvklartfakta }, soknadsland
     } = this.props;
 
     oppdaterData(konverterTilStegData(MKV.Koder.avklartefaktatyper.AARSAK_ENDRING_PERIODE, aarsakEndringPeriodeAvklartfakta));
@@ -41,7 +43,12 @@ export class VurderingEndrePeriode extends React.Component {
     this.hentOpprinneligPeriode(behandlingID);
 
     if (!redigerbart) this.settSluttDato(lovvalgsPeriode.tomDato);
+    this.setErEessiReady(soknadsland[0]);
   }
+
+  setErEessiReady = async landkode => this.setState({
+    erEessiReady: (await Api.Eessi.mottakerinstitusjoner.hent(EKV.Koder.buctyper.legislation.LA_BUC_04, landkode)).length > 0,
+  });
 
   settSluttDato = nyTomDato => this.setState({ nyTomDato: Utils.dato.formatterDatoTilNorsk(nyTomDato) });
 
@@ -154,6 +161,7 @@ export class VurderingEndrePeriode extends React.Component {
       begrunnelseFeilmelding,
       opprinneligLovvalgsperiode: { fom, tom },
       vedtaksbrevFritekst,
+      erEessiReady,
     } = this.state;
 
     const endretPeriodeBegrunnelse = begrunnelse;
@@ -168,15 +176,18 @@ export class VurderingEndrePeriode extends React.Component {
           begrunnelseKode: endretPeriodeBegrunnelse,
         },
       },
-      {
+    ];
+
+    if (!erEessiReady) {
+      pdfDokumenter.push({
         navn: 'Forhåndsvis A1',
         type: MKV.Koder.brev.produserbaredokumenter.ATTEST_A1,
         data: {
           mottaker: MKV.Koder.aktoersroller.MYNDIGHET,
           begrunnelseKode: endretPeriodeBegrunnelse,
         },
-      },
-    ];
+      });
+    }
 
     const formattertOpprinneligFom = Utils.dato.formatterDatoTilNorsk(fom);
     const formattertOpprinneligTom = Utils.dato.formatterDatoTilNorsk(tom);
@@ -259,6 +270,7 @@ VurderingEndrePeriode.propTypes = {
   tilstand: PT.shape({
     aarsakEndringPeriodeAvklartfakta: MPT.Avklartefakta.isRequired,
   }).isRequired,
+  soknadsland: PT.arrayOf(PT.string).isRequired,
 };
 
 VurderingEndrePeriode.defaultProps = {
@@ -268,6 +280,7 @@ VurderingEndrePeriode.defaultProps = {
 const mapStateToProps = state => ({
   lovvalgsPeriode: lovvalgsperioderSelectors.LovvalgsperiodeSelector(state),
   redigerbart: redigerbartSelectors.EndreLovvalgsPeriodeRedigerbartSelector(state),
+  soknadsland: soknadSelectors.SoknadslandSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.js
@@ -35,7 +35,7 @@ export class VurderingEndrePeriode extends React.Component {
 
   componentDidMount() {
     const {
-      behandlingID, redigerbart, lovvalgsPeriode, oppdaterData, tilstand: { aarsakEndringPeriodeAvklartfakta }, soknadsland
+      behandlingID, redigerbart, lovvalgsPeriode, oppdaterData, tilstand: { aarsakEndringPeriodeAvklartfakta }, soknadsland,
     } = this.props;
 
     oppdaterData(konverterTilStegData(MKV.Koder.avklartefaktatyper.AARSAK_ENDRING_PERIODE, aarsakEndringPeriodeAvklartfakta));

--- a/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.test.js
+++ b/src/sider/saksbehandling/komponenter/stegvelger/stegKomponenter/vurderingEndrePeriode.test.js
@@ -22,6 +22,7 @@ describe('vurderingEndrePeriode', () => {
       },
       oppdaterData: jest.fn(),
       slettData: jest.fn(),
+      soknadsland: ['SE'],
     };
   });
 


### PR DESCRIPTION
Skal ikke vise link for forhåndsvisning av A1 dersom det skal sendes sed ved endring av periode.