### PR TITLE
MELOSYS-3659 - Bugfiks: feil lagring av avklartefakta

### DIFF
--- a/src/felleskomponenter/sokkelskipliste/sokkelskipenkelt.js
+++ b/src/felleskomponenter/sokkelskipliste/sokkelskipenkelt.js
@@ -101,7 +101,7 @@ const SokkelSkipEnkelt = props => {
 
   const arbeidslandEndret = (land = {}) => {
     avklartefaktaEndretHandler(KV.Koder.referanseKoder.INSTALLASJON_ARBEIDSLAND, enhetNavn, land.kode);
-    avklartefaktaEndretHandler(MKV.Koder.avklartefaktatyper.ARBEIDSLAND, land.kode, KV.Koder.BoolskAvklartfaktaType.SANN);
+    avklartefaktaEndretHandler(MKV.Koder.avklartefaktatyper.ARBEIDSLAND, land.kode, land.kode);
     avklartefaktaEndretHandler(KV.Koder.referanseKoder.INSTALLASJON_ARBEIDSLAND_TYPE, enhetNavn, land.term);
   };
 

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVurderarbeidsland.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVurderarbeidsland.js
@@ -117,7 +117,7 @@ export const VurderingVurderarbeidsland = ({
     arbeidsland
       .filter(land => land)
       .forEach(land => {
-        oppdaterData(lagAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSLAND, land, KV.Koder.BoolskAvklartfaktaType.SANN, null));
+        oppdaterData(lagAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSLAND, land, land, null));
       });
   };
 
@@ -126,7 +126,7 @@ export const VurderingVurderarbeidsland = ({
   }, [arbeidsland.toString(), mounted]);
 
   const fjernSoknadsland = land => {
-    oppdaterData(lagAvklartfakta(KV.Koder.avklartefaktaKoder.FJERNET_ARBEIDSLAND, land, KV.Koder.BoolskAvklartfaktaType.SANN, null));
+    oppdaterData(lagAvklartfakta(KV.Koder.avklartefaktaKoder.FJERNET_ARBEIDSLAND, land, land, null));
   };
 
   const angreFjernSoknadsland = land => {


### PR DESCRIPTION
- Lagre arbeidsland under fakta-key for avklartefakta, i stedet for 'true'.