### PR TITLE
MELOSYS-3653 - Hotfix: Ikke forhåndsvis orientering til arbeidsgiver for 11.4.2

### DIFF
--- a/src/ducks/flyt/index.js
+++ b/src/ducks/flyt/index.js
@@ -1,0 +1,3 @@
+import * as flytSelectors from './selectors';
+
+export { flytSelectors };

--- a/src/ducks/flyt/selectors.js
+++ b/src/ducks/flyt/selectors.js
@@ -1,0 +1,9 @@
+import { createSelector } from 'reselect';
+
+import { vilkarSelectors } from '../vilkar';
+
+export const ErIArtikkel11_4Selector = createSelector(
+  vilkarSelectors.art11_4_1,
+  vilkarSelectors.art11_4_2,
+  (...vilkar) => vilkar.some(enkeltVilkar => enkeltVilkar.oppfylt)
+);

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
@@ -18,6 +18,7 @@ import { behandlingerSelectors } from '../../../ducks/behandlinger';
 import { lovvalgsperioderSelectors } from '../../../ducks/lovvalgsperioder';
 import { behandlingsresultatSelectors } from '../../../ducks/behandlingsresultat';
 import { vedtakSelectors } from '../../../ducks/vedtak';
+import { flytSelectors } from '../../../ducks/flyt';
 
 import PdfLenkeListe from '../../pdfLenkeListe';
 import DatoOmrade from '../../datoOmrade/datoOmrade';
@@ -41,6 +42,7 @@ const VurderingVedtak = ({
   vedtakLastes,
   visAntallManederUtland,
   pdfDokumenter,
+  erArtikkel11_4,
 }) => {
   const lovvalget = lovvalgsperioder[0] || {};
 
@@ -52,6 +54,7 @@ const VurderingVedtak = ({
   const lovvalgSomKodeTerm = KV.finnEnkeltKodeFraListe(lovvalgsbestemmelse, MKV.Kodekombinasjoner.alleLovvalg);
   const erNyVurdering = behandlingstype === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING;
   const fattVedtakDisabled = !redigerbart;
+  const bucType = erArtikkel11_4 ? EKV.Koder.buctyper.legislation.LA_BUC_05 : EKV.Koder.buctyper.legislation.LA_BUC_04;
 
   const validerForm = () => {
     touch('tomDato');
@@ -122,7 +125,7 @@ const VurderingVedtak = ({
               form={form}
               redigerbart={redigerbart}
               landkode={soknadsland[0]}
-              bucType={EKV.Koder.buctyper.legislation.LA_BUC_04}
+              bucType={bucType}
             />
           </Nav.Column>
         </Nav.Row>
@@ -156,6 +159,7 @@ VurderingVedtak.propTypes = {
   vedtakLastes: PT.bool.isRequired,
   visAntallManederUtland: PT.bool,
   pdfDokumenter: MPT.DokumentMetadataListe.isRequired,
+  erArtikkel11_4: PT.bool.isRequired,
 };
 
 VurderingVedtak.defaultProps = {
@@ -173,6 +177,7 @@ const mapStateToProps = state => ({
   vedtakLastes: vedtakSelectors.ErPendingSelector(state),
   formIsValid: isValid(KV.Form.ARTIKKEL_12_VEDTAK)(state),
   formValues: getFormValues(KV.Form.ARTIKKEL_12_VEDTAK)(state),
+  erArtikkel11_4: flytSelectors.ErIArtikkel11_4Selector(state),
   initialValues: {
     vedtakstypebegrunnelse: behandlingsresultatSelectors.BegrunnelseKoderSelector(state)[0],
     vedtakstype: behandlingsresultatSelectors.VedtakstypeSelector(state),

--- a/src/sider/saksbehandling/stegMap/vedtak.js
+++ b/src/sider/saksbehandling/stegMap/vedtak.js
@@ -37,7 +37,6 @@ class Vedtak extends Steg {
 
       const visSedLenkeForLovvalgsbestemmelser = [
         MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART12_1,
-        MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_4_2,
       ];
 
       if (lovvalgSomKodeTerm &&


### PR DESCRIPTION
- Fjerner forhpdnsvisnign av orienteringsbrev til arbeidsgiver for 11.4
- Bruker LA_BUC_05 i stedet for 04 i 11.4.