### PR TITLE
MELOSYS-3472 - Behandlingsmeny endringer for status anmodning om unntak sendt

### DIFF
--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -31,6 +31,10 @@ export const BehandlingstypeKodeSelector = createSelector(
   OppsummeringSelector,
   oppsummering => (oppsummering.behandlingstype ? oppsummering.behandlingstype.kode : '')
 );
+export const BehandlingsstatusKodeSelector = createSelector(
+  OppsummeringSelector,
+  oppsummering => (oppsummering.behandlingsstatus ? oppsummering.behandlingsstatus.kode : '')
+);
 
 export const ErArtikkel16AnmodningSendtSelector = createSelector(
   anmodningsperioderSelectors.AlleAnmodningsperioderSendtUtlandSelector,

--- a/src/ducks/redigerbart/selectors.js
+++ b/src/ducks/redigerbart/selectors.js
@@ -44,3 +44,8 @@ export const BrevBestillingRedigerbartIArtikkel13Selector = createSelector(
     return !erIArtikkel13_1Flyt || enVirksomhetErAvklart || mottaker !== MKV.Koder.aktoersroller.ARBEIDSGIVER;
   }
 );
+export const BehandlingsmenyRedigerbartSelector = createSelector(
+  RedigerbartSelector,
+  behandlingerSelectors.BehandlingsstatusKodeSelector,
+  (redigerbart, behandlingsstatus) => (behandlingsstatus === MKV.Koder.behandlinger.behandlingsstatus.ANMODNING_UNNTAK_SENDT ? true : redigerbart)
+);

--- a/src/ducks/redigerbart/selectors.js
+++ b/src/ducks/redigerbart/selectors.js
@@ -47,5 +47,5 @@ export const BrevBestillingRedigerbartIArtikkel13Selector = createSelector(
 export const BehandlingsmenyRedigerbartSelector = createSelector(
   RedigerbartSelector,
   behandlingerSelectors.BehandlingsstatusKodeSelector,
-  (redigerbart, behandlingsstatus) => (behandlingsstatus === MKV.Koder.behandlinger.behandlingsstatus.ANMODNING_UNNTAK_SENDT ? true : redigerbart)
+  (redigerbart, behandlingsstatus) => behandlingsstatus === MKV.Koder.behandlinger.behandlingsstatus.ANMODNING_UNNTAK_SENDT || redigerbart
 );

--- a/src/ducks/redigerbart/selectors.test.js
+++ b/src/ducks/redigerbart/selectors.test.js
@@ -1,0 +1,30 @@
+import * as selectors from './selectors';
+
+import MKV from '../../melosyskodeverk';
+
+describe('Redigerbartselectors', () => {
+  describe('BehandlingsmenyredigerbartSelector', () => {
+    const lagState = (redigerbart, behandlingsstatusKode) => ({
+      behandlinger: {
+        data: {
+          redigerbart,
+          oppsummering: {
+            behandlingsstatus: {
+              kode: behandlingsstatusKode,
+            },
+          },
+        },
+      },
+    });
+
+    each([
+      [true, MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING, true],
+      [false, MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING, false],
+      [true, MKV.Koder.behandlinger.behandlingsstatus.ANMODNING_UNNTAK_SENDT, true],
+      [true, MKV.Koder.behandlinger.behandlingsstatus.ANMODNING_UNNTAK_SENDT, false],
+    ]).it('returnerer %p dersom behandlingsstatus er %p og redigerbart er %p', (forventetResultat, behandlingsstatus, redigerbart) => {
+      const state = lagState(redigerbart, behandlingsstatus);
+      expect(selectors.BehandlingsmenyRedigerbartSelector(state)).toBe(forventetResultat);
+    });
+  });
+});

--- a/src/sider/saksbehandling/saksbehandling.js
+++ b/src/sider/saksbehandling/saksbehandling.js
@@ -149,6 +149,7 @@ class Saksbehandling extends Component {
       redigerbart,
       brevBestillingRedigerbart,
       brevBestillingRedigerbartIArtikkel13,
+      behandlingsmenyRedigerbart,
       match,
       lagreOgLukk,
       tilbakeleggOppgave,
@@ -208,7 +209,7 @@ class Saksbehandling extends Component {
                 soknadsperiodeFom={soknadsperiodeFom}
                 soknadsperiodeTom={soknadsperiodeTom}
                 renderBehandlingsmeny={() => <Behandlingsmeny
-                  redigerbart={redigerbart}
+                  redigerbart={behandlingsmenyRedigerbart}
                   lagreOgLukkHandle={lagreOgLukk}
                   tilbakeleggeHandle={tilbakeleggOppgave}
                   visHenleggDialogHandle={visHenleggDialogHandle}
@@ -285,6 +286,7 @@ Saksbehandling.propTypes = {
   sendAnmodningsperioder: PT.func.isRequired,
   brevBestillingRedigerbart: PT.bool.isRequired,
   brevBestillingRedigerbartIArtikkel13: PT.bool.isRequired,
+  behandlingsmenyRedigerbart: PT.bool.isRequired,
   anmodningsperioderErSendtUtlandet: PT.bool.isRequired,
   lagreAllData: PT.func.isRequired,
   lagreOgLukk: PT.func.isRequired,
@@ -351,6 +353,7 @@ const mapStateToProps = state => ({
   arbeidsland: avklartefaktaSelectors.ArbeidslandKTSelector(state),
   soknadsperiodeFom: Utils.dato.formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).fom),
   soknadsperiodeTom: Utils.dato.formatterDatoTilNorsk(soknadSelectors.SoknadsperiodeSelector(state).tom),
+  behandlingsmenyRedigerbart: redigerbartSelectors.BehandlingsmenyRedigerbartSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
Legger til mulighet for å henlegge og avslutte via behandlingsmeny dersom behandlingsstatus er ANMODNING_UNNTAK_SENDT(ble enige om å åpne hele behandlingsmenyen i dette tilfellet).