### PR TITLE
MELOSYS-4009 - Fiks feilmelding for ikke eksisterende org.nr.

### DIFF
--- a/src/ducks/organisasjoner/reducers.js
+++ b/src/ducks/organisasjoner/reducers.js
@@ -25,16 +25,16 @@ export default function reducer(state = initalState, action) {
     case BehandlingsgrunnlagTypes.OK: {
       if (!action.data.tilleggsData) { return state; }
       const { organisasjoner } = action.data.tilleggsData;
-      const eksisterendeOrganisasjoner = Array.isArray(state.data) ? state.data : [];
+      const eksisterendeOrganisasjoner = state.data;
 
       return { ...state, status: STATUS.OK, data: flettOrganisasjoner(organisasjoner, eksisterendeOrganisasjoner) };
     }
     case Types.PENDING:
       return { ...state, status: STATUS.PENDING };
     case Types.FEILET:
-      return { ...state, status: STATUS.ERROR, data: action.data };
+      return { ...state, status: STATUS.ERROR, resError: action.data };
     case Types.OK: {
-      const eksisterendeOrganisasjoner = Array.isArray(state.data) ? state.data : [];
+      const eksisterendeOrganisasjoner = state.data;
 
       return { ...state, status: STATUS.OK, data: flettOrganisasjoner(action.data, eksisterendeOrganisasjoner) };
     }

--- a/src/ducks/organisasjoner/reducers.test.js
+++ b/src/ducks/organisasjoner/reducers.test.js
@@ -25,13 +25,7 @@ describe('organisasjoner reducer', () => {
     expect(reducedState).toEqual({ data: [{ orgnr: 810072512 }, { orgnr: 873152362 }], status: Utils.STATUS.OK });
   });
 
-  it('returnerer ny state ved behandlingsgrunnlag/ok action når initialState er satt til feilobjekt', () => {
-    initialState = {
-      data: {
-        error: 'Not found',
-        status: 404,
-      },
-    };
+  it('returnerer ny state ved behandlingsgrunnlag/ok action', () => {
     const data = {
       tilleggsData: {
         organisasjoner: [
@@ -44,13 +38,7 @@ describe('organisasjoner reducer', () => {
     expect(reducedState).toEqual({ data: [{ orgnr: 873152362 }], status: Utils.STATUS.OK });
   });
 
-  it('returnerer ny state ved ok action når initialState er satt til feilobjekt', () => {
-    initialState = {
-      data: {
-        error: 'Not found',
-        status: 404,
-      },
-    };
+  it('returnerer ny state ved ok action', () => {
     const data = { orgnr: 873152362 };
 
     const reducedState = reducer(initialState, actions.OK(data));
@@ -62,13 +50,18 @@ describe('organisasjoner reducer', () => {
     expect(reducedState).toEqual({ data: [], status: Utils.STATUS.PENDING });
   });
 
-  it('returnerer ny state med status ERROR ved feilet action', () => {
+  it('returnerer ny state med status ERROR ved feilet action, overskriver ikke eksisterende organisasjoner', () => {
     const data = {
       error: 'Not found',
       status: 404,
     };
 
     const reducedState = reducer(initialState, actions.FEILET(data));
-    expect(reducedState).toEqual({ data, status: Utils.STATUS.ERROR });
+
+    expect(reducedState).toEqual({
+      data: initialState.data,
+      status: Utils.STATUS.ERROR,
+      resError: data,
+    });
   });
 });

--- a/src/felleskomponenter/kontaktopplysninger.js
+++ b/src/felleskomponenter/kontaktopplysninger.js
@@ -115,7 +115,7 @@ export class KontaktOpplysninger extends Component {
 
     try {
       const org = await this.props.hentOrg(kontaktorgnr);
-      return org === null || Utils._isEmpty(org) ? null : org;
+      return org;
     } catch (e) {
       Utils.logger.error(e);
       return null;

--- a/src/felleskomponenter/paneler/andreArbeidsforholdNorge/arbeidsforholdNorgeListe/orgnrinput.js
+++ b/src/felleskomponenter/paneler/andreArbeidsforholdNorge/arbeidsforholdNorgeListe/orgnrinput.js
@@ -2,7 +2,6 @@ import React, { useState, Fragment } from 'react';
 import PT from 'prop-types';
 
 import * as Nav from '../../../../utils/navFrontend';
-import * as Utils from '../../../../utils';
 
 const Orgnrinput = ({
   onOrgnrFunnet,
@@ -22,25 +21,18 @@ const Orgnrinput = ({
       return;
     }
 
-    /**
-     * TODO: Backend svarer foreløpig med 200 selv om org ikke finnes. Må derfor sjekke responsen for å se om org faktisk eksisterer.
-     */
-    try {
-      const action = await hentOrganisasjon(tillagtOrgnr);
-      const { data: organisasjon } = action;
-      const orgFunnet = !Utils._isEmpty(organisasjon);
+    const action = await hentOrganisasjon(tillagtOrgnr);
+    const { data } = action;
+    const organisasjon = data;
+    const orgFunnet = organisasjon.orgnr;
+    const httpStatus = !orgFunnet && data.response.status;
 
-      if (orgFunnet) {
-        onOrgnrFunnet(organisasjon);
-      } else {
-        setFeil('Kunne ikke finne organisasjon');
-      }
-    } catch (e) {
-      if (e.body.status === 404) setFeil('Kunne ikke finne organisasjon');
-      else {
-        Utils.logger.error(e);
-        setFeil('Feil ved henting av organisasjon');
-      }
+    if (orgFunnet) {
+      onOrgnrFunnet(organisasjon);
+    } else if (httpStatus === 404) {
+      setFeil('Kunne ikke finne organisasjon');
+    } else {
+      setFeil('Feil ved henting av organisasjon');
     }
   };
 

--- a/src/felleskomponenter/paneler/periodeInntektOgFullmektig/fullmektige/fullmektig.js
+++ b/src/felleskomponenter/paneler/periodeInntektOgFullmektig/fullmektige/fullmektig.js
@@ -39,7 +39,14 @@ function Fullmektig(props) {
   };
 
   const hentOrgFraApi = async () => {
-    if (fullmektig.orgnr) settOrg(await hentOrg(fullmektig.orgnr));
+    if (fullmektig.orgnr) {
+      try {
+        const hentetOrg = await hentOrg(fullmektig.orgnr);
+        settOrg(hentetOrg);
+      } catch (e) {
+        Utils.logger.error(e);
+      }
+    }
   };
 
   useEffect(() => {
@@ -60,7 +67,10 @@ function Fullmektig(props) {
           </Fragment>
         }
         {
-          !org && <SokFullmektigOrg lagreNyFullmektigOgOppdaterLokalt={orgnr => lagreNyFullmektigOgOppdaterLokalt(fullmektig.representererKode, orgnr)} />
+          !org && <SokFullmektigOrg
+            hentOrg={hentOrg}
+            lagreNyFullmektigOgOppdaterLokalt={orgnr => lagreNyFullmektigOgOppdaterLokalt(fullmektig.representererKode, orgnr)}
+          />
         }
         {
           org &&

--- a/src/felleskomponenter/paneler/periodeInntektOgFullmektig/fullmektige/fullmektige.js
+++ b/src/felleskomponenter/paneler/periodeInntektOgFullmektig/fullmektige/fullmektige.js
@@ -164,19 +164,21 @@ const mapStateToProps = state => ({
   redigerbart: redigerbartSelectors.PanelerRedigerbartSelector(state),
 });
 
-const hentOrg = orgNr => Api.Organisasjoner.hentOrganisasjon(orgNr);
-const hentAktoer = (saksnr, rolleKode, representererKode) => Api.Fagsaker.aktoer.hent(saksnr, rolleKode, representererKode);
-const lagreAktoer = (saksnr, data) => Api.Fagsaker.aktoer.send(saksnr, data);
-const slettAktoer = databaseID => Api.Fagsaker.aktoer.slett(databaseID);
+const FullmektigeWrapper = props => {
+  const hentOrg = orgNr => Api.Organisasjoner.hentOrganisasjon(orgNr);
+  const hentAktoer = (saksnr, rolleKode, representererKode) => Api.Fagsaker.aktoer.hent(saksnr, rolleKode, representererKode);
+  const lagreAktoer = (saksnr, data) => Api.Fagsaker.aktoer.send(saksnr, data);
+  const slettAktoer = databaseID => Api.Fagsaker.aktoer.slett(databaseID);
 
-const FullmektigeWrapper = props => (
-  <Fullmektige
-    {...props}
-    lagreAktoer={lagreAktoer}
-    hentAktoer={hentAktoer}
-    hentOrg={hentOrg}
-    slettAktoer={slettAktoer}
-  />
-);
+  return (
+    <Fullmektige
+      {...props}
+      lagreAktoer={lagreAktoer}
+      hentAktoer={hentAktoer}
+      hentOrg={hentOrg}
+      slettAktoer={slettAktoer}
+    />
+  );
+};
 
 export default connect(mapStateToProps)(FullmektigeWrapper);

--- a/src/felleskomponenter/paneler/periodeInntektOgFullmektig/fullmektige/sokFullmektigOrg.js
+++ b/src/felleskomponenter/paneler/periodeInntektOgFullmektig/fullmektige/sokFullmektigOrg.js
@@ -8,15 +8,21 @@ import { erOrgnrGyldig } from '../../../skjema/validering/generisk/organisasjon'
 import './sokFullmektigOrg.css';
 
 function SokFullmektigOrg(props) {
-  const { lagreNyFullmektigOgOppdaterLokalt } = props;
+  const { lagreNyFullmektigOgOppdaterLokalt, hentOrg } = props;
   const [orgnr, settOrgnr] = useState('');
   const [feilmelding, settFeilmelding] = useState(undefined);
 
-  const sok = () => {
+  const sok = async () => {
     if (erOrgnrGyldig(orgnr)) {
-      lagreNyFullmektigOgOppdaterLokalt(orgnr);
+      try {
+        await hentOrg(orgnr);
+        lagreNyFullmektigOgOppdaterLokalt(orgnr);
+      } catch (e) {
+        if (e.response.status === 404) settFeilmelding({ feilmelding: 'Kunne ikke finne organisasjon' });
+        else settFeilmelding({ feilmelding: 'Ukjent feil ved søk på org.nr.' });
+      }
     } else {
-      settFeilmelding({ feilmelding: 'Ugyldig orgnr' });
+      settFeilmelding({ feilmelding: 'Ugyldig org.nr.' });
     }
   };
 
@@ -45,6 +51,7 @@ function SokFullmektigOrg(props) {
 
 SokFullmektigOrg.propTypes = {
   lagreNyFullmektigOgOppdaterLokalt: PT.func.isRequired,
+  hentOrg: PT.func.isRequired,
 };
 
 export default SokFullmektigOrg;

--- a/src/felleskomponenter/paneler/periodeInntektOgFullmektig/fullmektige/sokFullmektigOrg.test.js
+++ b/src/felleskomponenter/paneler/periodeInntektOgFullmektig/fullmektige/sokFullmektigOrg.test.js
@@ -8,6 +8,7 @@ describe('SokFullmektigOrg', () => {
   beforeEach(() => {
     props = {
       lagreNyFullmektigOgOppdaterLokalt: jest.fn(),
+      hentOrg: jest.fn(),
     };
   });
 


### PR DESCRIPTION
- Dersom man la til et arbeidsforhold i Norge med org.nr. som ikke finnes, kom det ingen feilmelding, og nummeret forsvant. Dette er fikset. (Jeg vet ikke helt hva som var galt her, men tror det kan ha hatt noe å gjøre med at backend returnerte en tom body og status 200 for ikke-eksisterende org.nr.)
- Backend skal nå returnere 404 i stedet for 200 for manglende org. Har gjort endringer der hvor endepunktet brukes.

Backend: https://github.com/navikt/melosys-api/pull/236
Mock: https://github.com/navikt/melosys-web-mock/pull/309