### PR TITLE
MELOSYS-3606 - Bugfiks vedlegglenke journalføring

### DIFF
--- a/src/sider/journalforing/komponenter/informasjon.js
+++ b/src/sider/journalforing/komponenter/informasjon.js
@@ -208,7 +208,7 @@ class Informasjon extends Component {
               feltNavn={`vedlegg.pdf.tittel_${index}`}
               placeholder="(velg eller skriv inn egen tittel)"
               muligeValg={dokumenttitler}
-              linkTo={dokumentURI(journalpostID, dokumentID)}
+              linkTo={dokumentURI(journalpostID, elem.dokumentID)}
               dokumentTittel={skjemaVedlegg.pdf[`tittel_${index}`]}
               undoTittel={this.state.vedleggPdfTittler[index]}
               updateTittel={() => this.updateVedleggTittel(index, skjemaVedlegg.pdf[`tittel_${index}`])}


### PR DESCRIPTION
Hoveddokument ble vist når man trykket på et vedlegg i journalføring