### PR TITLE
Legg til landkode foran mottakerinstitusjon i nedtrekksmeny

### DIFF
--- a/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.js
+++ b/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.js
@@ -209,7 +209,7 @@ const SideDialogOpprettNyBuc = ({ behandlingID, dokumenter }) => {
           <MultiSelect
             label="Mottakerinstitusjoner"
             onChange={mottakerinstitusjonEndret}
-            options={tilgjengeligeMottakerinstitusjoner.map(item => ({ value: item.id, label: item.navn }))}
+            options={tilgjengeligeMottakerinstitusjoner.map(item => ({ value: item.id, label: `${item.landkode} - ${item.navn}` }))}
             feil={feil('mottakerinstitusjoner')}
             values={valgteMottakerinstitusjoner}
           />


### PR DESCRIPTION
Jeg fikk tilbakemelding fra Andreas om at det kommer til å være forvirrende for saksbehandlere med ei liste med til tider kryptiske navn på mottakerinstitusjoner. Legger derfor til landkode foran, iht. oppdaterte designskisser.