### PR TITLE
MELOSYS-4011 - Brev A001 Ytterligere informasjon

### DIFF
--- a/src/felleskomponenter/skjema/textarea/textarea.js
+++ b/src/felleskomponenter/skjema/textarea/textarea.js
@@ -56,7 +56,7 @@ function InnerTextAreaComponent({
 }
 
 InnerTextAreaComponent.propTypes = {
-  label: PT.string,
+  label: PT.node,
   placeholder: PT.string,
   maxLength: PT.number,
   visTellerFra: PT.number,

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
@@ -307,7 +307,7 @@ class VurderingArtikkel16Anmodning extends Component {
         navn: 'Forhåndsvis orienteringsbrev til bruker', type: MKV.Koder.brev.produserbaredokumenter.ORIENTERING_ANMODNING_UNNTAK, data: { mottaker: MKV.Koder.aktoersroller.BRUKER },
       },
       {
-        navn: 'Forhåndsvis anmodning til utenlandsk myndighet', type: MKV.Koder.brev.produserbaredokumenter.ANMODNING_UNNTAK, data: { mottaker: MKV.Koder.aktoersroller.MYNDIGHET },
+        navn: 'Forhåndsvis anmodning til utenlandsk myndighet', type: MKV.Koder.brev.produserbaredokumenter.ANMODNING_UNNTAK, data: { mottaker: MKV.Koder.aktoersroller.MYNDIGHET, fritekst: this.props.formValues.fritekstSed },
       },
     ];
 

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16Anmodning.js
@@ -297,17 +297,35 @@ class VurderingArtikkel16Anmodning extends Component {
 
     const pdfDokumenter = formValues.kreverMottakerinstitusjon ? [
       {
-        navn: 'Forhåndsvis orienteringsbrev til bruker', type: MKV.Koder.brev.produserbaredokumenter.ORIENTERING_ANMODNING_UNNTAK, data: { mottaker: MKV.Koder.aktoersroller.BRUKER },
+        navn: 'Forhåndsvis orienteringsbrev til bruker',
+        type: MKV.Koder.brev.produserbaredokumenter.ORIENTERING_ANMODNING_UNNTAK,
+        data: {
+          mottaker: MKV.Koder.aktoersroller.BRUKER,
+        },
       },
       {
-        navn: 'Forhåndsvis SED A001', type: EKV.Koder.sedtyper.A001, erSed: true, data: { fritekst: this.props.formValues.fritekstSed },
+        navn: 'Forhåndsvis SED A001',
+        type: EKV.Koder.sedtyper.A001,
+        erSed: true,
+        data: {
+          fritekst: this.props.formValues.fritekstSed,
+        },
       },
     ] : [
       {
-        navn: 'Forhåndsvis orienteringsbrev til bruker', type: MKV.Koder.brev.produserbaredokumenter.ORIENTERING_ANMODNING_UNNTAK, data: { mottaker: MKV.Koder.aktoersroller.BRUKER },
+        navn: 'Forhåndsvis orienteringsbrev til bruker',
+        type: MKV.Koder.brev.produserbaredokumenter.ORIENTERING_ANMODNING_UNNTAK,
+        data: {
+          mottaker: MKV.Koder.aktoersroller.BRUKER,
+        },
       },
       {
-        navn: 'Forhåndsvis anmodning til utenlandsk myndighet', type: MKV.Koder.brev.produserbaredokumenter.ANMODNING_UNNTAK, data: { mottaker: MKV.Koder.aktoersroller.MYNDIGHET, fritekst: this.props.formValues.fritekstSed },
+        navn: 'Forhåndsvis anmodning til utenlandsk myndighet',
+        type: MKV.Koder.brev.produserbaredokumenter.ANMODNING_UNNTAK,
+        data: {
+          mottaker: MKV.Koder.aktoersroller.MYNDIGHET,
+          fritekst: this.props.formValues.fritekstSed,
+        },
       },
     ];
 


### PR DESCRIPTION
- Send "Ytterligere informasjon til SED" til forhåndsvisning av Brev A001(Lenken for Brev A001 har navnet "Forhåndsvis anmodning til utenlandsk myndighet")
- Fikser en proptype som ikke var satt korrekt og ga warning i console