### PR TITLE
MELOSYS-3919 - Korrigert vedtak sender feil koder

### DIFF
--- a/src/felleskomponenter/skjema/vedtakstype/vedtakstype.js
+++ b/src/felleskomponenter/skjema/vedtakstype/vedtakstype.js
@@ -41,8 +41,8 @@ Vedtakstype.propTypes = {
 
 Vedtakstype.defaultProps = {
   className: undefined,
-  vedtakstypeFeltNavn: 'vedtakstypebegrunnelse',
-  vedtakstypebegrunnelseFeltNavn: 'vedtakstype',
+  vedtakstypeFeltNavn: 'vedtakstype',
+  vedtakstypebegrunnelseFeltNavn: 'vedtakstypebegrunnelse',
   vedtakstypeLabel: 'Hvilken type vedtak skal fattes?',
   vedtakstypebegrunnelseLabel: 'Bakgrunn for nytt vedtak',
 };


### PR DESCRIPTION
Feltnavnene for vedtakstype og vedtakstypebegrunnelse var forvekslet. Det førte til at feil verdier ble sendt til backend.