### PR TITLE
MELOSYS-3998 - Mottakerinstitusjoner forsvinner

### DIFF
--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.js
@@ -1,4 +1,6 @@
 import React, { useEffect } from 'react';
+import { reset } from 'redux-form';
+import { connect } from 'react-redux';
 import PT from 'prop-types';
 
 import MKV from '../../../melosyskodeverk';
@@ -20,9 +22,9 @@ import './vurderingArbeidsmonster.css';
  *
  * @param props Objekt Diverse props (se propTypes)
  */
-const LandLinje = props => {
+export const LandLinje = props => {
   const {
-    landKode, avklartMarginaltArbeidILand, oppdaterData, redigerbart,
+    landKode, avklartMarginaltArbeidILand, oppdaterData, redigerbart, resetForm,
   } = props;
 
   useEffect(() => {
@@ -36,6 +38,12 @@ const LandLinje = props => {
   const klikkHandler = () => {
     const verdi = erMarginaltArbeidIArbeidsland ? BoolskAvklartfaktaType.USANN : BoolskAvklartfaktaType.SANN;
     oppdaterData(lagAvklartfakta(MKV.Koder.avklartefaktatyper.MARGINALT_ARBEID, landKode.kode, verdi));
+
+    /* Ved valg av marginale land(skal ikke ha SED), reinitialize former med mottakerinstitusjoner,
+    slik at mottakerinstitusjoner i vedtakssteget/utpekingssteg oppdateres.
+    Unngår at bruker må endre på radioknapp "Vurdering av vesentlig aktivitet i Norge" for å oppdatere de nevnte stegene. */
+    resetForm(KV.Form.ARTIKKEL_13_X_VEDTAK);
+    resetForm(KV.Form.ARTIKKEL_13_UTPEKLAND);
   };
 
   return (
@@ -58,11 +66,18 @@ LandLinje.propTypes = {
   landKode: MPT.Kodeverk.isRequired,
   avklartMarginaltArbeidILand: PT.object,
   redigerbart: PT.bool.isRequired,
+  resetForm: PT.func.isRequired,
 };
 
 LandLinje.defaultProps = {
   avklartMarginaltArbeidILand: undefined,
 };
+
+const landLinjeMapDispatchToProps = dispatch => ({
+  resetForm: form => dispatch(reset(form)),
+});
+
+const ConnectedLandLinje = connect(null, landLinjeMapDispatchToProps)(LandLinje);
 
 const MarginaltArbeid = ({
   arbeidsland, redigerbart, marginaltArbeid, oppdaterData,
@@ -78,7 +93,7 @@ const MarginaltArbeid = ({
           const avklartMarginaltArbeidILand = marginaltArbeid.find(enkeltAvklaring => enkeltAvklaring.subjektID === land.kode);
 
           const key = `marginaltArbeidslandListe${land.kode}`;
-          return <LandLinje
+          return <ConnectedLandLinje
             landKode={land}
             avklartMarginaltArbeidILand={avklartMarginaltArbeidILand}
             key={key}

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.test.js
@@ -1,7 +1,12 @@
 import React from 'react';
 
-import { VurderingArbeidsmonster } from './vurderingArbeidsmonster';
+import * as KV from '../../../kodeverk';
+import * as Nav from '../../../utils/navFrontend';
 
+import MKV from '../../../melosyskodeverk';
+import { lagAvklartfakta } from '../../../regler/avklartefakta';
+
+import { VurderingArbeidsmonster, LandLinje } from './vurderingArbeidsmonster';
 
 describe('VurderingVurderarbeidsland', () => {
   let props = null;
@@ -27,10 +32,42 @@ describe('VurderingVurderarbeidsland', () => {
       oppdaterData: jest.fn(),
       slettData: jest.fn(),
       arbeidsland: [],
+      resetForm: jest.fn(),
     };
   });
 
   it('viser Arbeidsmønstersteg uten å krasje', () => {
     shallow(<VurderingArbeidsmonster {...props} />);
+  });
+});
+
+describe('LandLinje', () => {
+  const props = {
+    landKode: MKV.KTObjects.landkoder.find(({ kode }) => kode === MKV.Koder.landkoder.DE),
+    avklartMarginaltArbeidILand: { fakta: ['TRUE'] },
+    oppdaterData: jest.fn(),
+    redigerbart: true,
+    resetForm: jest.fn(),
+  };
+
+  describe('ved klikk på checkbox', () => {
+    const landLinje = shallow(<LandLinje {...props} />);
+    const checkbox = landLinje.find(Nav.Checkbox);
+    checkbox.simulate('change');
+
+    it('lagrer marginalt arbeid avklartfakta', () => {
+      expect(props.oppdaterData).toHaveBeenCalledTimes(1);
+      expect(props.oppdaterData).toHaveBeenLastCalledWith(lagAvklartfakta(
+        MKV.Koder.avklartefaktatyper.MARGINALT_ARBEID,
+        MKV.Koder.landkoder.DE,
+        KV.Koder.BoolskAvklartfaktaType.USANN
+      ));
+    });
+
+    it('kaller resetForm for vedtak- og utpekformene', () => {
+      expect(props.resetForm).toHaveBeenCalledTimes(2);
+      expect(props.resetForm).toHaveBeenCalledWith(KV.Form.ARTIKKEL_13_X_VEDTAK);
+      expect(props.resetForm).toHaveBeenCalledWith(KV.Form.ARTIKKEL_13_UTPEKLAND);
+    });
   });
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13_x_vedtak.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13_x_vedtak.js
@@ -251,7 +251,7 @@ const VurderingArtikkel13_x_vedtak_form = reduxForm({
   form: KV.Form.ARTIKKEL_13_X_VEDTAK,
   enableReinitialize: true,
   destroyOnUnmount: true,
-  keepDirtyOnReinitialize: false,
+  keepDirtyOnReinitialize: true,
   updateUnregisteredFields: true,
   validate: (values, props) => lagYupToReduxformErrorMapper(YupSkjemaer.artikkel13_x_vedtak, {
     context: {


### PR DESCRIPTION
- Fikser bug hvor mottakerinstitusjoner forsvinner ved forhåndsvisning av Vedtaksbrev og A1. Nærmere beskrivelse -> https://jira.adeo.no/browse/MELOSYS-3998.
- Sørger for at liste over mottakerinstitusjoner i vedtak-/utpekingssteg er oppdatert ved endring av maritimt arbeid