### PR TITLE
bugfix - Kun EU/EØS i journalføringsbilde

### DIFF
--- a/src/sider/journalforing/komponenter/journalforingform.js
+++ b/src/sider/journalforing/komponenter/journalforingform.js
@@ -49,7 +49,7 @@ const JournalforingForm = props => {
       />
       <Mui.Undertittel tekst="Knytt til brukers eksisterende sak eller opprett ny sak" ikon={Ikoner.CheckList} className="undertittel oversteUndertittel" />
       <FagsakVelger
-        sakstyper={MKV.KTObjects.sakstyper}
+        sakstyper={MKV.KTObjects.sakstyper.filter(({ kode }) => kode === MKV.Koder.sakstyper.EU_EOS)}
         behandlingstyper={behandlingstyper}
         fagsakListe={fagsakListe}
         settJournalforingHensikt={settJournalforingHensikt}


### PR DESCRIPTION
 Skal kun være mulig å velge sakstype EU/EØS i journalføringsbilde ved opprettelse av ny sak