### PR TITLE
MELOSYS-3701 - Inngangsvilkaar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9969,9 +9969,9 @@
       "integrity": "sha512-4FSoNCc2zDrH3QK3ok0fifcryNX7tIORaCvRI/JdwhsaEBAEfR1n42t98sPfnUG68erEMgSnautp76+HIjBseQ=="
     },
     "melosys-kodeverk": {
-      "version": "5.15.22",
-      "resolved": "https://registry.npmjs.org/melosys-kodeverk/-/melosys-kodeverk-5.15.22.tgz",
-      "integrity": "sha512-ym2slVzIFyZ97tq9pIexRaHZ8USVdxl4iYK3eAXBiXI3kDiSdY+Wlp8iyF1qGCoqkdzWg1eMZqdqx8oe0C5GGw=="
+      "version": "5.15.24",
+      "resolved": "https://registry.npmjs.org/melosys-kodeverk/-/melosys-kodeverk-5.15.24.tgz",
+      "integrity": "sha512-m3ySu8aki+IrskIIOhQQzJOuhqxGc6BnvDZ5LMOrJRukL+Gxqg2rkLJsn44xh2A0bH4pj0QT4+9HoeMzu5D2NA=="
     },
     "mem": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.15",
     "lodash.throttle": "^4.1.1",
     "melosys-ikoner-assets": "^1.0.1",
-    "melosys-kodeverk": "5.15.22",
+    "melosys-kodeverk": "5.15.24",
     "moment": "^2.24.0",
     "moment-duration-format": "^2.3.2",
     "moment-timezone": "^0.5.27",

--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -74,7 +74,7 @@ export const resetSaksopplysninger = () => (
     dispatch(behandlingsresultatOperations.resetBehandlingsresultatState());
     dispatch(avklartefaktaOperations.resetAvklartefaktaState());
     dispatch(lovvalgsperioderOperations.resetLovvalgsperioderState());
-    dispatch(vilkarOperations.resetVilkarState());
+    dispatch(vilkarOperations.resetState());
     dispatch(behandlingsperioderOperations.resetPerioderState());
     dispatch(utpekingsperioderOperations.resetUtpekingsperioderState());
   }

--- a/src/ducks/vilkar/actions.js
+++ b/src/ducks/vilkar/actions.js
@@ -8,7 +8,7 @@ import * as Types from './types';
  */
 
 /* eslint-disable import/prefer-default-export */
