### PR TITLE
MELOSYS-3714 - Kunne ikke krysse av for marginalt arbeid

### DIFF
--- a/src/ducks/avklartefakta/selectors.js
+++ b/src/ducks/avklartefakta/selectors.js
@@ -325,7 +325,7 @@ export const ArbeidslandMedYrkesAktivitetSelector = createSelector(
 
 const MarginaltArbeidFaktaerSelector = createSelector(
   AvklartefaktaSelector,
-  avklartefakta => avklartefakta.filter(enkelt => enkelt.referanse === KV.Koder.avklartefaktaKoder.MARGINALT_ARBEID)
+  avklartefakta => avklartefakta.filter(enkelt => enkelt.referanse === MKV.Koder.avklartefaktatyper.MARGINALT_ARBEID)
 );
 
 const MarginaleArbeidslandFaktaerSelector = createSelector(

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.js
@@ -26,7 +26,7 @@ const LandLinje = props => {
 
   useEffect(() => {
     if (avklartMarginaltArbeidILand) {
-      oppdaterData(konverterTilStegData(KV.Koder.avklartefaktaKoder.MARGINALT_ARBEID, avklartMarginaltArbeidILand));
+      oppdaterData(konverterTilStegData(MKV.Koder.avklartefaktatyper.MARGINALT_ARBEID, avklartMarginaltArbeidILand));
     }
   }, []);
 
@@ -34,7 +34,7 @@ const LandLinje = props => {
 
   const klikkHandler = () => {
     const verdi = erMarginaltArbeidIArbeidsland ? BoolskAvklartfaktaType.USANN : BoolskAvklartfaktaType.SANN;
-    oppdaterData(lagAvklartfakta(KV.Koder.avklartefaktaKoder.MARGINALT_ARBEID, landKode.kode, verdi));
+    oppdaterData(lagAvklartfakta(MKV.Koder.avklartefaktatyper.MARGINALT_ARBEID, landKode.kode, verdi));
   };
 
   return (

--- a/src/sider/saksbehandling/stegMap/arbeidsmonster.js
+++ b/src/sider/saksbehandling/stegMap/arbeidsmonster.js
@@ -84,7 +84,7 @@ class Arbeidsmonster extends Steg {
       redigerbart: _propsLight.generiskStegRedigerbart,
     });
     this.beregnRelevantUI = _propsLight => {
-      const marginaltArbeid = hentFaktaListe(KV.Koder.avklartefaktaKoder.MARGINALT_ARBEID, _propsLight.avklartefakta);
+      const marginaltArbeid = hentFaktaListe(MKV.Koder.avklartefaktatyper.MARGINALT_ARBEID, _propsLight.avklartefakta);
 
       const landMedVesentligArbeid = this.hentLandMedVesentligArbeid(_propsLight.arbeidsland, marginaltArbeid);
       const erNorgeValgt = landMedVesentligArbeid.includes(MKV.Koder.landkoder.NO);


### PR DESCRIPTION
- Kunne ikke krysse av for marginalt arbeid i Arbeidsmønstersteg
- KV.Koder.avklartefaktaKoder.MARGINALT_ARBEID var fjernet, men referansene til koden var ikke oppdatert. Bruker nå MARGINALT_ARBEID fra kodeverk.