### PR TITLE
MELOSYS-3946 - Feil mottakerinstitusjon ved sokkel/skip

### DIFF
--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
@@ -12,7 +12,6 @@ import * as MPT from '../../../proptypes';
 import * as Utils from '../../../utils';
 import * as KV from '../../../kodeverk';
 
-import { behandlingsgrunnlagSelectors } from '../../../ducks/behandlingsgrunnlag';
 import { avklartefaktaSelectors } from '../../../ducks/avklartefakta';
 import { behandlingerSelectors } from '../../../ducks/behandlinger';
 import { anmodningsperioderSelectors } from '../../../ducks/anmodningsperioder';
@@ -264,12 +263,11 @@ class VurderingArtikkel16Anmodning extends Component {
     const {
       anmodningsperiode,
       behandlingID,
-      gyldigeSoknadsland,
       medlemskap,
       redigerbart,
       tilstand,
       unntakFraBestemmelse,
-      soknadsland,
+      arbeidsland,
       formValues,
       form,
     } = this.props;
@@ -293,7 +291,7 @@ class VurderingArtikkel16Anmodning extends Component {
 
     const antallManeder = datoDiffMenneskelig(anmodningsperiode.fomDato, anmodningsperiode.tomDato);
 
-    const landSomTekstListe = gyldigeSoknadsland.map(enkeltLandObjekt => enkeltLandObjekt.term).join(', ');
+    const landSomTekstListe = arbeidsland.map(enkeltLandObjekt => enkeltLandObjekt.term).join(', ');
 
     const pdfDokumenter = formValues.kreverMottakerinstitusjon ? [
       {
@@ -462,7 +460,7 @@ class VurderingArtikkel16Anmodning extends Component {
               <Mottakerinstitusjonvelger
                 form={form}
                 redigerbart={redigerbart}
-                landkode={soknadsland[0]}
+                landkode={arbeidsland[0].kode}
                 bucType={EKV.Koder.buctyper.legislation.LA_BUC_01}
               />
             </Nav.Column>
@@ -489,8 +487,7 @@ VurderingArtikkel16Anmodning.propTypes = {
   anmodningsperiode: PT.object,
   medlemskap: MPT.Medlemskap.isRequired,
   lagreOgBestillAnmodningsperioder: PT.func.isRequired,
-  gyldigeSoknadsland: MPT.Soknadsland.isRequired,
-  soknadsland: PT.arrayOf(PT.string).isRequired,
+  arbeidsland: PT.arrayOf(PT.string).isRequired,
   behandlingID: PT.number.isRequired,
   lovvalgKode: PT.string.isRequired,
   redigerbart: PT.bool.isRequired,
@@ -521,8 +518,7 @@ VurderingArtikkel16Anmodning.defaultProps = {
 const mapStateToProps = state => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
   anmodningsperiode: anmodningsperioderSelectors.AnmodningsperiodeSelector(state),
-  gyldigeSoknadsland: avklartefaktaSelectors.ArbeidslandKTSelector(state),
-  soknadsland: behandlingsgrunnlagSelectors.SoknadslandSelector(state),
+  arbeidsland: avklartefaktaSelectors.ArbeidslandKTSelector(state),
   lovvalgKode: avklartefaktaSelectors.AvklartefaktaLovvalgKodeSelector(state),
   medlemskap: behandlingerSelectors.MedlemskapSelector(state),
   unntakFraBestemmelse: anmodningsperioderSelectors.UnntakFraBestemmelseSelector(state),

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
@@ -12,7 +12,7 @@ import * as Skjema from '../../skjema';
 import * as Utils from '../../../utils';
 import * as MPT from '../../../proptypes';
 
-import { behandlingsgrunnlagSelectors } from '../../../ducks/behandlingsgrunnlag';
+import { avklartefaktaSelectors } from '../../../ducks/avklartefakta';
 import { behandlingerSelectors } from '../../../ducks/behandlinger';
 import { lovvalgsperioderSelectors } from '../../../ducks/lovvalgsperioder';
 import { behandlingsresultatSelectors } from '../../../ducks/behandlingsresultat';
@@ -38,7 +38,7 @@ const finnLovvalgSomTerm = (lovvalgsbestemmelse = {}, tilleggsbestemmelse = {}) 
 
 const VurderingVedtak = ({
   lovvalgsperioder,
-  soknadsland,
+  arbeidsland,
   redigerbart,
   behandlingID,
   lagreOgFatteVedtak,
@@ -144,7 +144,7 @@ const VurderingVedtak = ({
               <Mottakerinstitusjonvelger
                 form={form}
                 redigerbart={redigerbart}
-                landkode={soknadsland[0]}
+                landkode={arbeidsland[0].kode}
                 bucType={bucType}
               />
             </Nav.Column>
@@ -168,7 +168,7 @@ const VurderingVedtak = ({
 VurderingVedtak.propTypes = {
   lagreOgFatteVedtak: PT.func.isRequired,
   lovvalgsperioder: PT.array.isRequired,
-  soknadsland: PT.arrayOf(PT.string).isRequired,
+  arbeidsland: PT.arrayOf(PT.string).isRequired,
   behandlingID: PT.number.isRequired,
   redigerbart: PT.bool.isRequired,
   lovvalgsland: PT.string,
@@ -192,7 +192,7 @@ VurderingVedtak.defaultProps = {
 
 const mapStateToProps = state => ({
   lovvalgsperioder: lovvalgsperioderSelectors.LovvalgsperioderSelector(state),
-  soknadsland: behandlingsgrunnlagSelectors.SoknadslandSelector(state),
+  arbeidsland: avklartefaktaSelectors.ArbeidslandKTSelector(state),
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
   behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
   behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),

--- a/src/sider/saksbehandling/stegMap/bostedsland.js
+++ b/src/sider/saksbehandling/stegMap/bostedsland.js
@@ -15,9 +15,15 @@ class Bostedsland extends Steg {
 
     const erSokkelSkipEttLand = SokkelSkip.finnAvklaring(propsLight.avklartefakta, KV.Koder.VurderingSokkelSkipTyper.SKIP_ETT_LAND);
 
+    const bostedslandFakta = hentFakta(KV.Koder.avklartefaktaKoder.BOSTEDSLAND, propsLight.avklartefakta);
+
+    const erBegrunnelserPaakrevd = !Bostedsland.finnAvklaring(propsLight.avklartefakta, MKV.Koder.landkoder.NO) && !erSokkelSkipEttLand;
+
+    const harAvklaring = Bostedsland.alleErAvklart(bostedslandFakta, erBegrunnelserPaakrevd);
+
     this.kriterier = [
       {
-        exec: () => erSokkelSkipEttLand,
+        exec: () => erSokkelSkipEttLand && harAvklaring,
         nesteSteg: STEG.ARTIKKEL_11_4,
       },
       {
@@ -51,12 +57,8 @@ class Bostedsland extends Steg {
       const { sakOgBehandling } = saksopplysninger;
       const { eosBarnetrygd = {} } = sakOgBehandling;
 
-      const bostedslandFakta = hentFakta(KV.Koder.avklartefaktaKoder.BOSTEDSLAND, _propsLight.avklartefakta);
-
-      const erBegrunnelserPaakrevd = !Bostedsland.finnAvklaring(_propsLight.avklartefakta, MKV.Koder.landkoder.NO) && !erSokkelSkipEttLand;
-
       return {
-        harAvklaring: Bostedsland.alleErAvklart(bostedslandFakta, erBegrunnelserPaakrevd),
+        harAvklaring,
         bostedslandFakta,
         harEOSBarnetrygdSak: eosBarnetrygd,
         erBegrunnelserPaakrevd,


### PR DESCRIPTION
- Fikser en bug hvor mottakerinstitusjon ble hentet basert på søknadsland ved art 11 og 12. Har endret det til å hente basert på arbeidsland. Se spesifikasjon fra fag i bugen på jira.
- Fikser en bug hvor bostedsland-steg tillot at man gikk videre uten at steget var avklart