### PR TITLE
MELOSYS-3651 - Kunne ikke gå videre fra Yrkesaktivtet-steg for behandlingstype NY_VURDERING

### DIFF
--- a/src/sider/saksbehandling/stegMap/yrkesaktivitet.js
+++ b/src/sider/saksbehandling/stegMap/yrkesaktivitet.js
@@ -3,6 +3,7 @@ import { FANE_STATUS, STEG } from '../../../felleskomponenter/stegvelger/stegMot
 import VurderingYrkesaktivitet from '../../../felleskomponenter/stegvelger/stegKomponenter/vurderingYrkesaktivitet';
 import Yrkesgruppe from './yrkesgruppe';
 
+import MKV from '../../../melosyskodeverk';
 import * as KV from '../../../kodeverk';
 import { hentFakta } from '../../../regler/avklartefakta';
 
@@ -11,8 +12,9 @@ class Yrkesaktivitet extends Steg {
     super(propsLight, stegPosisjon);
 
     const erSokkelEllerSkip = Yrkesgruppe.finnAvklaring(propsLight.avklartefakta, KV.Koder.VurderingYrkesgruppeTyper.SOKKEL_ELLER_SKIP);
-    const { erSoknad } = propsLight;
-    const erSoknadEllerSokkelSkip = erSoknad || erSokkelEllerSkip;
+    const { erSoknad, behandlingstype } = propsLight;
+    const erNyVurdering = KV.objektTilKode(behandlingstype) === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING;
+    const erSoknadEllerSokkelSkip = erSoknad || erSokkelEllerSkip || erNyVurdering;
 
     this.kriterier = [
       {


### PR DESCRIPTION
Kan foreløpig bare støtte revurdering av art12, da det ikke er noen måte å skille mellom revurdering av forskjellige behandlingstyper. Dette burde bli fikset i MELOSYS-1551.