### PR TITLE
MELOSYS-3577 - Tittel nullstilles ved avbryt journalforing

### DIFF
--- a/src/sider/journalforing/komponenter/informasjon.js
+++ b/src/sider/journalforing/komponenter/informasjon.js
@@ -45,7 +45,7 @@ class Informasjon extends Component {
 
   async componentDidMount() {
     const { vedlegg, journalforingSkjemaVerdier } = this.props;
-    await this.oppdaterState('hoveddokument.tittel', journalforingSkjemaVerdier.hoveddokument.tittel);
+    await this.oppdaterState('hoveddokumentTittel', journalforingSkjemaVerdier.hoveddokument.tittel);
     await this.oppdaterState('vedleggPdfTittler', vedlegg.reduce((acc, elem) => { acc.push(elem.tittel); return acc; }, []));
     await this.oppdaterFelter(this.props, true);
   }
@@ -198,7 +198,7 @@ class Informasjon extends Component {
             linkTo={dokumentURI(journalpostID, dokumentID)}
             dokumentTittel={hoveddokumentTittel}
             undoTittel={this.state.hoveddokumentTittel}
-            updateTittel={() => this.oppdaterState('hoveddokument.tittel', hoveddokumentTittel)}
+            updateTittel={() => this.oppdaterState('hoveddokumentTittel', hoveddokumentTittel)}
           />
         </Nav.Fieldset>
         <p>Vedlegg</p>

--- a/src/sider/journalforing/komponenter/informasjon.js
+++ b/src/sider/journalforing/komponenter/informasjon.js
@@ -54,9 +54,10 @@ class Informasjon extends Component {
     await this.oppdaterFelter(prevProps);
   }
 
-  oppdaterState = async (stateNavn, verdi) => {
-    await this.setState({ [stateNavn]: verdi });
+  oppdaterState = (stateNavn, verdi) => {
+    this.setState({ [stateNavn]: verdi });
   };
+
   oppdaterFelter = async (props, tvingOppdatering) => {
     const {
       brukerID: gammelBrukerID,


### PR DESCRIPTION
- Dersom man forsøkte å endre hoveddokumenttittel ved journalføring, for så å avbryte endringen, ble tittelen satt til en tom string.