### PR TITLE
bugfix - feil bruk av <Link />

### DIFF
--- a/src/sider/journalforing/komponenter/informasjon.less
+++ b/src/sider/journalforing/komponenter/informasjon.less
@@ -1,10 +1,5 @@
 .informasjon {
 
-  .informasjon__dokumentlenke {
-    display: block;
-    margin: 0 0 1em 0;
-  }
-
   .informasjon__spinner {
     float: right;
     margin-top: -3.2em;

--- a/src/sider/journalforing/komponenter/lenkelistevelger.js
+++ b/src/sider/journalforing/komponenter/lenkelistevelger.js
@@ -1,5 +1,4 @@
 import React, { Fragment, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { change, formValueSelector } from 'redux-form';
 import PT from 'prop-types';
@@ -33,7 +32,7 @@ function LenkeListeVelger(props) {
   return (
     <Nav.Row>
       <Nav.Column xs="9">
-        {!visListevelger && <Link to={linkTo} target="_blank" className="informasjon__dokumentlenke">{dokumentTittel}</Link>}
+        {!visListevelger && <Nav.Lenker href={linkTo} target="_blank">{dokumentTittel}</Nav.Lenker>}
       </Nav.Column>
       <Nav.Column xs="3">
         {!visListevelger && <Nav.Lenker onClick={tittelEndres}><img src={Ikoner.Pencil} alt="Edit" /><span>&nbsp;Endre tittel</span></Nav.Lenker>}


### PR DESCRIPTION
Fjerner feil bruk av `<Link />` (fra react-router) og bruker heller `<NAV.Lenker />`.
Bruk av `<Link />` fører til at stien blir prefixet med `/melosys` som gir feil proxying mot backend for å vise pdf-dokument.