### PR TITLE
MELOSYS-3797 - Hindre overskriving av inngangsvilkaar

### DIFF
--- a/src/ducks/vilkar/reducers.js
+++ b/src/ducks/vilkar/reducers.js
@@ -29,6 +29,10 @@ const velgArt16Objekt = (art16avslag, art16anmodning) => (
   art16avslag || art16anmodning
 );
 
+const hentIkkeSkrivbareVilkaarData = state => Constants.VILKAAR_FRONTEND_MANGLER_SKRIVETILGANG_TIL.map(v => (
+  state.data.find(enkeltVilkaar => enkeltVilkaar.vilkaar === v)
+)).filter(v => v != null);
+
 // Reducer
 export default function reducer(state = initialState, action) {
   switch (action.type) {
@@ -43,9 +47,7 @@ export default function reducer(state = initialState, action) {
         data: action.data,
       };
     case Types.RESET: {
-      const IKKE_SKRIVBARE_VILKAAR_DATA = Constants.VILKAAR_FRONTEND_MANGLER_SKRIVETILGANG_TIL.map(v => (
-        state.data.find(enkeltVilkaar => enkeltVilkaar.vilkaar === v)
-      )).filter(v => v != null);
+      const IKKE_SKRIVBARE_VILKAAR_DATA = hentIkkeSkrivbareVilkaarData(state);
       const data = [...initialState.data, ...IKKE_SKRIVBARE_VILKAAR_DATA];
 
       return {
@@ -72,11 +74,14 @@ export default function reducer(state = initialState, action) {
         vilkarTilObjekt(MKV.Koder.vilkaar.FO_883_2004_ART11_3A, action.data.vilkar.art11_3A),
         vilkarTilObjekt(MKV.Koder.vilkaar.FO_883_2004_ART11_4_1, action.data.vilkar.art11_4_1),
         vilkarTilObjekt(MKV.Koder.vilkaar.FO_883_2004_ART11_4_2, action.data.vilkar.art11_4_2),
-        vilkarTilObjekt(MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR, action.data.vilkar[MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR]),
       ].filter(vilkar => vilkar !== null);
-      /* eslint-enable max-len */
+
+      const IKKE_SKRIVBARE_VILKAAR_DATA = hentIkkeSkrivbareVilkaarData(state);
+      const data = [...vilkarArray, ...IKKE_SKRIVBARE_VILKAAR_DATA];
+
       return {
-        data: vilkarArray,
+        ...state,
+        data,
       };
     }
     default:

--- a/src/ducks/vilkar/reducers.test.js
+++ b/src/ducks/vilkar/reducers.test.js
@@ -12,6 +12,7 @@ describe('vilkar reducer', () => {
   beforeEach(() => {
     initialState = {
       data: [],
+      status: Utils.STATUS.OK,
     };
   });
 
@@ -35,6 +36,25 @@ describe('vilkar reducer', () => {
         },
       ],
       status: Utils.STATUS.NOT_STARTED,
+    });
+  });
+
+  it(`overskriver ikke inngangsvilkaar ved ${types.OPPDATER_VILKAR}`, () => {
+    initialState.data = [
+      {
+        vilkaar: MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR,
+      },
+    ];
+
+    const reducedState = reducer(initialState, actions.oppdaterState({}));
+
+    expect(reducedState).toEqual({
+      data: [
+        {
+          vilkaar: MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR,
+        },
+      ],
+      status: Utils.STATUS.OK,
     });
   });
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { FieldArray, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
@@ -13,7 +13,6 @@ import { avklartefaktaSelectors } from '../../../ducks/avklartefakta';
 import { behandlingsgrunnlagSelectors } from '../../../ducks/behandlingsgrunnlag';
 
 import MKV from '../../../melosyskodeverk';
-import { konverterTilStegData as konverterVilkarTilStegData } from '../../../regler/vilkar';
 
 import SoknadslandListe from './inngang/soknadslandListe';
 
@@ -71,7 +70,6 @@ export const VurderingInngang = ({
   redigerbart,
   oppdaterData,
   oppfyllerInngangsvilkar,
-  slettData,
   inngangsvilkaar,
   inngangsvilkaar: {
     begrunnelseKoder: inngangsvilkaarBegrunnelser,
@@ -82,38 +80,28 @@ export const VurderingInngang = ({
   begrunnelser: {
     opphold: soknadslandBegrunnelser,
   },
-}) => {
-  useEffect(() => {
-    oppdaterData(konverterVilkarTilStegData(MKV.Koder.vilkaar.FO_883_2004_INNGANGSVILKAAR, inngangsvilkaar));
-
-    return function cleanup() {
-      slettData();
-    };
-  }, []);
-
-  return (
-    <div className="vurderingInngang">
-      <Nav.typo.Undertittel>Kontroller inngangsvilkår</Nav.typo.Undertittel>
-      <Varsler
-        oppfyllerInngangsvilkar={oppfyllerInngangsvilkar}
-        inngangsvilkaarBegrunnelser={inngangsvilkaarBegrunnelser}
-        inngangsvilkaar={inngangsvilkaar}
-      />
-      <FieldArray
-        name="avklartefakta.soknadsland"
-        component={SoknadslandListe}
-        avklartefakta={avklartefakta}
-        soknadslandBegrunnelser={soknadslandBegrunnelser}
-        alleLandkoder={alleLandkoder}
-        redigerbart={redigerbart && oppfyllerInngangsvilkar}
-        oppdaterData={oppdaterData}
-      />
-      <div className="fane__knapplinje">
-        <Nav.Knapp disabled={!(redigerbart && harAvklaring)} className="fane__navigasjonsknapp" data-cy-nesteknapp="knapp_steg0" onClick={bekreftOgFortsett}>Bekreft og fortsett</Nav.Knapp>
-      </div>
+}) => (
+  <div className="vurderingInngang">
+    <Nav.typo.Undertittel>Kontroller inngangsvilkår</Nav.typo.Undertittel>
+    <Varsler
+      oppfyllerInngangsvilkar={oppfyllerInngangsvilkar}
+      inngangsvilkaarBegrunnelser={inngangsvilkaarBegrunnelser}
+      inngangsvilkaar={inngangsvilkaar}
+    />
+    <FieldArray
+      name="avklartefakta.soknadsland"
+      component={SoknadslandListe}
+      avklartefakta={avklartefakta}
+      soknadslandBegrunnelser={soknadslandBegrunnelser}
+      alleLandkoder={alleLandkoder}
+      redigerbart={redigerbart && oppfyllerInngangsvilkar}
+      oppdaterData={oppdaterData}
+    />
+    <div className="fane__knapplinje">
+      <Nav.Knapp disabled={!(redigerbart && harAvklaring)} className="fane__navigasjonsknapp" data-cy-nesteknapp="knapp_steg0" onClick={bekreftOgFortsett}>Bekreft og fortsett</Nav.Knapp>
     </div>
-  );
-};
+  </div>
+);
 
 VurderingInngang.propTypes = {
   bekreftOgFortsett: PT.func.isRequired,
@@ -125,7 +113,6 @@ VurderingInngang.propTypes = {
   }).isRequired,
   redigerbart: PT.bool.isRequired,
   oppdaterData: PT.func.isRequired,
-  slettData: PT.func.isRequired,
   inngangsvilkaar: MPT.Vilkaar.isRequired,
   oppfyllerInngangsvilkar: PT.bool.isRequired,
 };


### PR DESCRIPTION
- Ikke tillat overskriving av inngangsvilkaar ved vilkaar/OPPDATER_VILKAR action
- Fjerner lagring av inngangsvilkaar til stegstate i vurderingInngang.js

Dette er samme problemstilling som https://github.com/navikt/melosys-web/pull/967, bare en annen action som forårsaker det