### PR TITLE
MELOSYS-3106 - Gjenstående endringer i journalføringsbildet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "melosys-web",
-  "version": "2.0.4",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/felleskomponenter/skjema/validering/skjemaer/journalforing.js
+++ b/src/felleskomponenter/skjema/validering/skjemaer/journalforing.js
@@ -135,6 +135,9 @@ const journalforing = object().shape({
         .ensure()
         .required(VELG_EN_AVSENDER),
     }),
+  mottattDato: string()
+    .required(TAST_INN_DATO)
+    .erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO),
 
   /* Følgene felter viser ingen feilmeldinger til bruker, men må være en del av skjemaet for å kunne benytte .when() for andre felter. */
   journalforingHensikt: string(),

--- a/src/felleskomponenter/skjema/validering/skjemaer/journalforing.js
+++ b/src/felleskomponenter/skjema/validering/skjemaer/journalforing.js
@@ -90,16 +90,16 @@ const journalforing = object().shape({
     .when(['journalforingHensikt', 'opprettnysak_behandlingstype'], {
       is: kreverPeriodeOgLand,
       then: string()
-        .required(TAST_INN_DATO)
-        .erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO),
+        .erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO)
+        .required(TAST_INN_DATO),
     }),
   journalforingPeriodeTilOgMed: string()
     .when(['journalforingHensikt', 'opprettnysak_behandlingstype'], {
       is: kreverPeriodeOgLand,
       then: string()
-        .required(TAST_INN_DATO)
+        .erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO)
         .erEtterDatofelt('journalforingPeriodeFraOgMed', DATO_MA_VAERE_ETTER_FOM)
-        .erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO),
+        .required(TAST_INN_DATO),
     }),
   journalforingSoknadsland: array().of(string())
     .ensure()
@@ -136,8 +136,8 @@ const journalforing = object().shape({
         .required(VELG_EN_AVSENDER),
     }),
   mottattDato: string()
-    .required(TAST_INN_DATO)
-    .erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO),
+    .erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO)
+    .required(TAST_INN_DATO),
 
   /* Følgene felter viser ingen feilmeldinger til bruker, men må være en del av skjemaet for å kunne benytte .when() for andre felter. */
   journalforingHensikt: string(),

