### PR TITLE
MELOSYS-3680 - Feilmelding ved vedtak: default til tekst fra kodeverk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9969,9 +9969,9 @@
       "integrity": "sha512-4FSoNCc2zDrH3QK3ok0fifcryNX7tIORaCvRI/JdwhsaEBAEfR1n42t98sPfnUG68erEMgSnautp76+HIjBseQ=="
     },
     "melosys-kodeverk": {
-      "version": "5.15.17",
-      "resolved": "https://registry.npmjs.org/melosys-kodeverk/-/melosys-kodeverk-5.15.17.tgz",
-      "integrity": "sha512-etktonVol9/KDtP1CLsyuvwbxuD/2Z+PpDoKcq6sDzX0WRQzcUIIydbVj3HhmiWGTjeI+H0rCQLF8VgWmg0l0g=="
+      "version": "5.15.22",
+      "resolved": "https://registry.npmjs.org/melosys-kodeverk/-/melosys-kodeverk-5.15.22.tgz",
+      "integrity": "sha512-ym2slVzIFyZ97tq9pIexRaHZ8USVdxl4iYK3eAXBiXI3kDiSdY+Wlp8iyF1qGCoqkdzWg1eMZqdqx8oe0C5GGw=="
     },
     "mem": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.15",
     "lodash.throttle": "^4.1.1",
     "melosys-ikoner-assets": "^1.0.1",
-    "melosys-kodeverk": "5.15.17",
+    "melosys-kodeverk": "5.15.22",
     "moment": "^2.24.0",
     "moment-duration-format": "^2.3.2",
     "moment-timezone": "^0.5.27",

--- a/src/felleskomponenter/dialogboks/dialogboksValidering.js
+++ b/src/felleskomponenter/dialogboks/dialogboksValidering.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PT from 'prop-types';
 
 import * as Nav from '../../utils/navFrontend';
+import * as KV from '../../kodeverk';
 
 import MKV from '../../melosyskodeverk';
 
@@ -19,7 +20,17 @@ const feilmeldingMap = {
 };
 
 const hentFeilmelding = valideringKode => {
-  const feilmelding = feilmeldingMap[valideringKode];
+  let feilmelding = feilmeldingMap[valideringKode];
+
+  if (!feilmelding) {
+    const valideringKodeObjekt = KV.kodeTilObjekt(valideringKode, MKV.KTObjects.begrunnelser.kontroll_begrunnelser);
+    if (valideringKodeObjekt) {
+      feilmelding = {
+        tittel: 'Feil ved kontroll',
+        innhold: valideringKodeObjekt.term,
+      };
+    }
+  }
 
   if (!feilmelding) {
     return {

--- a/src/felleskomponenter/dialogboks/dialogboksValidering.test.js
+++ b/src/felleskomponenter/dialogboks/dialogboksValidering.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import * as Nav from '../../utils/navFrontend';
+import * as KV from '../../kodeverk';
 
 import DialogboksValidering from './dialogboksValidering';
 import MKV from '../../melosyskodeverk';
@@ -39,5 +40,24 @@ describe('DialogboksValidering', () => {
 
     expect(valideringer).toHaveLength(1);
     expect(valideringer.find(Nav.typo.Element).first().children().text()).toBe('Ukjent feil');
+  });
+
+  it('viser feilmelding fra kodeverk dersom ingen mapping for feilmelding finnes', () => {
+    props.valideringer = [
+      MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
+    ];
+    const dialogboksValidering = shallow(<DialogboksValidering {...props} />);
+
+    const valideringer = dialogboksValidering.find('div');
+    expect(valideringer).toHaveLength(1);
+
+    const elementer = valideringer.find(Nav.typo.Element);
+    const tekstomrader = valideringer.find(Nav.Tekstomrade);
+
+    expect(elementer.first().children().text()).toBe('Feil ved kontroll');
+    expect(tekstomrader.first().children().text()).toBe(KV.kodeTilTerm(
+      MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
+      MKV.KTObjects.begrunnelser.kontroll_begrunnelser
+    ));
   });
 });


### PR DESCRIPTION
- Forsøker å benytte tekst fra kodeverk til feilmelding ved vedtak, dersom vi ikke eksplisitt har oppgitt en feilmelding i frontend tilsvarende feilkoden.