### PR TITLE
MELOSYS-3753 - Utfall utpeking innsyn

### DIFF
--- a/src/ducks/behandlingsresultat/selectors.js
+++ b/src/ducks/behandlingsresultat/selectors.js
@@ -36,23 +36,13 @@ export const KontrollresultatBegrunnelseKoderSelector = createSelector(
   behandlingsresultat => behandlingsresultat.kontrollresultatBegrunnelseKoder
 );
 
-const UtfallRegistreringUnntakSelector = createSelector(
+export const UtfallRegistreringUnntakSelector = createSelector(
   BehandlingsresultatSelector,
   behandlingsresultat => behandlingsresultat.utfallRegistreringUnntak
 );
 
-const UtfallUtpekingSelector = createSelector(
+export const UtfallUtpekingSelector = createSelector(
   BehandlingsresultatSelector,
   behandlingsresultat => behandlingsresultat.utfallUtpeking
 );
 
-export const UtpekingVurderingSelector = createSelector(
-  state => BehandlingstemaKodeSelector(state),
-  UtfallRegistreringUnntakSelector,
-  UtfallUtpekingSelector,
-  (behandlingstema, utfallRegistreringUnntak, utfallUtpeking) => (
-    behandlingstema === MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND
-      ? utfallRegistreringUnntak
-      : utfallUtpeking
-  )
-);

--- a/src/ducks/behandlingsresultat/selectors.js
+++ b/src/ducks/behandlingsresultat/selectors.js
@@ -7,9 +7,6 @@
 
 import { createSelector } from 'reselect';
 
-import MKV from '../../melosyskodeverk';
-import { BehandlingstemaKodeSelector } from '../behandlinger/selectors';
-
 /* eslint import/prefer-default-export:"off" */
 export const BehandlingsresultatSelector = createSelector(
   state => (state.behandlingsresultat ? state.behandlingsresultat.data : []),

--- a/src/ducks/behandlingsresultat/selectors.js
+++ b/src/ducks/behandlingsresultat/selectors.js
@@ -37,3 +37,8 @@ export const UtfallRegistreringUnntakSelector = createSelector(
   BehandlingsresultatSelector,
   behandlingsresultat => behandlingsresultat.utfallRegistreringUnntak
 );
+
+export const UtfallUtpekingSelector = createSelector(
+  BehandlingsresultatSelector,
+  behandlingsresultat => behandlingsresultat.utfallUtpeking
+);

--- a/src/ducks/behandlingsresultat/selectors.js
+++ b/src/ducks/behandlingsresultat/selectors.js
@@ -7,6 +7,9 @@
 
 import { createSelector } from 'reselect';
 
+import MKV from '../../melosyskodeverk';
+import { BehandlingstemaKodeSelector } from '../behandlinger/selectors';
+
 /* eslint import/prefer-default-export:"off" */
 export const BehandlingsresultatSelector = createSelector(
   state => (state.behandlingsresultat ? state.behandlingsresultat.data : []),
@@ -33,12 +36,23 @@ export const KontrollresultatBegrunnelseKoderSelector = createSelector(
   behandlingsresultat => behandlingsresultat.kontrollresultatBegrunnelseKoder
 );
 
-export const UtfallRegistreringUnntakSelector = createSelector(
+const UtfallRegistreringUnntakSelector = createSelector(
   BehandlingsresultatSelector,
   behandlingsresultat => behandlingsresultat.utfallRegistreringUnntak
 );
 
-export const UtfallUtpekingSelector = createSelector(
+const UtfallUtpekingSelector = createSelector(
   BehandlingsresultatSelector,
   behandlingsresultat => behandlingsresultat.utfallUtpeking
+);
+
+export const UtpekingVurderingSelector = createSelector(
+  state => BehandlingstemaKodeSelector(state),
+  UtfallRegistreringUnntakSelector,
+  UtfallUtpekingSelector,
+  (behandlingstema, utfallRegistreringUnntak, utfallUtpeking) => (
+    behandlingstema === MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND
+      ? utfallRegistreringUnntak
+      : utfallUtpeking
+  )
 );

--- a/src/ducks/behandlingsresultat/selectors.test.js
+++ b/src/ducks/behandlingsresultat/selectors.test.js
@@ -1,0 +1,40 @@
+import * as selectors from './selectors';
+import MKV from '../../melosyskodeverk';
+
+describe('BehandlingsresultatSelectors', () => {
+  describe('UtpekingVurderingSelector', () => {
+    const lagState = behandlingstema => ({
+      behandlinger: {
+        data: {
+          oppsummering: {
+            behandlingstema: {
+              kode: behandlingstema,
+            },
+          },
+        },
+      },
+      behandlingsresultat: {
+        data: {
+          utfallRegistreringUnntak: MKV.Koder.utfallregistreringunntak.GODKJENT,
+          utfallUtpeking: MKV.Koder.utfallregistreringunntak.IKKE_GODKJENT,
+        },
+      },
+    });
+
+    each([
+      [
+        MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND,
+        MKV.Koder.utfallregistreringunntak.GODKJENT,
+      ],
+      [
+        MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE,
+        MKV.Koder.utfallregistreringunntak.IKKE_GODKJENT,
+      ],
+    ]).describe('UtpekginVurderingSelector med behandlingstema %p', (behandlingstema, forventet) => {
+      it(`returnerer ${forventet}`, () => {
+        const state = lagState(behandlingstema);
+        expect(selectors.UtpekingVurderingSelector(state)).toBe(forventet);
+      });
+    });
+  });
+});

--- a/src/ducks/flyt/selectors.js
+++ b/src/ducks/flyt/selectors.js
@@ -1,9 +1,12 @@
 import { createSelector } from 'reselect';
 
+import MKV from '../../melosyskodeverk';
 import * as KV from '../../kodeverk';
 
 import { avklartefaktaSelectors } from '../avklartefakta';
 import { vilkarSelectors } from '../vilkar';
+import { behandlingerSelectors } from '../behandlinger';
+import { behandlingsresultatSelectors } from '../behandlingsresultat';
 
 export const ErIArtikkel11_4Selector = createSelector(
   state => vilkarSelectors.art11_4_1(state),
@@ -24,4 +27,15 @@ export const HarOffentligTjenesteAnnetLandSelector = createSelector(
 export const HarLonnetArbeidAnnetLand = createSelector(
   state => avklartefaktaSelectors.LoennetArbeidAntallLandFaktaVerdiSelector(state),
   loennetArbeidAntallLand => loennetArbeidAntallLand === KV.Koder.LoennetArbeidAntallLand.ETT_ANNET_LAND
+);
+
+export const UtpekingVurderingSelector = createSelector(
+  state => behandlingerSelectors.BehandlingstemaKodeSelector(state),
+  state => behandlingsresultatSelectors.UtfallRegistreringUnntakSelector(state),
+  state => behandlingsresultatSelectors.UtfallUtpekingSelector(state),
+  (behandlingstema, utfallRegistreringUnntak, utfallUtpeking) => (
+    behandlingstema === MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND
+      ? utfallRegistreringUnntak
+      : utfallUtpeking
+  )
 );

--- a/src/ducks/flyt/selectors.js
+++ b/src/ducks/flyt/selectors.js
@@ -31,8 +31,8 @@ export const HarLonnetArbeidAnnetLand = createSelector(
 
 export const UtpekingVurderingSelector = createSelector(
   state => behandlingerSelectors.BehandlingstemaKodeSelector(state),
-  state => behandlingsresultatSelectors.UtfallRegistreringUnntakSelector(state),
-  state => behandlingsresultatSelectors.UtfallUtpekingSelector(state),
+  behandlingsresultatSelectors.UtfallRegistreringUnntakSelector,
+  behandlingsresultatSelectors.UtfallUtpekingSelector,
   (behandlingstema, utfallRegistreringUnntak, utfallUtpeking) => (
     behandlingstema === MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND
       ? utfallRegistreringUnntak

--- a/src/ducks/flyt/selectors.test.js
+++ b/src/ducks/flyt/selectors.test.js
@@ -1,7 +1,7 @@
 import * as selectors from './selectors';
 import MKV from '../../melosyskodeverk';
 
-describe('BehandlingsresultatSelectors', () => {
+describe('FlytSelectors', () => {
   describe('UtpekingVurderingSelector', () => {
     const lagState = behandlingstema => ({
       behandlinger: {
@@ -30,7 +30,7 @@ describe('BehandlingsresultatSelectors', () => {
         MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE,
         MKV.Koder.utfallregistreringunntak.IKKE_GODKJENT,
       ],
-    ]).describe('UtpekginVurderingSelector med behandlingstema %p', (behandlingstema, forventet) => {
+    ]).describe('UtpekingVurderingSelector med behandlingstema %p', (behandlingstema, forventet) => {
       it(`returnerer ${forventet}`, () => {
         const state = lagState(behandlingstema);
         expect(selectors.UtpekingVurderingSelector(state)).toBe(forventet);

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.js
@@ -228,7 +228,7 @@ const mapStateToProps = (state, ownProps) => ({
     tom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeTomSelector(state)),
     lovvalgsbestemmelse: ownProps.tilstand.lovvalgsbestemmelse || '',
     lovvalgsland: ownProps.tilstand.lovvalgsland,
-    utpekingVurdering: behandlingsresultatSelectors.UtfallRegistreringUnntakSelector(state),
+    utpekingVurdering: behandlingsresultatSelectors.UtfallUtpekingSelector(state),
     overgangsregelbestemmelser: behandlingsgrunnlagSelectors.OvergangsregelbestemmelserSelector(state).map(o => o.kode),
   },
   vurderingBegrunnelser: behandlingsresultatSelectors.KontrollresultatBegrunnelseKoderSelector(state),

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.js
@@ -228,7 +228,7 @@ const mapStateToProps = (state, ownProps) => ({
     tom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeTomSelector(state)),
     lovvalgsbestemmelse: ownProps.tilstand.lovvalgsbestemmelse || '',
     lovvalgsland: ownProps.tilstand.lovvalgsland,
-    utpekingVurdering: behandlingsresultatSelectors.UtfallUtpekingSelector(state),
+    utpekingVurdering: behandlingsresultatSelectors.UtpekingVurderingSelector(state),
     overgangsregelbestemmelser: behandlingsgrunnlagSelectors.OvergangsregelbestemmelserSelector(state).map(o => o.kode),
   },
   vurderingBegrunnelser: behandlingsresultatSelectors.KontrollresultatBegrunnelseKoderSelector(state),

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.js
@@ -15,6 +15,7 @@ import RegisterKontrollTreff from '../../registerkontrollTreff';
 import { behandlingerSelectors } from '../../../ducks/behandlinger';
 import { behandlingsresultatSelectors } from '../../../ducks/behandlingsresultat';
 import { behandlingsgrunnlagSelectors } from '../../../ducks/behandlingsgrunnlag';
+import { flytSelectors } from '../../../ducks/flyt';
 
 import { konverterLovvalgsbestemmelseTilStegData, lagLovvalgsbestemmelse } from '../../../regler/lovvalgsbestemmelser';
 import { konverterLovvalgslandTilStegData, lagLovvalgsland } from '../../../regler/lovvalgsland';
@@ -228,7 +229,7 @@ const mapStateToProps = (state, ownProps) => ({
     tom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeTomSelector(state)),
     lovvalgsbestemmelse: ownProps.tilstand.lovvalgsbestemmelse || '',
     lovvalgsland: ownProps.tilstand.lovvalgsland,
-    utpekingVurdering: behandlingsresultatSelectors.UtpekingVurderingSelector(state),
+    utpekingVurdering: flytSelectors.UtpekingVurderingSelector(state),
     overgangsregelbestemmelser: behandlingsgrunnlagSelectors.OvergangsregelbestemmelserSelector(state).map(o => o.kode),
   },
   vurderingBegrunnelser: behandlingsresultatSelectors.KontrollresultatBegrunnelseKoderSelector(state),


### PR DESCRIPTION
Utfall av utpeking ble ikke satt i backend, det førte til at det ikke ble vist i innsyn om utfallet var godkjenning eller ikke. Løsning i backend har blitt å legge til et nytt felt i behandlingsresultat. Legger til en selector for dette feltet, og kobler det til radio-knappene.