### PR TITLE
MELOSYS-2199 - Hent behandling ved endring av behandlingsstatus

### DIFF
--- a/src/ducks/behandlinger/actions.js
+++ b/src/ducks/behandlinger/actions.js
@@ -6,12 +6,6 @@ import * as Types from './types';
  * Dette er action creators som returnerer Redux-klargjorte actions
  * uten support for asynkrone kall.
  */
-export const oppdaterBehandlingsStatus = status => (
-  {
-    type: Types.BEHANDLINGSSTATUS_UPDATE,
-    data: status,
-  }
-);
 export function resetBenadlingerState() {
   return { type: Types.RESET };
 }

--- a/src/ducks/behandlinger/operations.js
+++ b/src/ducks/behandlinger/operations.js
@@ -21,9 +21,6 @@ export function hentBehandling(behandlingID) {
   });
 }
 
-export function oppdaterBehandlingsStatus(status) {
-  return Actions.oppdaterBehandlingsStatus(status);
-}
 export function resetBehandlingerState() {
   return Actions.resetBenadlingerState();
 }

--- a/src/ducks/behandlinger/reducers.js
+++ b/src/ducks/behandlinger/reducers.js
@@ -23,8 +23,6 @@ export default function reducer(state = initialState, action) {
     }
     case Types.RESET:
       return initialState;
-    case Types.BEHANDLINGSSTATUS_UPDATE:
-      return { ...state, status: STATUS.OK, data: { ...state.data, oppsummering: { ...state.data.oppsummering, behandlingsstatus: action.data } } };
     default:
       return state;
   }

--- a/src/ducks/behandlinger/types.js
+++ b/src/ducks/behandlinger/types.js
@@ -3,4 +3,3 @@ export const FEILET = 'behandlinger/FEILET';
 export const PENDING = 'behandlinger/PENDING';
 
 export const RESET = 'behandlinger/RESET';
-export const BEHANDLINGSSTATUS_UPDATE = 'behandlinger/BEHANDLINGSSTATUS_UPDATE';

--- a/src/felleskomponenter/behandlingsstatus.js
+++ b/src/felleskomponenter/behandlingsstatus.js
@@ -1,24 +1,25 @@
 import React, { Fragment } from 'react';
 import PT from 'prop-types';
 import moment from 'moment/moment';
+import { connect } from 'react-redux';
 
-import MKV from '../melosyskodeverk';
-import * as KV from '../kodeverk';
 import * as Api from '../services/api';
 import * as Nav from '../utils/navFrontend';
 import * as Mui from '../felleskomponenter/ui';
 import * as MPT from '../proptypes';
 import * as Utils from '../utils';
 
