### PR TITLE
Quickfix - Kontroller ved vedtak ble ikke vist

### DIFF
--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -12,7 +12,7 @@ export const sjekkStatuskode = async response => {
   }
   const error = new Error(response.statusText || response.type);
   error.response = response;
-  error.body = await response.json();
+  error.body = await response.clone().json();
   throw error;
 };
 


### PR DESCRIPTION
- Dersom det fantes overlappende perioder når man fattet vedtak, ble ikke kontrollene vist i frontend.
- Skjedde fordi response.json() ble kalt flere ganger. Den kan tydeligvis bare kalles 1 gang. En kjapp løsning ble å bruke response.clone() først.