### PR TITLE
Ikke installer cypress binary i bygg

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           node-version: '12.3.1'
       - name: npm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: npm i
       - name: build css
         run: npm run build:css

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
           node-version: '12.3.1'
 
       - name: npm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: npm i
 
       - name: build css


### PR DESCRIPTION
- Lar være å installere cypress binary i bygget, siden vi ikke kjører cypress testene her uansett. Dette forkorter npm install med omtrent 1 minutt.