### PR TITLE
MELOSYS-3198 - Søknadsland mangler i dropdown

### DIFF
--- a/src/felleskomponenter/skjema/landvelger/LandVelger.js
+++ b/src/felleskomponenter/skjema/landvelger/LandVelger.js
@@ -3,17 +3,12 @@ import PT from 'prop-types';
 
 import MKV from '../../../melosyskodeverk';
 
-import * as KV from '../../../kodeverk';
 import EnkeltLand from './enkeltLand';
 import MultiLand from './multiLand';
 
+import { lagDatalistID, landTekstFormat } from './utils';
+
 import './landvelger.css';
-
-/** Hjelpere som deles av hovedkomponent og subkomponentene EnkeltLand og MultiLand */
-const landTekstFormat = landObjekt => (`${landObjekt.term} (${landObjekt.kode})`);
-const kodeTilObjekt = (kode, alleLandkoder) => alleLandkoder.find(enkeltKode => KV.objektTilKode(enkeltKode) === kode);
-
-const uuid = require('uuid/v4');
 
 /** Dette er inngangskomponent for MultiLand eller EnkeltLand. Disse avgjøres via
  * prop-type multiLand som er subkomponenter i landvelgeren.
@@ -21,7 +16,7 @@ const uuid = require('uuid/v4');
  */
 const LandVelger = props => {
   const { multiLand } = props;
-  const dataListID = `datalist-${uuid()}`;
+  const dataListID = lagDatalistID();
 
   return (
     <div>
@@ -51,7 +46,5 @@ LandVelger.defaultProps = {
   label: undefined,
   bredde: 'XL',
 };
-
-export { kodeTilObjekt, landTekstFormat };
 
 export default LandVelger;

--- a/src/felleskomponenter/skjema/landvelger/enkeltLand.js
+++ b/src/felleskomponenter/skjema/landvelger/enkeltLand.js
@@ -5,9 +5,10 @@ import { Field } from 'redux-form';
 import * as Utils from '../../../utils';
 import * as Nav from '../../../utils/navFrontend';
 import * as MPT from '../../../proptypes';
+import * as KV from '../../../kodeverk';
 import * as SkjemaUtils from '../utils';
 
-import { kodeTilObjekt, landTekstFormat } from './LandVelger';
+import { landTekstFormat } from './utils';
 
 import './landvelger.css';
 
@@ -20,7 +21,7 @@ export class EnkeltLand extends Component {
   componentDidMount = () => {
     const { value } = this.props.input;
     const { landkoder } = this.props;
-    const landkodeObjekt = value && kodeTilObjekt(value, landkoder);
+    const landkodeObjekt = value && KV.kodeTilObjekt(value, landkoder);
     const inputVerdi = landkodeObjekt ? landTekstFormat(landkodeObjekt) : '';
     this.setInputVerdi(inputVerdi);
   };

--- a/src/felleskomponenter/skjema/landvelger/enkeltLandPure.js
+++ b/src/felleskomponenter/skjema/landvelger/enkeltLandPure.js
@@ -4,7 +4,10 @@ import classnames from 'classnames';
 
 import * as Nav from '../../../utils/navFrontend';
 import * as MPT from '../../../proptypes';
+import * as Utils from '../../../utils';
 import { kodeTilObjekt, landTekstFormat } from './LandVelger';
+
+import MKV from '../../../melosyskodeverk';
 
 import './landvelger.css';
 
@@ -116,10 +119,12 @@ class EnkeltLandPure extends Component {
 
     const cl = classnames({ landliste__linje__input: true, [className]: true });
 
+    const dataListID = `datalist-${Utils._uuid()}`;
+
     return (
       <div>
         <Nav.Input
-          list="alleLand"
+          list={dataListID}
           label={label}
           bredde={bredde}
           feil={feilObjekt}
@@ -131,6 +136,13 @@ class EnkeltLandPure extends Component {
           onKeyDown={inputTastNedHandler}
           disabled={disabled}
         />
+        <div className="landliste__dataliste">
+          <datalist id={dataListID}>
+            {
+              MKV.KTObjects.landkoder.map(item => (<option key={item.kode} value={landTekstFormat(item)} />))
+            }
+          </datalist>
+        </div>
       </div>
     );
   }

--- a/src/felleskomponenter/skjema/landvelger/enkeltLandPure.js
+++ b/src/felleskomponenter/skjema/landvelger/enkeltLandPure.js
@@ -4,8 +4,9 @@ import classnames from 'classnames';
 
 import * as Nav from '../../../utils/navFrontend';
 import * as MPT from '../../../proptypes';
-import * as Utils from '../../../utils';
-import { kodeTilObjekt, landTekstFormat } from './LandVelger';
+import * as KV from '../../../kodeverk';
+
+import { landTekstFormat, lagDatalistID } from './utils';
 
 import MKV from '../../../melosyskodeverk';
 
@@ -35,7 +36,7 @@ class EnkeltLandPure extends Component {
   oppdaterInputVerdi = () => {
     const { value } = this.props;
     const { landkoder } = this.props;
-    const landkodeObjekt = value && kodeTilObjekt(value, landkoder);
+    const landkodeObjekt = value && KV.kodeTilObjekt(value, landkoder);
     const inputVerdi = landkodeObjekt ? landTekstFormat(landkodeObjekt) : '';
     this.setInputVerdi(inputVerdi);
   };
@@ -119,7 +120,7 @@ class EnkeltLandPure extends Component {
 
     const cl = classnames({ landliste__linje__input: true, [className]: true });
 
-    const dataListID = `datalist-${Utils._uuid()}`;
+    const dataListID = lagDatalistID();
 
     return (
       <div>

--- a/src/felleskomponenter/skjema/landvelger/enkeltLandPure.test.js
+++ b/src/felleskomponenter/skjema/landvelger/enkeltLandPure.test.js
@@ -25,6 +25,14 @@ describe('EnkeltLandPure', () => {
     expect(input.props().bredde).toBe(props.bredde);
   });
 
+  it('viser en datalist som er koblet til inputfelt', () => {
+    const enkeltLandPure = shallow(<EnkeltLandPure {...props} />);
+    const input = enkeltLandPure.find('Input');
+    const datalist = enkeltLandPure.find('datalist');
+
+    expect(input.props().list).toBe(datalist.props().id);
+  });
+
   describe('ved endring av tekst', () => {
     it('sendes tekst som value prop til nav input-komponent', () => {
       const enkeltLandPure = shallow(<EnkeltLandPure {...props} />);

--- a/src/felleskomponenter/skjema/landvelger/index.js
+++ b/src/felleskomponenter/skjema/landvelger/index.js
@@ -1,5 +1,5 @@
-import Landvelger, { landTekstFormat } from './LandVelger';
+import Landvelger from './LandVelger';
 import EnkeltLandPure from './enkeltLandPure';
 
-export { EnkeltLandPure, landTekstFormat };
+export { EnkeltLandPure };
 export default Landvelger;

--- a/src/felleskomponenter/skjema/landvelger/multiLand.js
+++ b/src/felleskomponenter/skjema/landvelger/multiLand.js
@@ -7,7 +7,7 @@ import * as Nav from '../../../utils/navFrontend';
 import * as KV from '../../../kodeverk';
 import * as SkjemaUtils from '../utils';
 
-import { kodeTilObjekt, landTekstFormat } from './LandVelger';
+import { landTekstFormat } from './utils';
 
 import * as MPT from '../../../proptypes';
 import './landvelger.css';
@@ -124,7 +124,7 @@ function MultiLand(props) {
   return (
     <div className="landliste">
       {
-        props.landkoder.length > 0 && valgteLand.map(land => <MultiLandEnkelt key={land} slettLandHandler={slettLandHandler} landObjekt={kodeTilObjekt(land, props.landkoder)} />)
+        props.landkoder.length > 0 && valgteLand.map(land => <MultiLandEnkelt key={land} slettLandHandler={slettLandHandler} landObjekt={KV.kodeTilObjekt(land, props.landkoder)} />)
       }
       <div className="landliste__leggtil">
         <Nav.Input

--- a/src/felleskomponenter/skjema/landvelger/utils.js
+++ b/src/felleskomponenter/skjema/landvelger/utils.js
@@ -1,0 +1,4 @@
+import * as Utils from '../../../utils';
+
+export const lagDatalistID = () => `datalist-${Utils._uuid()}`;
+export const landTekstFormat = landObjekt => (`${landObjekt.term} (${landObjekt.kode})`);

--- a/src/felleskomponenter/skjema/landvelger/utils.test.js
+++ b/src/felleskomponenter/skjema/landvelger/utils.test.js
@@ -1,0 +1,23 @@
+import { lagDatalistID, landTekstFormat } from './utils';
+
+import * as KV from '../../../kodeverk';
+import MKV from '../../../melosyskodeverk';
+
+describe('Landvelger Utils', () => {
+  describe('lagDatalistID', () => {
+    it('returnerer en string', () => {
+      const datalistID = lagDatalistID();
+
+      expect(datalistID.includes('datalist-')).toBe(true);
+    });
+  });
+
+  describe('landTekstFormat', () => {
+    it('returnerer en formattert string med land og landkode', () => {
+      const KTObject = KV.kodeTilObjekt(MKV.Koder.landkoder.DE, MKV.KTObjects.landkoder);
+      const formattertString = landTekstFormat(KTObject);
+
+      expect(formattertString).toBe('Tyskland (DE)');
+    });
+  });
+});

--- a/src/felleskomponenter/stegvelger/stegKomponenter/inngang/soknadslandHandlingLeggTil.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/inngang/soknadslandHandlingLeggTil.js
@@ -2,13 +2,10 @@
 import React, { useState } from 'react';
 import PT from 'prop-types';
 import Ikon from 'melosys-ikoner-assets';
-import * as KV from '../../../../kodeverk';
 import * as Nav from '../../../../utils/navFrontend';
 import * as MPT from '../../../../proptypes';
 
 import EnkeltLandPure from '../../../skjema/landvelger/enkeltLandPure';
-
-import { landTekstFormat } from '../../../skjema/landvelger';
 
 import './soknadslandHandlingLeggTil.css';
 
@@ -102,11 +99,6 @@ function SoknadslandHandlingLeggTil(props) {
             redigerbart={redigerbart}
           />
         )}
-      </div>
-      <div className="soknadsland__dataliste">
-        <datalist id="alleLand">
-          {alleLandkoder.map(item => (<option key={KV.objektTilKode(item)} value={landTekstFormat(item)} />))}
-        </datalist>
       </div>
     </div>
   );


### PR DESCRIPTION
- Fikser bug hvor søknadsland oppgitt i Inngangssteget ikke dukket opp i landvelger i forretningsstedsteget. Feilen var at det ble brukt samme datalist i forretningsstedsteget som ble brukt i inngangssteget for å legge til søknadsland.
- Flyttet på noen hjelpemetoder i LandVelger.js som passer bedre i landvelger/utils.js.