### PR TITLE
MELOSYS-3911 - Ikke vis tekst om å sjekke felter hvis mapping til felter feiler

### DIFF
--- a/src/felleskomponenter/dialogboks/dialogboksValidering.tsx
+++ b/src/felleskomponenter/dialogboks/dialogboksValidering.tsx
@@ -86,29 +86,34 @@ export const VedtakValideringsfeil = ({
   validering,
 }: {
   validering: Validering
-}) => (
-  <Fragment>
-    <Validering valideringKode={validering.kode} />
-    {
-      validering.felter.length > 0 && 'Sjekk følgende felt(er):'
-    }
-    <ul>
+}) => {
+  const felter = validering.felter.map(felt => {
+    const { panel, panelEntryNr, felt: feltNavn } = Utils.mapping.mapBehandlingsgrunnlagpathTilGUI(felt);
+    const key = `${panel}${panelEntryNr}${feltNavn}`;
+    const tekst = panel && feltNavn ? `${panel} - ${feltNavn}` : null;
+
+    if (!tekst) return null;
+
+    return (
+      <li key={key}>{tekst}</li>
+    );
+  }).filter(felt => felt);
+
+  return (
+    <Fragment>
+      <Validering valideringKode={validering.kode} />
       {
-        validering.felter.map(felt => {
-          const { panel, panelEntryNr, felt: feltNavn } = Utils.mapping.mapBehandlingsgrunnlagpathTilGUI(felt);
-          const key = `${panel}${panelEntryNr}${feltNavn}`;
-          const tekst = panel && feltNavn ? `${panel} - ${feltNavn}` : null;
-
-          if (!tekst) return null;
-
-          return (
-            <li key={key}>{tekst}</li>
-          );
-        })
+        felter.length > 0 &&
+        <Fragment>
+          Sjekk følgende felt(er):
+          <ul>
+            { felter }
+          </ul>
+        </Fragment>
       }
-    </ul>
-  </Fragment>
-);
+    </Fragment>
+  );
+};
 
 VedtakValideringsfeil.propTypes = {
   validering: PT.shape({


### PR DESCRIPTION
- Når mappingen fra feltnavn i behandlingsgrunnlag til feltnavn i gui feilet før, ble det fortsatt vist teksten "Sjekk følgende felt(er):". Med denne PRen skal ikke denne teksten vises før mapping av minst ett felt er vellykket.