### PR TITLE
MELOSYS-3878 - oppdatere 11.5 flyt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9969,9 +9969,9 @@
       "integrity": "sha512-4FSoNCc2zDrH3QK3ok0fifcryNX7tIORaCvRI/JdwhsaEBAEfR1n42t98sPfnUG68erEMgSnautp76+HIjBseQ=="
     },
     "melosys-kodeverk": {
-      "version": "5.15.30",
-      "resolved": "https://registry.npmjs.org/melosys-kodeverk/-/melosys-kodeverk-5.15.30.tgz",
-      "integrity": "sha512-9ciTBu5tc4e6ABMsiWdrcin+pFJM3ySCHQAuzyzHlGo3LtGmfVwRoJBmddP5RaCnXi2iDKQtFHZ1X5TrXW0xKA=="
+      "version": "5.15.31",
+      "resolved": "https://registry.npmjs.org/melosys-kodeverk/-/melosys-kodeverk-5.15.31.tgz",
+      "integrity": "sha512-YTbgZvNrwF5eOiui/+kcFGgMKsWlMsiOM548KvOOl/d1mHTjlvc6hgWgHFGjHCPE8yVrwlDGICfCWSVOLz3Qfw=="
     },
     "mem": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.15",
     "lodash.throttle": "^4.1.1",
     "melosys-ikoner-assets": "^1.0.1",
-    "melosys-kodeverk": "5.15.30",
+    "melosys-kodeverk": "5.15.31",
     "moment": "^2.24.0",
     "moment-duration-format": "^2.3.2",
     "moment-timezone": "^0.5.27",

