### PR TITLE
MELOSYS-3882 - Utpekingsperiode lovvalgsland mangler ved 13.4

### DIFF
--- a/src/ducks/utpekingsperioder/operations.js
+++ b/src/ducks/utpekingsperioder/operations.js
@@ -39,6 +39,7 @@ export function lagre() {
 const byggUtpekingsperiode = (stegState, reduxState) => {
   const periode = behandlingsgrunnlagSelectors.PeriodeSelector(reduxState);
   const lovvalgsland = stegState.lovvalgsland || avklartefaktaSelectors.OmfattesILandSelector(reduxState);
+  if (!lovvalgsland) return [];
 
   return [{
     fomDato: periode.fom,

--- a/src/ducks/utpekingsperioder/operations.test.js
+++ b/src/ducks/utpekingsperioder/operations.test.js
@@ -293,5 +293,36 @@ describe('utpekingsperioder operations', () => {
 
       expect(store.getActions()).toEqual(expectedActions);
     });
+
+    it('bygger tom utpekingsperiode dersom stegstate.lovvalgsland ikke er satt', () => {
+      const avklartfakta = {
+        avklartefaktaKode: null,
+        referanse: KV.Koder.avklartefaktaKoder.LOENNET_ARBEID_ANTALL_LAND,
+        fakta: [KV.Koder.LoennetArbeidAntallLand.ETT_ANNET_LAND],
+        subjektID: null,
+        begrunnelseKoder: [],
+        begrunnelseFritekst: null,
+      };
+
+      initialState.avklartefakta.data = [avklartfakta];
+
+      const stegState = {
+        lovvalgsbestemmelse: MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_3,
+        lovvalgsland: undefined,
+      };
+
+      const expectedActions = [
+        {
+          type: types.OPPDATER_UTPEKINGSPERIODER,
+          utpekingsperioder: [],
+        },
+      ];
+
+      const store = mockStore(initialState);
+
+      store.dispatch(operations.oppdaterUtpekingsperioderState(stegState));
+
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13UtpekLand.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13UtpekLand.js
@@ -17,7 +17,7 @@ import { MottakerinstitusjonvelgerFlervalg } from '../../mottakerinstitusjonvelg
 
 import { avklartefaktaSelectors } from '../../../ducks/avklartefakta';
 import { behandlingerSelectors } from '../../../ducks/behandlinger';
-import { utpekingsperioderSelectors } from '../../../ducks/utpekingsperioder';
+import { utpekingsperioderSelectors, utpekingsperioderOperations } from '../../../ducks/utpekingsperioder';
 import { redigerbartSelectors } from '../../../ducks/redigerbart';
 import { formOperations } from '../../../ducks/form';
 import { flytSelectors } from '../../../ducks/flyt';
@@ -43,6 +43,7 @@ export const VurderingArtikkel13UtpekLand = ({
   harLonnetArbeidAnnetLand,
   oppdaterData,
   slettData,
+  lagreUtpekingsperioder,
 }) => {
   useEffect(() => {
     oppdaterData(konverterLovvalgslandTilStegData(lovvalgsland));
@@ -96,6 +97,14 @@ export const VurderingArtikkel13UtpekLand = ({
 
   const visLandvelger = erOffentligArbeidUtland || harLonnetArbeidAnnetLand;
   const lovvalgslandTittel = visLandvelger ? 'Velg lovvalgsland' : 'Lovvalgsland';
+
+  const vedKlikkForhandsvis = () => {
+    const formValid = validerForm();
+    if (!formValid) return false;
+
+    lagreUtpekingsperioder();
+    return true;
+  };
 
   return (
     <Fragment>
@@ -166,7 +175,7 @@ export const VurderingArtikkel13UtpekLand = ({
       </Nav.Row>
       <Nav.Row>
         <Nav.Column xs="6">
-          {redigerbart && <PdfLenkeListe behandlingID={behandlingID} dokumenter={pdfDokumenter} />}
+          {redigerbart && <PdfLenkeListe behandlingID={behandlingID} dokumenter={pdfDokumenter} vedKlikk={vedKlikkForhandsvis} />}
         </Nav.Column>
       </Nav.Row>
       <Nav.Hovedknapp onClick={vedKlikkUtpek} disabled={!redigerbart} type="hoved">SEND PÅSTAND</Nav.Hovedknapp>
@@ -191,6 +200,7 @@ VurderingArtikkel13UtpekLand.propTypes = {
   harLonnetArbeidAnnetLand: PT.bool.isRequired,
   oppdaterData: PT.func.isRequired,
   slettData: PT.func.isRequired,
+  lagreUtpekingsperioder: PT.func.isRequired,
 };
 
 VurderingArtikkel13UtpekLand.defaultProps = {
@@ -219,6 +229,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   touchAll: () => dispatch(formOperations.touchAll(KV.Form.ARTIKKEL_13_UTPEKLAND)),
+  lagreUtpekingsperioder: () => dispatch(utpekingsperioderOperations.lagre()),
 });
 
 const VurderingArtikkel13UtpekLand_form = reduxForm({

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13UtpekLand.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13UtpekLand.test.js
@@ -26,6 +26,7 @@ describe('VurderingArtikkel13_1_UtpekLand', () => {
       harLonnetArbeidAnnetLand: true,
       oppdaterData: jest.fn(),
       slettData: jest.fn(),
+      lagreUtpekingsperioder: jest.fn(),
     };
   });
 


### PR DESCRIPTION
- Fikser bug hvor utpekingsperiode ikke ble lagret korrekt ved 13.3 og 13.4, fordi lovvalgsland manglet
- Lagrer utpekingsperioden før forhåndsvisning, siden perioden ikke opprettes før land er valgt i skjermbildet ved utpeking 13.3 og 13.4