### PR TITLE
MELOSYS-3500 & 3501 - Dialogbokser låst etter anmodning sendt

### DIFF
--- a/src/ducks/redigerbart/selectors.js
+++ b/src/ducks/redigerbart/selectors.js
@@ -49,3 +49,11 @@ export const BehandlingsmenyRedigerbartSelector = createSelector(
   behandlingerSelectors.BehandlingsstatusKodeSelector,
   (redigerbart, behandlingsstatus) => behandlingsstatus === MKV.Koder.behandlinger.behandlingsstatus.ANMODNING_UNNTAK_SENDT || redigerbart
 );
+export const ModalHenleggRedigerbartSelector = createSelector(
+  BehandlingsmenyRedigerbartSelector,
+  redigerbart => redigerbart
+);
+export const ModalAvsluttSomBortfaltRedigerbartSelector = createSelector(
+  BehandlingsmenyRedigerbartSelector,
+  redigerbart => redigerbart
+);

--- a/src/ducks/redigerbart/selectors.test.js
+++ b/src/ducks/redigerbart/selectors.test.js
@@ -3,20 +3,20 @@ import * as selectors from './selectors';
 import MKV from '../../melosyskodeverk';
 
 describe('Redigerbartselectors', () => {
-  describe('BehandlingsmenyredigerbartSelector', () => {
-    const lagState = (redigerbart, behandlingsstatusKode) => ({
-      behandlinger: {
-        data: {
-          redigerbart,
-          oppsummering: {
-            behandlingsstatus: {
-              kode: behandlingsstatusKode,
-            },
+  const lagState = (redigerbart, behandlingsstatusKode) => ({
+    behandlinger: {
+      data: {
+        redigerbart,
+        oppsummering: {
+          behandlingsstatus: {
+            kode: behandlingsstatusKode,
           },
         },
       },
-    });
+    },
+  });
 
+  describe('BehandlingsmenyredigerbartSelector', () => {
     each([
       [true, MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING, true],
       [false, MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING, false],
@@ -25,6 +25,30 @@ describe('Redigerbartselectors', () => {
     ]).it('returnerer %p dersom behandlingsstatus er %p og redigerbart er %p', (forventetResultat, behandlingsstatus, redigerbart) => {
       const state = lagState(redigerbart, behandlingsstatus);
       expect(selectors.BehandlingsmenyRedigerbartSelector(state)).toBe(forventetResultat);
+    });
+  });
+
+  describe('ModalHenleggRedigerbartSelector', () => {
+    each([
+      [true, MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING, true],
+      [false, MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING, false],
+      [true, MKV.Koder.behandlinger.behandlingsstatus.ANMODNING_UNNTAK_SENDT, true],
+      [true, MKV.Koder.behandlinger.behandlingsstatus.ANMODNING_UNNTAK_SENDT, false],
+    ]).it('returnerer %p dersom behandlingsstatus er %p og redigerbart er %p', (forventetResultat, behandlingsstatus, redigerbart) => {
+      const state = lagState(redigerbart, behandlingsstatus);
+      expect(selectors.ModalHenleggRedigerbartSelector(state)).toBe(forventetResultat);
+    });
+  });
+
+  describe('ModalAvsluttSomBortfaltRedigerbartSelector', () => {
+    each([
+      [true, MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING, true],
+      [false, MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING, false],
+      [true, MKV.Koder.behandlinger.behandlingsstatus.ANMODNING_UNNTAK_SENDT, true],
+      [true, MKV.Koder.behandlinger.behandlingsstatus.ANMODNING_UNNTAK_SENDT, false],
+    ]).it('returnerer %p dersom behandlingsstatus er %p og redigerbart er %p', (forventetResultat, behandlingsstatus, redigerbart) => {
+      const state = lagState(redigerbart, behandlingsstatus);
+      expect(selectors.ModalAvsluttSomBortfaltRedigerbartSelector(state)).toBe(forventetResultat);
     });
   });
 });

--- a/src/felleskomponenter/dialogboks/dialogboksAvsluttSakSomBortfalt.js
+++ b/src/felleskomponenter/dialogboks/dialogboksAvsluttSakSomBortfalt.js
@@ -44,7 +44,7 @@ DialogboksAvsluttSakSomBortfalt.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.ModalAvsluttSomBortfaltRedigerbartSelector(state),
 });
 
 export default connect(mapStateToProps)(DialogboksAvsluttSakSomBortfalt);

--- a/src/felleskomponenter/dialogboks/dialogboksHenlegg.js
+++ b/src/felleskomponenter/dialogboks/dialogboksHenlegg.js
@@ -167,7 +167,7 @@ DialogboksHenleggSak.defaultProps = {
 
 const mapStateToProps = state => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
-  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
+  redigerbart: redigerbartSelectors.ModalHenleggRedigerbartSelector(state),
 });
 
 export default connect(mapStateToProps, null)(DialogboksHenleggSak);


### PR DESCRIPTION
- Låser opp dialogboksene for "henlegg" og "avslutt sak som bortfalt" for behandlingsstatus ANMODNING_UNNTAK_SENDT.