+import { behandlingerOperations } from '../ducks/behandlinger';
+
 import './behandlingsstatus.css';
 
 const BehandlingsStatus = ({
-  oppdaterBehandlingsStatus,
   oppdaterStatus,
   behandlingID,
   redigerbart,
   oppsummering,
   behandlingsstatusMap,
+  hentBehandling,
 }) => {
   const [behandlingsstatus, setBehandlingsStatus] = React.useState('VELG');
   const [statusmelding, setStatusMelding] = React.useState(null);
@@ -38,10 +39,9 @@ const BehandlingsStatus = ({
     if (behandlingsstatus === 'VELG') {
       return false;
     }
-    const term = KV.kodeTilTerm(behandlingsstatus, MKV.KTObjects.behandlinger.behandlingsstatus);
-    const nyBehandlingsStatus = { kode: behandlingsstatus, term };
+
     oppdaterStatus(behandlingID, behandlingsstatus).then(() => {
-      oppdaterBehandlingsStatus(nyBehandlingsStatus);
+      hentBehandling(behandlingID);
       oppdaterStatusMelding();
     }).catch(Utils.logger.error);
     return true;
@@ -75,9 +75,9 @@ BehandlingsStatus.propTypes = {
   behandlingID: PT.number.isRequired,
   redigerbart: PT.bool,
   oppsummering: MPT.Behandlinger.Oppsummering,
-  oppdaterBehandlingsStatus: PT.func.isRequired,
   oppdaterStatus: PT.func,
   behandlingsstatusMap: PT.objectOf(PT.arrayOf(MPT.Kodeverk)).isRequired,
+  hentBehandling: PT.func.isRequired,
 };
 
 BehandlingsStatus.defaultProps = {
@@ -86,4 +86,8 @@ BehandlingsStatus.defaultProps = {
   oppdaterStatus: Api.Behandlinger.status.oppdaterStatus,
 };
 
-export default BehandlingsStatus;
+const mapDispatchToProps = dispatch => ({
+  hentBehandling: behandlingID => dispatch(behandlingerOperations.hentBehandling(behandlingID)),
+});
+
+export default connect(null, mapDispatchToProps)(BehandlingsStatus);

--- a/src/sider/registrering/registrering.js
+++ b/src/sider/registrering/registrering.js
@@ -65,7 +65,6 @@ const Registrering = props => {
     person,
     lovvalgsperiodeFom,
     lovvalgsperiodeTom,
-    oppdaterBehandlingsStatus,
     lovvalgsland,
     visOppfriskModal,
     behandlingOppfriskes,
@@ -150,7 +149,6 @@ const Registrering = props => {
                 behandlingID={behandlingID}
                 redigerbart={redigerbart}
                 oppsummering={oppsummering}
-                oppdaterBehandlingsStatus={oppdaterBehandlingsStatus}
                 behandlingsstatusMap={behandlingsstatusMap}
               />}
             />
@@ -190,7 +188,6 @@ Registrering.propTypes = {
   behandlingstema: PT.string.isRequired,
   lovvalgsperiodeFom: PT.string,
   lovvalgsperiodeTom: PT.string,
-  oppdaterBehandlingsStatus: PT.func.isRequired,
   tilForsiden: PT.func.isRequired,
   lovvalgsland: MPT.Kodeverk.isRequired,
   visOppfriskModal: PT.func.isRequired,
@@ -231,7 +228,6 @@ const mapDispatchToProps = dispatch => ({
   hentFagsaker: saksnummer => dispatch(fagsakOperations.hent(saksnummer)),
   resetFagsakState: () => dispatch(fagsakOperations.resetFagsakState()),
   hentLovvalgsperioder: behandlingID => dispatch(lovvalgsperioderOperations.hent(behandlingID)),
-  oppdaterBehandlingsStatus: behandlingsstatus => dispatch(behandlingerOperations.oppdaterBehandlingsStatus(behandlingsstatus)),
   tilbakeleggOppgave: (oppgaveID, venterPaaDokumentasjon) => oppgaverOperations.tilbakelegg(oppgaveID, venterPaaDokumentasjon),
 });
 

--- a/src/sider/saksbehandling/saksbehandling.js
+++ b/src/sider/saksbehandling/saksbehandling.js
@@ -173,7 +173,6 @@ class Saksbehandling extends Component {
       person,
       lovvalgsperiodeFom,
       lovvalgsperiodeTom,
-      oppdaterBehandlingsStatus,
       visHenleggDialogHandle,
       visAvsluttSakSomBortfaltDialogHandle,
       visAvslagSoknadDialogHandle,
@@ -251,7 +250,6 @@ class Saksbehandling extends Component {
                   behandlingID={behandlingID}
                   redigerbart={redigerbart}
                   oppsummering={oppsummering}
-                  oppdaterBehandlingsStatus={oppdaterBehandlingsStatus}
                   behandlingsstatusMap={behandlingsstatusMap}
                 />}
               />
@@ -314,7 +312,6 @@ Saksbehandling.propTypes = {
   lagreAllData: PT.func.isRequired,
   lagreOgLukk: PT.func.isRequired,
   tilbakeleggOppgave: PT.func.isRequired,
-  oppdaterBehandlingsStatus: PT.func.isRequired,
   resetSaksopplysninger: PT.func.isRequired,
   visHenleggDialogHandle: PT.func.isRequired,
   visAvsluttSakSomBortfaltDialogHandle: PT.func.isRequired,
@@ -408,7 +405,6 @@ const mapDispatchToProps = dispatch => ({
   lagrePerioder: () => dispatch(behandlingsperioderOperations.lagre()),
   sendAnmodningsperioder: (behandlingID, body) => dispatch(anmodningsperioderOperations.send(behandlingID, body)),
   lagreAllData: () => dispatch(datalastingOperations.lagreAllData()),
-  oppdaterBehandlingsStatus: behandlingsstatus => dispatch(behandlingerOperations.oppdaterBehandlingsStatus(behandlingsstatus)),
   resetSaksopplysninger: () => dispatch(datalastingOperations.resetSaksopplysninger()),
 });
 

--- a/src/sider/sedbehandling/sedbehandling.js
+++ b/src/sider/sedbehandling/sedbehandling.js
@@ -14,7 +14,7 @@ import Behandlingsstatus from '../../felleskomponenter/behandlingsstatus';
 import Behandlingsmeny from './komponenter/behandlingsmeny';
 
 import { fagsakSelectors } from '../../ducks/fagsaker';
-import { behandlingerOperations, behandlingerSelectors } from '../../ducks/behandlinger';
+import { behandlingerSelectors } from '../../ducks/behandlinger';
 import { redigerbartSelectors } from '../../ducks/redigerbart';
 import { datalastingOperations } from '../../ducks/datalasting';
 import { behandlingsgrunnlagOperations, behandlingsgrunnlagSelectors } from '../../ducks/behandlingsgrunnlag';
@@ -70,7 +70,6 @@ const SedBehandling = ({
   behandlingsgrunnlagPeriodeTom,
   lovvalgsperiodeFom,
   lovvalgsperiodeTom,
-  oppdaterBehandlingsStatus,
   location,
   lastInnSaksopplysninger,
   resetSaksopplysninger,
@@ -148,7 +147,6 @@ const SedBehandling = ({
                 behandlingID={behandlingID}
                 redigerbart={redigerbart}
                 oppsummering={oppsummering}
-                oppdaterBehandlingsStatus={oppdaterBehandlingsStatus}
                 behandlingsstatusMap={behandlingsstatusMap}
                 oppdaterStatus={oppdaterStatus}
               />}
@@ -183,7 +181,6 @@ SedBehandling.propTypes = {
   behandlingsgrunnlagPeriodeTom: PT.string,
   lovvalgsperiodeFom: PT.string,
   lovvalgsperiodeTom: PT.string,
-  oppdaterBehandlingsStatus: PT.func.isRequired,
   location: PT.object.isRequired,
   lastInnSaksopplysninger: PT.func.isRequired,
   resetSaksopplysninger: PT.func.isRequired,
@@ -228,7 +225,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  oppdaterBehandlingsStatus: behandlingsstatus => dispatch(behandlingerOperations.oppdaterBehandlingsStatus(behandlingsstatus)),
   lastInnSaksopplysninger: (saksnummer, behandlingID) => dispatch(datalastingOperations.lastInnSaksopplysningerSedBehandling(saksnummer, behandlingID)),
   resetSaksopplysninger: () => dispatch(datalastingOperations.resetSaksopplysninger()),
   hentBehandlingsgrunnlag: behandlingID => dispatch(behandlingsgrunnlagOperations.hent(behandlingID)),

--- a/src/sider/vurderutpeking/vurderutpeking.js
+++ b/src/sider/vurderutpeking/vurderutpeking.js
@@ -17,7 +17,7 @@ import Behandlingsmeny from './komponenter/behandlingsmeny';
 import { formSelectors } from '../../ducks/form';
 import { redigerbartSelectors } from '../../ducks/redigerbart';
 import { fagsakSelectors } from '../../ducks/fagsaker';
-import { behandlingerSelectors, behandlingerOperations } from '../../ducks/behandlinger';
+import { behandlingerSelectors } from '../../ducks/behandlinger';
 import { datalastingOperations } from '../../ducks/datalasting';
 import { behandlingsgrunnlagSelectors, behandlingsgrunnlagOperations } from '../../ducks/behandlingsgrunnlag';
 import { vilkarOperations } from '../../ducks/vilkar';
@@ -81,7 +81,6 @@ const Vurderutpeking = ({
   visAvsluttSakSomBortfaltDialogHandle,
   visAvslagSoknadDialogHandle,
   visRevurderFagsakDialogHandle,
-  oppdaterBehandlingsStatus,
   brevBestillingRedigerbart,
   brevBestillingRedigerbartIArtikkel13,
   resetSaksopplysninger,
@@ -184,7 +183,6 @@ const Vurderutpeking = ({
                 behandlingID={behandlingID}
                 redigerbart={redigerbart}
                 oppsummering={oppsummering}
-                oppdaterBehandlingsStatus={oppdaterBehandlingsStatus}
                 behandlingsstatusMap={behandlingsstatusMap}
               />}
             />
@@ -228,7 +226,6 @@ Vurderutpeking.propTypes = {
   visOppfriskModal: PT.func.isRequired,
   startOgVisOppfriskModal: PT.func.isRequired,
   visRevurderFagsakDialogHandle: PT.func.isRequired,
-  oppdaterBehandlingsStatus: PT.func.isRequired,
   brevBestillingRedigerbart: PT.bool.isRequired,
   brevBestillingRedigerbartIArtikkel13: PT.bool.isRequired,
   resetSaksopplysninger: PT.func.isRequired,
@@ -281,7 +278,6 @@ const mapDispatchToProps = dispatch => ({
   lagreAnmodningsperioder: () => dispatch(anmodningsperioderOperations.lagre()),
   oppdaterOgLagreBehandlingsperioder: () => dispatch(behandlingsperioderOperations.oppdaterOgLagre()),
   lagreAllData: () => dispatch(datalastingOperations.lagreAllData()),
-  oppdaterBehandlingsStatus: behandlingsstatus => dispatch(behandlingerOperations.oppdaterBehandlingsStatus(behandlingsstatus)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Vurderutpeking);


### PR DESCRIPTION
Fikk et ønske fra Jonas om at "Behandling sist oppdatert" skulle oppdateres i skjermbildet i det man endrer behandlingsstatus(for øyeblikket må man laste inn siden på nytt for å se dette).

- Gjør en GET på behandling ved endring av status
- Fjerner død kode i behandlinger-duck