### PR TITLE
Prodfikser uke 20

### DIFF
--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -58,6 +58,7 @@ export const lastInnSaksopplysningerBehandleMottattAOU = (behandlingID, anmodnin
   dispatch => {
     try {
       dispatch(behandlingerOperations.hentBehandling(behandlingID));
+      dispatch(behandlingsresultatOperations.hent(behandlingID));
       dispatch(anmodningsperioderOperations.hent(behandlingID));
       dispatch(anmodningsperiodesvarOperations.hent(anmodningsperiodeID));
     } catch (e) {

--- a/src/felleskomponenter/stegvelger/stegKomponenter/felles/multiVilkaar.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/felles/multiVilkaar.js
@@ -53,6 +53,10 @@ class MultiVilkaar extends Component {
     oppdaterData(lagBegrunnelse(id, null, value));
   };
 
+  hentAvslagBegrunnelser = () => (
+    this.props.vilkaar16 ? (this.props.vilkaar16.begrunnelseKoder || []) : []
+  );
+
   render () {
     const {
       redigerbart, vilkaar12, vilkaarKode12, vilkaarNavn12, begrunnelser12, vilkaar16,
@@ -61,6 +65,7 @@ class MultiVilkaar extends Component {
     const innvilgelse = vilkaar12.oppfylt;
     const anmodningOmUnntak = vilkaar12.oppfylt === false && vilkaar16.oppfylt === true;
     const avslag = vilkaar12.oppfylt === false && vilkaar16.oppfylt === false;
+    const visFritekstfelt = this.hentAvslagBegrunnelser().includes(MKV.Koder.begrunnelser.art16_1_avslag.SAERLIG_AVSLAGSGRUNN);
 
     return (
       <div>
@@ -120,15 +125,17 @@ class MultiVilkaar extends Component {
                     defaultElementer={vilkaar16.begrunnelseKoder}
                     disabled={!redigerbart}
                   />
-                  <Nav.Textarea
-                    id="art16_1_avslag"
-                    label="Begrunnelse for avslag (fritekst):"
-                    maxLength={255}
-                    bredde="fullbredde"
-                    value={vilkaar16.begrunnelseFritekst || ''}
-                    onChange={this.fritekstEndret}
-                    disabled={!redigerbart}
-                  />
+                  { visFritekstfelt &&
+                    <Nav.Textarea
+                      id="art16_1_avslag"
+                      label="Begrunnelse for avslag (fritekst):"
+                      maxLength={255}
+                      bredde="fullbredde"
+                      value={vilkaar16.begrunnelseFritekst || ''}
+                      onChange={this.fritekstEndret}
+                      disabled={!redigerbart}
+                    />
+                  }
                 </Nav.Fieldset>
               )}
             </Nav.Column>

--- a/src/sider/registrering/anmodningunntak/saksopplysninger.js
+++ b/src/sider/registrering/anmodningunntak/saksopplysninger.js
@@ -261,7 +261,7 @@ const Saksopplysninger = ({
       <form name="anmodningunntak" id="anmodningunntak" onSubmit={overstyrSubmit}>
         <div className="stegvelger panelSeksjon">
           <div className="panel stegFane steg0 stegFane--aktiv">
-            <Nav.typo.Systemtittel>Behandle anmodning om unntak</Nav.typo.Systemtittel>
+            <Nav.typo.Systemtittel>Vurder anmodning om unntak</Nav.typo.Systemtittel>
             <br />
             <div className="vurderUnntaksperiode">
               <Nav.Row className="seksjon">
@@ -331,7 +331,7 @@ const Saksopplysninger = ({
                           <Nav.Column xs="6">
                             <Nav.Textarea
                               disabled={!redigerbart}
-                              label="Skriv inn begrunnelse for delvis innvilgelse..."
+                              label="Skriv begrunnelse til SED"
                               onChange={textAreaOnChange}
                               value={begrunnelseFritekst}
                               maxLength={255}
@@ -356,7 +356,7 @@ const Saksopplysninger = ({
                   <Nav.Column xs="6">
                     <Nav.Textarea
                       disabled={!redigerbart}
-                      label="Skriv inn begrunnelse for avslaget..."
+                      label="Skriv begrunnelse til SED"
                       onChange={textAreaOnChange}
                       value={begrunnelseFritekst}
                       maxLength={255}

--- a/src/sider/registrering/anmodningunntak/saksopplysninger.js
+++ b/src/sider/registrering/anmodningunntak/saksopplysninger.js
@@ -275,17 +275,17 @@ const Saksopplysninger = ({
                   <DatoOmradeMedVarighet periode={sed.lovvalgsperiode} label="Søknadsperiode" />
                 </Nav.Column>
               </Nav.Row>
-              <Nav.Row className="seksjon">
-                <Nav.Column xs="12">
-                  {
-                    vurderingBegrunnelser.length > 0 &&
+              {
+                vurderingBegrunnelser.length > 0 &&
+                <Nav.Row className="seksjon">
+                  <Nav.Column xs="12">
                     <Fragment>
                       <Nav.typo.Element>Treff ved automatisk kontroll</Nav.typo.Element>
                       <RegisterkontrollTreff vurderingBegrunnelser={vurderingBegrunnelser} />
                     </Fragment>
-                  }
-                </Nav.Column>
-              </Nav.Row>
+                  </Nav.Column>
+                </Nav.Row>
+              }
               <Nav.Row className="seksjon">
                 <Nav.Column xs="12">
                   <Nav.Fieldset legend="Vurder unntaksperiode" disabled={!redigerbart}>

--- a/src/sider/registrering/unntaksperioder/saksopplysninger.js
+++ b/src/sider/registrering/unntaksperioder/saksopplysninger.js
@@ -271,17 +271,16 @@ const Saksopplysninger = ({
             <Nav.typo.Systemtittel>Registrering av unntaksperioder</Nav.typo.Systemtittel>
             <br />
             <div className="vurderingEndrePeriode">
-              <Nav.Row className="seksjon">
-                <Nav.Column xs="12">
-                  {
-                    vurderingBegrunnelser.length > 0 &&
+              { vurderingBegrunnelser.length > 0 &&
+                <Nav.Row className="seksjon">
+                  <Nav.Column xs="12">
                     <Fragment>
                       <Nav.typo.Element>Treff ved automatisk kontroll</Nav.typo.Element>
                       <RegisterkontrollTreff vurderingBegrunnelser={vurderingBegrunnelser} />
                     </Fragment>
-                  }
-                </Nav.Column>
-              </Nav.Row>
+                  </Nav.Column>
+                </Nav.Row>
+              }
               <Nav.Row className="seksjon">
                 <Nav.Column xs="12">
                   <Nav.Fieldset legend="Vurder unntaksperiode" disabled={!redigerbart}>


### PR DESCRIPTION
Samler flere bugs for å få de ut i test (og prod) samtidig. Ser ut til at dette er alle som gjelder frontend nå.

- **MELOSYS-3132** - Vis fritekst for avslag kun dersom særlig avslagsgrunn er valgt
- **MELOSYS-3612** - Tekstendringer A001 inn
- **MELOSYS-3658** - Hent behandlingsresultat for å kunne vise kontrollresultater