--- a/src/felleskomponenter/ui/knapp.js
+++ b/src/felleskomponenter/ui/knapp.js
@@ -9,9 +9,10 @@ const Knapp = ({
   ikon,
   children,
   htmlType,
+  type,
   ...rest
 }) => (
-  <Nav.Knapp htmlType={htmlType} {...rest} >
+  <Nav.Knapp htmlType={htmlType} type={type} {...rest} >
     {
       ikon && <img src={ikon} height={20} alt={ikon} className="ikon" />
     }
@@ -22,13 +23,15 @@ const Knapp = ({
 Knapp.propTypes = {
   ikon: PT.string,
   children: PT.node,
-  htmlType: PT.string,
+  htmlType: PT.oneOf(['submit', 'button', 'reset']),
+  type: PT.oneOf(['standard', 'hoved', 'fare', 'flat']),
 };
 
 Knapp.defaultProps = {
   ikon: undefined,
   children: undefined,
   htmlType: 'button',
+  type: 'standard',
 };
 
 export default Knapp;

--- a/src/sider/journalforing/journalforing.js
+++ b/src/sider/journalforing/journalforing.js
@@ -49,14 +49,6 @@ class Journalforing extends Component {
     this.setState({ valgtDokumentID });
   };
 
-  /** Handlers for de 2 individuelle knappene "knytt til sak" og "opprett ny sak" er egne
-   * funksjoner. Allikevel trenger vi en default handler som Redux Form hekter på gjennom <form onsubmit="" .../>
-   * @param event
-   */
-  overstyrSubmit = event => {
-    event.preventDefault();
-  };
-
   /** Selv om saksbehandler velger å avbryte journalføringsoppgaven vil den fortsatt ligge
    * i "Mine Oppgaver"-listen. Vi trenger derfor ikke å gi noen melding til backend om at
    * noe er avbrutt - kun redirecte til forsiden.
@@ -377,13 +369,15 @@ class Journalforing extends Component {
       }
     }
   };
-  erikkeSubmittable = () => {
+
+  kanSubmittes = () => {
     const { journalforSEDSkjemaVerdier } = this.props;
     if (journalforSEDSkjemaVerdier.brukerID) {
-      return false;
+      return true;
     }
-    return Utils._isEmpty(this.props.journalforingSkjemaVerdier.saksnummer);
+    return !Utils._isEmpty(this.props.journalforingSkjemaVerdier.saksnummer);
   };
+
   behandlingstyper = [
     ...MKV.KTObjects.behandlinger.behandlingstyper
       .filter(({ kode }) =>
@@ -440,6 +434,9 @@ class Journalforing extends Component {
                         avsenderNavn={avsenderNavn}
                         behandlingstype={behandlingstype}
                         sakstype={sakstype}
+                        submitJournalforing={this.submitJournalforing}
+                        avbrytJournalforing={this.avbrytJournalforing}
+                        kanSubmittes={this.kanSubmittes()}
                       />
                     }
                     {
@@ -457,18 +454,11 @@ class Journalforing extends Component {
                         hentOgVisRepresentant={hentOgVisRepresentant}
                         overstyrSubmit={this.overstyrSubmit}
                         behandlingstyper={this.behandlingstyper}
+                        submitJournalforing={this.submitJournalforing}
+                        avbrytJournalforing={this.avbrytJournalforing}
+                        kanSubmittes={this.kanSubmittes()}
                       />
                     }
-                    <div className="journalforing__fotknapper">
-                      <Nav.Row>
-                        <Nav.Column xs="6">
-                          <Nav.Hovedknapp disabled={this.erikkeSubmittable()} onClick={this.submitJournalforing}>JOURNALFØR</Nav.Hovedknapp>
-                        </Nav.Column>
-                        <Nav.Column xs="6">
-                          <Nav.Knapp onClick={this.avbrytJournalforing}>Avbryt Journalføring</Nav.Knapp>
-                        </Nav.Column>
-                      </Nav.Row>
-                    </div>
                   </div>
                 </Nav.Panel>
               </Sticky>

--- a/src/sider/journalforing/journalforing.js
+++ b/src/sider/journalforing/journalforing.js
@@ -452,7 +452,6 @@ class Journalforing extends Component {
                         knyttTilEksisterendeSak={knyttTilEksisterendeSak}
                         opprettFagsak={opprettFagsak}
                         hentOgVisRepresentant={hentOgVisRepresentant}
-                        overstyrSubmit={this.overstyrSubmit}
                         behandlingstyper={this.behandlingstyper}
                         submitJournalforing={this.submitJournalforing}
                         avbrytJournalforing={this.avbrytJournalforing}

--- a/src/sider/journalforing/journalforing.js
+++ b/src/sider/journalforing/journalforing.js
@@ -99,6 +99,7 @@ class Journalforing extends Component {
       representantID, representantKontaktPerson, avsenderNavn, hoveddokumentTittel, vedlegg: vedleggSkjema,
       skalTilordnes,
       ikkeSendForvaltingsmelding,
+      mottattDato,
     } = journalforingSkjemaVerdier;
 
     const { dokumentID } = hoveddokument;
@@ -115,6 +116,7 @@ class Journalforing extends Component {
       oppgaveID,
       vedlegg,
       skalTilordnes,
+      mottattDato: Utils.dato.formatterDatoTilISO(mottattDato),
     };
     if (intensjon === JOURNALFORING_HENSIKT.KNYTT) {
       journalPostData = { ...journalPostData, ikkeSendForvaltingsmelding: null };

--- a/src/sider/journalforing/komponenter/fotknapper.js
+++ b/src/sider/journalforing/komponenter/fotknapper.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import * as PT from 'prop-types';
+
+import * as Nav from '../../../utils/navFrontend';
+import * as Mui from '../../../felleskomponenter/ui';
+
+const Fotknapper = ({
+  avbrytJournalforing,
+  kanSubmittes,
+}) => (
+  <div className="journalforing__fotknapper">
+    <Nav.Row>
+      <Nav.Column xs="6">
+        <Mui.Knapp type="hoved" htmlType="submit" disabled={!kanSubmittes}>JOURNALFØR</Mui.Knapp>
+      </Nav.Column>
+      <Nav.Column xs="6">
+        <Mui.Knapp onClick={avbrytJournalforing}>Avbryt Journalføring</Mui.Knapp>
+      </Nav.Column>
+    </Nav.Row>
+  </div>
+);
+
+Fotknapper.propTypes = {
+  avbrytJournalforing: PT.func.isRequired,
+  kanSubmittes: PT.bool.isRequired,
+};
+
+export default Fotknapper;

--- a/src/sider/journalforing/komponenter/informasjon.js
+++ b/src/sider/journalforing/komponenter/informasjon.js
@@ -18,7 +18,6 @@ import LenkeListeVelger from './lenkelistevelger';
 import { PersonSelectors } from '../../../ducks/personer';
 import { OrganisasjonSelectors } from '../../../ducks/organisasjoner';
 import { formSelectors } from '../../../ducks/form';
-import { journalforingSelectors } from '../../../ducks/journalforing';
 
 import './informasjon.css';
 
@@ -154,7 +153,6 @@ class Informasjon extends Component {
     const {
       journalpostID,
       dokumentID,
-      mottattDato,
       vedlegg,
       settFeltInnhold,
       hentOgVisRepresentant,
@@ -184,12 +182,12 @@ class Informasjon extends Component {
           hentOgVisRepresentant={hentOgVisRepresentant}
         />
         <Mui.Undertittel tekst="Dokumenter" ikon={Ikoner.Filenew} className="undertittel oversteUndertittel" />
-        <Nav.Input
+        <Skjema.Input
+          datoFelt
           label="Mottatt dato"
           type="dato"
           bredde="S"
-          disabled
-          value={Utils.dato.formatterDatoTilNorsk(mottattDato)}
+          feltNavn="mottattDato"
         />
 
         <Nav.Fieldset legend="Hoveddokument:">
@@ -237,7 +235,6 @@ Informasjon.propTypes = {
   hentOgVisRepresentant: PT.func.isRequired,
   journalpostID: PT.string,
   dokumentID: PT.string,
-  mottattDato: PT.string.isRequired,
   vedlegg: PT.arrayOf(PT.shape({ dokumentID: PT.string, tittel: PT.string })),
   settFeltInnhold: PT.func.isRequired,
 };
@@ -252,7 +249,6 @@ Informasjon.defaultProps = {
 const mapStateToProps = state => ({
   person: PersonSelectors.personerSelector(state),
   organisasjon: OrganisasjonSelectors.organisasjonerSelector(state),
-  mottattDato: journalforingSelectors.MottattDatoSelector(state),
   journalforingSkjemaVerdier: formSelectors.JournalforingFormSelector(state).values,
 });
 

--- a/src/sider/journalforing/komponenter/journalforingform.js
+++ b/src/sider/journalforing/komponenter/journalforingform.js
@@ -17,6 +17,7 @@ import { journalforingSelectors } from '../../../ducks/journalforing';
 import Informasjon from '../komponenter/informasjon';
 import FagsakVelger from './fagsakVelger';
 import SendForvaltningsMelding from './sendForvaltningsMelding';
+import Fotknapper from './fotknapper';
 
 const JournalforingForm = props => {
   const {
@@ -27,15 +28,17 @@ const JournalforingForm = props => {
     hentOgVisBruker,
     fagsakListe,
     hentOgVisRepresentant,
-    overstyrSubmit,
     behandlingstyper,
     formValues,
     settJournalforingHensikt,
+    avbrytJournalforing,
+    kanSubmittes,
+    handleSubmit,
   } = props;
   const visForvaltningsMelding = formValues.saksnummer === '-1' && formValues.opprettnysak_behandlingstype === MKV.Koder.behandlinger.behandlingstyper.SOEKNAD;
 
   return (
-    <form onSubmit={overstyrSubmit}>
+    <form onSubmit={handleSubmit}>
       <Informasjon
         journalpostID={journalpostID}
         dokumentID={hoveddokumentID}
@@ -59,6 +62,7 @@ const JournalforingForm = props => {
         </Fragment>
       }
       <Skjema.Checkbox feltNavn="skalTilordnes" label="Legg til behandlingen i mine oppgaver" />
+      <Fotknapper kanSubmittes={kanSubmittes} avbrytJournalforing={avbrytJournalforing} />
     </form>
   );
 };
@@ -75,6 +79,10 @@ JournalforingForm.propTypes = {
   overstyrSubmit: PT.func.isRequired,
   settJournalforingHensikt: PT.func.isRequired,
   behandlingstyper: PT.arrayOf(MPT.Kodeverk).isRequired,
+  submitJournalforing: PT.func.isRequired,
+  avbrytJournalforing: PT.func.isRequired,
+  kanSubmittes: PT.bool.isRequired,
+  handleSubmit: PT.func.isRequired,
 };
 
 JournalforingForm.defaultProps = {
@@ -113,10 +121,13 @@ const mapStateToProps = state => ({
     submittable: false,
   },
 });
+
 const mapDispatchToProps = dispatch => ({
   settJournalforingHensikt: journalforingHensikt => dispatch(change(KV.Form.JOURNALFORING, 'journalforingHensikt', journalforingHensikt)),
 });
+
 const form = {
+  onSubmit: (values, dispatch, props) => props.submitJournalforing(),
   form: KV.Form.JOURNALFORING,
   enableReinitialize: true,
   destroyOnUnmount: true,
@@ -132,7 +143,6 @@ const form = {
 
     return Validering.Skjemaer.lagYupToReduxformErrorMapper(Validering.Skjemaer.journalforing, options)(values);
   },
-  onSubmit: () => {},
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(reduxForm(form)(JournalforingForm));

--- a/src/sider/journalforing/komponenter/journalforingform.js
+++ b/src/sider/journalforing/komponenter/journalforingform.js
@@ -76,7 +76,6 @@ JournalforingForm.propTypes = {
   fagsakListe: PT.array.isRequired,
   hentOgVisRepresentant: PT.func.isRequired,
   formValues: PT.object,
-  overstyrSubmit: PT.func.isRequired,
   settJournalforingHensikt: PT.func.isRequired,
   behandlingstyper: PT.arrayOf(MPT.Kodeverk).isRequired,
   submitJournalforing: PT.func.isRequired,

--- a/src/sider/journalforing/komponenter/journalforingsed.js
+++ b/src/sider/journalforing/komponenter/journalforingsed.js
@@ -11,6 +11,7 @@ import * as Ikoner from '../../../resources/images';
 import * as Mui from '../../../felleskomponenter/ui';
 
 import Brukernavnskjema from '../../../felleskomponenter/brukernavnskjema';
+import Fotknapper from './fotknapper';
 
 import { journalforingSelectors } from '../../../ducks/journalforing';
 
@@ -22,8 +23,11 @@ const JournalforingSED = ({
   sakstype,
   behandlingstype,
   form,
+  kanSubmittes,
+  avbrytJournalforing,
+  handleSubmit,
 }) => (
-  <form>
+  <form onSubmit={handleSubmit}>
     <Mui.Undertittel tekst="Informasjon om bruker" ikon={Ikoner.AccountCircle} className="undertittel oversteUndertittel" />
     <Nav.Row>
       <Nav.Column xs="6">
@@ -50,6 +54,7 @@ const JournalforingSED = ({
         <Nav.typo.Normaltekst>{behandlingstype.term}</Nav.typo.Normaltekst>
       </Nav.Column>
     </Nav.Row>
+    <Fotknapper kanSubmittes={kanSubmittes} avbrytJournalforing={avbrytJournalforing} />
   </form>
 );
 
@@ -59,6 +64,10 @@ JournalforingSED.propTypes = {
   sakstype: MPT.Kodeverk.isRequired,
   behandlingstype: MPT.Kodeverk.isRequired,
   form: PT.string.isRequired,
+  submitJournalforing: PT.func.isRequired,
+  avbrytJournalforing: PT.func.isRequired,
+  kanSubmittes: PT.bool.isRequired,
+  handleSubmit: PT.func.isRequired,
 };
 
 const form = {
@@ -70,6 +79,7 @@ const form = {
 };
 
 const mapStateToProps = state => ({
+  onSubmit: (values, dispatch, props) => props.submitJournalforing(),
   formValues: getFormValues(KV.Form.JOURNALFORING_SED)(state),
   initialValues: {
     submittable: true,

--- a/src/sider/journalforing/komponenter/knyttTilSak.js
+++ b/src/sider/journalforing/komponenter/knyttTilSak.js
@@ -32,6 +32,7 @@ const KnyttTilSak = props => {
               behandlingstyper &&
               behandlingstyper
                 .filter(elem => elem.kode !== MKV.Koder.behandlinger.behandlingstyper.SOEKNAD
+                  && elem.kode !== MKV.Koder.behandlinger.behandlingstyper.VURDER_TRYGDETID
                   && elem.kode !== MKV.Koder.behandlinger.behandlingstyper.ANMODNING_OM_UNNTAK_HOVEDREGEL
                   && elem.kode !== MKV.Koder.behandlinger.behandlingstyper.ØVRIGE_SED)
                 .map(elem => <option key={elem.kode} value={elem.kode}>{elem.term}</option>)

--- a/src/sider/journalforing/komponenter/lenkelistevelger.js
+++ b/src/sider/journalforing/komponenter/lenkelistevelger.js
@@ -7,6 +7,7 @@ import * as Skjema from '../../../felleskomponenter/skjema/';
 import * as Utils from '../../../utils';
 import * as Ikoner from '../../../resources/images';
 import * as Nav from '../../../utils/navFrontend';
+import * as Mui from '../../../felleskomponenter/ui';
 import { formSelectors } from '../../../ducks/form';
 
 function LenkeListeVelger(props) {
@@ -41,7 +42,7 @@ function LenkeListeVelger(props) {
         {visListevelger &&
           <Fragment>
             <Skjema.ListeVelger feltNavn={feltNavn} label="" placeholdere={placeholder} muligeValg={muligeValg} />
-            <Nav.Knapp disabled={erTomTittel()} onClick={lagre}>Lagre Tittel</Nav.Knapp>&nbsp;<Nav.Flatknapp onClick={avbryt}>Avbryt</Nav.Flatknapp>
+            <Mui.Knapp disabled={erTomTittel()} onClick={lagre}>Lagre Tittel</Mui.Knapp>&nbsp;<Mui.Knapp type="flat" onClick={avbryt}>Avbryt</Mui.Knapp>
           </Fragment>
         }
       </Nav.Column>


### PR DESCRIPTION
### Løser flere saker knytter til journalføringsbildet i denne PRen:

#### MELOSYS-3106
Gjør det mulig å endre mottatt dato for dokument i journalføringsbiltet. `mottattDato` sendes ved POST, og det er lagt inn validering av feltet.
**Schema:** https://github.com/navikt/melosys-schema/pull/128

#### MELOSYS-3358
Skal ikke kunne velge forespørsel om trygdetid ved knytting til eksisterende sak.

#### MELOSYS-3434
Fjerner falsk submit (`event.preventDefault()`) og bruker redux-form med `onSubmit` og `handleSubmit`. Bruker `<Mui.Knapp/>` for alle knapper i journalføringsbildet med `htmlType="button"`for alle bortsett fra submit-knappen.
Fotknappene flyttes i en egen komponent fordi de skal brukes på "innsiden" av `<form/>`.