### PR TITLE
MELOSYS-4049 - Enter for å velge checkboxer radiobuttons i stegvelger

### DIFF
--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.js
@@ -8,6 +8,7 @@ import MKV from '../../../melosyskodeverk';
 import * as Nav from '../../../utils/navFrontend';
 import * as MPT from '../../../proptypes';
 import * as KV from '../../../kodeverk';
+import * as Mui from '../../../felleskomponenter/ui';
 
 import EnkeltAvklartfakta from './felles/enkeltAvklartfakta';
 import { BoolskAvklartfaktaType, VurderingVesentligAktivitetINorgeTyper } from '../../../kodeverk/koder';
@@ -49,11 +50,11 @@ export const LandLinje = props => {
   return (
     <div className="land__enkeltlinje">
       <span>{`${landKode.term} (${landKode.kode})`}</span>
-      <Nav.Checkbox
+      <Mui.Checkbox
         disabled={!redigerbart}
         checked={erMarginaltArbeidIArbeidsland === true}
         value={BoolskAvklartfaktaType.SANN}
-        onChange={klikkHandler}
+        onCheck={klikkHandler}
         label="ja"
         className="marginaltArbeidCheckbox"
       />

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import * as KV from '../../../kodeverk';
-import * as Nav from '../../../utils/navFrontend';
+import * as Mui from '../../../felleskomponenter/ui';
 
 import MKV from '../../../melosyskodeverk';
 import { lagAvklartfakta } from '../../../regler/avklartefakta';
@@ -52,8 +52,9 @@ describe('LandLinje', () => {
 
   describe('ved klikk på checkbox', () => {
     const landLinje = shallow(<LandLinje {...props} />);
-    const checkbox = landLinje.find(Nav.Checkbox);
-    checkbox.simulate('change');
+    const checkbox = landLinje.find(Mui.Checkbox);
+    const checkboxOnCheck = checkbox.props().onCheck;
+    checkboxOnCheck();
 
     it('lagrer marginalt arbeid avklartfakta', () => {
       expect(props.oppdaterData).toHaveBeenCalledTimes(1);

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
@@ -11,6 +11,7 @@ import * as Nav from '../../../utils/navFrontend';
 import * as MPT from '../../../proptypes';
 import * as Utils from '../../../utils';
 import * as KV from '../../../kodeverk';
+import * as Mui from '../../../felleskomponenter/ui';
 
 import { avklartefaktaSelectors } from '../../../ducks/avklartefakta';
 import { behandlingerSelectors } from '../../../ducks/behandlinger';
@@ -42,9 +43,13 @@ const TidligereMedlemPeriodeLinje = ({
   const label = `Periode: ${formatterDatoTilNorsk(periode.fom)} - ${formatterDatoTilNorsk(periode.tom)}`;
 
   return (
-    <Fragment>
-      <Nav.Checkbox feil={feil} disabled={!redigerbart} onChange={() => onChange(periodeID)} label={label} value="something" checked={checked} />
-    </Fragment>
+    <Mui.Checkbox
+      feil={feil}
+      disabled={!redigerbart}
+      onCheck={() => onChange(periodeID)}
+      label={label}
+      checked={checked}
+    />
   );
 };
 

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingGodkjennUtpekingAnnetLand.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingGodkjennUtpekingAnnetLand.js
@@ -17,8 +17,8 @@ const VurderingGodkjennUtpekingAnnetLand = ({
 }) => {
   const [varsleUtland, setVarsleUtland] = useState(false);
 
-  const vedEndring = event => {
-    setVarsleUtland(event.target.checked);
+  const vedEndring = ({ checked }) => {
+    setVarsleUtland(checked);
   };
 
   const hovedknappHandler = () => {
@@ -42,9 +42,9 @@ const VurderingGodkjennUtpekingAnnetLand = ({
         redigerbart &&
         <Nav.Row className="sendA012">
           <Nav.Column xs="12">
-            <Nav.Checkbox
+            <Mui.Checkbox
               label="Send A012"
-              onChange={vedEndring}
+              onCheck={vedEndring}
             />
           </Nav.Column>
         </Nav.Row>

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingGodkjennUtpekingAnnetLand.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingGodkjennUtpekingAnnetLand.test.js
@@ -21,9 +21,9 @@ describe('vurderingGodkjennUtpekingAnnetLand', () => {
   it('trykk på knapp kaller lagreOgGodkjennUnntaksperioder', () => {
     const komponent = shallow(<VurderingGodkjennUtpekingAnnetLand {...props} />);
 
-    const checkbox = komponent.find(Nav.Checkbox);
-    const event = { target: { checked: true } };
-    checkbox.simulate('change', event);
+    const checkbox = komponent.find(Mui.Checkbox);
+    const checkboxOnCheck = checkbox.props().onCheck;
+    checkboxOnCheck({ checked: true });
 
     const hovedknapp = komponent.find(Mui.Knapp);
     hovedknapp.simulate('click');

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVirksomhet.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVirksomhet.js
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import PT from 'prop-types';
 
 import * as Nav from '../../../utils/navFrontend';
+import * as Mui from '../../../felleskomponenter/ui';
 import * as MPT from '../../../proptypes';
 
 import { konverterTilStegData, lagAvklartfakta, slettAvklartfakta } from '../../../regler/avklartefakta';
@@ -28,16 +29,21 @@ const VirksomheterLinje = props => {
     return cleanup;
   }, []);
 
-  const virksomhetErValgt = avklartVirksomhet && avklartVirksomhet.fakta.includes('TRUE');
+  const virksomhetErValgt = avklartVirksomhet && avklartVirksomhet.fakta.includes(KV.Koder.BoolskAvklartfaktaType.SANN);
 
   const virksomhetKlikkHandler = () => {
-    const verdi = virksomhetErValgt ? 'FALSE' : 'TRUE';
+    const verdi = virksomhetErValgt ? KV.Koder.BoolskAvklartfaktaType.USANN : KV.Koder.BoolskAvklartfaktaType.SANN;
     oppdaterData(lagAvklartfakta(KV.Koder.avklartefaktaKoder.VIRKSOMHET, virksomheten.virksomhetId, verdi));
   };
 
   return (
     <div className="arbeidsgiver__enkeltlinje">
-      <Nav.Checkbox disabled={!redigerbart} checked={virksomhetErValgt === true} onChange={virksomhetKlikkHandler} label={`${virksomheten.navn}`} />
+      <Mui.Checkbox
+        disabled={!redigerbart}
+        checked={virksomhetErValgt === true}
+        onCheck={virksomhetKlikkHandler}
+        label={`${virksomheten.navn}`}
+      />
     </div>
   );
 };

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVurderarbeidsland.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVurderarbeidsland.js
@@ -33,8 +33,8 @@ const IngenSokkelSkipEllerHjemmebaser = ({
     };
   }, []);
 
-  const vedEndring = e => {
-    if (e.target.checked) {
+  const vedEndring = ({ checked }) => {
+    if (checked) {
       oppdaterData(lagAvklartfakta(KV.Koder.avklartefaktaKoder.ARBEID_UTFORES_I_OPPGITT_LAND, null, KV.Koder.BoolskAvklartfaktaType.SANN, null));
     } else {
       slettData(slettAvklartfakta(KV.Koder.avklartefaktaKoder.ARBEID_UTFORES_I_OPPGITT_LAND));
@@ -49,9 +49,9 @@ const IngenSokkelSkipEllerHjemmebaser = ({
         Panelene er ikke utfylt med informasjon om arbeid på sokkel, skip eller hjemmebaser. Fyll ut feltene hvis det er relevant for å vurdere arbeidsland.
       </Nav.AlertStripe>
       <Nav.Fieldset legend="">
-        <Nav.Checkbox
+        <Mui.Checkbox
           label="Arbeid utføres i land som er oppgitt"
-          onChange={vedEndring}
+          onCheck={vedEndring}
           disabled={!redigerbart}
           checked={erChecked}
         />

--- a/src/felleskomponenter/ui/checkbox/checkbox.test.tsx
+++ b/src/felleskomponenter/ui/checkbox/checkbox.test.tsx
@@ -10,21 +10,25 @@ describe('Checkbox', () => {
   const mockedProps = mock<ComponentProps<typeof Checkbox>>();
   const props = instance(mockedProps);
   props.label = '';
+  props.value = 'Arbeidsgiver';
 
   beforeEach(() => {
     props.onCheck = jest.fn();
   });
 
-  it('kaller onCheck med checkbox-verdi ved change event', () => {
+  it('kaller onCheck med checkbox-verdi og checkbox-value ved change event', () => {
     const checkbox = shallow(<Checkbox {...props} />);
     const event = { target: { checked: true } };
     checkbox.simulate('change', event);
 
     expect(props.onCheck).toHaveBeenCalledTimes(1);
-    expect(props.onCheck).toHaveBeenLastCalledWith(true);
+    expect(props.onCheck).toHaveBeenLastCalledWith(expect.objectContaining({
+      value: props.value,
+      checked: true,
+    }));
   });
 
-  it('kaller oncheck med checkbox-verdi ved trykk på enter-tast', () => {
+  it('kaller oncheck med checkbox-verdi og checkbox-value ved trykk på enter-tast', () => {
     props.checked = true;
     let checkbox = mount(<Checkbox {...props} />);
     let navCheckbox = checkbox.find(Nav.Checkbox);
@@ -36,7 +40,10 @@ describe('Checkbox', () => {
     if (onKeyPress) onKeyPress(event);
 
     expect(props.onCheck).toHaveBeenCalledTimes(1);
-    expect(props.onCheck).toHaveBeenLastCalledWith(false);
+    expect(props.onCheck).toHaveBeenLastCalledWith(expect.objectContaining({
+      value: props.value,
+      checked: false,
+    }));
 
     props.checked = false;
     checkbox = mount(<Checkbox {...props} />);
@@ -46,6 +53,9 @@ describe('Checkbox', () => {
     if (onKeyPress) onKeyPress(event);
 
     expect(props.onCheck).toHaveBeenCalledTimes(2);
-    expect(props.onCheck).toHaveBeenLastCalledWith(true);
+    expect(props.onCheck).toHaveBeenLastCalledWith(expect.objectContaining({
+      value: props.value,
+      checked: true,
+    }));
   });
 });

--- a/src/felleskomponenter/ui/checkbox/checkbox.test.tsx
+++ b/src/felleskomponenter/ui/checkbox/checkbox.test.tsx
@@ -1,0 +1,51 @@
+import React, { ComponentProps, KeyboardEvent } from 'react';
+import { mount, shallow } from 'enzyme';
+import { mock, instance } from 'ts-mockito';
+
+import * as Nav from '../../../utils/navFrontend';
+
+import Checkbox from './index';
+
+describe('Checkbox', () => {
+  const mockedProps = mock<ComponentProps<typeof Checkbox>>();
+  const props = instance(mockedProps);
+  props.label = '';
+
+  beforeEach(() => {
+    props.onCheck = jest.fn();
+  });
+
+  it('kaller onCheck med checkbox-verdi ved change event', () => {
+    const checkbox = shallow(<Checkbox {...props} />);
+    const event = { target: { checked: true } };
+    checkbox.simulate('change', event);
+
+    expect(props.onCheck).toHaveBeenCalledTimes(1);
+    expect(props.onCheck).toHaveBeenLastCalledWith(true);
+  });
+
+  it('kaller oncheck med checkbox-verdi ved trykk på enter-tast', () => {
+    props.checked = true;
+    let checkbox = mount(<Checkbox {...props} />);
+    let navCheckbox = checkbox.find(Nav.Checkbox);
+
+    const mockedEvent = mock<KeyboardEvent<HTMLInputElement>>();
+    const event = instance(mockedEvent);
+    event.key = 'Enter';
+    let { onKeyPress } = navCheckbox.props();
+    if (onKeyPress) onKeyPress(event);
+
+    expect(props.onCheck).toHaveBeenCalledTimes(1);
+    expect(props.onCheck).toHaveBeenLastCalledWith(false);
+
+    props.checked = false;
+    checkbox = mount(<Checkbox {...props} />);
+    navCheckbox = checkbox.find(Nav.Checkbox);
+
+    ({ onKeyPress } = navCheckbox.props());
+    if (onKeyPress) onKeyPress(event);
+
+    expect(props.onCheck).toHaveBeenCalledTimes(2);
+    expect(props.onCheck).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/src/felleskomponenter/ui/checkbox/checkbox.test.tsx
+++ b/src/felleskomponenter/ui/checkbox/checkbox.test.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, KeyboardEvent } from 'react';
+import React, { ComponentProps, KeyboardEvent, ChangeEvent } from 'react';
 import { mount, shallow } from 'enzyme';
 import { mock, instance } from 'ts-mockito';
 
@@ -18,8 +18,15 @@ describe('Checkbox', () => {
 
   it('kaller onCheck med checkbox-verdi og checkbox-value ved change event', () => {
     const checkbox = shallow(<Checkbox {...props} />);
-    const event = { target: { checked: true } };
-    checkbox.simulate('change', event);
+    const navCheckbox = checkbox.find(Nav.Checkbox);
+    const navCheckboxOnChange = navCheckbox.props().onChange;
+    const mockedEvent = mock<ChangeEvent<HTMLInputElement>>();
+    const event = instance(mockedEvent);
+    const mockedTarget = mock<HTMLInputElement>();
+    event.target = instance(mockedTarget);
+    event.target.checked = true;
+
+    if (navCheckboxOnChange) navCheckboxOnChange(event);
 
     expect(props.onCheck).toHaveBeenCalledTimes(1);
     expect(props.onCheck).toHaveBeenLastCalledWith(expect.objectContaining({

--- a/src/felleskomponenter/ui/checkbox/checkbox.tsx
+++ b/src/felleskomponenter/ui/checkbox/checkbox.tsx
@@ -5,13 +5,13 @@ import * as Nav from '../../../utils/navFrontend';
 type NavCheckboxProps = ComponentProps<typeof Nav.Checkbox>;
 type FilteredNavCheckboxProps = Omit<NavCheckboxProps, 'onChange' | 'onKeyPress'>;
 
-interface onCheckOptions {
+interface onCheckProperties {
   checked: boolean,
   value: any,
 }
 
 interface CheckboxProps extends FilteredNavCheckboxProps {
-  onCheck: (options: onCheckOptions) => void,
+  onCheck: (options: onCheckProperties) => void,
 }
 
 class Checkbox extends Component<CheckboxProps> {

--- a/src/felleskomponenter/ui/checkbox/checkbox.tsx
+++ b/src/felleskomponenter/ui/checkbox/checkbox.tsx
@@ -1,0 +1,42 @@
+import React, { Component, ComponentProps, ChangeEvent, KeyboardEvent } from 'react';
+
+import * as Nav from '../../../utils/navFrontend';
+
+type NavCheckboxProps = ComponentProps<typeof Nav.Checkbox>;
+type FilteredNavCheckboxProps = Omit<NavCheckboxProps, 'onChange' | 'onKeyPress'>;
+
+interface CheckboxProps extends FilteredNavCheckboxProps {
+  onCheck: (checked: boolean) => void,
+}
+
+class Checkbox extends Component<CheckboxProps> {
+  private navCheckbox: HTMLInputElement | null = null;
+
+  render() {
+    const {
+      onCheck,
+      ...rest
+    } = this.props;
+
+    const handleKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && this.navCheckbox) {
+        onCheck(!this.navCheckbox.checked);
+      }
+    };
+
+    const changeHandler = (e: ChangeEvent<HTMLInputElement>) => {
+      onCheck(e.target.checked);
+    };
+
+    return (
+      <Nav.Checkbox
+        onChange={changeHandler}
+        onKeyPress={handleKeyPress}
+        checkboxRef={ref => { this.navCheckbox = ref; }}
+        {...rest}
+      />
+    );
+  }
+}
+
+export default Checkbox;

--- a/src/felleskomponenter/ui/checkbox/checkbox.tsx
+++ b/src/felleskomponenter/ui/checkbox/checkbox.tsx
@@ -5,8 +5,13 @@ import * as Nav from '../../../utils/navFrontend';
 type NavCheckboxProps = ComponentProps<typeof Nav.Checkbox>;
 type FilteredNavCheckboxProps = Omit<NavCheckboxProps, 'onChange' | 'onKeyPress'>;
 
+interface onCheckOptions {
+  checked: boolean,
+  value: any,
+}
+
 interface CheckboxProps extends FilteredNavCheckboxProps {
-  onCheck: (checked: boolean) => void,
+  onCheck: (options: onCheckOptions) => void,
 }
 
 class Checkbox extends Component<CheckboxProps> {
@@ -20,12 +25,18 @@ class Checkbox extends Component<CheckboxProps> {
 
     const handleKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter' && this.navCheckbox) {
-        onCheck(!this.navCheckbox.checked);
+        onCheck({
+          checked: !this.navCheckbox.checked,
+          value: rest.value,
+        });
       }
     };
 
     const changeHandler = (e: ChangeEvent<HTMLInputElement>) => {
-      onCheck(e.target.checked);
+      onCheck({
+        checked: e.target.checked,
+        value: rest.value,
+      });
     };
 
     return (

--- a/src/felleskomponenter/ui/checkbox/checkbox.tsx
+++ b/src/felleskomponenter/ui/checkbox/checkbox.tsx
@@ -11,7 +11,7 @@ interface onCheckProperties {
 }
 
 interface CheckboxProps extends FilteredNavCheckboxProps {
-  onCheck: (options: onCheckProperties) => void,
+  onCheck: (properties: onCheckProperties) => void,
 }
 
 class Checkbox extends Component<CheckboxProps> {

--- a/src/felleskomponenter/ui/checkbox/index.ts
+++ b/src/felleskomponenter/ui/checkbox/index.ts
@@ -1,0 +1,3 @@
+import Checkbox from './checkbox';
+
+export default Checkbox;

--- a/src/felleskomponenter/ui/checkboxgruppe.js
+++ b/src/felleskomponenter/ui/checkboxgruppe.js
@@ -3,6 +3,7 @@ import PT from 'prop-types';
 
 import * as Nav from '../../utils/navFrontend';
 import * as MPT from '../../proptypes';
+import * as Mui from '.';
 
 const Checkboxgruppe = ({
   legend,
@@ -13,8 +14,8 @@ const Checkboxgruppe = ({
 }) => {
   const [valgteCheckboxer, setValgteCheckboxer] = useState(muligeValg.map(valg => valg.kode).filter(kode => defaultValg.includes(kode)));
 
-  const onChangeHandler = e => {
-    const verdi = e.target.value;
+  const onChangeHandler = ({ value }) => {
+    const verdi = value;
 
     const nyeValgteCheckboxer = valgteCheckboxer.includes(verdi) ? valgteCheckboxer.filter(checkbox => checkbox !== verdi) : [...valgteCheckboxer, verdi];
 
@@ -25,14 +26,14 @@ const Checkboxgruppe = ({
   return (
     <Nav.Fieldset legend={legend}>
       {
-        muligeValg.map(valg => <Nav.Checkbox
+        muligeValg.map(valg => <Mui.Checkbox
           key={valg.kode}
           name="annetBostedsland"
           label={valg.term}
           value={valg.kode}
-          defaultChecked={valgteCheckboxer.includes(valg.kode)}
+          checked={valgteCheckboxer.includes(valg.kode)}
           disabled={disabled}
-          onChange={onChangeHandler}
+          onCheck={onChangeHandler}
         />)
       }
     </Nav.Fieldset>

--- a/src/felleskomponenter/ui/checkboxgruppe.test.js
+++ b/src/felleskomponenter/ui/checkboxgruppe.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import MKV from '../../melosyskodeverk';
-import * as Nav from '../../utils/navFrontend';
+import * as Mui from '.';
 
 import Checkboxgruppe from './checkboxgruppe';
 
@@ -19,14 +19,14 @@ describe('Checkboxgruppe', () => {
 
   it('viser en liste med checkboxer', () => {
     const checkboxgruppe = shallow(<Checkboxgruppe {...props} />);
-    const checkboxer = checkboxgruppe.find(Nav.Checkbox);
+    const checkboxer = checkboxgruppe.find(Mui.Checkbox);
 
     expect(checkboxer).toHaveLength(props.muligeValg.length);
   });
 
   it('setter disabled korrekt', () => {
     const checkboxgruppe = shallow(<Checkboxgruppe {...props} />);
-    const checkboxer = checkboxgruppe.find(Nav.Checkbox);
+    const checkboxer = checkboxgruppe.find(Mui.Checkbox);
 
     checkboxer.forEach(checkbox => {
       expect(checkbox.props().disabled).toBe(props.disabled);
@@ -35,11 +35,32 @@ describe('Checkboxgruppe', () => {
 
   it('sender oppdatert state til onChange handler', () => {
     const checkboxgruppe = shallow(<Checkboxgruppe {...props} />);
-    const checkboxer = checkboxgruppe.find(Nav.Checkbox);
+    let checkboxer = checkboxgruppe.find(Mui.Checkbox);
+    const firstCheckbox = checkboxer.first();
+    const firstCheckboxOnCheck = firstCheckbox.props().onCheck;
+    const firstCheckboxValue = firstCheckbox.props().value;
 
-    const event = { target: { value: '' } };
-    checkboxer.last().simulate('change', event);
+    firstCheckboxOnCheck({ value: firstCheckboxValue });
 
     expect(props.onChange).toHaveBeenCalledTimes(1);
+    expect(props.onChange).toHaveBeenLastCalledWith(expect.arrayContaining([
+      MKV.Koder.begrunnelser.arbeidsland.BASELAND,
+      MKV.Koder.begrunnelser.arbeidsland.SKIP_INNENRIKS,
+    ]));
+
+    checkboxer = checkboxgruppe.find(Mui.Checkbox);
+    const lastCheckbox = checkboxer.last();
+    const lastCheckboxOnCheck = lastCheckbox.props().onCheck;
+    const lastCheckboxValue = lastCheckbox.props().value;
+
+    lastCheckboxOnCheck({ value: lastCheckboxValue });
+
+    expect(props.onChange).toHaveBeenCalledTimes(2);
+    expect(props.onChange).toHaveBeenLastCalledWith(expect.arrayContaining([
+      MKV.Koder.begrunnelser.arbeidsland.SKIP_INNENRIKS,
+    ]));
+    expect(props.onChange).toHaveBeenLastCalledWith(expect.not.arrayContaining([
+      MKV.Koder.begrunnelser.arbeidsland.BASELAND,
+    ]));
   });
 });

--- a/src/felleskomponenter/ui/index.js
+++ b/src/felleskomponenter/ui/index.js
@@ -6,10 +6,12 @@ import Undertittel from './undertittel';
 import Elementskrift from './elementskrift';
 import RedigerbarListe from './redigerbarliste';
 import LesMerPanel from './lesmerpanel';
+import Checkbox from './checkbox';
 
 export {
   Knapp,
   KodeTermSelect,
+  Checkbox,
   Checkboxgruppe,
   ListevelgerFlervalg,
   Undertittel,


### PR DESCRIPTION
- Legger til mulighet for å velge checkboxer i stegvelger med enter-tast.
- Laget en egen checkbox komponent for å slippe å implementere denne logikken flere steder.
- Så på å gjøre dette for checkboxer i "Opprett ny BUC-fanen" også, men her blir enter-trykket fanget opp av formen og den submittes. Går sikkert an å fikse på, men brukte ikke tid på det da storyen bare går på stegvelger.