### PR TITLE
MELOSYS-3806 - Skal ikke være mulig å journalføre med behandlingstema ARBEID_NORGE_BOSATT_ANNET_LAND

### DIFF
--- a/src/sider/journalforing/journalforing.js
+++ b/src/sider/journalforing/journalforing.js
@@ -407,7 +407,6 @@ class Journalforing extends Component {
       kode === MKV.Koder.behandlinger.behandlingstema.ARBEID_ETT_LAND_ØVRIG ||
       kode === MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV ||
       kode === MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND ||
-      kode === MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND ||
       kode === MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL ||
       kode === MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED ||
       kode === MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM ||

--- a/src/sider/opprettnysak/opprettnysak.js
+++ b/src/sider/opprettnysak/opprettnysak.js
@@ -71,7 +71,9 @@ const OpprettNySak = ({
 
   const oppgaverFinnes = radioValg.length > 0;
 
-  const filtrerteBehandlingstemaer = MKV.KTObjects.behandlinger.behandlingstema.filter(({ kode }) => MKVUtils.erSoknad(kode));
+  const filtrerteBehandlingstemaer = MKV.KTObjects.behandlinger.behandlingstema
+    .filter(({ kode }) => MKVUtils.erSoknad(kode))
+    .filter(({ kode }) => kode !== MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND);
 
   const settJournalpostID = oppgaveID => {
     const { journalpostID } = oppgaver.find(oppgave => oppgave.oppgaveID === oppgaveID);


### PR DESCRIPTION
Behandlingstema Arbeid eller selvstendig virksomhet i NO - bosatt annet land er tilgjengelig i journalføringsbildet. Dette bør gjøres utilgjengelig inntil vi støtter behandlingen fullt ut i Melosys.
