### PR TITLE
MELOSYS-4039 - Bruk feilkoder ved anmodning bestilling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,7 +40,7 @@
     "import/no-extraneous-dependencies": [0],
     "import/prefer-default-export": 0,
     "import/no-named-as-default": 0,
-    "import/no-unresolved": [2, { "ignore": ["AppTypes", "Domene"] }],
+    "import/no-unresolved": [2, { "ignore": ["AppTypes", "Domene", "melosys-api"] }],
     "jsx-a11y/aria-props": 2,
     "jsx-a11y/aria-proptypes": 2,
     "jsx-a11y/aria-role": 2,

--- a/src/ducks/anmodningunntak/selectors.test.ts
+++ b/src/ducks/anmodningunntak/selectors.test.ts
@@ -8,6 +8,65 @@ import MKV from '../../melosyskodeverk';
 import { STATUS } from '../../services/utils';
 
 describe('AnmodningOmUnntakselectors', () => {
+  describe('FeilmeldingSelector', () => {
+    it('returnerer feilmelding fra response ved 400-feil', () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.anmodningomunntak = {
+        status: STATUS.ERROR,
+        data: {
+          data: {
+            status: 400,
+            message: 'Funksjonell feil',
+            feilkoder: [],
+            error: 'Funksjonell feil',
+          },
+        },
+      };
+
+      const [feilmelding] = selectors.FeilmeldingSelector(state);
+      expect(feilmelding.innhold).toEqual('Funksjonell feil');
+      expect(feilmelding.tittel).toEqual('Feil ved anmodning om unntak');
+    });
+
+    it('returnerer generisk feilmelding ved 500-feil', () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.anmodningomunntak = {
+        status: STATUS.ERROR,
+        data: {
+          data: {
+            status: 500,
+            message: 'Melding som ikke blir brukt',
+            feilkoder: [],
+            error: 'Funksjonell feil',
+          },
+        },
+      };
+
+      const [feilmelding] = selectors.FeilmeldingSelector(state);
+      expect(feilmelding.tittel).toEqual('Teknisk feil');
+    });
+
+    it(`returnerer tom liste ved status ${STATUS.OK}`, () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.anmodningomunntak = {
+        status: STATUS.OK,
+        data: {
+          data: {
+            status: 500,
+            message: 'Melding som ikke blir brukt',
+            feilkoder: [],
+            error: 'Funksjonell feil',
+          },
+        },
+      };
+
+      const feilmelding = selectors.FeilmeldingSelector(state);
+      expect(feilmelding).toHaveLength(0);
+    });
+  });
   describe('FeilkoderSelector', () => {
     it('returnerer feilkoder ved status ERROR', () => {
       const mockedState = mock<RootState>();

--- a/src/ducks/anmodningunntak/selectors.test.ts
+++ b/src/ducks/anmodningunntak/selectors.test.ts
@@ -1,52 +1,137 @@
+import { mock, instance } from 'ts-mockito';
+import { RootState } from 'AppTypes';
+
 import * as selectors from './selectors';
-import * as DucksTestUtils from '../test-utils';
+
+import MKV from '../../melosyskodeverk';
+
+import { STATUS } from '../../services/utils';
 
 describe('AnmodningOmUnntakselectors', () => {
   describe('FeilmeldingSelector', () => {
     it('feilmelding fra response ved 400-feil', () => {
-      const state = DucksTestUtils.lagState({
-        anmodningomunntak: {
-          status: 'ERROR',
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.anmodningomunntak = {
+        status: 'ERROR',
+        data: {
           data: {
-            data: {
-              status: 400,
-              message: 'Funksjonell feil',
-            },
+            status: 400,
+            message: 'Funksjonell feil',
+            error: 'Valideringsfeil',
           },
         },
-      });
+      };
 
       const [feilmelding] = selectors.FeilmeldingSelector(state);
       expect(feilmelding.innhold).toEqual('Funksjonell feil');
     });
 
     it('generisk feilmelding ved 500-feil', () => {
-      const state = DucksTestUtils.lagState({
-        anmodningomunntak: {
-          status: 'ERROR',
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.anmodningomunntak = {
+        status: 'ERROR',
+        data: {
           data: {
-            data: {
-              status: 500,
-              message: 'Melding som ikke blir brukt',
-            },
+            status: 500,
+            message: 'Melding som ikke blir brukt',
+            error: 'Valideringsfeil',
           },
         },
-      });
+      };
 
       const [feilmelding] = selectors.FeilmeldingSelector(state);
       expect(feilmelding.tittel).toEqual('Teknisk feil');
     });
 
     it('tom liste ved ingen feil', () => {
-      const state = DucksTestUtils.lagState({
-        anmodningomunntak: {
-          status: 'OK',
-          data: {},
-        },
-      });
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.anmodningomunntak = {
+        status: 'OK',
+        data: {},
+      };
 
       const feilmelding = selectors.FeilmeldingSelector(state);
       expect(feilmelding).toHaveLength(0);
+    });
+  });
+
+  describe('FeilkoderSelector', () => {
+    it('returnerer feilkoder ved status ERROR', () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.anmodningomunntak = {
+        data: {
+          data: {
+            feilkoder: [],
+            error: 'Valideringsfeil',
+            status: 404,
+            message: 'Valideringsfeil',
+          },
+        },
+        status: STATUS.ERROR,
+      };
+
+      const forventetResultat = state.anmodningomunntak.data.data && state.anmodningomunntak.data.data.feilkoder;
+
+      expect(selectors.FeilkoderSelector(state)).toBe(forventetResultat);
+    });
+
+    it('returnerer tom array ved status OK', () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.anmodningomunntak = {
+        data: {
+          data: {
+            feilkoder: [
+              {
+                kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.OVERLAPPENDE_MEDL_PERIODER,
+                felter: [],
+              },
+              {
+                kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
+                felter: [],
+              },
+            ],
+            error: 'Valideringsfeil',
+            status: 404,
+            message: 'Valideringsfeil',
+          },
+        },
+        status: STATUS.OK,
+      };
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
+    });
+
+    it('returnerer tom array ved feilkoder undefined', () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.anmodningomunntak = {
+        data: {
+          data: {
+            error: 'Valideringsfeil',
+            status: 404,
+            message: 'Valideringsfeil',
+          },
+        },
+        status: STATUS.ERROR,
+      };
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
+    });
+
+    it('returnerer tom array ved data undefined', () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.anmodningomunntak = {
+        data: {},
+        status: STATUS.ERROR,
+      };
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
     });
   });
 });

--- a/src/ducks/anmodningunntak/selectors.test.ts
+++ b/src/ducks/anmodningunntak/selectors.test.ts
@@ -8,56 +8,6 @@ import MKV from '../../melosyskodeverk';
 import { STATUS } from '../../services/utils';
 
 describe('AnmodningOmUnntakselectors', () => {
-  describe('FeilmeldingSelector', () => {
-    it('feilmelding fra response ved 400-feil', () => {
-      const mockedState = mock<RootState>();
-      const state = instance(mockedState);
-      state.anmodningomunntak = {
-        status: 'ERROR',
-        data: {
-          data: {
-            status: 400,
-            message: 'Funksjonell feil',
-            error: 'Valideringsfeil',
-          },
-        },
-      };
-
-      const [feilmelding] = selectors.FeilmeldingSelector(state);
-      expect(feilmelding.innhold).toEqual('Funksjonell feil');
-    });
-
-    it('generisk feilmelding ved 500-feil', () => {
-      const mockedState = mock<RootState>();
-      const state = instance(mockedState);
-      state.anmodningomunntak = {
-        status: 'ERROR',
-        data: {
-          data: {
-            status: 500,
-            message: 'Melding som ikke blir brukt',
-            error: 'Valideringsfeil',
-          },
-        },
-      };
-
-      const [feilmelding] = selectors.FeilmeldingSelector(state);
-      expect(feilmelding.tittel).toEqual('Teknisk feil');
-    });
-
-    it('tom liste ved ingen feil', () => {
-      const mockedState = mock<RootState>();
-      const state = instance(mockedState);
-      state.anmodningomunntak = {
-        status: 'OK',
-        data: {},
-      };
-
-      const feilmelding = selectors.FeilmeldingSelector(state);
-      expect(feilmelding).toHaveLength(0);
-    });
-  });
-
   describe('FeilkoderSelector', () => {
     it('returnerer feilkoder ved status ERROR', () => {
       const mockedState = mock<RootState>();

--- a/src/ducks/anmodningunntak/selectors.ts
+++ b/src/ducks/anmodningunntak/selectors.ts
@@ -54,3 +54,14 @@ export const FeilmeldingSelector = createSelector(
     return [];
   }
 );
+
+export const FeilkoderSelector = createSelector(
+  HttpResponsDataSelector,
+  ReduxStatusSelector,
+  (httpResponsData, reduxStatus) => {
+    if (httpResponsData && httpResponsData.feilkoder && reduxStatus === STATUS.ERROR) {
+      return httpResponsData.feilkoder;
+    }
+    return [];
+  }
+);

--- a/src/ducks/anmodningunntak/selectors.ts
+++ b/src/ducks/anmodningunntak/selectors.ts
@@ -24,6 +24,23 @@ const HttpResponsDataSelector = createSelector(
   anmodningOmUnntakData => anmodningOmUnntakData.data
 );
 
+const HttpStatusSelector = createSelector(
+  HttpResponsDataSelector,
+  httpResponsData => httpResponsData && httpResponsData.status
+);
+
+const HttpMessageSelector = createSelector(
+  HttpResponsDataSelector,
+  httpResponsData => httpResponsData && httpResponsData.message
+);
+
+export const FeilmeldingSelector = createSelector(
+  ReduxStatusSelector,
+  HttpStatusSelector,
+  HttpMessageSelector,
+  DucksUtils.hentFeilmeldingByStateName('anmodning om unntak')
+);
+
 export const FeilkoderSelector = createSelector(
   HttpResponsDataSelector,
   ReduxStatusSelector,

--- a/src/ducks/anmodningunntak/selectors.ts
+++ b/src/ducks/anmodningunntak/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector, Selector } from 'reselect';
 import { RootState, StateSection } from 'AppTypes';
 
-import { STATUS } from '../../services/utils';
+import * as DucksUtils from '../utils';
 import * as Types from './types';
 
 const AnmodningOmUnntakSelector: Selector<RootState, StateSection<Types.Data>> = createSelector(
@@ -27,10 +27,5 @@ const HttpResponsDataSelector = createSelector(
 export const FeilkoderSelector = createSelector(
   HttpResponsDataSelector,
   ReduxStatusSelector,
-  (httpResponsData, reduxStatus) => {
-    if (httpResponsData && httpResponsData.feilkoder && reduxStatus === STATUS.ERROR) {
-      return httpResponsData.feilkoder;
-    }
-    return [];
-  }
+  DucksUtils.hentFeilkoder
 );

--- a/src/ducks/anmodningunntak/selectors.ts
+++ b/src/ducks/anmodningunntak/selectors.ts
@@ -24,37 +24,6 @@ const HttpResponsDataSelector = createSelector(
   anmodningOmUnntakData => anmodningOmUnntakData.data
 );
 
-const HttpStatusSelector = createSelector(
-  HttpResponsDataSelector,
-  httpResponsData => httpResponsData && httpResponsData.status
-);
-
-const HttpMessageSelector = createSelector(
-  HttpResponsDataSelector,
-  httpResponsData => httpResponsData && httpResponsData.message
-);
-
-export const FeilmeldingSelector = createSelector(
-  ReduxStatusSelector,
-  HttpStatusSelector,
-  HttpMessageSelector,
-  (reduxStatus, httpStatus, httpMessage) => {
-    if (reduxStatus === STATUS.ERROR) {
-      if (httpStatus && httpStatus < 500) {
-        return [{
-          tittel: 'Feil ved anmodning om unntak',
-          innhold: httpMessage,
-        }];
-      }
-      return [{
-        tittel: 'Teknisk feil',
-        innhold: 'Det oppsto en teknisk feil ved anmodning om unntak. Ta kontakt med brukerstøtte dersom problemet oppstår gjentatte ganger.',
-      }];
-    }
-    return [];
-  }
-);
-
 export const FeilkoderSelector = createSelector(
   HttpResponsDataSelector,
   ReduxStatusSelector,

--- a/src/ducks/anmodningunntak/types.ts
+++ b/src/ducks/anmodningunntak/types.ts
@@ -1,13 +1,12 @@
+import { ErrorResponse } from 'melosys-api';
+
 export const OK = 'anmodningunntak/OK';
 export const FEILET = 'anmodningunntak/FEILET';
 export const PENDING = 'anmodningunntak/PENDING';
 export const RESET = 'anmodningunntak/RESET';
 
 export interface Data {
-  data?: {
-    status?: number,
-    message?: string,
-  }
+  data?: ErrorResponse,
 }
 
 interface ResetAction {

--- a/src/ducks/journalforing/selectors.js
+++ b/src/ducks/journalforing/selectors.js
@@ -90,12 +90,12 @@ const JournalforingDataSelector = createSelector(
 
 const HttpStatusSelector = createSelector(
   JournalforingDataSelector,
-  journalforingData => journalforingData.status
+  journalforingData => journalforingData && journalforingData.status
 );
 
 const HttpMessageSelector = createSelector(
   JournalforingDataSelector,
-  journalforingData => journalforingData.message
+  journalforingData => journalforingData && journalforingData.message
 );
 
 export const FeilmeldingSelector = createSelector(

--- a/src/ducks/journalforing/selectors.js
+++ b/src/ducks/journalforing/selectors.js
@@ -6,6 +6,9 @@
  */
 
 import { createSelector } from 'reselect';
+
+import * as DucksUtils from '../utils';
+
 import { STATUS } from '../../services/utils';
 
 const JournalforingSelector = createSelector(
@@ -109,4 +112,10 @@ export const FeilmeldingSelector = createSelector(
     }
     return [];
   }
+);
+
+export const FeilkoderSelector = createSelector(
+  JournalforingDataSelector,
+  ReduxStatusSelector,
+  DucksUtils.hentFeilkoder
 );

--- a/src/ducks/journalforing/selectors.js
+++ b/src/ducks/journalforing/selectors.js
@@ -9,8 +9,6 @@ import { createSelector } from 'reselect';
 
 import * as DucksUtils from '../utils';
 
-import { STATUS } from '../../services/utils';
-
 const JournalforingSelector = createSelector(
   state => state.journalforing || {},
   journalforing => journalforing
@@ -104,14 +102,7 @@ export const FeilmeldingSelector = createSelector(
   ReduxStatusSelector,
   HttpStatusSelector,
   HttpMessageSelector,
-  (reduxStatus, httpStatus, httpMessage) => {
-    if (reduxStatus === STATUS.ERROR) {
-      return httpStatus < 500
-        ? [{ tittel: 'Feil ved journalføring', innhold: httpMessage }]
-        : [{ tittel: 'Teknisk feil', innhold: 'Det oppsto en teknisk feil ved journalføring. Ta kontakt med brukerstøtte dersom problemet oppstår gjentatte ganger.' }];
-    }
-    return [];
-  }
+  DucksUtils.hentFeilmeldingByStateName('journalføring')
 );
 
 export const FeilkoderSelector = createSelector(

--- a/src/ducks/journalforing/selectors.test.js
+++ b/src/ducks/journalforing/selectors.test.js
@@ -7,14 +7,15 @@ import { STATUS } from '../../services/utils';
 
 describe('Journalforingselectors', () => {
   describe('FeilmeldingSelector', () => {
-    it('feilmelding fra response ved 400-feil', () => {
+    it('returnerer feilmelding fra response ved 400-feil', () => {
       const state = DucksTestUtils.lagState({
         journalforing: {
-          status: 'ERROR',
+          status: STATUS.ERROR,
           data: {
             data: {
               status: 400,
               message: 'Funksjonell feil',
+              error: 'Funksjonell feil',
             },
           },
         },
@@ -22,16 +23,18 @@ describe('Journalforingselectors', () => {
 
       const [feilmelding] = selectors.FeilmeldingSelector(state);
       expect(feilmelding.innhold).toEqual('Funksjonell feil');
+      expect(feilmelding.tittel).toEqual('Feil ved journalføring');
     });
 
-    it('generisk feilmelding ved 500-feil', () => {
+    it('returnerer generisk feilmelding ved 500-feil', () => {
       const state = DucksTestUtils.lagState({
         journalforing: {
-          status: 'ERROR',
+          status: STATUS.ERROR,
           data: {
             data: {
               status: 500,
               message: 'Melding som ikke blir brukt',
+              error: 'Funksjonell feil',
             },
           },
         },
@@ -41,12 +44,16 @@ describe('Journalforingselectors', () => {
       expect(feilmelding.tittel).toEqual('Teknisk feil');
     });
 
-    it('tom liste ved ingen feil', () => {
+    it(`returnerer tom liste ved status ${STATUS.OK}`, () => {
       const state = DucksTestUtils.lagState({
         journalforing: {
-          status: 'OK',
+          status: STATUS.OK,
           data: {
-            data: {},
+            data: {
+              status: 500,
+              message: 'Melding som ikke blir brukt',
+              error: 'Funksjonell feil',
+            },
           },
         },
       });

--- a/src/ducks/journalforing/selectors.test.js
+++ b/src/ducks/journalforing/selectors.test.js
@@ -1,23 +1,21 @@
 import * as selectors from './selectors';
+import * as DucksTestUtils from '../test-utils';
+
+import MKV from '../../melosyskodeverk';
+
+import { STATUS } from '../../services/utils';
 
 describe('Journalforingselectors', () => {
-  const lagState = ({
-    status, data,
-  }) => ({
-    journalforing: {
-      status,
-      data,
-    },
-  });
-
   describe('FeilmeldingSelector', () => {
     it('feilmelding fra response ved 400-feil', () => {
-      const state = lagState({
-        status: 'ERROR',
-        data: {
+      const state = DucksTestUtils.lagState({
+        journalforing: {
+          status: 'ERROR',
           data: {
-            status: 400,
-            message: 'Funksjonell feil',
+            data: {
+              status: 400,
+              message: 'Funksjonell feil',
+            },
           },
         },
       });
@@ -27,12 +25,14 @@ describe('Journalforingselectors', () => {
     });
 
     it('generisk feilmelding ved 500-feil', () => {
-      const state = lagState({
-        status: 'ERROR',
-        data: {
+      const state = DucksTestUtils.lagState({
+        journalforing: {
+          status: 'ERROR',
           data: {
-            status: 500,
-            message: 'Melding som ikke blir brukt',
+            data: {
+              status: 500,
+              message: 'Melding som ikke blir brukt',
+            },
           },
         },
       });
@@ -42,15 +42,84 @@ describe('Journalforingselectors', () => {
     });
 
     it('tom liste ved ingen feil', () => {
-      const state = lagState({
-        status: 'OK',
-        data: {
-          data: {},
+      const state = DucksTestUtils.lagState({
+        journalforing: {
+          status: 'OK',
+          data: {
+            data: {},
+          },
         },
       });
 
       const feilmelding = selectors.FeilmeldingSelector(state);
       expect(feilmelding).toHaveLength(0);
+    });
+  });
+
+  describe('FeilkoderSelector', () => {
+    it('returnerer feilkoder ved status ERROR', () => {
+      const state = DucksTestUtils.lagState({
+        journalforing: {
+          data: {
+            data: {
+              feilkoder: [],
+            },
+          },
+          status: STATUS.ERROR,
+        },
+      });
+
+      const forventetResultat = state.journalforing.data.data.feilkoder;
+
+      expect(selectors.FeilkoderSelector(state)).toBe(forventetResultat);
+    });
+
+    it('returnerer tom array ved status OK', () => {
+      const state = DucksTestUtils.lagState({
+        journalforing: {
+          data: {
+            data: {
+              feilkoder: [
+                {
+                  kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.OVERLAPPENDE_MEDL_PERIODER,
+                  felter: [],
+                },
+                {
+                  kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
+                  felter: [],
+                },
+              ],
+            },
+          },
+          status: STATUS.OK,
+        },
+      });
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
+    });
+
+    it('returnerer tom array ved feilkoder undefined', () => {
+      const state = DucksTestUtils.lagState({
+        journalforing: {
+          data: {
+            data: {},
+          },
+          status: STATUS.ERROR,
+        },
+      });
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
+    });
+
+    it('returnerer tom array ved data undefined', () => {
+      const state = DucksTestUtils.lagState({
+        journalforing: {
+          data: {},
+          status: STATUS.ERROR,
+        },
+      });
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
     });
   });
 });

--- a/src/ducks/utils/index.ts
+++ b/src/ducks/utils/index.ts
@@ -2,12 +2,47 @@ import { ErrorResponse } from 'melosys-api';
 
 import { STATUS } from '../../services/utils';
 
-export const hentFeilkoder = (res: ErrorResponse | undefined, status: string) => {
-  if (res && res.feilkoder && status === STATUS.ERROR) {
+export const hentFeilkoder = (res: ErrorResponse | undefined, reduxStatus: string) => {
+  if (res && res.feilkoder && reduxStatus === STATUS.ERROR) {
     return res.feilkoder;
   }
   return [];
 };
+
+const hentFeilmelding = ({
+  reduxStatus,
+  httpStatus,
+  httpMessage,
+  stateName,
+}: {
+  reduxStatus: string,
+  httpStatus: number | undefined,
+  httpMessage: string | undefined,
+  stateName: string,
+}) => {
+  if (reduxStatus === STATUS.ERROR) {
+    if (httpStatus && httpStatus < 500) {
+      return [{
+        tittel: `Feil ved ${stateName}`,
+        innhold: httpMessage,
+      }];
+    }
+    return [{
+      tittel: 'Teknisk feil',
+      innhold: `Det oppsto en teknisk feil ved ${stateName}. Ta kontakt med brukerstøtte dersom problemet oppstår gjentatte ganger.`,
+    }];
+  }
+  return [];
+};
+
+export const hentFeilmeldingByStateName = (stateName: string) => (
+  (reduxStatus: string, httpStatus: number | undefined, httpMessage: string | undefined) => hentFeilmelding({
+    reduxStatus,
+    httpStatus,
+    httpMessage,
+    stateName,
+  })
+);
 
 export const harFeilkode = (data: any) => data.feilkoder && data.feilkoder.length > 0;
 

--- a/src/ducks/utils/index.ts
+++ b/src/ducks/utils/index.ts
@@ -1,3 +1,14 @@
+import { ErrorResponse } from 'melosys-api';
+
+import { STATUS } from '../../services/utils';
+
+export const hentFeilkoder = (res: ErrorResponse | undefined, status: string) => {
+  if (res && res.feilkoder && status === STATUS.ERROR) {
+    return res.feilkoder;
+  }
+  return [];
+};
+
 export const harFeilkode = (data: any) => data.feilkoder && data.feilkoder.length > 0;
 
 export const harFeilmelding = (data: any) => data.message;

--- a/src/ducks/utpek/selectors.js
+++ b/src/ducks/utpek/selectors.js
@@ -7,7 +7,7 @@ const UtpekSelector = createSelector(
   utpek => utpek
 );
 
-const StatusSelector = createSelector(
+const ReduxStatusSelector = createSelector(
   state => state.utpek.status,
   status => status
 );
@@ -17,8 +17,30 @@ const ResponsDataSelector = createSelector(
   data => data.data
 );
 
+const HttpResponsDataSelector = createSelector(
+  UtpekSelector,
+  utpek => utpek.data
+);
+
+const HttpStatusSelector = createSelector(
+  HttpResponsDataSelector,
+  httpResponsData => httpResponsData && httpResponsData.status
+);
+
+const HttpMessageSelector = createSelector(
+  HttpResponsDataSelector,
+  httpResponsData => httpResponsData && httpResponsData.message
+);
+
+export const FeilmeldingSelector = createSelector(
+  ReduxStatusSelector,
+  HttpStatusSelector,
+  HttpMessageSelector,
+  DucksUtils.hentFeilmeldingByStateName('utpeking')
+);
+
 export const FeilkoderSelector = createSelector(
   ResponsDataSelector,
-  StatusSelector,
+  ReduxStatusSelector,
   DucksUtils.hentFeilkoder
 );

--- a/src/ducks/utpek/selectors.js
+++ b/src/ducks/utpek/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-import { STATUS } from '../../services/utils';
+import * as DucksUtils from '../utils';
 
 const UtpekSelector = createSelector(
   state => state.utpek.data,
@@ -12,13 +12,13 @@ const StatusSelector = createSelector(
   status => status
 );
 
-export const FeilkoderSelector = createSelector(
+const ResponsDataSelector = createSelector(
   UtpekSelector,
+  data => data.data
+);
+
+export const FeilkoderSelector = createSelector(
+  ResponsDataSelector,
   StatusSelector,
-  (utpek, status) => {
-    if (status === STATUS.ERROR) {
-      return utpek.data.feilkoder;
-    }
-    return [];
-  }
+  DucksUtils.hentFeilkoder
 );

--- a/src/ducks/utpek/selectors.test.js
+++ b/src/ducks/utpek/selectors.test.js
@@ -1,26 +1,22 @@
 import * as selectors from './selectors';
+import * as DucksTestUtils from '../test-utils';
 
 import MKV from '../../melosyskodeverk';
 
 import { STATUS } from '../../services/utils';
 
 describe('utpek selectors', () => {
-  const lagState = ({ data, status }) => ({
-    utpek: {
-      data,
-      status,
-    },
-  });
-
   describe('FeilkoderSelector', () => {
     it('returnerer feilkoder ved status ERROR', () => {
-      const state = lagState({
-        data: {
+      const state = DucksTestUtils.lagState({
+        utpek: {
           data: {
-            feilkoder: [],
+            data: {
+              feilkoder: [],
+            },
           },
+          status: STATUS.ERROR,
         },
-        status: STATUS.ERROR,
       });
 
       const forventetResultat = state.utpek.data.data.feilkoder;
@@ -29,22 +25,48 @@ describe('utpek selectors', () => {
     });
 
     it('returnerer tom array ved status OK', () => {
-      const state = lagState({
-        data: {
+      const state = DucksTestUtils.lagState({
+        utpek: {
           data: {
-            feilkoder: [
-              {
-                kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.OVERLAPPENDE_MEDL_PERIODER,
-                felter: [],
-              },
-              {
-                kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
-                felter: [],
-              },
-            ],
+            data: {
+              feilkoder: [
+                {
+                  kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.OVERLAPPENDE_MEDL_PERIODER,
+                  felter: [],
+                },
+                {
+                  kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
+                  felter: [],
+                },
+              ],
+            },
           },
+          status: STATUS.OK,
         },
-        status: STATUS.OK,
+      });
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
+    });
+
+    it('returnerer tom array ved feilkoder undefined', () => {
+      const state = DucksTestUtils.lagState({
+        utpek: {
+          data: {
+            data: {},
+          },
+          status: STATUS.ERROR,
+        },
+      });
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
+    });
+
+    it('returnerer tom array ved data undefined', () => {
+      const state = DucksTestUtils.lagState({
+        utpek: {
+          data: {},
+          status: STATUS.ERROR,
+        },
       });
 
       expect(selectors.FeilkoderSelector(state)).toEqual([]);

--- a/src/ducks/utpek/selectors.test.js
+++ b/src/ducks/utpek/selectors.test.js
@@ -6,6 +6,62 @@ import MKV from '../../melosyskodeverk';
 import { STATUS } from '../../services/utils';
 
 describe('utpek selectors', () => {
+  describe('FeilmeldingSelector', () => {
+    it('returnerer feilmelding fra response ved 400-feil', () => {
+      const state = DucksTestUtils.lagState({
+        utpek: {
+          status: STATUS.ERROR,
+          data: {
+            data: {
+              status: 400,
+              message: 'Funksjonell feil',
+              error: 'Funksjonell feil',
+            },
+          },
+        },
+      });
+
+      const [feilmelding] = selectors.FeilmeldingSelector(state);
+      expect(feilmelding.innhold).toEqual('Funksjonell feil');
+      expect(feilmelding.tittel).toEqual('Feil ved utpeking');
+    });
+
+    it('returnerer generisk feilmelding ved 500-feil', () => {
+      const state = DucksTestUtils.lagState({
+        utpek: {
+          status: STATUS.ERROR,
+          data: {
+            data: {
+              status: 500,
+              message: 'Melding som ikke blir brukt',
+              error: 'Funksjonell feil',
+            },
+          },
+        },
+      });
+
+      const [feilmelding] = selectors.FeilmeldingSelector(state);
+      expect(feilmelding.tittel).toEqual('Teknisk feil');
+    });
+
+    it(`returnerer tom liste ved status ${STATUS.OK}`, () => {
+      const state = DucksTestUtils.lagState({
+        utpek: {
+          status: STATUS.OK,
+          data: {
+            data: {
+              status: 500,
+              message: 'Melding som ikke blir brukt',
+              error: 'Funksjonell feil',
+            },
+          },
+        },
+      });
+
+      const feilmelding = selectors.FeilmeldingSelector(state);
+      expect(feilmelding).toHaveLength(0);
+    });
+  });
   describe('FeilkoderSelector', () => {
     it('returnerer feilkoder ved status ERROR', () => {
       const state = DucksTestUtils.lagState({

--- a/src/ducks/vedtak/selectors.js
+++ b/src/ducks/vedtak/selectors.js
@@ -31,12 +31,12 @@ const HttpResponsDataSelector = createSelector(
 
 const HttpStatusSelector = createSelector(
   HttpResponsDataSelector,
-  httpResponsData => httpResponsData.status
+  httpResponsData => httpResponsData && httpResponsData.status
 );
 
 const HttpMessageSelector = createSelector(
   HttpResponsDataSelector,
-  httpResponsData => httpResponsData.message
+  httpResponsData => httpResponsData && httpResponsData.message
 );
 
 export const FeilmeldingSelector = createSelector(

--- a/src/ducks/vedtak/selectors.js
+++ b/src/ducks/vedtak/selectors.js
@@ -14,23 +14,40 @@ const DataSelector = createSelector(
   vedtak => vedtak.data
 );
 
-const StatusSelector = createSelector(
+const ReduxStatusSelector = createSelector(
   VedtakSelector,
-  status => status.status
+  vedtak => vedtak.status
 );
 
 export const ErPendingSelector = createSelector(
-  StatusSelector,
+  ReduxStatusSelector,
   status => status === STATUS.PENDING
 );
 
-const ResponsDataSelector = createSelector(
+const HttpResponsDataSelector = createSelector(
   DataSelector,
   data => data.data
 );
 
+const HttpStatusSelector = createSelector(
+  HttpResponsDataSelector,
+  httpResponsData => httpResponsData.status
+);
+
+const HttpMessageSelector = createSelector(
+  HttpResponsDataSelector,
+  httpResponsData => httpResponsData.message
+);
+
+export const FeilmeldingSelector = createSelector(
+  ReduxStatusSelector,
+  HttpStatusSelector,
+  HttpMessageSelector,
+  DucksUtils.hentFeilmeldingByStateName('vedtak')
+);
+
 export const FeilkoderSelector = createSelector(
-  ResponsDataSelector,
-  StatusSelector,
+  HttpResponsDataSelector,
+  ReduxStatusSelector,
   DucksUtils.hentFeilkoder
 );

--- a/src/ducks/vedtak/selectors.js
+++ b/src/ducks/vedtak/selectors.js
@@ -1,5 +1,7 @@
 import { createSelector } from 'reselect';
 
+import * as DucksUtils from '../utils';
+
 import { STATUS } from '../../services/utils';
 
 const VedtakSelector = createSelector(
@@ -30,10 +32,5 @@ const ResponsDataSelector = createSelector(
 export const FeilkoderSelector = createSelector(
   ResponsDataSelector,
   StatusSelector,
-  (responsData, status) => {
-    if (status === STATUS.ERROR) {
-      return responsData.feilkoder;
-    }
-    return [];
-  }
+  DucksUtils.hentFeilkoder
 );

--- a/src/ducks/vedtak/selectors.test.js
+++ b/src/ducks/vedtak/selectors.test.js
@@ -1,26 +1,22 @@
 import * as selectors from './selectors';
+import * as DucksTestUtils from '../test-utils';
 
 import MKV from '../../melosyskodeverk';
 
 import { STATUS } from '../../services/utils';
 
 describe('vedtak selectors', () => {
-  const lagState = ({ data, status }) => ({
-    vedtak: {
-      data,
-      status,
-    },
-  });
-
   describe('FeilkoderSelector', () => {
     it('returnerer feilkoder ved status ERROR', () => {
-      const state = lagState({
-        data: {
+      const state = DucksTestUtils.lagState({
+        vedtak: {
           data: {
-            feilkoder: [],
+            data: {
+              feilkoder: [],
+            },
           },
+          status: STATUS.ERROR,
         },
-        status: STATUS.ERROR,
       });
 
       const forventetResultat = state.vedtak.data.data.feilkoder;
@@ -29,22 +25,48 @@ describe('vedtak selectors', () => {
     });
 
     it('returnerer tom array ved status OK', () => {
-      const state = lagState({
-        data: {
+      const state = DucksTestUtils.lagState({
+        vedtak: {
           data: {
-            feilkoder: [
-              {
-                kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.OVERLAPPENDE_MEDL_PERIODER,
-                felter: [],
-              },
-              {
-                kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
-                felter: [],
-              },
-            ],
+            data: {
+              feilkoder: [
+                {
+                  kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.OVERLAPPENDE_MEDL_PERIODER,
+                  felter: [],
+                },
+                {
+                  kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
+                  felter: [],
+                },
+              ],
+            },
           },
+          status: STATUS.OK,
         },
-        status: STATUS.OK,
+      });
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
+    });
+
+    it('returnerer tom array ved feilkoder undefined', () => {
+      const state = DucksTestUtils.lagState({
+        vedtak: {
+          data: {
+            data: {},
+          },
+          status: STATUS.ERROR,
+        },
+      });
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
+    });
+
+    it('returnerer tom array ved data undefined', () => {
+      const state = DucksTestUtils.lagState({
+        vedtak: {
+          data: {},
+          status: STATUS.ERROR,
+        },
       });
 
       expect(selectors.FeilkoderSelector(state)).toEqual([]);

--- a/src/ducks/vedtak/selectors.test.js
+++ b/src/ducks/vedtak/selectors.test.js
@@ -6,6 +6,62 @@ import MKV from '../../melosyskodeverk';
 import { STATUS } from '../../services/utils';
 
 describe('vedtak selectors', () => {
+  describe('FeilmeldingSelector', () => {
+    it('returnerer feilmelding fra response ved 400-feil', () => {
+      const state = DucksTestUtils.lagState({
+        vedtak: {
+          status: STATUS.ERROR,
+          data: {
+            data: {
+              status: 400,
+              message: 'Funksjonell feil',
+              error: 'Funksjonell feil',
+            },
+          },
+        },
+      });
+
+      const [feilmelding] = selectors.FeilmeldingSelector(state);
+      expect(feilmelding.innhold).toEqual('Funksjonell feil');
+      expect(feilmelding.tittel).toEqual('Feil ved vedtak');
+    });
+
+    it('returnerer generisk feilmelding ved 500-feil', () => {
+      const state = DucksTestUtils.lagState({
+        vedtak: {
+          status: STATUS.ERROR,
+          data: {
+            data: {
+              status: 500,
+              message: 'Melding som ikke blir brukt',
+              error: 'Funksjonell feil',
+            },
+          },
+        },
+      });
+
+      const [feilmelding] = selectors.FeilmeldingSelector(state);
+      expect(feilmelding.tittel).toEqual('Teknisk feil');
+    });
+
+    it(`returnerer tom liste ved status ${STATUS.OK}`, () => {
+      const state = DucksTestUtils.lagState({
+        vedtak: {
+          status: STATUS.OK,
+          data: {
+            data: {
+              status: 500,
+              message: 'Melding som ikke blir brukt',
+              error: 'Funksjonell feil',
+            },
+          },
+        },
+      });
+
+      const feilmelding = selectors.FeilmeldingSelector(state);
+      expect(feilmelding).toHaveLength(0);
+    });
+  });
   describe('FeilkoderSelector', () => {
     it('returnerer feilkoder ved status ERROR', () => {
       const state = DucksTestUtils.lagState({

--- a/src/ducks/videresending/selectors.test.ts
+++ b/src/ducks/videresending/selectors.test.ts
@@ -8,7 +8,7 @@ import { STATUS } from '../../services/utils';
 
 describe('Videresendingselectors', () => {
   describe('FeilmeldingSelector', () => {
-    it('feilmelding fra response ved 400-feil', () => {
+    it('returnerer feilmelding fra response ved 400-feil', () => {
       const mockedState = mock<RootState>();
       const state = instance(mockedState);
       state.videresending = {
@@ -25,9 +25,10 @@ describe('Videresendingselectors', () => {
 
       const [feilmelding] = selectors.FeilmeldingSelector(state);
       expect(feilmelding.innhold).toEqual('Funksjonell feil');
+      expect(feilmelding.tittel).toEqual('Feil ved videresending');
     });
 
-    it('generisk feilmelding ved 500-feil', () => {
+    it('returnerer generisk feilmelding ved 500-feil', () => {
       const mockedState = mock<RootState>();
       const state = instance(mockedState);
       state.videresending = {
@@ -46,12 +47,19 @@ describe('Videresendingselectors', () => {
       expect(feilmelding.tittel).toEqual('Teknisk feil');
     });
 
-    it('tom liste ved ingen feil', () => {
+    it(`returnerer tom liste ved status ${STATUS.OK}`, () => {
       const mockedState = mock<RootState>();
       const state = instance(mockedState);
       state.videresending = {
         status: 'OK',
-        data: {},
+        data: {
+          data: {
+            status: 500,
+            message: 'Melding som ikke blir brukt',
+            feilkoder: [],
+            error: 'Funksjonell feil',
+          },
+        },
       };
 
       const feilmelding = selectors.FeilmeldingSelector(state);

--- a/src/ducks/videresending/selectors.test.ts
+++ b/src/ducks/videresending/selectors.test.ts
@@ -1,52 +1,138 @@
+import { mock, instance } from 'ts-mockito';
+import { RootState } from 'AppTypes';
+
 import * as selectors from './selectors';
-import * as DucksTestUtils from '../test-utils';
+
+import MKV from '../../melosyskodeverk';
+import { STATUS } from '../../services/utils';
 
 describe('Videresendingselectors', () => {
   describe('FeilmeldingSelector', () => {
     it('feilmelding fra response ved 400-feil', () => {
-      const state = DucksTestUtils.lagState({
-        videresending: {
-          status: 'ERROR',
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.videresending = {
+        status: 'ERROR',
+        data: {
           data: {
-            data: {
-              status: 400,
-              message: 'Funksjonell feil',
-            },
+            status: 400,
+            message: 'Funksjonell feil',
+            feilkoder: [],
+            error: 'Funksjonell feil',
           },
         },
-      });
+      };
 
       const [feilmelding] = selectors.FeilmeldingSelector(state);
       expect(feilmelding.innhold).toEqual('Funksjonell feil');
     });
 
     it('generisk feilmelding ved 500-feil', () => {
-      const state = DucksTestUtils.lagState({
-        videresending: {
-          status: 'ERROR',
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.videresending = {
+        status: 'ERROR',
+        data: {
           data: {
-            data: {
-              status: 500,
-              message: 'Melding som ikke blir brukt',
-            },
+            status: 500,
+            message: 'Melding som ikke blir brukt',
+            feilkoder: [],
+            error: 'Funksjonell feil',
           },
         },
-      });
+      };
 
       const [feilmelding] = selectors.FeilmeldingSelector(state);
       expect(feilmelding.tittel).toEqual('Teknisk feil');
     });
 
     it('tom liste ved ingen feil', () => {
-      const state = DucksTestUtils.lagState({
-        videresending: {
-          status: 'OK',
-          data: {},
-        },
-      });
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.videresending = {
+        status: 'OK',
+        data: {},
+      };
 
       const feilmelding = selectors.FeilmeldingSelector(state);
       expect(feilmelding).toHaveLength(0);
+    });
+  });
+
+  describe('FeilkoderSelector', () => {
+    it('returnerer feilkoder ved status ERROR', () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.videresending = {
+        data: {
+          data: {
+            feilkoder: [],
+            error: 'Valideringsfeil',
+            status: 404,
+            message: 'Valideringsfeil',
+          },
+        },
+        status: STATUS.ERROR,
+      };
+
+      const forventetResultat = state.videresending.data.data && state.videresending.data.data.feilkoder;
+
+      expect(selectors.FeilkoderSelector(state)).toBe(forventetResultat);
+    });
+
+    it('returnerer tom array ved status OK', () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.videresending = {
+        data: {
+          data: {
+            feilkoder: [
+              {
+                kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.OVERLAPPENDE_MEDL_PERIODER,
+                felter: [],
+              },
+              {
+                kode: MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
+                felter: [],
+              },
+            ],
+            error: 'Valideringsfeil',
+            status: 404,
+            message: 'Valideringsfeil',
+          },
+        },
+        status: STATUS.OK,
+      };
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
+    });
+
+    it('returnerer tom array ved feilkoder undefined', () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.videresending = {
+        data: {
+          data: {
+            error: 'Valideringsfeil',
+            status: 404,
+            message: 'Valideringsfeil',
+          },
+        },
+        status: STATUS.ERROR,
+      };
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
+    });
+
+    it('returnerer tom array ved data undefined', () => {
+      const mockedState = mock<RootState>();
+      const state = instance(mockedState);
+      state.videresending = {
+        data: {},
+        status: STATUS.ERROR,
+      };
+
+      expect(selectors.FeilkoderSelector(state)).toEqual([]);
     });
   });
 });

--- a/src/ducks/videresending/selectors.ts
+++ b/src/ducks/videresending/selectors.ts
@@ -1,8 +1,10 @@
 import { createSelector, Selector } from 'reselect';
 import { RootState, StateSection } from 'AppTypes';
 
-import { STATUS } from '../../services/utils';
 import * as Types from './types';
+import * as DucksUtils from '../utils';
+
+import { STATUS } from '../../services/utils';
 
 const VideresendingSelector: Selector<RootState, StateSection<Types.Data>> = createSelector(
   state => state.videresending,
@@ -53,4 +55,10 @@ export const FeilmeldingSelector = createSelector(
     }
     return [];
   }
+);
+
+export const FeilkoderSelector = createSelector(
+  HttpResponsDataSelector,
+  ReduxStatusSelector,
+  DucksUtils.hentFeilkoder
 );

--- a/src/ducks/videresending/selectors.ts
+++ b/src/ducks/videresending/selectors.ts
@@ -4,8 +4,6 @@ import { RootState, StateSection } from 'AppTypes';
 import * as Types from './types';
 import * as DucksUtils from '../utils';
 
-import { STATUS } from '../../services/utils';
-
 const VideresendingSelector: Selector<RootState, StateSection<Types.Data>> = createSelector(
   state => state.videresending,
   videresending => videresending
@@ -40,21 +38,7 @@ export const FeilmeldingSelector = createSelector(
   ReduxStatusSelector,
   HttpStatusSelector,
   HttpMessageSelector,
-  (reduxStatus, httpStatus, httpMessage) => {
-    if (reduxStatus === STATUS.ERROR) {
-      if (httpStatus && httpStatus < 500) {
-        return [{
-          tittel: 'Feil ved videresending',
-          innhold: httpMessage,
-        }];
-      }
-      return [{
-        tittel: 'Teknisk feil',
-        innhold: 'Det oppsto en teknisk feil ved videresending. Ta kontakt med brukerstøtte dersom problemet oppstår gjentatte ganger.',
-      }];
-    }
-    return [];
-  }
+  DucksUtils.hentFeilmeldingByStateName('videresending')
 );
 
 export const FeilkoderSelector = createSelector(

--- a/src/ducks/videresending/types.ts
+++ b/src/ducks/videresending/types.ts
@@ -1,13 +1,12 @@
+import { ErrorResponse } from 'melosys-api';
+
 export const OK = 'videresending/OK';
 export const FEILET = 'videresending/FEILET';
 export const PENDING = 'videresending/PENDING';
 export const RESET = 'videresending/RESET';
 
 export interface Data {
-  data?: {
-    status?: number,
-    message?: string,
-  }
+  data?: ErrorResponse,
 }
 
 interface ResetAction {

--- a/src/felleskomponenter/dialogboks/dialogboksValidering.test.tsx
+++ b/src/felleskomponenter/dialogboks/dialogboksValidering.test.tsx
@@ -38,16 +38,16 @@ describe('DialogboksValidering', () => {
     expect(dialogboksValidering.find(Nav.Modal)).toHaveLength(1);
   });
 
-  it('Viser en liste over vedtakValideringsfeil', () => {
+  it('Viser en liste over valideringsfeil', () => {
     const dialogboksValidering = shallow(<DialogboksValidering {...props} />);
-    const vedtakValideringsfeil = dialogboksValidering.find(Valideringsfeil);
+    const valideringsfeil = dialogboksValidering.find(Valideringsfeil);
 
-    expect(vedtakValideringsfeil).toHaveLength(2);
-    expect(vedtakValideringsfeil.first().props().validering.kode).toBe(props.valideringer[0].kode);
-    expect(vedtakValideringsfeil.last().props().validering.kode).toBe(props.valideringer[1].kode);
+    expect(valideringsfeil).toHaveLength(2);
+    expect(valideringsfeil.first().props().validering.kode).toBe(props.valideringer[0].kode);
+    expect(valideringsfeil.last().props().validering.kode).toBe(props.valideringer[1].kode);
   });
 
-  it('Viser en liste over feilmeldinger for journalforingValideringerFeilmeldinger', () => {
+  it('Viser en liste over feilmeldinger for feilmeldinger', () => {
     props.valideringer = [];
     props.feilmeldinger = [
       { tittel: 'tittel1', innhold: 'innhold1' },
@@ -58,6 +58,20 @@ describe('DialogboksValidering', () => {
     const feilmeldinger = dialogboksValidering.find(ModalBody);
 
     expect(feilmeldinger).toHaveLength(2);
+  });
+
+  it('foretrekker å vise valideringer', () => {
+    props.feilmeldinger = [
+      { tittel: 'tittel1', innhold: 'innhold1' },
+      { tittel: 'tittel2', innhold: 'innhold2' },
+    ];
+
+    const dialogboksValidering = shallow(<DialogboksValidering {...props} />);
+    const valideringsfeil = dialogboksValidering.find(Valideringsfeil);
+    const feilmeldinger = dialogboksValidering.find(ModalBody);
+
+    expect(valideringsfeil).toHaveLength(2);
+    expect(feilmeldinger).toHaveLength(0);
   });
 });
 

--- a/src/felleskomponenter/dialogboks/dialogboksValidering.test.tsx
+++ b/src/felleskomponenter/dialogboks/dialogboksValidering.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import * as Nav from '../../utils/navFrontend';
 import * as KV from '../../kodeverk';
 
-import DialogboksValidering, { Validering, ModalBody, VedtakValideringsfeil } from './dialogboksValidering';
+import DialogboksValidering, { Validering, ModalBody, Valideringsfeil } from './dialogboksValidering';
 
 import MKV from '../../melosyskodeverk';
 
@@ -40,7 +40,7 @@ describe('DialogboksValidering', () => {
 
   it('Viser en liste over vedtakValideringsfeil', () => {
     const dialogboksValidering = shallow(<DialogboksValidering {...props} />);
-    const vedtakValideringsfeil = dialogboksValidering.find(VedtakValideringsfeil);
+    const vedtakValideringsfeil = dialogboksValidering.find(Valideringsfeil);
 
     expect(vedtakValideringsfeil).toHaveLength(2);
     expect(vedtakValideringsfeil.first().props().validering.kode).toBe(props.valideringer[0].kode);
@@ -85,7 +85,7 @@ describe('Validering', () => {
 });
 
 describe('VedtakValideringsfeil', () => {
-  const props: ComponentProps<typeof VedtakValideringsfeil> = {
+  const props: ComponentProps<typeof Valideringsfeil> = {
     validering: {
       kode: 'abc',
       felter: [
@@ -96,7 +96,7 @@ describe('VedtakValideringsfeil', () => {
   };
 
   it('viser Validering', () => {
-    const vedtakValideringsfeil = shallow(<VedtakValideringsfeil {...props} />);
+    const vedtakValideringsfeil = shallow(<Valideringsfeil {...props} />);
     const validering = vedtakValideringsfeil.find(Validering);
 
     expect(validering).toHaveLength(1);
@@ -104,7 +104,7 @@ describe('VedtakValideringsfeil', () => {
   });
 
   it('viser en liste over felter', () => {
-    const vedtakValideringsfeil = shallow(<VedtakValideringsfeil {...props} />);
+    const vedtakValideringsfeil = shallow(<Valideringsfeil {...props} />);
     const ul = vedtakValideringsfeil.find('ul');
     const li = vedtakValideringsfeil.find('li');
 

--- a/src/felleskomponenter/dialogboks/dialogboksValidering.tsx
+++ b/src/felleskomponenter/dialogboks/dialogboksValidering.tsx
@@ -82,7 +82,7 @@ Validering.propTypes = {
   valideringKode: PT.string.isRequired,
 };
 
-export const VedtakValideringsfeil = ({
+export const Valideringsfeil = ({
   validering,
 }: {
   validering: Validering
@@ -110,7 +110,7 @@ export const VedtakValideringsfeil = ({
   </Fragment>
 );
 
-VedtakValideringsfeil.propTypes = {
+Valideringsfeil.propTypes = {
   validering: PT.shape({
     kode: PT.string.isRequired,
     felter: PT.arrayOf(PT.string).isRequired,
@@ -139,19 +139,19 @@ export const DialogboksValidering = ({
     }
   };
 
-  const journalforingValideringInnhold = feilmeldinger.map(feilmelding => <ModalBody tittel={feilmelding.tittel} innhold={feilmelding.innhold} key={Utils._uuid()} />);
+  const feilmeldingerInnhold = feilmeldinger.map(feilmelding => <ModalBody tittel={feilmelding.tittel} innhold={feilmelding.innhold} key={Utils._uuid()} />);
 
-  const vedtakValideringInnhold = valideringer.map(validering => <VedtakValideringsfeil validering={validering} key={validering.kode} />);
+  const valideringerInnhold = valideringer.map(validering => <Valideringsfeil validering={validering} key={validering.kode} />);
 
   const innhold = Utils._isEmpty(feilmeldinger)
-    ? vedtakValideringInnhold
-    : journalforingValideringInnhold;
+    ? valideringerInnhold
+    : feilmeldingerInnhold;
 
   return (
     <Nav.Modal
       className="dialogboksValidering"
       isOpen
-      contentLabel="Valideringer for fattet vedtak"
+      contentLabel="Valideringsmeldinger"
       onRequestClose={avbryt}
       closeButton={false}
       shouldCloseOnOverlayClick

--- a/src/felleskomponenter/dialogboks/dialogboksValidering.tsx
+++ b/src/felleskomponenter/dialogboks/dialogboksValidering.tsx
@@ -143,9 +143,7 @@ export const DialogboksValidering = ({
 
   const valideringerInnhold = valideringer.map(validering => <Valideringsfeil validering={validering} key={validering.kode} />);
 
-  const innhold = Utils._isEmpty(feilmeldinger)
-    ? valideringerInnhold
-    : feilmeldingerInnhold;
+  const innhold = valideringer.length > 0 ? valideringerInnhold : feilmeldingerInnhold;
 
   return (
     <Nav.Modal

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -24,3 +24,17 @@ declare module 'Domene' {
 declare module 'melosys-kodeverk' {
   export type KTObject = { kode: string, term: string | null };
 }
+
+declare module 'melosys-api' {
+  interface Feilkode {
+    kode: string,
+    felter: string[],
+  }
+
+  export interface ErrorResponse {
+    error: string,
+    status: number,
+    message: string,
+    feilkoder?: Feilkode[],
+  }
+}

--- a/src/modals/modals.js
+++ b/src/modals/modals.js
@@ -144,8 +144,8 @@ const mapStateToProps = state => ({
   visAvsluttSakSomBortfaltDialog: modalerSelectors.ErAvsluttSakSomBortfaltSynligSelector(state),
   visRevurderFagsak: modalerSelectors.ErRevurderFagsakSynligSelector(state),
   visValideringModal: modalerSelectors.ErValideringSynligSelector(state),
-  valideringerFeilkoder: [...vedtakSelectors.FeilkoderSelector(state), ...utpekSelectors.FeilkoderSelector(state)],
-  valideringerFeilmeldinger: [...journalforingSelectors.FeilmeldingSelector(state), ...videresendingSelectors.FeilmeldingSelector(state), ...anmodningunntakSelectors.FeilmeldingSelector(state)],
+  valideringerFeilkoder: [...vedtakSelectors.FeilkoderSelector(state), ...utpekSelectors.FeilkoderSelector(state), ...anmodningunntakSelectors.FeilkoderSelector(state)],
+  valideringerFeilmeldinger: [...journalforingSelectors.FeilmeldingSelector(state), ...videresendingSelectors.FeilmeldingSelector(state)],
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/modals/modals.js
+++ b/src/modals/modals.js
@@ -144,8 +144,20 @@ const mapStateToProps = state => ({
   visAvsluttSakSomBortfaltDialog: modalerSelectors.ErAvsluttSakSomBortfaltSynligSelector(state),
   visRevurderFagsak: modalerSelectors.ErRevurderFagsakSynligSelector(state),
   visValideringModal: modalerSelectors.ErValideringSynligSelector(state),
-  valideringerFeilkoder: [...vedtakSelectors.FeilkoderSelector(state), ...utpekSelectors.FeilkoderSelector(state), ...anmodningunntakSelectors.FeilkoderSelector(state)],
-  valideringerFeilmeldinger: [...journalforingSelectors.FeilmeldingSelector(state), ...videresendingSelectors.FeilmeldingSelector(state)],
+  valideringerFeilkoder: [
+    ...vedtakSelectors.FeilkoderSelector(state),
+    ...utpekSelectors.FeilkoderSelector(state),
+    ...anmodningunntakSelectors.FeilkoderSelector(state),
+    ...journalforingSelectors.FeilkoderSelector(state),
+    ...videresendingSelectors.FeilkoderSelector(state),
+  ],
+  valideringerFeilmeldinger: [
+    ...vedtakSelectors.FeilmeldingSelector(state),
+    ...utpekSelectors.FeilmeldingSelector(state),
+    ...anmodningunntakSelectors.FeilmeldingSelector(state),
+    ...journalforingSelectors.FeilmeldingSelector(state),
+    ...videresendingSelectors.FeilmeldingSelector(state),
+  ],
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
- Vi(Eivind og jeg) ble enige om å bruke feilkoder-felt i stedet for melding-felt ved valideringsfeil ved bestiling av anmodning
- Bruker ts-mockito til å mocke RootState. Synes det er litt ryddigere enn lagState()-funksjonen. Vil gjerne bruke ts-mockito i alle tester, men det er kanskje lurt å beholde lagState() litt til, da den kan trenges i testfiler som bare er skrevet i js.