-export function oppdaterVilkarState(alleVilkaar) {
+export function oppdaterState(alleVilkaar) {
   return ({
     type: Types.OPPDATER_VILKAR,
     data: { vilkar: alleVilkaar },
@@ -19,6 +19,6 @@ export function oppdaterVilkarState(alleVilkaar) {
  *
  * @returns {{type: *}}
  */
-export function resetVilkarState() {
+export function resetState() {
   return { type: Types.RESET };
 }

--- a/src/ducks/vilkar/operations.js
+++ b/src/ducks/vilkar/operations.js
@@ -16,6 +16,8 @@ import * as Selectors from './selectors';
 
 import { behandlingerSelectors } from '../behandlinger';
 
+import MKV from '../../melosyskodeverk';
+
 export function hent(behandlingID) {
   return doThenDispatch(() => Api.Vilkar.hent(behandlingID), {
     OK: Types.OK,
@@ -24,7 +26,7 @@ export function hent(behandlingID) {
   });
 }
 
-export function send(behandlingID, body) {
+function send(behandlingID, body) {
   return doThenDispatch(() => Api.Vilkar.send(behandlingID, body), {
     OK: Types.OK,
     FEILET: Types.FEILET,
@@ -32,19 +34,27 @@ export function send(behandlingID, body) {
   });
 }
 
+const VILKAAR_FRONTEND_MANGLER_SKRIVETILGANG_TIL = [
+  MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR,
+];
+
+const filtrerVilkar = vilkar => vilkar.filter(enkeltVilkar => !VILKAAR_FRONTEND_MANGLER_SKRIVETILGANG_TIL.includes(enkeltVilkar.vilkaar));
+
 export function lagre() {
   return (dispatch, getState) => {
     const vilkar = Selectors.VilkarSelector(getState());
     const bid = behandlingerSelectors.BehandlingIDSelector(getState());
-    dispatch(send(bid, vilkar));
+
+    const filtrerteVilkar = filtrerVilkar(vilkar);
+
+    return dispatch(send(bid, filtrerteVilkar));
   };
 }
 
-export function oppdaterVilkarState(skjema) {
-  return dispatch => (dispatch(Actions.oppdaterVilkarState(skjema)));
+export function oppdaterState(skjema) {
+  return dispatch => (dispatch(Actions.oppdaterState(skjema)));
 }
 
-export function resetVilkarState() {
-  return Actions.resetVilkarState();
+export function resetState() {
+  return Actions.resetState();
 }
-

--- a/src/ducks/vilkar/operations.test.js
+++ b/src/ducks/vilkar/operations.test.js
@@ -1,0 +1,159 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import MKV from '../../melosyskodeverk';
+
+import { vilkarOperations as operations, vilkarTypes as types } from './index';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('vilkar operations', () => {
+  let initialState = null;
+
+  beforeEach(() => {
+    fetch.resetMocks();
+    fetch.mockResponse(JSON.stringify({}));
+
+    initialState = {
+      vilkar: {
+        data: [],
+      },
+      behandlinger: {
+        data: {
+          behandlingID: 4,
+        },
+      },
+    };
+  });
+
+  describe('hent', () => {
+    it('henter vilkar og lager OK action', async () => {
+      const expectedActions = [
+        { type: types.PENDING },
+        { type: types.OK, data: {} },
+      ];
+
+      const store = mockStore(initialState);
+      const bid = 5;
+
+      await store.dispatch(operations.hent(bid));
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenLastCalledWith(`/api/vilkaar/${bid}`, expect.anything());
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+
+    it('lager FEILET ved feil i api-kall', async () => {
+      const error = new Error('feil ved kall til Api');
+      fetch.mockReject(error);
+
+      const expectedActions = [
+        { type: types.PENDING },
+        { type: types.FEILET, data: error.toString() },
+      ];
+
+      const store = mockStore(initialState);
+      const bid = 5;
+
+      await store.dispatch(operations.hent(bid));
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenLastCalledWith(`/api/vilkaar/${bid}`, expect.anything());
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  describe('lagre', () => {
+    it('filtrerer bort Inngangsvilkaar når vilkaar lagres og lager OK action', async () => {
+      initialState.vilkar.data = [
+        {
+          vilkaar: MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR,
+        },
+        {
+          vilkaar: MKV.Koder.vilkaar.FO_883_2004_ART12_1,
+        },
+      ];
+
+      const expectedActions = [
+        { type: types.PENDING },
+        { type: types.OK, data: {} },
+      ];
+
+      const store = mockStore(initialState);
+
+      await store.dispatch(operations.lagre());
+
+      expect(store.getActions()).toEqual(expectedActions);
+
+      expect(fetch).toHaveBeenLastCalledWith(
+        '/api/vilkaar/4',
+        expect.objectContaining({
+          body: JSON.stringify([
+            {
+              vilkaar: MKV.Koder.vilkaar.FO_883_2004_ART12_1,
+            },
+          ]),
+        })
+      );
+    });
+
+    it('lager FEILET ved feil i api-kall', async () => {
+      const error = new Error('feil ved kall til Api');
+      fetch.mockReject(error);
+
+      const expectedActions = [
+        { type: types.PENDING },
+        { type: types.FEILET, data: error.toString() },
+      ];
+
+      const store = mockStore(initialState);
+
+      await store.dispatch(operations.lagre());
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenLastCalledWith('/api/vilkaar/4', expect.anything());
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  describe('oppdaterState', () => {
+    it('lager OPPDATER_BEHANDLINGSGRUNNLAG action', () => {
+      const vilkar = [
+        { vilkaar: 'test' },
+        { vilkaar: 'test2' },
+      ];
+
+      const expectedActions = [
+        {
+          type: types.OPPDATER_VILKAR,
+          data: {
+            vilkar,
+          },
+        },
+      ];
+
+      const store = mockStore(initialState);
+
+      store.dispatch(operations.oppdaterState(vilkar));
+
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  describe('resetState', () => {
+    it('lager RESET action', () => {
+      const expectedActions = [
+        {
+          type: types.RESET,
+        },
+      ];
+
+      const store = mockStore(initialState);
+
+      store.dispatch(operations.resetState());
+
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});

--- a/src/ducks/vilkar/reducers.js
+++ b/src/ducks/vilkar/reducers.js
@@ -62,6 +62,7 @@ export default function reducer(state = initialState, action) {
         vilkarTilObjekt(MKV.Koder.vilkaar.FO_883_2004_ART11_3A, action.data.vilkar.art11_3A),
         vilkarTilObjekt(MKV.Koder.vilkaar.FO_883_2004_ART11_4_1, action.data.vilkar.art11_4_1),
         vilkarTilObjekt(MKV.Koder.vilkaar.FO_883_2004_ART11_4_2, action.data.vilkar.art11_4_2),
+        vilkarTilObjekt(MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR, action.data.vilkar[MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR]),
       ].filter(vilkar => vilkar !== null);
       /* eslint-enable max-len */
       return {

--- a/src/ducks/vilkar/selectors.js
+++ b/src/ducks/vilkar/selectors.js
@@ -15,6 +15,11 @@ export const VilkarSelector = createSelector(
   vurdering => vurdering
 );
 
+export const inngangsvilkaarSelector = createSelector(
+  VilkarSelector,
+  alleVilkar => alleVilkar.find(enkelt => enkelt.vilkaar === MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR)
+);
+
 export const vesentligVirksomhetSelector = createSelector(
   state => VilkarSelector(state),
   alleVilkar => (alleVilkar.find(enkelt => enkelt.vilkaar === MKV.Koder.vilkaar.ART12_1_VESENTLIG_VIRKSOMHET) || {})

--- a/src/felleskomponenter/stegvelger/Stegvelger.js
+++ b/src/felleskomponenter/stegvelger/Stegvelger.js
@@ -616,7 +616,7 @@ const mapDispatchToProps = dispatch => ({
   hentAvklartefakta: behandlingID => dispatch(avklartefaktaOperations.hent(behandlingID)),
   hentLovvalgsperioder: behandlingID => dispatch(lovvalgsperioderOperations.hent(behandlingID)),
   oppdaterPerioderState: skjema => dispatch(behandlingsperioderOperations.oppdaterPerioderState(skjema)),
-  oppdaterVilkaar: vilkaarListe => dispatch(vilkarOperations.oppdaterVilkarState(vilkaarListe)),
+  oppdaterVilkaar: vilkaarListe => dispatch(vilkarOperations.oppdaterState(vilkaarListe)),
   oppdaterAvklartefakta: avklartefaktaListe => dispatch(avklartefaktaOperations.oppdaterAvklarteFaktaState(avklartefaktaListe)),
   oppdaterLovvalgperioder: stegState => dispatch(lovvalgsperioderOperations.oppdaterLovvalgsperioderState(stegState)),
   hentMedlemsPerioder: behandlingID => dispatch(behandlingsperioderOperations.hentMedlemsPerioder(behandlingID)),

--- a/src/felleskomponenter/stegvelger/Stegvelger.js
+++ b/src/felleskomponenter/stegvelger/Stegvelger.js
@@ -380,6 +380,7 @@ class Stegvelger extends Component {
       arbeidslandMedYrkesaktivitet: props.arbeidslandMedYrkesaktivitet,
       valgteVirksomheter: props.valgteVirksomheter,
       vilkar: props.vilkar,
+      inngangsvilkaar: props.inngangsvilkaar,
       redigerbart: props.redigerbart,
       generiskStegRedigerbart: props.generiskStegRedigerbart,
       erIDirekteTilArtikkel16Flyt: props.erIDirekteTilArtikkel16Flyt,
@@ -512,6 +513,7 @@ Stegvelger.propTypes = {
   oppdaterLovvalgperioder: PT.func.isRequired,
   valgteVirksomheter: PT.array,
   vilkar: PT.array.isRequired,
+  inngangsvilkaar: MPT.Vilkaar,
   lagreVilkarHandler: PT.func.isRequired,
   lagreAvklartefaktaHandler: PT.func.isRequired,
   lagreLovvalgsperioderHandler: PT.func.isRequired,
@@ -570,6 +572,7 @@ Stegvelger.defaultProps = {
   valgteLovvalgsVilkarBestemmelse: '',
   maritimtarbeid: [],
   hjemmebase: null,
+  inngangsvilkaar: {},
 };
 
 const mapStateToProps = state => ({
@@ -578,6 +581,7 @@ const mapStateToProps = state => ({
   arbeidsgivereIPerioden: avklartefaktaSelectors.VirksomheterIPeriodenSelector(state),
   avklartefakta: avklartefaktaSelectors.AvklartefaktaSelector(state),
   vilkar: vilkarSelectors.VilkarSelector(state),
+  inngangsvilkaar: vilkarSelectors.inngangsvilkaarSelector(state),
   lovvalgsperioder: lovvalgsperioderSelectors.LovvalgsperioderSelector(state),
   behandlingsPerioder: behandlingsperioderSelectors.behandlingsPerioderSelector(state),
   arbeidsland: avklartefaktaSelectors.ArbeidslandKTSelector(state),

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.js
@@ -8,48 +8,82 @@ import * as MPT from '../../../proptypes';
 import * as Nav from '../../../utils/navFrontend';
 import * as KV from '../../../kodeverk';
 
-import MKV from '../../../melosyskodeverk';
-
 import { avklartefaktaSelectors } from '../../../ducks/avklartefakta';
-import { fagsakSelectors } from '../../../ducks/fagsaker';
 import { behandlingsgrunnlagSelectors } from '../../../ducks/behandlingsgrunnlag';
+
+import MKV from '../../../melosyskodeverk';
 
 import SoknadslandListe from './inngang/soknadslandListe';
 
-const VurderingInngang = props => {
-  const {
-    bekreftOgFortsett, alleLandkoder, begrunnelser, avklartefakta,
-    tilstand, redigerbart, oppdaterData, slettData, sakstype,
-  } = props;
-
-  useEffect(() => (
-    function cleanup() {
-      slettData();
-    }
-  ), []);
-
-  const soknadslandBegrunnelser = begrunnelser.opphold;
-  const { harAvklaring } = tilstand;
-
-  const oppfyllerInngangsvilkar = sakstype === MKV.Koder.sakstyper.EU_EOS;
-
+export const Varsler = ({
+  oppfyllerInngangsvilkar,
+  inngangsvilkaarBegrunnelser,
+}) => {
   const oppfyllerInngangsvilkarCl = classNames({
     liste__element: true,
     'liste__element--oppfylt': oppfyllerInngangsvilkar,
     'liste__element--ikkeoppfylt': !oppfyllerInngangsvilkar,
   });
 
+  const varselCl = classNames({
+    liste__element: true,
+    'liste__element--varsel': true,
+  });
+
+  const oppfyltTekst = `Søknaden oppfyller${oppfyllerInngangsvilkar ? ' ' : ' ikke '}inngangsvilkårene for EU/EØS-saker etter forordning 883/2004.`;
+
+  return (
+    <ul className="betingelser__liste">
+      <li className={oppfyllerInngangsvilkarCl}>{oppfyltTekst}</li>
+      {
+        !oppfyllerInngangsvilkar &&
+        inngangsvilkaarBegrunnelser.map(begrunnelseKode => (
+          <li key={begrunnelseKode} className={oppfyllerInngangsvilkarCl}>
+            {KV.kodeTilTerm(begrunnelseKode, MKV.KTObjects.begrunnelser.inngangsvilkaar)}
+          </li>
+        ))
+      }
+      {
+        oppfyllerInngangsvilkar &&
+        <li className={varselCl}>Sjekk eventuelt at området dekkes av forordningen.</li>
+      }
+    </ul>
+  );
+};
+
+Varsler.propTypes = {
+  oppfyllerInngangsvilkar: PT.bool.isRequired,
+  inngangsvilkaarBegrunnelser: PT.arrayOf(PT.string).isRequired,
+};
+
+export const VurderingInngang = ({
+  bekreftOgFortsett,
+  alleLandkoder,
+  avklartefakta,
+  redigerbart,
+  oppdaterData,
+  oppfyllerInngangsvilkar,
+  slettData,
+  inngangsvilkaar: {
+    begrunnelseKoder: inngangsvilkaarBegrunnelser,
+  },
+  tilstand: {
+    harAvklaring,
+  },
+  begrunnelser: {
+    opphold: soknadslandBegrunnelser,
+  },
+}) => {
+  useEffect(() => (
+    function cleanup() {
+      slettData();
+    }
+  ), []);
+
   return (
     <div className="vurderingInngang">
       <Nav.typo.Undertittel>Kontroller inngangsvilkår</Nav.typo.Undertittel>
-      <ul className="betingelser__liste">
-        <li className={oppfyllerInngangsvilkarCl}>
-          Søknaden oppfyller inngangsvilkårene for EU/EØS-saker etter forordning 883/2004.
-        </li>
-        <li className="liste__element liste__element--varsel">
-          Sjekk eventuelt at området dekkes av forordningen.
-        </li>
-      </ul>
+      <Varsler oppfyllerInngangsvilkar={oppfyllerInngangsvilkar} inngangsvilkaarBegrunnelser={inngangsvilkaarBegrunnelser} />
       <FieldArray
         name="avklartefakta.soknadsland"
         component={SoknadslandListe}
@@ -71,15 +105,17 @@ VurderingInngang.propTypes = {
   avklartefakta: MPT.AvklartefaktaListe.isRequired,
   alleLandkoder: PT.arrayOf(MPT.Kodeverk).isRequired,
   begrunnelser: PT.object.isRequired,
-  tilstand: PT.object.isRequired,
+  tilstand: PT.shape({
+    harAvklaring: PT.bool.isRequired,
+  }).isRequired,
   redigerbart: PT.bool.isRequired,
   oppdaterData: PT.func.isRequired,
   slettData: PT.func.isRequired,
-  sakstype: PT.string.isRequired,
+  inngangsvilkaar: MPT.Vilkaar.isRequired,
+  oppfyllerInngangsvilkar: PT.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
-  sakstype: fagsakSelectors.SakstypeKodeSelector(state),
   initialValues: {
     soknadsland: behandlingsgrunnlagSelectors.SoknadslandSelector(state),
     fjernedeLand: avklartefaktaSelectors.IkkeGyldigeSoknadslandFaktaerSelector(state),

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.js
@@ -12,6 +12,7 @@ import { avklartefaktaSelectors } from '../../../ducks/avklartefakta';
 import { behandlingsgrunnlagSelectors } from '../../../ducks/behandlingsgrunnlag';
 
 import MKV from '../../../melosyskodeverk';
+import { konverterTilStegData as konverterVilkarTilStegData } from '../../../regler/vilkar';
 
 import SoknadslandListe from './inngang/soknadslandListe';
 
@@ -64,6 +65,7 @@ export const VurderingInngang = ({
   oppdaterData,
   oppfyllerInngangsvilkar,
   slettData,
+  inngangsvilkaar,
   inngangsvilkaar: {
     begrunnelseKoder: inngangsvilkaarBegrunnelser,
   },
@@ -74,11 +76,13 @@ export const VurderingInngang = ({
     opphold: soknadslandBegrunnelser,
   },
 }) => {
-  useEffect(() => (
-    function cleanup() {
+  useEffect(() => {
+    oppdaterData(konverterVilkarTilStegData(MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR, inngangsvilkaar));
+
+    return function cleanup() {
       slettData();
-    }
-  ), []);
+    };
+  }, []);
 
   return (
     <div className="vurderingInngang">

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.js
@@ -26,11 +26,6 @@ export const Varsler = ({
     'liste__element--ikkeoppfylt': !oppfyllerInngangsvilkar,
   });
 
-  const varselCl = classNames({
-    liste__element: true,
-    'liste__element--varsel': true,
-  });
-
   const oppfyltTekst = `Søknaden oppfyller${oppfyllerInngangsvilkar ? ' ' : ' ikke '}inngangsvilkårene for EU/EØS-saker etter forordning 883/2004.`;
 
   return (
@@ -43,10 +38,6 @@ export const Varsler = ({
             {KV.kodeTilTerm(begrunnelseKode, MKV.KTObjects.begrunnelser.inngangsvilkaar)}
           </li>
         ))
-      }
-      {
-        oppfyllerInngangsvilkar &&
-        <li className={varselCl}>Sjekk eventuelt at området dekkes av forordningen.</li>
       }
     </ul>
   );

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.js
@@ -85,7 +85,7 @@ export const VurderingInngang = ({
         avklartefakta={avklartefakta}
         soknadslandBegrunnelser={soknadslandBegrunnelser}
         alleLandkoder={alleLandkoder}
-        redigerbart={redigerbart}
+        redigerbart={redigerbart && oppfyllerInngangsvilkar}
         oppdaterData={oppdaterData}
       />
       <div className="fane__knapplinje">

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.test.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import { FieldArray } from 'redux-form';
+
+import * as Mui from '../../ui';
+import * as Nav from '../../../utils/navFrontend';
+
+import MKV from '../../../melosyskodeverk';
+
+import { VurderingInngang, Varsler } from './vurderingInngang';
+import SoknadslandListe from './inngang/soknadslandListe';
+
+describe('Varsler', () => {
+  let props = null;
+
+  beforeEach(() => {
+    props = {
+      oppfyllerInngangsvilkar: true,
+      inngangsvilkaarBegrunnelser: [],
+    };
+  });
+
+  it('Viser melding om oppfyllte inngangsvilkår', () => {
+    const varsler = shallow(<Varsler {...props} />);
+    const lis = varsler.find('li');
+
+    expect(lis).toHaveLength(2);
+    expect(lis.first().text()).toBe('Søknaden oppfyller inngangsvilkårene for EU/EØS-saker etter forordning 883/2004.');
+    expect(lis.last().text()).toBe('Sjekk eventuelt at området dekkes av forordningen.');
+  });
+
+  it('Viser feilmelding ved ikke oppfylte inngangsvilkår', () => {
+    props.oppfyllerInngangsvilkar = false;
+    props.inngangsvilkaarBegrunnelser = [
+      MKV.Koder.begrunnelser.inngangsvilkaar.MANGLER_STATSBORGERSKAP,
+      MKV.Koder.begrunnelser.inngangsvilkaar.TEKNISK_FEIL,
+    ];
+    const varsler = shallow(<Varsler {...props} />);
+    const lis = varsler.find('li');
+
+    expect(lis).toHaveLength(3);
+    expect(lis.first().text()).toBe('Søknaden oppfyller ikke inngangsvilkårene for EU/EØS-saker etter forordning 883/2004.');
+    expect(lis.at(1).text()).toBe(MKV.Terms.begrunnelser.inngangsvilkaar.MANGLER_STATSBORGERSKAP);
+    expect(lis.last().text()).toBe(MKV.Terms.begrunnelser.inngangsvilkaar.TEKNISK_FEIL);
+  });
+});
+
+
+describe('VurderingInngang', () => {
+  let props = null;
+
+  beforeEach(() => {
+    props = {
+      bekreftOgFortsett: jest.fn(),
+      avklartefakta: [],
+      alleLandkoder: [],
+      begrunnelser: {
+        opphold: [],
+      },
+      tilstand: {
+        harAvklaring: true,
+      },
+      redigerbart: true,
+      oppdaterData: jest.fn(),
+      slettData: jest.fn(),
+      sakstype: MKV.Koder.sakstyper.EU_EOS,
+      inngangsvilkaar: {
+        vilkaar: MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR,
+        oppfylt: true,
+        begrunnelseKoder: [],
+        begrunnelseFritekst: 'Begrunnelse',
+      },
+      oppfyllerInngangsvilkar: true,
+    };
+  });
+
+  it('viser varsler for inngangsvilkår', () => {
+    const vurderingInngang = shallow(<VurderingInngang {...props} />);
+    const varsler = vurderingInngang.find(Varsler);
+    const varslerProps = varsler.props();
+
+    expect(varsler).toHaveLength(1);
+    expect(varslerProps.oppfyllerInngangsvilkar).toBe(props.oppfyllerInngangsvilkar);
+    expect(varslerProps.inngangsvilkaarBegrunnelser).toBe(props.inngangsvilkaar.begrunnelseKoder);
+  });
+
+  it('viser en fieldarray for søknadsland', () => {
+    const vurderingInngang = shallow(<VurderingInngang {...props} />);
+    const fieldArray = vurderingInngang.find(FieldArray);
+    const fieldarrayProps = fieldArray.props();
+
+    expect(fieldarrayProps.component).toBe(SoknadslandListe);
+    expect(fieldarrayProps.avklartefakta).toBe(props.avklartefakta);
+    expect(fieldarrayProps.soknadslandBegrunnelser).toBe(props.begrunnelser.opphold);
+    expect(fieldarrayProps.alleLandkoder).toBe(props.alleLandkoder);
+    expect(fieldarrayProps.redigerbart).toBe(props.redigerbart);
+    expect(fieldarrayProps.oppdaterData).toBe(props.oppdaterData);
+  });
+
+  it('viser knapp for å gå videre i stegvelger', () => {
+    const vurderingInngang = shallow(<VurderingInngang {...props} />);
+    const bekreftOgFortsettKnapp = vurderingInngang.find(Nav.Knapp);
+
+    expect(bekreftOgFortsettKnapp).toHaveLength(1);
+    expect(bekreftOgFortsettKnapp.props().onClick).toBe(props.bekreftOgFortsett);
+  });
+
+  describe('knapp for å gå videre i stegvelger', () => {
+    it('er ikke disabled dersom redigerbart og harAvklaring er true', () => {
+      const vurderingInngang = shallow(<VurderingInngang {...props} />);
+      const bekreftOgFortsettKnapp = vurderingInngang.find(Nav.Knapp);
+
+      expect(bekreftOgFortsettKnapp.props().disabled).toBe(false);
+    });
+
+    it('er disabled dersom redigerbart er false', () => {
+      props.redigerbart = false;
+      const vurderingInngang = shallow(<VurderingInngang {...props} />);
+      const bekreftOgFortsettKnapp = vurderingInngang.find(Nav.Knapp);
+
+      expect(bekreftOgFortsettKnapp.props().disabled).toBe(true);
+    });
+
+    it('er disabled dersom harAvklaring er false', () => {
+      props.tilstand.harAvklaring = false;
+      const vurderingInngang = shallow(<VurderingInngang {...props} />);
+      const bekreftOgFortsettKnapp = vurderingInngang.find(Nav.Knapp);
+
+      expect(bekreftOgFortsettKnapp.props().disabled).toBe(true);
+    });
+  });
+});

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { FieldArray } from 'redux-form';
 
-import * as Mui from '../../ui';
 import * as Nav from '../../../utils/navFrontend';
 
 import MKV from '../../../melosyskodeverk';

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.test.js
@@ -22,9 +22,8 @@ describe('Varsler', () => {
     const varsler = shallow(<Varsler {...props} />);
     const lis = varsler.find('li');
 
-    expect(lis).toHaveLength(2);
+    expect(lis).toHaveLength(1);
     expect(lis.first().text()).toBe('Søknaden oppfyller inngangsvilkårene for EU/EØS-saker etter forordning 883/2004.');
-    expect(lis.last().text()).toBe('Sjekk eventuelt at området dekkes av forordningen.');
   });
 
   it('Viser feilmelding ved ikke oppfylte inngangsvilkår', () => {

--- a/src/felleskomponenter/stegvelger/stegMap/inngang.js
+++ b/src/felleskomponenter/stegvelger/stegMap/inngang.js
@@ -7,6 +7,8 @@ class Inngang extends Steg {
   constructor(propsLight, stegPosisjon) {
     super(propsLight, stegPosisjon);
 
+    const { inngangsvilkaar } = propsLight;
+
     this.kriterier = [];
     this.id = STEG.INNGANG;
     this.tittel = 'Inngang';
@@ -16,9 +18,11 @@ class Inngang extends Steg {
       alleLandkoder: _propsLight.landkoder,
       avklartefakta: _propsLight.avklartefakta,
       redigerbart: _propsLight.generiskStegRedigerbart,
+      oppfyllerInngangsvilkar: this.oppfyllerInngangsvilkaar(inngangsvilkaar),
+      inngangsvilkaar,
     });
     this.beregnRelevantUI = _propsLight => {
-      const harAvklaring = this.harAvklaring(_propsLight.soknadslandFaktaer);
+      const harAvklaring = this.harAvklaring(_propsLight.soknadslandFaktaer, inngangsvilkaar);
 
       return ({
         harAvklaring,
@@ -32,11 +36,16 @@ class Inngang extends Steg {
     this.status = FANE_STATUS.OK;
   }
 
-  harAvklaring = avklartefakta => (
+  harAvklaring = (avklartefakta, inngangsvilkaar) => (
     avklartefakta.some(enkeltFakta => (
       (enkeltFakta.referanse === KV.Koder.SOKNADSLAND) &&
       this.faktaErSannEllerIkkeArbeidsland(enkeltFakta.fakta)
-    ))
+    )) &&
+    this.oppfyllerInngangsvilkaar(inngangsvilkaar)
+  )
+
+  oppfyllerInngangsvilkaar = inngangsvilkaar => (
+    inngangsvilkaar.oppfylt
   )
 
   faktaErSannEllerIkkeArbeidsland = fakta => (

--- a/src/felleskomponenter/stegvelger/stegMap/inngang.js
+++ b/src/felleskomponenter/stegvelger/stegMap/inngang.js
@@ -18,11 +18,11 @@ class Inngang extends Steg {
       alleLandkoder: _propsLight.landkoder,
       avklartefakta: _propsLight.avklartefakta,
       redigerbart: _propsLight.generiskStegRedigerbart,
-      oppfyllerInngangsvilkar: this.oppfyllerInngangsvilkaar(inngangsvilkaar),
+      oppfyllerInngangsvilkar: this.oppfyllerInngangsvilkaar(propsLight.inngangsvilkaar),
       inngangsvilkaar,
     });
     this.beregnRelevantUI = _propsLight => {
-      const harAvklaring = this.harAvklaring(_propsLight.soknadslandFaktaer, inngangsvilkaar);
+      const harAvklaring = this.harAvklaring(propsLight.soknadslandFaktaer, inngangsvilkaar);
 
       return ({
         harAvklaring,
@@ -36,17 +36,20 @@ class Inngang extends Steg {
     this.status = FANE_STATUS.OK;
   }
 
-  harAvklaring = (avklartefakta, inngangsvilkaar) => (
-    avklartefakta.some(enkeltFakta => (
+  harAvklaring = (avklartefakta, inngangsvilkaar) => {
+    const faktaAvklart = avklartefakta.some(enkeltFakta => (
       (enkeltFakta.referanse === KV.Koder.SOKNADSLAND) &&
       this.faktaErSannEllerIkkeArbeidsland(enkeltFakta.fakta)
-    )) &&
-    this.oppfyllerInngangsvilkaar(inngangsvilkaar)
-  )
+    ));
 
-  oppfyllerInngangsvilkaar = inngangsvilkaar => (
-    inngangsvilkaar.oppfylt
-  )
+    const oppfyllerInngangsvilkaar = this.oppfyllerInngangsvilkaar(inngangsvilkaar);
+
+    return faktaAvklart && oppfyllerInngangsvilkaar;
+  }
+
+  oppfyllerInngangsvilkaar = inngangsvilkaar => {
+    return inngangsvilkaar.oppfylt;
+  }
 
   faktaErSannEllerIkkeArbeidsland = fakta => (
     fakta.includes(KV.Koder.SoknadslandFaktaTyper.SANN) ||

--- a/src/felleskomponenter/stegvelger/stegMap/inngang.js
+++ b/src/felleskomponenter/stegvelger/stegMap/inngang.js
@@ -47,9 +47,9 @@ class Inngang extends Steg {
     return faktaAvklart && oppfyllerInngangsvilkaar;
   }
 
-  oppfyllerInngangsvilkaar = inngangsvilkaar => {
-    return inngangsvilkaar.oppfylt;
-  }
+  oppfyllerInngangsvilkaar = inngangsvilkaar => (
+    inngangsvilkaar.oppfylt
+  )
 
   faktaErSannEllerIkkeArbeidsland = fakta => (
     fakta.includes(KV.Koder.SoknadslandFaktaTyper.SANN) ||

--- a/src/proptypes/index.js
+++ b/src/proptypes/index.js
@@ -34,6 +34,7 @@ import { TimerTimelonnet, TimerTimelonnetLinje } from './timerTimelonnet';
 import { Utenlandsopphold } from './utenlandsopphold';
 import { Utpekingsperiode, Utpekingsperioder } from './utpekingsperioder';
 import { Vedtakstype } from './vedtakstype';
+import { Vilkaar } from './vilkaar';
 import { Virksomhet } from './virksomhet';
 import { Yrkesgruppe } from './yrkesgruppe';
 
@@ -99,6 +100,7 @@ export {
   Utpekingsperioder,
   Vedlegg,
   Vedtakstype,
+  Vilkaar,
   Virksomhet,
   Vurdering,
 };

--- a/src/proptypes/vedtakstype.js
+++ b/src/proptypes/vedtakstype.js
@@ -1,5 +1,6 @@
 import PT from 'prop-types';
-import * as MKV from 'melosys-kodeverk';
+
+import MKV from '../melosyskodeverk';
 
 const VedtakstypePropType = PT.oneOf([
   MKV.Koder.vedtakstyper.KORRIGERT_VEDTAK,

--- a/src/proptypes/vilkaar.js
+++ b/src/proptypes/vilkaar.js
@@ -1,0 +1,10 @@
+import PT from 'prop-types';
+
+const VilkaarPropType = PT.shape({
+  vilkaar: PT.string,
+  oppfylt: PT.bool,
+  begrunnelseKoder: PT.arrayOf(PT.string),
+  begrunnelseFritekst: PT.string,
+});
+
+export { VilkaarPropType as Vilkaar };

--- a/src/sider/rammeverk/komponenter/topplinje.js
+++ b/src/sider/rammeverk/komponenter/topplinje.js
@@ -8,10 +8,6 @@ import * as MPT from '../../../proptypes/';
 import * as Utils from '../../../utils/utils';
 
 import { saksbehandlerSelectors } from '../../../ducks/saksbehandler/';
-import { fagsakOperations } from '../../../ducks/fagsaker/';
-import { vilkarOperations } from '../../../ducks/vilkar/';
-import { avklartefaktaOperations } from '../../../ducks/avklartefakta/';
-import { lovvalgsperioderOperations } from '../../../ducks/lovvalgsperioder/';
 import { oppgaverOperations } from '../../../ducks/oppgaver/';
 
 import './topplinje.css';
@@ -67,10 +63,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  resetFagsakState: () => dispatch(fagsakOperations.resetFagsakState()),
-  resetVilkarState: () => dispatch(vilkarOperations.resetVilkarState()),
-  resetAvklartefaktaState: () => dispatch(avklartefaktaOperations.resetAvklartefaktaState()),
-  resetLovvalgsperiode: () => dispatch(lovvalgsperioderOperations.resetLovvalgsperioderState()),
   hentOppgaveOversikt: () => dispatch(oppgaverOperations.oversikt()),
 });
 

--- a/src/sider/saksbehandling/saksbehandling.js
+++ b/src/sider/saksbehandling/saksbehandling.js
@@ -121,8 +121,8 @@ class Saksbehandling extends Component {
   lagreVilkarHandler = async () => {
     const { behandlingID } = this.state;
 
-    const { sendVilkar, vilkar } = this.props;
-    sendVilkar(behandlingID, vilkar);
+    const { lagreVilkar, vilkar } = this.props;
+    lagreVilkar(behandlingID, vilkar);
   };
 
   lagreAvklartefaktaHandler = async () => {
@@ -300,7 +300,7 @@ Saksbehandling.propTypes = {
   resetBehandlingerState: PT.func.isRequired,
   resetBehandlingsPerioderState: PT.func.isRequired,
   resetLovvalgsperiode: PT.func.isRequired,
-  sendVilkar: PT.func.isRequired,
+  lagreVilkar: PT.func.isRequired,
   sendAvklartefakta: PT.func.isRequired,
   sendLovvalgsperioder: PT.func.isRequired,
   lagrePerioder: PT.func.isRequired,
@@ -391,15 +391,15 @@ const mapDispatchToProps = dispatch => ({
   oppfriskSaksopplysninger: saksnummer => saksopplysningerOperations.oppfrisk(saksnummer),
   resetFagsakState: () => dispatch(fagsakOperations.resetFagsakState()),
   resetBehandlingsresultatState: () => dispatch(behandlingsresultatOperations.resetBehandlingsresultatState()),
-  resetVilkarState: () => dispatch(vilkarOperations.resetVilkarState()),
+  resetVilkarState: () => dispatch(vilkarOperations.resetState()),
   resetAvklartefaktaState: () => dispatch(avklartefaktaOperations.resetAvklartefaktaState()),
   resetBehandlingsgrunnlagState: () => dispatch(behandlingsgrunnlagOperations.resetState()),
   resetLovvalgsperiode: () => dispatch(lovvalgsperioderOperations.resetLovvalgsperioderState()),
   resetBehandlingerState: () => dispatch(behandlingerOperations.resetBehandlingerState()),
   resetBehandlingsPerioderState: () => dispatch(behandlingsperioderOperations.resetPerioderState()),
   sendAvklartefakta: (behandlingID, body) => dispatch(avklartefaktaOperations.send(behandlingID, body)),
-  sendVilkar: (behandlingID, body) => dispatch(vilkarOperations.send(behandlingID, body)),
-  oppdaterVilkarState: skjema => dispatch(vilkarOperations.oppdaterVilkarState(skjema)),
+  lagreVilkar: () => dispatch(vilkarOperations.lagre()),
+  oppdaterVilkarState: skjema => dispatch(vilkarOperations.oppdaterState(skjema)),
   oppdaterBehandlingerState: skjema => dispatch(behandlingsperioderOperations.oppdaterPerioderState(skjema)),
   sendLovvalgsperioder: (behandlingID, body) => dispatch(lovvalgsperioderOperations.send(behandlingID, body)),
   lagrePerioder: () => dispatch(behandlingsperioderOperations.lagre()),

--- a/src/sider/saksbehandling/saksbehandling.js
+++ b/src/sider/saksbehandling/saksbehandling.js
@@ -118,13 +118,6 @@ class Saksbehandling extends Component {
     return false;
   };
 
-  lagreVilkarHandler = async () => {
-    const { behandlingID } = this.state;
-
-    const { lagreVilkar, vilkar } = this.props;
-    lagreVilkar(behandlingID, vilkar);
-  };
-
   lagreAvklartefaktaHandler = async () => {
     const { behandlingID } = this.state;
     const { sendAvklartefakta, avklartefakta } = this.props;
@@ -211,7 +204,7 @@ class Saksbehandling extends Component {
               <Saksopplysninger
                 behandlingID={behandlingID}
                 visOppfriskModal={visOppfriskModal}
-                lagreVilkarHandler={this.lagreVilkarHandler}
+                lagreVilkarHandler={this.props.lagreVilkar}
                 lagreAvklartefaktaHandler={this.lagreAvklartefaktaHandler}
                 lagreLovvalgsperioderHandler={this.lagreLovvalgsperioderHandler}
                 lagreAnmodningsperioderHandler={this.lagreAnmodningsperioderHandler}

--- a/src/sider/saksbehandling/stegMap/inngang.js
+++ b/src/sider/saksbehandling/stegMap/inngang.js
@@ -5,7 +5,8 @@ class SaksbehandlingInngang extends Inngang {
   constructor(propsLight, stegPosisjon) {
     super(propsLight, stegPosisjon);
 
-    const harAvklaring = this.harAvklaring(propsLight.avklartefakta);
+    const { avklartefakta, inngangsvilkaar } = propsLight;
+    const harAvklaring = this.harAvklaring(avklartefakta, inngangsvilkaar);
 
     this.kriterier = [
       {

--- a/src/sider/vurderutpeking/stegMap/inngang.js
+++ b/src/sider/vurderutpeking/stegMap/inngang.js
@@ -5,9 +5,12 @@ class VurderUtpekingInngang extends Inngang {
   constructor(propsLight, stegPosisjon) {
     super(propsLight, stegPosisjon);
 
+    const { avklartefakta, inngangsvilkaar } = propsLight;
+    const harAvklaring = this.harAvklaring(avklartefakta, inngangsvilkaar);
+
     this.kriterier = [
       {
-        exec: () => this.harAvklaring(propsLight.avklartefakta),
+        exec: () => harAvklaring,
         nesteSteg: STEG.VIRKSOMHETER,
       },
     ];


### PR DESCRIPTION
- Inngangsvilkaar vil nå alltid hentes fra backend gjennom api/vilkaar
- Viser feilkode i inngangsteg hvis inngangsvilkaar ikke er oppfylt, og låser stegvelger
- Filtrerer ut inngangsvilkaar ved POST av vilkaar, da inngangsvilkaar styres av backend/regelmodul
- litt testing og opprydding i vilkar/operations

Mock: https://github.com/navikt/melosys-web-mock/pull/306