### PR TITLE
Tomt valg for begrunnelse art. 16 kræsjer

### DIFF
--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
@@ -198,11 +198,13 @@ class VurderingArtikkel16Anmodning extends Component {
     this.lagreVilkar();
   };
 
-  begrunnelserEndringHandler = async event => {
+  begrunnelserEndringHandler = async ({ target }) => {
     this.setState({ begrunnelserFeilmelding: undefined });
 
+    const { value } = target;
+    const begrunnelse = value ? [value] : [];
     const { oppdaterData } = this.props;
-    await oppdaterData(lagBegrunnelse('art16_1_anmodning', [event.target.value]));
+    await oppdaterData(lagBegrunnelse('art16_1_anmodning', begrunnelse));
     this.lagreVilkar();
   };
 


### PR DESCRIPTION
Sender tom liste i stedet for liste med en tom string ved tomt valg for begrunnelse ved anmodning om unntak art. 16.