### PR TITLE
MELOSYS-3507 - visning av logiske vedlegg jfr

### DIFF
--- a/src/ducks/journalforing/selectors.js
+++ b/src/ducks/journalforing/selectors.js
@@ -14,12 +14,17 @@ export const JournalforingAlle = createSelector(
 
 export const JournalforingHovedDokument = createSelector(
   state => state.journalforing.data || {},
-  journalforing => journalforing.hoveddokument || { tittel: '', dokumentID: null }
+  journalforing => journalforing.hoveddokument || { tittel: '', dokumentID: null, logiskeVedlegg: [] }
 );
 
 export const JournalforingHovedDokumentTittelSelector = createSelector(
   JournalforingHovedDokument,
   hoveddokument => hoveddokument.tittel
+);
+
+export const JournalforingLogiskeVedleggSelector = createSelector(
+  JournalforingHovedDokument,
+  hoveddokument => hoveddokument.logiskeVedlegg || []
 );
 
 export const JournalforingVedleggsDokumenter = createSelector(

--- a/src/felleskomponenter/sideDialog/sideDialogDokumenter.js
+++ b/src/felleskomponenter/sideDialog/sideDialogDokumenter.js
@@ -80,7 +80,7 @@ const RenderOversiktRad = ({ oversikt }) => {
   const {
     mottaksretning, avsenderEllerMottaker, journalpostID, mottattDato, journalforingDato, hoveddokument, vedlegg,
   } = oversikt;
-  const { dokumentID, tittel } = hoveddokument;
+  const { dokumentID, tittel, logiskeVedlegg } = hoveddokument;
   if (!dokumentID) return null;
   return (
     <tr>
@@ -88,6 +88,7 @@ const RenderOversiktRad = ({ oversikt }) => {
       <td>
         <span>
           <PdfLink journalpostID={journalpostID} dokumentID={dokumentID} tittel={tittel} />
+          { logiskeVedlegg.map(logiskVedlegg => <RenderVedleggLink key={uuid()} journalpostID={journalpostID} dokument={{ tittel: logiskVedlegg }} />) }
           { vedlegg.map(vedleggDokument => <RenderVedleggLink key={uuid()} journalpostID={journalpostID} dokument={vedleggDokument} />) }
         </span>
       </td>

--- a/src/felleskomponenter/skjema/listevelger/listevelgerFlervalg.js
+++ b/src/felleskomponenter/skjema/listevelger/listevelgerFlervalg.js
@@ -5,6 +5,7 @@ import Ikon from 'melosys-ikoner-assets';
 
 import * as KV from '../../../kodeverk';
 import * as Nav from '../../../utils/navFrontend';
+import * as Mui from '../../ui';
 
 import './listevelger.css';
 
@@ -26,10 +27,10 @@ const ListevelgerValgtElement = ({
       <div className="listevelger__innhold">
         { element }
       </div>
-      <Nav.Knapp mini disabled={disabled} className="listevelger__linje__knapp" onClick={slettElement}>
+      <Mui.Knapp mini disabled={disabled} className="listevelger__linje__knapp" onClick={slettElement}>
         <div className="knapp__ikon"><Ikon kind="minus" size="24" /></div>
         <div className="knapp__tittel">Fjern</div>
-      </Nav.Knapp>
+      </Mui.Knapp>
     </div>
   );
 };

--- a/src/felleskomponenter/skjema/validering/skjemaer/journalforing.js
+++ b/src/felleskomponenter/skjema/validering/skjemaer/journalforing.js
@@ -68,8 +68,10 @@ const journalforing = object().shape({
     }),
   avsenderNavn: string()
     .required(SKRIV_INN_NAVN_PA_AVSENDER),
-  hoveddokumentTittel: string()
-    .required(VELG_DOKUMENTTITTEL_FRA_LISTEN_ELLER_SKRIV_DIN_EGEN),
+  hoveddokument: object().shape({
+    tittel: string()
+      .required(VELG_DOKUMENTTITTEL_FRA_LISTEN_ELLER_SKRIV_DIN_EGEN),
+  }),
   representantID: lazy(value => (value === '' ?
     string()
     :

--- a/src/sider/journalforing/journalforing.js
+++ b/src/sider/journalforing/journalforing.js
@@ -56,18 +56,15 @@ class Journalforing extends Component {
   avbrytJournalforing = () => {
     this.props.tilForsiden();
   };
-  mapLogiskeVedleggsTitlerTilVedlegg = titler => {
-    const dokumentID = null;
-    return titler.map(tittel => ({ dokumentID, tittel }));
-  };
+
   mapFysiskeVedleggsTitlerTilVedlegg = pdf => {
     const { vedleggsdokumenter } = this.props;
     if (!vedleggsdokumenter || vedleggsdokumenter.length === 0) return [];
     const pdfTitler = Object.values(pdf);
     if (pdfTitler.length === 0) return [];
     return pdfTitler.map((tittel, index) => {
-      const { dokumentID } = vedleggsdokumenter[index];
-      return ({ dokumentID, tittel });
+      const { dokumentID, logiskeVedlegg } = vedleggsdokumenter[index];
+      return ({ dokumentID, tittel, logiskeVedlegg });
     });
   };
   /** Ikke all informasjon som vises i skjemaet skal sendes tilbake til backend. Et eksempel på det er dato som
@@ -88,22 +85,27 @@ class Journalforing extends Component {
     const {
       brukerID, avsenderID, arbeidsgiverID,
       opprettnysak_behandlingstype: behandlingstypeKode,
-      representantID, representantKontaktPerson, representantRepresenterer, avsenderNavn, hoveddokumentTittel, vedlegg: vedleggSkjema,
+      representantID, representantKontaktPerson, representantRepresenterer, avsenderNavn,
+      hoveddokument: { tittel, logiskeVedlegg },
+      vedlegg: vedleggSkjema,
       skalTilordnes,
       ikkeSendForvaltingsmelding,
       mottattDato,
     } = journalforingSkjemaVerdier;
 
     const { dokumentID } = hoveddokument;
-    const vedlegg = [...this.mapFysiskeVedleggsTitlerTilVedlegg(vedleggSkjema.pdf), ...this.mapLogiskeVedleggsTitlerTilVedlegg(vedleggSkjema.logiskeTitler)];
+    const vedlegg = [...this.mapFysiskeVedleggsTitlerTilVedlegg(vedleggSkjema.pdf)];
 
     // Data for /tilordne i.e KNYTT
     let journalPostData = {
       avsenderID,
       avsenderNavn,
       brukerID,
-      dokumentID,
-      hoveddokumentTittel,
+      hoveddokument: {
+        dokumentID,
+        tittel,
+        logiskeVedlegg: logiskeVedlegg.filter(lv => lv), // fjern tomme titler
+      },
       journalpostID,
       oppgaveID,
       vedlegg,
@@ -510,7 +512,7 @@ Journalforing.propTypes = {
   sokOrgnr: PT.func.isRequired,
   errors: PT.object.isRequired,
   touch: PT.func.isRequired,
-  vedleggsdokumenter: PT.arrayOf(PT.shape({ tittel: PT.string, dokumentID: PT.string })).isRequired,
+  vedleggsdokumenter: PT.arrayOf(PT.shape({ tittel: PT.string, dokumentID: PT.string, logiskeVedlegg: PT.arrayOf(PT.string) })).isRequired,
   tilForsiden: PT.func.isRequired,
   journalforSEDSkjemaIsValid: PT.bool.isRequired,
   journalforSEDSkjemaVerdier: PT.object,

--- a/src/sider/journalforing/komponenter/informasjon.js
+++ b/src/sider/journalforing/komponenter/informasjon.js
@@ -45,7 +45,7 @@ class Informasjon extends Component {
 
   async componentDidMount() {
     const { vedlegg, journalforingSkjemaVerdier } = this.props;
-    await this.oppdaterState('hoveddokumentTittel', journalforingSkjemaVerdier.hoveddokumentTittel);
+    await this.oppdaterState('hoveddokument.tittel', journalforingSkjemaVerdier.hoveddokument.tittel);
     await this.oppdaterState('vedleggPdfTittler', vedlegg.reduce((acc, elem) => { acc.push(elem.tittel); return acc; }, []));
     await this.oppdaterFelter(this.props, true);
   }
@@ -158,7 +158,7 @@ class Informasjon extends Component {
       hentOgVisRepresentant,
       journalforingSkjemaVerdier,
     } = this.props;
-    const { hoveddokumentTittel, vedlegg: skjemaVedlegg } = journalforingSkjemaVerdier;
+    const { hoveddokument: { tittel: hoveddokumentTittel }, vedlegg: skjemaVedlegg } = journalforingSkjemaVerdier;
     const {
       spinner: { brukerNavn: visBrukerSpinner },
       spinner: { avsenderNavn: visAvsenderSpinner },
@@ -192,13 +192,13 @@ class Informasjon extends Component {
 
         <Nav.Fieldset legend="Hoveddokument:">
           <LenkeListeVelger
-            feltNavn="hoveddokumentTittel"
+            feltNavn="hoveddokument.tittel"
             placeholder="(velg eller skriv inn egen tittel)"
             muligeValg={dokumenttitler}
             linkTo={dokumentURI(journalpostID, dokumentID)}
             dokumentTittel={hoveddokumentTittel}
             undoTittel={this.state.hoveddokumentTittel}
-            updateTittel={() => this.oppdaterState('hoveddokumentTittel', hoveddokumentTittel)}
+            updateTittel={() => this.oppdaterState('hoveddokument.tittel', hoveddokumentTittel)}
           />
         </Nav.Fieldset>
         <p>Vedlegg</p>
@@ -216,7 +216,7 @@ class Informasjon extends Component {
           </Fragment>)
         }
         <Skjema.ListeVelger
-          feltNavn="vedlegg.logiskeTitler"
+          feltNavn="hoveddokument.logiskeVedlegg"
           label="Velg ny tittel:"
           gruppe
           tillatFritekst

--- a/src/sider/journalforing/komponenter/journalforingform.js
+++ b/src/sider/journalforing/komponenter/journalforingform.js
@@ -105,10 +105,12 @@ const mapStateToProps = state => ({
     representantID: '',
     representantRepresenterer: '',
     mottattDato: Utils.dato.formatterDatoTilNorsk(journalforingSelectors.MottattDatoSelector(state)),
-    hoveddokumentTittel: journalforingSelectors.JournalforingHovedDokumentTittelSelector(state) || 'Uten tittel',
+    hoveddokument: {
+      tittel: journalforingSelectors.JournalforingHovedDokumentTittelSelector(state) || 'Uten tittel',
+      logiskeVedlegg: journalforingSelectors.JournalforingLogiskeVedleggSelector(state),
+    },
     vedlegg: {
       pdf: toVedleggMedProps(journalforingSelectors.JournalforingVedleggsDokumenter(state)),
-      logiskeTitler: [],
     },
     sakstype: MKV.Koder.sakstyper.EU_EOS,
     opprettBehandling: BOOLSK.USANN,

--- a/src/sider/journalforing/komponenter/knyttTilSak.js
+++ b/src/sider/journalforing/komponenter/knyttTilSak.js
@@ -21,7 +21,12 @@ const KnyttTilSak = props => {
   if (sisteBehandling.behandlingsstatus.kode === MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET) {
     return (
       <div className="panelramme">
-        <Mui.Elementskrift tekst="Melding om saksbehandlingstid" ikon={Ikoner.InformationCircle} className="elementTittel oversteUndertittel" style={clsElementskrift} />
+        <Mui.Elementskrift
+          tekst="Tidligere behandling er avsluttet. Velg hva du vil gjøre med dokumentet"
+          ikon={Ikoner.InformationCircle}
+          className="elementTittel oversteUndertittel"
+          style={clsElementskrift}
+        />
         <Skjema.RadioGruppe feltNavn="opprettBehandling" label="Knytt til sak">
           <Skjema.Radio feltNavn="opprettBehandling" value={BOOLSK.SANN} label="Opprett ny behandling" />
           <Skjema.Radio feltNavn="opprettBehandling" value={BOOLSK.USANN} label="Uten å opprette behandling" />


### PR DESCRIPTION
Schema er oppdatert til å sende logiske vedlegg som en liste med titler i hoveddokument: https://github.com/navikt/melosys-schema/pull/137

Fikser visning av logiske vedlegg i journalføringsbildet. Har ingen skjemavalidering på inputen til boksene, så ved en tom boks fjernes vedlegget. Dto er også oppdatert for dokumentlisten, så noen små endringer er blitt gjort her.

Fikser også en tekst som var feil (MELOSYS-3509): https://github.com/navikt/melosys-web/commit/f8ce61e5e089ef0f83c31afd5829060efbc3c21e