### PR TITLE
MELOSYS-3443 kontaktorgnr valgfritt

### DIFF
--- a/src/sider/saksbehandling/komponenter/kontaktopplysninger.js
+++ b/src/sider/saksbehandling/komponenter/kontaktopplysninger.js
@@ -24,7 +24,7 @@ export class KontaktOpplysninger extends Component {
   async componentDidMount() {
     const kontaktopplysninger = await this.hentOgVisKontaktOpplysninger();
     this.kalkulerSynlighetVedMount(kontaktopplysninger);
-    this.finnOgVisOrganisasjon(kontaktopplysninger.kontaktorgnr);
+    if (kontaktopplysninger.kontaktorgnr) this.finnOgVisOrganisasjon(kontaktopplysninger.kontaktorgnr);
   }
 
   settKontaktOrgnr = orgnr => this.setState({ kontaktorgnr: orgnr, orgnrFeilmelding: undefined });


### PR DESCRIPTION
- Fjerner en unødvendig feilmelding når man åpner kontaktopplysninger hvor orgnr ikke er oppgitt.

Det virker som det er mulig å lagre kontaktopplysningsnavn uten orgnr allerede, så denne oppgaven ble litt overflødig.