### PR TITLE
Fjerner feature-toggle for visning av eessi-relaterte ting

### DIFF
--- a/src/felleskomponenter/pdfLenkeListe/index.js
+++ b/src/felleskomponenter/pdfLenkeListe/index.js
@@ -3,7 +3,6 @@ import PT from 'prop-types';
 import * as MPT from '../../proptypes';
 import { dokumenterOperations } from '../../ducks/dokumenter';
 import * as Nav from '../../utils/navFrontend';
-import * as Utils from '../../utils';
 
 import './pdfLenkeListe.css';
 
@@ -12,20 +11,7 @@ const uuid = require('uuid/v4');
 class PdfLenkeListe extends Component {
   state = {
     feilmelding: false,
-    kanForhandsviseSed: false,
   };
-
-  async componentDidMount() {
-    this.oppdaterKanForhandsviseSed(await Utils.feature.toggle([
-      { namespace: 'default', cluster: 'prod-fss' },
-      { namespace: 'q2', cluster: 'dev-fss' },
-      { namespace: 't8', cluster: 'dev-fss' },
-    ]));
-  }
-
-  oppdaterKanForhandsviseSed(kanVises) {
-    this.setState({ kanForhandsviseSed: kanVises });
-  }
 
   klikk = async dokument => {
     const { behandlingID, vedKlikk } = this.props;
@@ -65,13 +51,10 @@ class PdfLenkeListe extends Component {
     );
   }
 
-  featureToggleLenker = dokumenter => dokumenter.filter(dokument => !(dokument.erSed && !this.state.kanForhandsviseSed));
-
   render() {
-    const dokumenter = this.featureToggleLenker(this.props.dokumenter);
     return (
       <div className="pdfLenkeListe">
-        { dokumenter.map(dokument => this.lagDokumentLenke(dokument)) }
+        { this.props.dokumenter.map(dokument => this.lagDokumentLenke(dokument)) }
         { this.state.feilmelding &&
           <Nav.AlertStripe type="advarsel" className="varsel">{this.state.feilmelding}</Nav.AlertStripe>
         }

--- a/src/felleskomponenter/sideDialog/sideDialog.js
+++ b/src/felleskomponenter/sideDialog/sideDialog.js
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import PT from 'prop-types';
 import { Panel } from 'nav-frontend-paneler';
 
-import * as Utils from '../../utils';
 import SideDialogDokumenter from './sideDialogDokumenter';
 import SideDialogBrevBestilling from './brevBestilling';
 import SideDialogOpprettNyBuc from './sideDialogOpprettNyBuc';
@@ -63,6 +62,8 @@ class SideDialog extends Component {
     faner: [
       { navn: 'dokumenter', tittel: 'Dokumenter' },
       { navn: 'brevbestilling', tittel: 'Send brev' },
+      { navn: 'sedbestilling', tittel: 'Opprett ny BUC' },
+      { navn: 'besvarsed', tittel: 'SED-utveksling' },
     ],
   };
 
@@ -71,19 +72,6 @@ class SideDialog extends Component {
     aktivFane: this.props.faner[0].navn,
     faner: this.props.faner,
   };
-
-  async componentDidMount() {
-    const skalVises = await Utils.feature.toggle([
-      { namespace: 'default', cluster: 'prod-fss' },
-      { namespace: 'q2', cluster: 'dev-fss' },
-      { namespace: 't8', cluster: 'dev-fss' },
-    ]);
-
-    if (skalVises) {
-      this.leggTilFane({ navn: 'sedbestilling', tittel: 'Opprett ny BUC' });
-      this.leggTilFane({ navn: 'besvarsed', tittel: 'SED-utveksling' });
-    }
-  }
 
   /**  Trigges når brukeren klikker en annen fane (historikk, melding eller dokumenter)
    * slik at riktig komponent under menyen vises. Data fra komponenten slik som navn ligger under


### PR DESCRIPTION
Nå har eessi komt til q1, og vi trenger da ikke å filtrere ut eessi-ting i noen av miljøene. 