### PR TITLE
MELOSYS-3707 - Bruk POST for forhåndsvisning av sed

### DIFF
--- a/src/ducks/dokumenter/operations.js
+++ b/src/ducks/dokumenter/operations.js
@@ -50,7 +50,7 @@ export async function forhandsvisBrev(behandlingID, dokumenttypeKode, data) {
 }
 
 export async function forhandsvisSed(behandlingID, sedType, data) {
-  const vilSendeAnmodningOmMerInformasjon = data.vilSendeAnmodningOmMerInformasjon || data.vilSendeAnmodningOmMerInformasjon === false ? false : null;
+  const vilSendeAnmodningOmMerInformasjon = data.vilSendeAnmodningOmMerInformasjon || (data.vilSendeAnmodningOmMerInformasjon === false ? false : null);
 
   const utfyltdata = {
     fritekst: data.fritekst || null,

--- a/src/ducks/dokumenter/operations.js
+++ b/src/ducks/dokumenter/operations.js
@@ -49,8 +49,17 @@ export async function forhandsvisBrev(behandlingID, dokumenttypeKode, data) {
   return false;
 }
 
-export async function forhandsvisSed(behandlingID, sedType) {
-  const response = await Api.Dokumenter.pdf.forhandsvisSed(behandlingID, sedType);
+export async function forhandsvisSed(behandlingID, sedType, data) {
+  const vilSendeAnmodningOmMerInformasjon = data.vilSendeAnmodningOmMerInformasjon || data.vilSendeAnmodningOmMerInformasjon === false ? false : null;
+
+  const utfyltdata = {
+    fritekst: data.fritekst || null,
+    nyttLovvalgsland: data.nyttLovvalgsland || null,
+    begrunnelseUtenlandskMyndighet: data.begrunnelseUtenlandskMyndighet || null,
+    vilSendeAnmodningOmMerInformasjon,
+  };
+
+  const response = await Api.Dokumenter.pdf.forhandsvisSed(behandlingID, sedType, utfyltdata);
 
   if (response.ok) {
     return getObjectURL(response);

--- a/src/felleskomponenter/pdfLenkeListe/index.js
+++ b/src/felleskomponenter/pdfLenkeListe/index.js
@@ -32,10 +32,12 @@ class PdfLenkeListe extends Component {
     let fileURL;
 
     try {
+      const data = dokument.data || {};
+
       if (dokument.erSed) {
-        fileURL = await dokumenterOperations.forhandsvisSed(behandlingID, dokument.type);
+        fileURL = await dokumenterOperations.forhandsvisSed(behandlingID, dokument.type, data);
       } else {
-        fileURL = await dokumenterOperations.forhandsvisBrev(behandlingID, dokument.type, dokument.data);
+        fileURL = await dokumenterOperations.forhandsvisBrev(behandlingID, dokument.type, data);
       }
     } catch (e) {
       if (e.status >= 500) {

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingAvslaaUtpeking.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingAvslaaUtpeking.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PT from 'prop-types';
 import { connect } from 'react-redux';
-import { reduxForm } from 'redux-form';
+import { reduxForm, formValueSelector, isValid } from 'redux-form';
 import * as EKV from 'eessi-kodeverk';
 
 import * as Nav from '../../../utils/navFrontend';
@@ -12,6 +12,7 @@ import * as Mui from '../../../felleskomponenter/ui';
 import PdfLenkeListe from '../../../felleskomponenter/pdfLenkeListe';
 
 import { behandlingerSelectors } from '../../../ducks/behandlinger';
+import { formOperations } from '../../../ducks/form';
 
 import { lagYupToReduxformErrorMapper, Skjemaer as YupSkjemaer } from '../../../yup';
 
@@ -19,14 +20,35 @@ export const VurderingAvslaaUtpeking = ({
   redigerbart,
   behandlingID,
   handleSubmit,
+  fritekst,
+  nyttLovvalgsland,
+  begrunnelseUtenlandskMyndighet,
+  vilSendeAnmodningOmMerInformasjon,
+  touchAll,
+  formIsValid,
 }) => {
   const pdfDokumenter = [
     {
       navn: 'Forhåndsvis SED A004',
       type: EKV.Koder.sedtyper.A004,
       erSed: true,
+      data: {
+        fritekst,
+        nyttLovvalgsland,
+        begrunnelseUtenlandskMyndighet,
+        vilSendeAnmodningOmMerInformasjon,
+      },
     },
   ];
+
+  const vedKlikkForhandsvis = () => {
+    if (!formIsValid) {
+      touchAll();
+      return false;
+    }
+
+    return formIsValid;
+  };
 
   return (
     <form onSubmit={handleSubmit}>
@@ -57,7 +79,7 @@ export const VurderingAvslaaUtpeking = ({
             visTellerFra={500}
             maxLength={500}
           />
-          <PdfLenkeListe behandlingID={behandlingID} dokumenter={pdfDokumenter} />
+          <PdfLenkeListe behandlingID={behandlingID} dokumenter={pdfDokumenter} vedKlikk={vedKlikkForhandsvis} />
         </Fragment>
       }
       <Mui.Knapp mini disabled={!redigerbart} htmlType="submit" type="hoved">AVSLUTT OG SEND SED</Mui.Knapp>
@@ -70,12 +92,34 @@ VurderingAvslaaUtpeking.propTypes = {
   behandlingID: PT.number.isRequired,
   handleSubmit: PT.func.isRequired,
   avvisUtpeking: PT.func.isRequired,
+  fritekst: PT.string,
+  nyttLovvalgsland: PT.string,
+  begrunnelseUtenlandskMyndighet: PT.string,
+  vilSendeAnmodningOmMerInformasjon: PT.bool,
+  touchAll: PT.func.isRequired,
+  formIsValid: PT.bool.isRequired,
 };
 
-VurderingAvslaaUtpeking.defaultProps = {};
+VurderingAvslaaUtpeking.defaultProps = {
+  fritekst: '',
+  nyttLovvalgsland: '',
+  begrunnelseUtenlandskMyndighet: '',
+  vilSendeAnmodningOmMerInformasjon: false,
+};
+
+const avslaaUtpekingFormValueSelector = formValueSelector(KV.Form.AVSLAA_UTPEKING);
 
 const mapStateToProps = state => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
+  fritekst: avslaaUtpekingFormValueSelector(state, 'fritekst'),
+  nyttLovvalgsland: avslaaUtpekingFormValueSelector(state, 'nyttLovvalgsland'),
+  begrunnelseUtenlandskMyndighet: avslaaUtpekingFormValueSelector(state, 'begrunnelseUtenlandskMyndighet'),
+  vilSendeAnmodningOmMerInformasjon: avslaaUtpekingFormValueSelector(state, 'vilSendeAnmodningOmMerInformasjon'),
+  formIsValid: isValid(KV.Form.AVSLAA_UTPEKING)(state),
+});
+
+const mapDispatchToProps = dispatch => ({
+  touchAll: () => dispatch(formOperations.touchAll(KV.Form.AVSLAA_UTPEKING)),
 });
 
 const avsluttOgSendSed = (values, dispatch, props) => {
@@ -99,4 +143,4 @@ const VurderingAvslaaUtpekingForm = reduxForm({
   validate: lagYupToReduxformErrorMapper(YupSkjemaer.avslaa_utpeking),
 })(VurderingAvslaaUtpeking);
 
-export default connect(mapStateToProps)(VurderingAvslaaUtpekingForm);
+export default connect(mapStateToProps, mapDispatchToProps)(VurderingAvslaaUtpekingForm);

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingAvslaaUtpeking.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingAvslaaUtpeking.test.js
@@ -15,6 +15,12 @@ describe('VurderingAvslaaUtpeking', () => {
       behandlingID: 4,
       handleSubmit: jest.fn(),
       avvisUtpeking: jest.fn(),
+      fritekst: '',
+      nyttLovvalgsland: 'CZ',
+      begrunnelseUtenlandskMyndighet: 'Begrunnelse',
+      vilSendeAnmodningOmMerInformasjon: true,
+      touchAll: jest.fn(),
+      formIsValid: true,
     };
   });
 

--- a/src/services/modules/dokumenter/pdf/utkast.js
+++ b/src/services/modules/dokumenter/pdf/utkast.js
@@ -1,4 +1,4 @@
-import { getAsPDF, postAsJsonReceiveAsPDF } from '../../../utils';
+import { postAsJsonReceiveAsPDF } from '../../../utils';
 import { API_BASE_URL, DOKUMENTER } from '../../../api-constants';
 
 
@@ -11,5 +11,4 @@ import { API_BASE_URL, DOKUMENTER } from '../../../api-constants';
  */
 export const forhandsvisBrev = (behandlingID, produserbartDokument, data) => postAsJsonReceiveAsPDF(`${API_BASE_URL}${DOKUMENTER}/pdf/brev/utkast/${behandlingID}/${produserbartDokument}`, data, true);
 
-export const forhandsvisSed = (behandlingID, sedType) => getAsPDF(`${API_BASE_URL}${DOKUMENTER}/pdf/sed/utkast/${behandlingID}/${sedType}`, true);
-
+export const forhandsvisSed = (behandlingID, sedType, data) => postAsJsonReceiveAsPDF(`${API_BASE_URL}${DOKUMENTER}/pdf/sed/utkast/${behandlingID}/${sedType}`, data, true);


### PR DESCRIPTION
- Forhåndsvisning av sed er nå en POST
- Legger til validering av felter når man forhåndsviser A004 ved avslag av motatt A003

Mock: https://github.com/navikt/melosys-web-mock/pull/304
Schema: https://github.com/navikt/melosys-schema/pull/152