--- a/src/ducks/avklartefakta/reducers.js
+++ b/src/ducks/avklartefakta/reducers.js
@@ -60,6 +60,7 @@ export default function reducer(state = initialState, action) {
         ARBEID_SOKKEL_SKIP,
         AARSAK_ENDRING_PERIODE,
         MARGINALT_ARBEID,
+        INFORMERT_MYNDIGHET,
       } = MKV.Koder.avklartefaktatyper;
 
       const {
@@ -100,6 +101,7 @@ export default function reducer(state = initialState, action) {
         ...lagAvklartfaktaObjektMedKode(avklartefakta[ARBEID_UTFORES_I_OPPGITT_LAND], null),
         ...lagAvklartfaktaObjektMedKode(avklartefakta[LOENNET_ARBEID_ANTALL_LAND], null),
         ...lagAvklartfaktaObjektMedKode(avklartefakta[OFFENTLIG_ARBEID_ANTALL_LAND], null),
+        ...lagAvklartfaktaObjektMedKode(avklartefakta[INFORMERT_MYNDIGHET], INFORMERT_MYNDIGHET),
       ].filter(fakta => fakta !== Types.NULL);
 
       return { ...state, data: [...avklartefaktaUt] };

--- a/src/felleskomponenter/mottakerinstitusjonvelger.js
+++ b/src/felleskomponenter/mottakerinstitusjonvelger.js
@@ -31,6 +31,10 @@ export const MottakerinstitusjonvelgerSchema = ({
 
   useEffect(() => {
     oppdaterKreverMottakerinstitusjon(!Utils._isEmpty(mottakerinstitusjoner));
+
+    return () => {
+      oppdaterKreverMottakerinstitusjon(undefined);
+    };
   }, [mottakerinstitusjoner]);
 
   if (Utils._isEmpty(mottakerinstitusjoner) || !redigerbart) {

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.js
@@ -380,6 +380,9 @@ const mapStateToProps = (state, ownProps) => {
       'days'
     ) !== 0;
 
+  const informerUtenlandskTrygdemyndighet = !Utils._isEmpty(ownProps.informertMyndighetFakta);
+  const mottakerLand = ownProps.informertMyndighetFakta.subjektID;
+
   return ({
     behandlingsgrunnlagFom: behandlingsgrunnlagSelectors.PeriodeFomSelector(state),
     behandlingsgrunnlagTom: behandlingsgrunnlagSelectors.PeriodeTomSelector(state),
@@ -399,7 +402,8 @@ const mapStateToProps = (state, ownProps) => {
       mottakerinstitusjoner: avklartefaktaSelectors.IkkeMarginaleArbeidslandKTSelector(state) || [],
       lovvalgsbestemmelse: ownProps.lovvalgsbestemmelseSomSkalVises,
       fritekstSed: '',
-      informerUtenlandskTrygdemyndighet: null,
+      informerUtenlandskTrygdemyndighet,
+      mottakerLand,
     },
   });
 };

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.js
@@ -21,13 +21,33 @@ import { avklartefaktaSelectors } from '../../../ducks/avklartefakta';
 import { formOperations } from '../../../ducks/form';
 
 import PdfLenkeListe from '../../pdfLenkeListe';
-import { MottakerinstitusjonvelgerFlervalg } from '../../mottakerinstitusjonvelger';
+import Mottakerinstitusjonvelger, { MottakerinstitusjonvelgerFlervalg } from '../../mottakerinstitusjonvelger';
 import { lagYupToReduxformErrorMapper, Skjemaer as YupSkjemaer } from '../../../yup';
 import { lagLovvalgsbestemmelse, konverterLovvalgsbestemmelseTilStegData } from '../../../regler/lovvalgsbestemmelser';
 import { lagLovvalgsperiode } from '../../../regler/lovvalgsperiode';
 import { lagTilleggBestemmelse, slettTilleggBestemmelse } from '../../../regler/tilleggbestemmelser';
 
 import './vurderingArbeidEttLandOvrigVedtak.css';
+
+const art11_5_ErValgt = formValues => (
+  formValues.lovvalgsbestemmelse === MKV.Koder.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004.FO_883_2004_ART11_5
+);
+
+const art11_3B_ErValgt = formValues => (
+  formValues.lovvalgsbestemmelse === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_3B
+);
+
+const sjekkSkalSendeSed = formValues => {
+  const { kreverMottakerinstitusjon } = formValues;
+
+  if (art11_5_ErValgt(formValues)) {
+    return kreverMottakerinstitusjon;
+  } else if (art11_3B_ErValgt(formValues)) {
+    return true;
+  }
+
+  return false;
+};
 
 export const VurderingArbeidEttLandOvrigVedtak = ({
   redigerbart,
@@ -85,7 +105,7 @@ export const VurderingArbeidEttLandOvrigVedtak = ({
     return formIsValid;
   };
 
-  const pdfDokumenter = [
+  let pdfDokumenter = [
     {
       navn: 'Forhåndsvis vedtaksbrev og A1',
       type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV,
@@ -94,15 +114,21 @@ export const VurderingArbeidEttLandOvrigVedtak = ({
         fritekst: formValues.vedtaksbrevFritekst,
       },
     },
-    {
-      navn: 'Forhåndsvis SED A010',
-      type: EKV.Koder.sedtyper.A010,
-      erSed: true,
-      data: {
-        fritekst: formValues.fritekstSed,
-      },
-    },
   ];
+
+  if (sjekkSkalSendeSed(formValues)) {
+    pdfDokumenter = [
+      ...pdfDokumenter,
+      {
+        navn: 'Forhåndsvis SED A010',
+        type: EKV.Koder.sedtyper.A010,
+        erSed: true,
+        data: {
+          fritekst: formValues.fritekstSed,
+        },
+      },
+    ];
+  }
 
   const fom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.fom);
   const tom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.tom);
@@ -129,8 +155,13 @@ export const VurderingArbeidEttLandOvrigVedtak = ({
     }
   }, [formValues.lovvalgsbestemmelse]);
 
+  const visSendSEDValg = art11_5_ErValgt(formValues);
+  const visMottakerinstitusjonvelgerFlervalg = art11_3B_ErValgt(formValues);
+
+  const skalSendeSed = sjekkSkalSendeSed(formValues);
+
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit} className="vurderingArbeidEttLandOvrigVedtak">
       <Nav.typo.Undertittel>{overskrift}</Nav.typo.Undertittel>
       <Nav.Row className="velgLovvalgsbestemmelse">
         <Nav.Column xs="7">
@@ -157,6 +188,7 @@ export const VurderingArbeidEttLandOvrigVedtak = ({
         </Fragment>
       }
       <Skjema.PeriodeForkorter
+        className="periodeForkorter"
         redigerbart={redigerbart}
         checkboxClassName="forkortLovvalgsperiode"
         checkboxLabel="Lovvalget innvilges for en kortere periode"
@@ -185,7 +217,63 @@ export const VurderingArbeidEttLandOvrigVedtak = ({
         </Nav.Column>
       </Nav.Row>
       {
+        visSendSEDValg &&
+        <Nav.Row>
+          <Nav.Column xs="6">
+            <Skjema.RadioGruppe feltNavn="informerUtenlandskTrygdemyndighet" label="Skal utenlandsk trygdemyndighet informeres?">
+              <Skjema.Radio
+                feltNavn="informerUtenlandskTrygdemyndighet"
+                label="Ja"
+                value
+                disabled={!redigerbart}
+              />
+              <Skjema.Radio
+                feltNavn="informerUtenlandskTrygdemyndighet"
+                label="Nei"
+                value={false}
+                disabled={!redigerbart}
+              />
+            </Skjema.RadioGruppe>
+          </Nav.Column>
+        </Nav.Row>
+      }
+      {
+        visSendSEDValg && formValues.informerUtenlandskTrygdemyndighet &&
+        <Nav.Row>
+          <Nav.Column xs="6">
+            <Skjema.LandVelger
+              label="Hvilket land skal informeres?"
+              feltNavn="mottakerLand"
+              disabled={!redigerbart}
+            />
+            {
+              formValues.mottakerLand &&
+              <Mottakerinstitusjonvelger
+                form={form}
+                redigerbart={redigerbart}
+                landkode={formValues.mottakerLand}
+                bucType={EKV.Koder.buctyper.legislation.LA_BUC_05}
+              />
+            }
+          </Nav.Column>
+        </Nav.Row>
+      }
+      {
+        visMottakerinstitusjonvelgerFlervalg &&
+        <Nav.Row>
+          <Nav.Column xs="8">
+            <MottakerinstitusjonvelgerFlervalg
+              feltnavn="mottakerinstitusjoner"
+              bucType={EKV.Koder.buctyper.legislation.LA_BUC_05}
+              redigerbart={redigerbart}
+              form={form}
+            />
+          </Nav.Column>
+        </Nav.Row>
+      }
+      {
         redigerbart &&
+        skalSendeSed &&
         <Nav.Row className="fritekstSed">
           <Nav.Column xs="8">
             <Skjema.Textarea
@@ -198,16 +286,6 @@ export const VurderingArbeidEttLandOvrigVedtak = ({
           </Nav.Column>
         </Nav.Row>
       }
-      <Nav.Row>
-        <Nav.Column xs="8">
-          <MottakerinstitusjonvelgerFlervalg
-            feltnavn="mottakerinstitusjoner"
-            bucType={EKV.Koder.buctyper.legislation.LA_BUC_05}
-            redigerbart={redigerbart}
-            form={form}
-          />
-        </Nav.Column>
-      </Nav.Row>
       <Nav.Row>
         <Nav.Column xs="6">
           {redigerbart && <PdfLenkeListe behandlingID={behandlingID} dokumenter={pdfDokumenter} vedKlikk={vedKlikkForhandsvis} />}
@@ -281,6 +359,7 @@ const mapStateToProps = (state, ownProps) => {
       mottakerinstitusjoner: avklartefaktaSelectors.IkkeMarginaleArbeidslandKTSelector(state) || [],
       lovvalgsbestemmelse: ownProps.lovvalgsbestemmelseSomSkalVises,
       fritekstSed: '',
+      informerUtenlandskTrygdemyndighet: null,
     },
   });
 };
@@ -295,10 +374,17 @@ const fattVedtak = async (values, dispatch, props) => {
     await props.endreLovvalgsPeriode(props.lovvalgsperiode.fomDato, Utils.dato.formatterDatoTilISO(values.tomDato));
   }
 
+  let mottakerinstitusjoner = null;
+  if (art11_5_ErValgt(values)) {
+    mottakerinstitusjoner = values.mottakerLand ? [values.mottakerinstitusjon] : [];
+  } else if (art11_3B_ErValgt(values)) {
+    mottakerinstitusjoner = values.mottakerinstitusjoner.filter(inst => inst.kreverMottakerinstitusjon).map(inst => inst.id);
+  }
+
   props.lagreOgFatteVedtak({
     behandlingsresultatTypeKode: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
     fritekst: values.vedtaksbrevFritekst,
-    mottakerinstitusjoner: values.mottakerinstitusjoner.filter(inst => inst.kreverMottakerinstitusjon).map(inst => inst.id),
+    mottakerinstitusjoner,
     vedtakstype: values.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
     revurderBegrunnelse: values.vedtakstypebegrunnelse,
   });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.js
@@ -23,11 +23,47 @@ import { formOperations } from '../../../ducks/form';
 import PdfLenkeListe from '../../pdfLenkeListe';
 import Mottakerinstitusjonvelger, { MottakerinstitusjonvelgerFlervalg } from '../../mottakerinstitusjonvelger';
 import { lagYupToReduxformErrorMapper, Skjemaer as YupSkjemaer } from '../../../yup';
+import { lagAvklartfakta, slettAvklartfakta, konverterTilStegData as konverterAvklartfaktaTilStegData } from '../../../regler/avklartefakta';
 import { lagLovvalgsbestemmelse, konverterLovvalgsbestemmelseTilStegData } from '../../../regler/lovvalgsbestemmelser';
 import { lagLovvalgsperiode } from '../../../regler/lovvalgsperiode';
 import { lagTilleggBestemmelse, slettTilleggBestemmelse } from '../../../regler/tilleggbestemmelser';
 
 import './vurderingArbeidEttLandOvrigVedtak.css';
+
+const InformertMyndighetVelger = ({
+  redigerbart,
+  oppdaterData,
+  slettData,
+  informertMyndighetFakta,
+}) => {
+  useEffect(() => {
+    oppdaterData(konverterAvklartfaktaTilStegData(MKV.Koder.avklartefaktatyper.INFORMERT_MYNDIGHET, informertMyndighetFakta));
+
+    return () => {
+      slettData(slettAvklartfakta(MKV.Koder.avklartefaktatyper.INFORMERT_MYNDIGHET));
+    };
+  }, []);
+
+  const oppdaterInformertMyndighetFakta = land => {
+    oppdaterData(lagAvklartfakta(MKV.Koder.avklartefaktatyper.INFORMERT_MYNDIGHET, land, KV.Koder.SoknadslandFaktaTyper.SANN));
+  };
+
+  return (
+    <Skjema.LandVelger
+      label="Hvilket land skal informeres?"
+      feltNavn="mottakerLand"
+      disabled={!redigerbart}
+      onChange={oppdaterInformertMyndighetFakta}
+    />
+  );
+};
+
+InformertMyndighetVelger.propTypes = {
+  redigerbart: PT.bool.isRequired,
+  oppdaterData: PT.func.isRequired,
+  slettData: PT.func.isRequired,
+  informertMyndighetFakta: MPT.Avklartefakta.isRequired,
+};
 
 const art11_5_ErValgt = formValues => (
   formValues.lovvalgsbestemmelse === MKV.Koder.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004.FO_883_2004_ART11_5
@@ -69,6 +105,7 @@ export const VurderingArbeidEttLandOvrigVedtak = ({
   behandlingsgrunnlagFom,
   behandlingsgrunnlagTom,
   soknadsperiode,
+  informertMyndighetFakta,
 }) => {
   useEffect(() => {
     if (lovvalgsbestemmelseSomSkalLagres) {
@@ -241,10 +278,11 @@ export const VurderingArbeidEttLandOvrigVedtak = ({
         visSendSEDValg && formValues.informerUtenlandskTrygdemyndighet &&
         <Nav.Row>
           <Nav.Column xs="6">
-            <Skjema.LandVelger
-              label="Hvilket land skal informeres?"
-              feltNavn="mottakerLand"
-              disabled={!redigerbart}
+            <InformertMyndighetVelger
+              redigerbart={redigerbart}
+              oppdaterData={oppdaterData}
+              slettData={slettData}
+              informertMyndighetFakta={informertMyndighetFakta}
             />
             {
               formValues.mottakerLand &&
@@ -320,6 +358,7 @@ VurderingArbeidEttLandOvrigVedtak.propTypes = {
     fom: PT.string.isRequired,
     tom: PT.string.isRequired,
   }).isRequired,
+  informertMyndighetFakta: MPT.Avklartefakta,
 };
 
 VurderingArbeidEttLandOvrigVedtak.defaultProps = {
@@ -328,6 +367,7 @@ VurderingArbeidEttLandOvrigVedtak.defaultProps = {
   lovvalgsbestemmelseSomSkalVises: '',
   lovvalgsbestemmelseSomSkalLagres: '',
   behandlingsgrunnlagTom: null,
+  informertMyndighetFakta: {},
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.less
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.less
@@ -1,3 +1,10 @@
-.velgLovvalgsbestemmelse {
-  margin-top: 20px;
+.vurderingArbeidEttLandOvrigVedtak {
+  .velgLovvalgsbestemmelse {
+    margin-top: 20px;
+  }
+
+  .periodeForkorter {
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
 }

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.test.js
@@ -44,7 +44,7 @@ describe('VurderingArbeidEttLandOvrigVedtak', () => {
     });
 
     describe('viser nødvendige felter dersom', () => {
-      it('man velger å informere utenlandsk trygdemyndighet', () => {
+      test('man velger å informere utenlandsk trygdemyndighet', () => {
         props.formValues.informerUtenlandskTrygdemyndighet = true;
         props.formValues.kreverMottakerinstitusjon = true;
         props.formValues.mottakerLand = MKV.Koder.landkoder.DE;
@@ -68,7 +68,7 @@ describe('VurderingArbeidEttLandOvrigVedtak', () => {
     });
 
     describe('gjemmer unødvendige felter dersom', () => {
-      it('man velger å informere utenlandsk trygdemyndighet, men ingen mottakerinstitusjoner finnes for valgt land', () => {
+      test('man velger å informere utenlandsk trygdemyndighet, men ingen mottakerinstitusjoner finnes for valgt land', () => {
         props.formValues.informerUtenlandskTrygdemyndighet = true;
         props.formValues.kreverMottakerinstitusjon = false;
         const vurderingArbeidEttLandOvrigVedtak = shallow(<VurderingArbeidEttLandOvrigVedtak {...props} />);
@@ -88,7 +88,7 @@ describe('VurderingArbeidEttLandOvrigVedtak', () => {
         ]));
       });
 
-      it('man velger å ikke informere utenlandsk trygdemyndighet', () => {
+      test('man velger å ikke informere utenlandsk trygdemyndighet', () => {
         props.formValues.informerUtenlandskTrygdemyndighet = false;
         const vurderingArbeidEttLandOvrigVedtak = shallow(<VurderingArbeidEttLandOvrigVedtak {...props} />);
 
@@ -106,6 +106,35 @@ describe('VurderingArbeidEttLandOvrigVedtak', () => {
           }),
         ]));
       });
+    });
+  });
+
+  describe('ved 11_3B', () => {
+    let vurderingArbeidEttLandOvrigVedtak = null;
+
+    beforeEach(() => {
+      props.formValues.lovvalgsbestemmelse = MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_3B;
+      vurderingArbeidEttLandOvrigVedtak = shallow(<VurderingArbeidEttLandOvrigVedtak {...props} />);
+    });
+
+    it('viser periodeforkorter', () => {
+      expect(vurderingArbeidEttLandOvrigVedtak.find(Skjema.PeriodeForkorter)).toHaveLength(1);
+    });
+
+    it('viser fritekst til vedtaksbrev', () => {
+      expect(vurderingArbeidEttLandOvrigVedtak.findWhere(n =>
+        n.type() === Skjema.Textarea &&
+        n.props().label === 'Fritekst til vedtaksbrev')).toHaveLength(1);
+    });
+
+    it('viser mottakerinstitusjonsvelgerFlervalg', () => {
+      expect(vurderingArbeidEttLandOvrigVedtak.find(MottakerinstitusjonvelgerFlervalg)).toHaveLength(1);
+    });
+
+    it('viser ytterligere informasjon til SED', () => {
+      expect(vurderingArbeidEttLandOvrigVedtak.findWhere(n =>
+        n.type() === Skjema.Textarea &&
+        n.props().label === 'Ytterligere informasjon til SED (valgfri)')).toHaveLength(1);
     });
   });
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.test.js
@@ -1,8 +1,12 @@
 import React from 'react';
+import * as EKV from 'eessi-kodeverk';
 
 import { VurderingArbeidEttLandOvrigVedtak } from './vurderingArbeidEttLandOvrigVedtak';
+import Mottakerinstitusjonvelger, { MottakerinstitusjonvelgerFlervalg } from '../../mottakerinstitusjonvelger';
+import PdfLenkeListe from '../../pdfLenkeListe';
 
 import * as KV from '../../../kodeverk';
+import * as Skjema from '../../skjema';
 
 import MKV from '../../../melosyskodeverk';
 
@@ -34,7 +38,74 @@ describe('VurderingArbeidEttLandOvrigVedtak', () => {
     };
   });
 
-  it('viser Arbeidsmønstersteg uten å krasje', () => {
-    shallow(<VurderingArbeidEttLandOvrigVedtak {...props} />);
+  describe('ved art11_5', () => {
+    beforeEach(() => {
+      props.formValues.lovvalgsbestemmelse = MKV.Koder.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004.FO_883_2004_ART11_5;
+    });
+
+    describe('viser nødvendige felter dersom', () => {
+      it('man velger å informere utenlandsk trygdemyndighet', () => {
+        props.formValues.informerUtenlandskTrygdemyndighet = true;
+        props.formValues.kreverMottakerinstitusjon = true;
+        props.formValues.mottakerLand = MKV.Koder.landkoder.DE;
+
+        const vurderingArbeidEttLandOvrigVedtak = shallow(<VurderingArbeidEttLandOvrigVedtak {...props} />);
+
+        const mottakerinstitusjoner = vurderingArbeidEttLandOvrigVedtak.find(Mottakerinstitusjonvelger);
+        const ytterligereInformasjon = vurderingArbeidEttLandOvrigVedtak.findWhere(n =>
+          n.type() === Skjema.Textarea &&
+          n.props().label === 'Ytterligere informasjon til SED (valgfri)');
+        const pdfLenkeListe = vurderingArbeidEttLandOvrigVedtak.find(PdfLenkeListe);
+
+        expect(mottakerinstitusjoner).toHaveLength(1);
+        expect(ytterligereInformasjon).toHaveLength(1);
+        expect(pdfLenkeListe.props().dokumenter).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            type: EKV.Koder.sedtyper.A010,
+          }),
+        ]));
+      });
+    });
+
+    describe('gjemmer unødvendige felter dersom', () => {
+      it('man velger å informere utenlandsk trygdemyndighet, men ingen mottakerinstitusjoner finnes for valgt land', () => {
+        props.formValues.informerUtenlandskTrygdemyndighet = true;
+        props.formValues.kreverMottakerinstitusjon = false;
+        const vurderingArbeidEttLandOvrigVedtak = shallow(<VurderingArbeidEttLandOvrigVedtak {...props} />);
+
+        const mottakerinstitusjoner = vurderingArbeidEttLandOvrigVedtak.find(Mottakerinstitusjonvelger);
+        const ytterligereInformasjon = vurderingArbeidEttLandOvrigVedtak.findWhere(n =>
+          n.type() === Skjema.Textarea &&
+          n.props().label === 'Ytterligere informasjon til SED (valgfri)');
+        const pdfLenkeListe = vurderingArbeidEttLandOvrigVedtak.find(PdfLenkeListe);
+
+        expect(mottakerinstitusjoner).toHaveLength(0);
+        expect(ytterligereInformasjon).toHaveLength(0);
+        expect(pdfLenkeListe.props().dokumenter).not.toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            type: EKV.Koder.sedtyper.A010,
+          }),
+        ]));
+      });
+
+      it('man velger å ikke informere utenlandsk trygdemyndighet', () => {
+        props.formValues.informerUtenlandskTrygdemyndighet = false;
+        const vurderingArbeidEttLandOvrigVedtak = shallow(<VurderingArbeidEttLandOvrigVedtak {...props} />);
+
+        const mottakerinstitusjoner = vurderingArbeidEttLandOvrigVedtak.find(Mottakerinstitusjonvelger);
+        const ytterligereInformasjon = vurderingArbeidEttLandOvrigVedtak.findWhere(n =>
+          n.type() === Skjema.Textarea &&
+          n.props().label === 'Ytterligere informasjon til SED (valgfri)');
+        const pdfLenkeListe = vurderingArbeidEttLandOvrigVedtak.find(PdfLenkeListe);
+
+        expect(mottakerinstitusjoner).toHaveLength(0);
+        expect(ytterligereInformasjon).toHaveLength(0);
+        expect(pdfLenkeListe.props().dokumenter).not.toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            type: EKV.Koder.sedtyper.A010,
+          }),
+        ]));
+      });
+    });
   });
 });

--- a/src/sider/saksbehandling/stegMap/arbeid_ett_land_ovrig_vedtak.js
+++ b/src/sider/saksbehandling/stegMap/arbeid_ett_land_ovrig_vedtak.js
@@ -2,6 +2,8 @@ import Steg from '../../../felleskomponenter/stegvelger/stegMotor/steg';
 import { FANE_STATUS, STEG } from '../../../felleskomponenter/stegvelger/stegMotor/typer';
 import VurderingArbeidEttLandOvrigVedtak from '../../../felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtak';
 
+import { hentFakta } from '../../../regler/avklartefakta';
+
 import MKV from '../../../melosyskodeverk';
 
 class ArbeidEttLandOvrigVedtak extends Steg {
@@ -15,6 +17,8 @@ class ArbeidEttLandOvrigVedtak extends Steg {
 
     const lovvalgsbestemmelseSomSkalLagres = propsLight.lovvalgsbestemmelse;
 
+    const informertMyndighetFakta = hentFakta(MKV.Koder.avklartefaktatyper.INFORMERT_MYNDIGHET, propsLight.avklartefakta);
+
     this.kriterier = [];
     this.id = STEG.ARBEID_ETT_LAND_OVRIG_VEDTAK;
     this.tittel = 'Vedtak';
@@ -23,6 +27,7 @@ class ArbeidEttLandOvrigVedtak extends Steg {
       redigerbart: _propsLight.generiskStegRedigerbart,
       lovvalgsbestemmelseSomSkalVises,
       lovvalgsbestemmelseSomSkalLagres,
+      informertMyndighetFakta,
     });
     this.beregnRelevantUI = () => ({});
     this.handlers = {

--- a/src/yup/skjemaer/arbeid_ett_land_ovrig_vedtak.js
+++ b/src/yup/skjemaer/arbeid_ett_land_ovrig_vedtak.js
@@ -5,7 +5,9 @@ import MKV from '../../melosyskodeverk';
 const VELG_EN_BESTEMMELSE = 'Velg en bestemmelse.';
 const VELG_EN_VEDTAKSTYPE = { melding: 'Velg en vedtakstype' };
 const OPPGI_BEGRUNNELSE = { melding: 'Oppgi begrunnelse' };
-const MOTTAKERINSTITUSJON_KREVES = { melding: 'Mottaker institusjon kreves' };
+const MOTTAKERINSTITUSJON_KREVES = { melding: 'Mottakerinstitusjon kreves' };
+const VELG_OM_UTENLANDSK_TRYGDEMYNDIGHET_SKAL_INFORMERES = { melding: 'Velg om utenlandsk trygdemyndighet skal informeres' };
+const VELG_LAND = { melding: 'Velg land' };
 
 const arbeid_ett_land_ovrig_vedtak = object().shape({
   lovvalgsbestemmelse: string()
@@ -39,6 +41,20 @@ const arbeid_ett_land_ovrig_vedtak = object().shape({
       then: string().required(MOTTAKERINSTITUSJON_KREVES),
     }),
   })),
+  kreverMottakerinstitusjon: bool().required(),
+  mottakerinstitusjon: string().when('kreverMottakerinstitusjon', {
+    is: true,
+    then: string().required(MOTTAKERINSTITUSJON_KREVES),
+  }),
+  informerUtenlandskTrygdemyndighet: bool()
+    .nullable()
+    .required(VELG_OM_UTENLANDSK_TRYGDEMYNDIGHET_SKAL_INFORMERES),
+  mottakerLand: string()
+    .when('informerUtenlandskTrygdemyndighet', {
+      is: true,
+      then: string()
+        .required(VELG_LAND),
+    }),
 });
 
 export { arbeid_ett_land_ovrig_vedtak };


### PR DESCRIPTION
- Ved behandlingstema ARBEID_ETT_LAND_ØVRIG vedtakssteg kan man nå velge om man skal sende A010, og hvilket land man skal sende den til. Dersom det ikke finnes noen mottaksinstitusjoner for landet(landet er ikke påkoblet buc05), vises bare felter for sending av A1.