### PR TITLE
MELOSYS-3888 - Vise antall apne behandlinger i oppgaveplukker

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -70,10 +70,12 @@
     }],
     "linebreak-style": "off",
     "no-bitwise": [ "error", {"allow" : ["^"]} ],
+    "no-extra-semi": "off",
+    "@typescript-eslint/no-extra-semi": ["error"],
     // Støtt typescript reference, hvor det trengs tre slash(///)
     "spaced-comment": ["error", "always", { "markers": ["/"] }]
   },
-  "extends": ["react-app","airbnb"],
+  "extends": ["react-app","airbnb", "plugin:@typescript-eslint/eslint-recommended"],
   "plugins": [
     "jsx-a11y",
     "jest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19930,6 +19930,15 @@
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
+    "ts-mockito": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ts-mockito/-/ts-mockito-2.6.1.tgz",
+      "integrity": "sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
+      }
+    },
     "ts-pnp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2006,6 +2006,16 @@
       "integrity": "sha512-2xtoL22/3Mv6a70i4+4RB7VgbDDORoWwjcqeNysojZA0R7NK17RbY5Gof/2QiFfJgX+KkWghbwJ+d/2SB8Ndzg==",
       "dev": true
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/http-proxy": {
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.4.tgz",
@@ -2136,6 +2146,39 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.9.tgz",
+      "integrity": "sha512-mpC0jqxhP4mhmOl3P4ipRsgTgbNofMRXJb08Ms6gekViLj61v1hOZEKWDCyWsdONr6EjEA6ZHXC446wdywDe0w==",
+      "dev": true,
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.8.tgz",
+      "integrity": "sha512-HzOyJb+wFmyEhyfp4D4NYrumi+LQgQL/68HvJO+q6XtuHSDvw6Aqov7sCAhjbNq3bUPgPqbdvjXC5HeB2oEAPg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.5.tgz",
+      "integrity": "sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/react-test-renderer": {

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "semver": "^6.3.0",
     "shelljs": "^0.8.3",
     "source-map-explorer": "^2.1.1",
+    "ts-mockito": "^2.6.1",
     "typescript": "^4.0.2",
     "write-pkg": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -149,6 +149,8 @@
     "@types/node": "^14.6.0",
     "@types/react": "^16.9.46",
     "@types/react-dom": "^16.9.8",
+    "@types/react-redux": "^7.1.9",
+    "@types/react-router-dom": "^5.1.5",
     "@types/redux-form": "^8.2.7",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",

--- a/src/felleskomponenter/mottakerinstitusjonvelger.js
+++ b/src/felleskomponenter/mottakerinstitusjonvelger.js
@@ -7,7 +7,7 @@ import * as Api from '../services/api';
 import * as Utils from '../utils';
 import MKV from '../melosyskodeverk';
 
-import { useAsyncCallbackState } from '../hooks/useCallbackState';
+import { useAsyncCallbackState } from '../hooks';
 import { SelectWrappedComponent } from './skjema/input/select';
 
 const MOTTAKERINSTITUSJON = 'mottakerinstitusjon';

--- a/src/felleskomponenter/skjema/input/select.test.tsx
+++ b/src/felleskomponenter/skjema/input/select.test.tsx
@@ -1,17 +1,15 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
+import { shallow } from 'enzyme';
+import { mock, instance } from 'ts-mockito';
+import { WrappedFieldMetaProps } from 'redux-form';
+
+import * as Nav from '../../../utils/navFrontend';
 
 import Select, { SelectWrappedComponent } from './select';
 
 describe('Select', () => {
-  let props = null;
-
-  beforeEach(() => {
-    props = {
-      feltNavn: '',
-      id: '1',
-      className: '',
-    };
-  });
+  const mockedProps = mock<ComponentProps<typeof Select>>();
+  const props = instance(mockedProps);
 
   it('viser en redux form Field komponent med korrekte props', () => {
     props.feltNavn = 'feltnavn';
@@ -28,15 +26,11 @@ describe('Select', () => {
 });
 
 describe('SelectWrappedComponent', () => {
-  let props = null;
-
-  beforeEach(() => {
-    props = {
-      label: '',
-      input: {},
-      meta: {},
-    };
-  });
+  const mockedProps = mock<ComponentProps<typeof SelectWrappedComponent>>();
+  const props = instance(mockedProps);
+  props.label = '';
+  const mockedMeta = mock<WrappedFieldMetaProps>();
+  props.meta = instance(mockedMeta);
 
   it('viser en Nav Select', () => {
     const selectWrappedComponent = shallow(<SelectWrappedComponent {...props} />);
@@ -47,7 +41,7 @@ describe('SelectWrappedComponent', () => {
     props.label = 'label tekst';
     const selectWrappedComponent = shallow(<SelectWrappedComponent {...props} />);
 
-    expect(selectWrappedComponent.find('Select').props().label).toBe(props.label);
+    expect(selectWrappedComponent.find(Nav.Select).props().label).toBe(props.label);
   });
 
   it('setter feil-prop dersom meta.error prop finnes', () => {
@@ -56,20 +50,20 @@ describe('SelectWrappedComponent', () => {
     props.meta.error = 'err';
     const selectWrappedComponent = shallow(<SelectWrappedComponent {...props} />);
 
-    expect(selectWrappedComponent.find('Select').props().feil.feilmelding).toBe(props.meta.error);
+    expect(selectWrappedComponent.find(Nav.Select).props().feil).toEqual({ feilmelding: props.meta.error });
   });
 
   it('setter ikke feil-prop dersom meta.error prop ikke finnes', () => {
     props.meta.error = null;
     const selectWrappedComponent = shallow(<SelectWrappedComponent {...props} />);
 
-    expect(selectWrappedComponent.find('Select').props().feil).toBeUndefined();
+    expect(selectWrappedComponent.find(Nav.Select).props().feil).toBeUndefined();
   });
 
   it('sender children-prop til Nav Select sin children-prop', () => {
     props.children = 'children';
     const selectWrappedComponent = shallow(<SelectWrappedComponent {...props} />);
 
-    expect(selectWrappedComponent.find('Select').props().children).toContain(props.children);
+    expect(selectWrappedComponent.find(Nav.Select).props().children).toContain(props.children);
   });
 });

--- a/src/felleskomponenter/skjema/input/select.tsx
+++ b/src/felleskomponenter/skjema/input/select.tsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import PT from 'prop-types';
-import { Field } from 'redux-form';
+import { Field, WrappedFieldProps } from 'redux-form';
 import * as Nav from '../../../utils/navFrontend';
 import * as SkjemaUtils from '../utils';
 
 import '../skjema.css';
+
+interface SelectWrappedComponentBaseProps extends Nav.SelectProps {
+  emptyFieldDisabled?: boolean,
+  emptyFieldText?: string,
+  onChange?: (event: ChangeEvent) => void,
+}
+
+type SelectWrappedComponentProps = SelectWrappedComponentBaseProps & WrappedFieldProps;
 
 function SelectWrappedComponent({
   input,
@@ -15,11 +23,11 @@ function SelectWrappedComponent({
   emptyFieldText,
   onChange,
   ...rest
-}) {
+}: SelectWrappedComponentProps) {
   const { touched, active } = meta;
   const feil = (touched && !active) ? SkjemaUtils.mapReduxFormFeilTilNavFeil(meta) : undefined;
 
-  const innerChange = e => {
+  const innerChange = (e: ChangeEvent) => {
     if (onChange) onChange(e);
     input.onChange(e);
   };
@@ -56,9 +64,15 @@ SelectWrappedComponent.propTypes = {
   onChange: PT.func,
 };
 
+interface SelectProps extends SelectWrappedComponentBaseProps {
+  id?: string,
+  className?: string,
+  feltNavn: string,
+}
+
 function Select({
   id, feltNavn, className, ...rest
-}) {
+}: SelectProps) {
   return (
     <Field
       name={feltNavn}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useEventTargetValueState } from './useEventTargetValueState';
+export { useCallbackState, useAsyncCallbackState } from './useCallbackState';

--- a/src/hooks/useCallbackState.test.ts
+++ b/src/hooks/useCallbackState.test.ts
@@ -4,15 +4,17 @@ import { useAsyncCallbackState, useCallbackState } from './useCallbackState';
 
 describe('useCallbackState', () => {
   it('tar imot et callback og lagrer resultatet til state', async () => {
-    const sum = (a, b) => a + b;
+    const sum = (a: number, b: number) => a + b;
     const { result } = renderHook(() => useCallbackState(() => sum(1, 2), 0));
 
     const [state] = result.current;
     expect(state).toBe(3);
   });
+});
 
+describe('useAsyncCallbackState', () => {
   it('tar imot et async callback og lagrer resultatet til state', async () => {
-    const asyncSum = async (a, b) => a + b;
+    const asyncSum = async (a: number, b: number) => a + b;
 
     const rh = renderHook(() => useAsyncCallbackState(() => asyncSum(1, 2), 0));
 

--- a/src/hooks/useCallbackState.ts
+++ b/src/hooks/useCallbackState.ts
@@ -2,8 +2,13 @@ import { useEffect, useState } from 'react';
 
 import * as Utils from '../utils';
 
-export const useCallbackState = (callback, defaultState = null, errorHandler = Utils.logger.error, deps = []) => {
-  const [state, setState] = useState(defaultState);
+export const useCallbackState = <StateType>(
+  callback: () => StateType,
+  defaultState: StateType,
+  errorHandler: (e: Error) => void = Utils.logger.error,
+  deps: any[] = []
+): [StateType, (state: StateType) => void] => {
+  const [state, setState] = useState<StateType>(defaultState);
 
   useEffect(() => {
     // Kaller callback og oppdaterer state dersom alle dependencies finnes
@@ -19,7 +24,12 @@ export const useCallbackState = (callback, defaultState = null, errorHandler = U
   return [state, setState];
 };
 
-export const useAsyncCallbackState = (asyncCallback, defaultState = null, errorHandler = Utils.logger.error, deps = []) => {
+export const useAsyncCallbackState = <StateType>(
+  asyncCallback: () => Promise<StateType>,
+  defaultState: StateType,
+  errorHandler: (e: Error) => void = Utils.logger.error,
+  deps: any[] = []
+): [StateType, (state: StateType) => void] => {
   const [state, setState] = useState(defaultState);
 
   useEffect(() => {

--- a/src/kodeverk/form.ts
+++ b/src/kodeverk/form.ts
@@ -1,4 +1,7 @@
 export const BEHANDLINGS_FORM = 'behandlingsform';
+export interface BehandlingsFormData {
+  behandlingstema: string,
+}
 export const BREV_BESTILLING = 'brevbestilling';
 export const FORSIDE_JOURNALFORINGS_FORM = 'journalforingsform';
 export const JOURNALFORING = 'journalforing';

--- a/src/services/api-constants.js
+++ b/src/services/api-constants.js
@@ -21,6 +21,7 @@ export const SAKSBEHANDLER = 'saksbehandler';
 export const SAKSFLYT = 'saksflyt';
 export const SAKSOPPLYSNINGER = 'saksopplysninger';
 export const SERVERINFO = 'serverinfo';
+export const STATISTIKK = 'statistikk';
 export const SVAR = 'svar';
 export const UNNTAKSPERIODER = 'unntaksperioder';
 export const UTPEKING = 'utpeking';

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -14,6 +14,7 @@ import * as Oppgaver from './modules/oppgaver';
 import * as Registrering from './modules/registrering/';
 import * as Saksbehandler from './modules/saksbehandler';
 import * as Saksflyt from './modules/saksflyt';
+import * as Statistikk from './modules/statistikk';
 import * as ServerInfo from './modules/serverinfo';
 import * as Utpekingsperioder from './modules/utpekingsperioder';
 import * as Vilkar from './modules/vilkar';
@@ -37,6 +38,7 @@ export {
   Saksopplysninger,
   Saksflyt,
   ServerInfo,
+  Statistikk,
   Utpekingsperioder,
   Vilkar,
 };

--- a/src/services/modules/statistikk.ts
+++ b/src/services/modules/statistikk.ts
@@ -1,4 +1,10 @@
 import { getAsJson } from '../utils';
 import { API_BASE_URL, STATISTIKK } from '../api-constants';
 
-export const hentServerInfo = () => getAsJson(`${API_BASE_URL}${STATISTIKK}`);
+interface StatistikkResDto {
+  aapneBehandlinger: {
+    [index: string]: number,
+  }
+}
+
+export const hent = (): Promise<StatistikkResDto> => getAsJson(`${API_BASE_URL}${STATISTIKK}`);

--- a/src/services/modules/statistikk.ts
+++ b/src/services/modules/statistikk.ts
@@ -1,0 +1,4 @@
+import { getAsJson } from '../utils';
+import { API_BASE_URL, STATISTIKK } from '../api-constants';
+
+export const hentServerInfo = () => getAsJson(`${API_BASE_URL}${STATISTIKK}`);

--- a/src/sider/forside/komponenter/behandling.test.tsx
+++ b/src/sider/forside/komponenter/behandling.test.tsx
@@ -1,0 +1,25 @@
+import React, { ComponentProps } from 'react';
+import { shallow } from 'enzyme';
+import { mock, instance } from 'ts-mockito';
+
+import MKV from '../../../melosyskodeverk';
+
+import * as Skjema from '../../../felleskomponenter/skjema';
+
+import { Behandling } from './behandling';
+
+describe('Behandling', () => {
+  const mockedProps = mock<ComponentProps<typeof Behandling>>();
+  const props = instance(mockedProps);
+
+  it(`viser ikke behandlingstema ${MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND} i prod`, () => {
+    props.erProdish = true;
+    const behandling = shallow(<Behandling {...props} />);
+    const select = behandling.find(Skjema.Select);
+    const options = select.find('option');
+
+    options.forEach(option => {
+      expect(option.props().value).not.toBe(MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND);
+    });
+  });
+});

--- a/src/sider/forside/komponenter/behandling.tsx
+++ b/src/sider/forside/komponenter/behandling.tsx
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { reduxForm } from 'redux-form';
-import { withRouter } from 'react-router-dom';
-import PT from 'prop-types';
+import { connect, ConnectedProps } from 'react-redux';
+import { reduxForm, InjectedFormProps } from 'redux-form';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { KTObject } from 'melosys-kodeverk';
+import { RootState } from 'AppTypes';
 
 import MKV from '../../../melosyskodeverk';
 
@@ -15,10 +16,30 @@ import { serverinfoSelectors } from '../../../ducks/serverinfo';
 
 import './behandling.css';
 
-const compareTerm = (a, b) => a.term.localeCompare(b.term);
+const compareTerm = (a: KTObject, b: KTObject) => {
+  if (!a.term) return 1;
+  if (!b.term) return -1;
 
-class Behandling extends Component {
-  submitOgVideresend = async form => {
+  return a.term.localeCompare(b.term);
+};
+
+const mapStateToProps = (state: RootState) => ({
+  erProdish: serverinfoSelectors.ErProdishSelector(state),
+  initialValues: {
+    behandlingstema: MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER,
+  },
+});
+const connector = connect(mapStateToProps);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+type BehandlingProps = PropsFromRedux & RouteComponentProps;
+
+interface FormData {
+  behandlingstema: string,
+}
+
+class Behandling extends Component<InjectedFormProps<FormData, BehandlingProps> & BehandlingProps> {
+  submitOgVideresend = async (form: any) => {
     const { handleSubmit, history } = this.props;
     const redirectURL = await handleSubmit(form);
 
@@ -35,6 +56,7 @@ class Behandling extends Component {
     const ikkePlukkbareBehandlingstemaer = erProdish ? [
       MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND,
     ] : [];
+    const behandlingstemaErPlukkbart = (behandlingtemaKTObject: KTObject) => !ikkePlukkbareBehandlingstemaer.includes(behandlingtemaKTObject.kode);
 
     return (
       <Nav.Panel className="forside__sidepanel sidepanel__behandling">
@@ -46,9 +68,15 @@ class Behandling extends Component {
               <Skjema.Select feltNavn="behandlingstema" bredde="fullbredde" label="Behandlingstema">
                 {
                   MKV.KTObjects.behandlinger.behandlingstema
-                    .filter(({ kode }) => !ikkePlukkbareBehandlingstemaer.includes(kode))
+                    .filter(behandlingstemaErPlukkbart)
                     .sort(compareTerm)
-                    .map(({ kode, term }) => (<option key={kode} value={kode}>{term}</option>))
+                    .map(({ kode, term }: KTObject) => {
+                      const tekst = term;
+
+                      return (
+                        <option key={kode} value={kode}>{tekst}</option>
+                      );
+                    })
                 }
               </Skjema.Select>
             </Nav.Column>
@@ -60,28 +88,10 @@ class Behandling extends Component {
   }
 }
 
-Behandling.propTypes = {
-  erProdish: PT.bool.isRequired,
-  handleSubmit: PT.func.isRequired,
-  history: PT.object.isRequired,
-  formValues: PT.object,
-};
-
-Behandling.defaultProps = {
-  formValues: {},
-};
-
-const mapStateToProps = state => ({
-  erProdish: serverinfoSelectors.ErProdishSelector(state),
-  initialValues: {
-    behandlingstema: MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER,
-  },
-});
-
-const BehandlngForm = reduxForm({
+const BehandlngForm = reduxForm<FormData, BehandlingProps>({
   form: KV.Form.BEHANDLINGS_FORM,
   destroyOnUnmount: false,
   onSubmit: form => oppgaverOperations.sendBehandlingsOppgave(form),
 })(Behandling);
 
-export default withRouter(connect(mapStateToProps, null)(BehandlngForm));
+export default withRouter(connector(BehandlngForm));

--- a/src/sider/forside/komponenter/behandling.tsx
+++ b/src/sider/forside/komponenter/behandling.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { reduxForm, InjectedFormProps } from 'redux-form';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
@@ -34,9 +34,13 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type BehandlingProps = PropsFromRedux & RouteComponentProps;
 
-class Behandling extends Component<InjectedFormProps<KV.Form.BehandlingsFormData, BehandlingProps> & BehandlingProps> {
-  submitOgVideresend = async (form: any) => {
-    const { handleSubmit, history } = this.props;
+
+const Behandling = ({
+  handleSubmit,
+  history,
+  erProdish,
+}: InjectedFormProps<KV.Form.BehandlingsFormData, BehandlingProps> & BehandlingProps) => {
+  const submitOgVideresend = async (form: any) => {
     const redirectURL = await handleSubmit(form);
 
     /* eslint-disable no-alert */
@@ -46,43 +50,39 @@ class Behandling extends Component<InjectedFormProps<KV.Form.BehandlingsFormData
     return true;
   };
 
-  render() {
-    const { erProdish } = this.props;
+  const ikkePlukkbareBehandlingstemaer = erProdish ? [
+    MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND,
+  ] : [];
+  const behandlingstemaErPlukkbart = (behandlingtemaKTObject: KTObject) => !ikkePlukkbareBehandlingstemaer.includes(behandlingtemaKTObject.kode);
 
-    const ikkePlukkbareBehandlingstemaer = erProdish ? [
-      MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND,
-    ] : [];
-    const behandlingstemaErPlukkbart = (behandlingtemaKTObject: KTObject) => !ikkePlukkbareBehandlingstemaer.includes(behandlingtemaKTObject.kode);
+  return (
+    <Nav.Panel className="forside__sidepanel sidepanel__behandling">
+      <Nav.typo.Systemtittel>Behandle sak</Nav.typo.Systemtittel>
+      <p>Velg behandlingstema for å få tildelt en sak.</p>
+      <form className="behandling__skjema" onSubmit={submitOgVideresend}>
+        <Nav.Row>
+          <Nav.Column xs="8">
+            <Skjema.Select feltNavn="behandlingstema" bredde="fullbredde" label="Behandlingstema">
+              {
+                MKV.KTObjects.behandlinger.behandlingstema
+                  .filter(behandlingstemaErPlukkbart)
+                  .sort(compareTerm)
+                  .map(({ kode, term }: KTObject) => {
+                    const tekst = term;
 
-    return (
-      <Nav.Panel className="forside__sidepanel sidepanel__behandling">
-        <Nav.typo.Systemtittel>Behandle sak</Nav.typo.Systemtittel>
-        <p>Velg behandlingstema for å få tildelt en sak.</p>
-        <form className="behandling__skjema" onSubmit={this.submitOgVideresend}>
-          <Nav.Row>
-            <Nav.Column xs="8">
-              <Skjema.Select feltNavn="behandlingstema" bredde="fullbredde" label="Behandlingstema">
-                {
-                  MKV.KTObjects.behandlinger.behandlingstema
-                    .filter(behandlingstemaErPlukkbart)
-                    .sort(compareTerm)
-                    .map(({ kode, term }: KTObject) => {
-                      const tekst = term;
-
-                      return (
-                        <option key={kode} value={kode}>{tekst}</option>
-                      );
-                    })
-                }
-              </Skjema.Select>
-            </Nav.Column>
-          </Nav.Row>
-          <Nav.Knapp className="behandling__knapp">Behandle sak</Nav.Knapp>
-        </form>
-      </Nav.Panel>
-    );
-  }
-}
+                    return (
+                      <option key={kode} value={kode}>{tekst}</option>
+                    );
+                  })
+              }
+            </Skjema.Select>
+          </Nav.Column>
+        </Nav.Row>
+        <Nav.Knapp className="behandling__knapp">Behandle sak</Nav.Knapp>
+      </form>
+    </Nav.Panel>
+  );
+};
 
 const BehandlngForm = reduxForm<KV.Form.BehandlingsFormData, BehandlingProps>({
   form: KV.Form.BEHANDLINGS_FORM,

--- a/src/sider/forside/komponenter/behandling.tsx
+++ b/src/sider/forside/komponenter/behandling.tsx
@@ -34,11 +34,7 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type BehandlingProps = PropsFromRedux & RouteComponentProps;
 
-interface FormData {
-  behandlingstema: string,
-}
-
-class Behandling extends Component<InjectedFormProps<FormData, BehandlingProps> & BehandlingProps> {
+class Behandling extends Component<InjectedFormProps<KV.Form.BehandlingsFormData, BehandlingProps> & BehandlingProps> {
   submitOgVideresend = async (form: any) => {
     const { handleSubmit, history } = this.props;
     const redirectURL = await handleSubmit(form);
@@ -88,7 +84,7 @@ class Behandling extends Component<InjectedFormProps<FormData, BehandlingProps> 
   }
 }
 
-const BehandlngForm = reduxForm<FormData, BehandlingProps>({
+const BehandlngForm = reduxForm<KV.Form.BehandlingsFormData, BehandlingProps>({
   form: KV.Form.BEHANDLINGS_FORM,
   destroyOnUnmount: false,
   onSubmit: form => oppgaverOperations.sendBehandlingsOppgave(form),

--- a/src/sider/forside/komponenter/behandling.tsx
+++ b/src/sider/forside/komponenter/behandling.tsx
@@ -66,7 +66,7 @@ const Behandling = ({
       <p>Velg behandlingstema for å få tildelt en sak.</p>
       <form className="behandling__skjema" onSubmit={submitOgVideresend}>
         <Nav.Row>
-          <Nav.Column xs="8">
+          <Nav.Column xs="12" >
             <Skjema.Select feltNavn="behandlingstema" bredde="fullbredde" label="Behandlingstema">
               {
                 MKV.KTObjects.behandlinger.behandlingstema

--- a/src/sider/forside/komponenter/behandling.tsx
+++ b/src/sider/forside/komponenter/behandling.tsx
@@ -38,7 +38,7 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 type BehandlingProps = PropsFromRedux & RouteComponentProps;
 
 
-const Behandling = ({
+export const Behandling = ({
   handleSubmit,
   history,
   erProdish,

--- a/src/sider/forside/komponenter/behandling.tsx
+++ b/src/sider/forside/komponenter/behandling.tsx
@@ -10,9 +10,12 @@ import MKV from '../../../melosyskodeverk';
 import * as KV from '../../../kodeverk';
 import * as Nav from '../../../utils/navFrontend';
 import * as Skjema from '../../../felleskomponenter/skjema';
+import * as Api from '../../../services/api';
 
 import { oppgaverOperations } from '../../../ducks/oppgaver';
 import { serverinfoSelectors } from '../../../ducks/serverinfo';
+
+import { useAsyncCallbackState } from '../../../hooks';
 
 import './behandling.css';
 
@@ -40,6 +43,8 @@ const Behandling = ({
   history,
   erProdish,
 }: InjectedFormProps<KV.Form.BehandlingsFormData, BehandlingProps> & BehandlingProps) => {
+  const [statistikk] = useAsyncCallbackState(Api.Statistikk.hent, { aapneBehandlinger: {} });
+
   const submitOgVideresend = async (form: any) => {
     const redirectURL = await handleSubmit(form);
 
@@ -68,10 +73,10 @@ const Behandling = ({
                   .filter(behandlingstemaErPlukkbart)
                   .sort(compareTerm)
                   .map(({ kode, term }: KTObject) => {
-                    const tekst = term;
+                    const antallAapneBehandlinger = statistikk.aapneBehandlinger[kode] || 0;
 
                     return (
-                      <option key={kode} value={kode}>{tekst}</option>
+                      <option key={kode} value={kode}>{term}&nbsp;&nbsp;({antallAapneBehandlinger})</option>
                     );
                   })
               }

--- a/src/utils/navFrontend.js
+++ b/src/utils/navFrontend.js
@@ -3,7 +3,7 @@ import { Panel } from 'nav-frontend-paneler';
 import AlertStripe, { AlertStripeAdvarsel, AlertStripeInfo } from 'nav-frontend-alertstriper';
 import EtikettBase from 'nav-frontend-etiketter';
 import { Container, Row, Column } from 'nav-frontend-grid';
-import { Checkbox, Radio, RadioPanelGruppe, SkjemaGruppe, Fieldset, Select, Input, Textarea } from 'nav-frontend-skjema';
+import { Checkbox, Radio, RadioPanelGruppe, SkjemaGruppe, Fieldset, Select, SelectProps, Input, Textarea } from 'nav-frontend-skjema';
 import * as typo from 'nav-frontend-typografi';
 import { Knapp, Hovedknapp, Flatknapp } from 'nav-frontend-knapper';
 import Lesmerpanel from 'nav-frontend-lesmerpanel';
@@ -19,7 +19,7 @@ import { LenkepanelBase } from 'nav-frontend-lenkepanel';
 export {
   AlertStripeAdvarsel, AlertStripe, AlertStripeInfo,
   Container, Row, Column,
-  Checkbox, Radio, RadioPanelGruppe, SkjemaGruppe, Fieldset, Select, Input, Textarea,
+  Checkbox, Radio, RadioPanelGruppe, SkjemaGruppe, Fieldset, Select, SelectProps, Input, Textarea,
   EkspanderbartpanelBase, Panel,
   EtikettBase,
   typo,


### PR DESCRIPTION
- Viser antall apne behandlinger i select for behandlingstema ved oppgaveplukker
- Bruker ts-mockito(https://www.npmjs.com/package/ts-mockito) for å mocke interfaces(gjør at vi slipper å skrive store mengder mock-data i tester). Så på https://www.npmjs.com/package/ts-auto-mock også, men den virket ikke like populær.