### PR TITLE
MELOSYS-3911 - Tekstendring for tittel ved visning av kontrollkode

### DIFF
--- a/src/felleskomponenter/dialogboks/dialogboksValidering.test.tsx
+++ b/src/felleskomponenter/dialogboks/dialogboksValidering.test.tsx
@@ -84,15 +84,28 @@ describe('Validering', () => {
     expect(modalBody.props().tittel).toBe('Ukjent feil');
   });
 
-  it('viser feilmelding fra kodeverk dersom ingen mapping for feilmelding finnes', () => {
+  it('viser feilmelding fra kodeverk dersom ingen mapping for feilmelding finnes, og kontrollkode stammer fra manglende utfylling av felter', () => {
     const validering = shallow(<Validering valideringKode={MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE} />);
+
+    const modalBody = validering.find(ModalBody);
+    expect(modalBody).toHaveLength(1);
+
+    expect(modalBody.props().tittel).toBe('Manglende utfylling');
+    expect(modalBody.props().innhold).toBe(KV.kodeTilTerm(
+      MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
+      MKV.KTObjects.begrunnelser.kontroll_begrunnelser
+    ));
+  });
+
+  it(`viser feilmelding fra kodeverk dersom ingen mapping for feilmelding finnes, og kontrollkode er ${MKV.Koder.begrunnelser.kontroll_begrunnelser.INGEN_SLUTTDATO}`, () => {
+    const validering = shallow(<Validering valideringKode={MKV.Koder.begrunnelser.kontroll_begrunnelser.INGEN_SLUTTDATO} />);
 
     const modalBody = validering.find(ModalBody);
     expect(modalBody).toHaveLength(1);
 
     expect(modalBody.props().tittel).toBe('Feil ved kontroll');
     expect(modalBody.props().innhold).toBe(KV.kodeTilTerm(
-      MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE,
+      MKV.Koder.begrunnelser.kontroll_begrunnelser.INGEN_SLUTTDATO,
       MKV.KTObjects.begrunnelser.kontroll_begrunnelser
     ));
   });

--- a/src/felleskomponenter/dialogboks/dialogboksValidering.tsx
+++ b/src/felleskomponenter/dialogboks/dialogboksValidering.tsx
@@ -1,5 +1,6 @@
 import React, { KeyboardEvent, Fragment } from 'react';
 import PT from 'prop-types';
+import { KTObject } from 'melosys-kodeverk';
 
 import * as Nav from '../../utils/navFrontend';
 import * as KV from '../../kodeverk';
@@ -31,15 +32,27 @@ const feilmeldingMap = new Map<string, Feilmelding>([
   ],
 ]);
 
+const hentFeilmeldingTittel = (kontrollKode: string) => {
+  switch (kontrollKode) {
+    case MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_BOSTEDSADRESSE:
+    case MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_OPPL_ARBEIDSSTED:
+    case MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_OPPL_ANDRE_ARBEIDSFORHOLD_NO:
+    case MKV.Koder.begrunnelser.kontroll_begrunnelser.MANGLENDE_OPPL_ANDRE_ARBEIDSFORHOLD_UTL:
+      return 'Manglende utfylling';
+    default:
+      return 'Feil ved kontroll';
+  }
+};
+
 const hentFeilmelding = (valideringKode: string) => {
   let feilmelding = feilmeldingMap.get(valideringKode);
 
   if (!feilmelding) {
-    const valideringKodeObjekt = KV.kodeTilObjekt(valideringKode, MKV.KTObjects.begrunnelser.kontroll_begrunnelser);
+    const valideringKodeObjekt: KTObject = KV.kodeTilObjekt(valideringKode, MKV.KTObjects.begrunnelser.kontroll_begrunnelser);
     if (valideringKodeObjekt) {
       feilmelding = {
-        tittel: 'Feil ved kontroll',
-        innhold: valideringKodeObjekt.term,
+        tittel: hentFeilmeldingTittel(valideringKodeObjekt.kode),
+        innhold: valideringKodeObjekt.term || '',
       };
     }
   }


### PR DESCRIPTION
Etter prat med Jonas:
- Viser "Manglende utfylling" som tittel på feilmelding dersom kontrollkoden som utløste feilmeldingen har med utfylling av felter i panelene å gjøre