### PR TITLE
MELOSYS-4013 - Valider felter for utenlandskident

### DIFF
--- a/src/kodeverk/panel.js
+++ b/src/kodeverk/panel.js
@@ -1,6 +1,7 @@
 export const informasjonOmBruker = {
   tittel: 'Informasjon om bruker',
   undertitler: {
+    utenlandskID: 'Utenlandsk ID',
     annenOppgittAdresse: 'Annen adresse oppgitt i søknaden som ikke er registrert i TPS:',
     medlemskap: 'Medlemskap',
     kontantytelser: 'Kontantytelser fra NAV',

--- a/src/yup/skjemaer/saksopplysninger.js
+++ b/src/yup/skjemaer/saksopplysninger.js
@@ -18,6 +18,19 @@ const SLUTTDATO_ER_APEN = lagMelding(
 
 const erIkkeBeslutningLovvalgAnnetLand = behandlingstema => behandlingstema !== MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND;
 
+const utenlandskIdent = object().shape({
+  ident: string().nullable().required(lagMelding(
+    KV.Panel.informasjonOmBruker.tittel,
+    KV.Panel.informasjonOmBruker.undertitler.utenlandskID,
+    'Utenlandsk ID kreves'
+  )),
+  landkode: string().nullable().required(lagMelding(
+    KV.Panel.informasjonOmBruker.tittel,
+    KV.Panel.informasjonOmBruker.undertitler.utenlandskID,
+    'Land for utenlandsk ID kreves'
+  )),
+});
+
 const saksopplysninger = object().when('$behandlingstema', {
   is: erIkkeBeslutningLovvalgAnnetLand,
   then: object().shape({
@@ -93,6 +106,7 @@ const saksopplysninger = object().when('$behandlingstema', {
       is: MKVUtils.erUtsendt,
       then: string().required(SLUTTDATO_ER_APEN),
     }),
+    utenlandskIdent: array().of(utenlandskIdent),
   }),
 });
 


### PR DESCRIPTION
- Når man forhåndsviste SED og hadde oppgitt en utenlandsk ident uten land, fikk man feilmelding fra forhåndsvisnings-endepunktet(feilen oppstod i melosys-eessi). Denne PRen sjekker at feltene for utenlandsk ident er satt, slik at denne feilen ikke inntreffer.