### PR TITLE
MELOSYS-3797 - Reset av vilkaar overskrev inngangsvilkaar

### DIFF
--- a/src/ducks/vilkar/constants.js
+++ b/src/ducks/vilkar/constants.js
@@ -1,0 +1,5 @@
+import MKV from '../../melosyskodeverk';
+
+export const VILKAAR_FRONTEND_MANGLER_SKRIVETILGANG_TIL = [
+  MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR,
+];

--- a/src/ducks/vilkar/operations.js
+++ b/src/ducks/vilkar/operations.js
@@ -13,10 +13,9 @@ import { doThenDispatch } from '../../services/utils';
 import * as Types from './types';
 import * as Actions from '../vilkar/actions';
 import * as Selectors from './selectors';
+import * as Constants from './constants';
 
 import { behandlingerSelectors } from '../behandlinger';
-
-import MKV from '../../melosyskodeverk';
 
 export function hent(behandlingID) {
   return doThenDispatch(() => Api.Vilkar.hent(behandlingID), {
@@ -34,11 +33,7 @@ function send(behandlingID, body) {
   });
 }
 
-const VILKAAR_FRONTEND_MANGLER_SKRIVETILGANG_TIL = [
-  MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR,
-];
-
-const filtrerVilkar = vilkar => vilkar.filter(enkeltVilkar => !VILKAAR_FRONTEND_MANGLER_SKRIVETILGANG_TIL.includes(enkeltVilkar.vilkaar));
+const filtrerVilkar = vilkar => vilkar.filter(enkeltVilkar => !Constants.VILKAAR_FRONTEND_MANGLER_SKRIVETILGANG_TIL.includes(enkeltVilkar.vilkaar));
 
 export function lagre() {
   return (dispatch, getState) => {

--- a/src/ducks/vilkar/reducers.js
+++ b/src/ducks/vilkar/reducers.js
@@ -9,6 +9,7 @@ import MKV from '../../melosyskodeverk';
 import { STATUS } from '../../services/utils';
 
 import * as Types from './types';
+import * as Constants from './constants';
 
 const initialState = {
   data: [],
@@ -41,8 +42,17 @@ export default function reducer(state = initialState, action) {
         status: STATUS.OK,
         data: action.data,
       };
-    case Types.RESET:
-      return { ...initialState };
+    case Types.RESET: {
+      const IKKE_SKRIVBARE_VILKAAR_DATA = Constants.VILKAAR_FRONTEND_MANGLER_SKRIVETILGANG_TIL.map(v => (
+        state.data.find(enkeltVilkaar => enkeltVilkaar.vilkaar === v)
+      )).filter(v => v != null);
+      const data = [...initialState.data, ...IKKE_SKRIVBARE_VILKAAR_DATA];
+
+      return {
+        ...initialState,
+        data,
+      };
+    }
     case Types.OPPDATER_VILKAR: {
       // Gjennomgå alle vilkår som kan være satt. Dersom de er 'undefined', vil det si at
       // saksbehandler ikke har vært innom denne vurderingen og kanskje aldri kommer tid. Siden

--- a/src/ducks/vilkar/reducers.test.js
+++ b/src/ducks/vilkar/reducers.test.js
@@ -1,0 +1,40 @@
+import reducer from './reducers';
+
+import * as types from './types';
+import * as actions from './actions';
+import * as Utils from '../../services/utils';
+
+import MKV from '../../melosyskodeverk';
+
+describe('vilkar reducer', () => {
+  let initialState = null;
+
+  beforeEach(() => {
+    initialState = {
+      data: [],
+    };
+  });
+
+  it(`returnerer inngangsvilkaar og status ${Utils.STATUS.NOT_STARTED} ved ${types.RESET}`, () => {
+    initialState = {
+      data: [
+        {
+          vilkaar: 'testvilkaar',
+        },
+        {
+          vilkaar: MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR,
+        },
+      ],
+    };
+    const reducedState = reducer(initialState, actions.resetState());
+
+    expect(reducedState).toEqual({
+      data: [
+        {
+          vilkaar: MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR,
+        },
+      ],
+      status: Utils.STATUS.NOT_STARTED,
+    });
+  });
+});


### PR DESCRIPTION
- Når Norge er utpekt ved A003, kunne det skje at man mistet inngangsvilkår i det man trykket "Bekreft og fortsett". Årsaken til det var mest sannsynlig at det ble dispatchet en vilkar/RESET.
- Denne bugen er ikke så lett å reprodusere, da det ikke er alltid denne reseten skjer. Jeg har ikke klart å finne ut av hvorfor den skjer noen ganger, og ikke andre, men det har mest sannsynlig fungert slik en god stund.