### PR TITLE
MELOSYS-3852 - Send overgangsregelbestemmelser som kode

### DIFF
--- a/src/ducks/behandlingsgrunnlag/operations.js
+++ b/src/ducks/behandlingsgrunnlag/operations.js
@@ -6,7 +6,6 @@ import * as Types from './types';
 import * as Selectors from './selectors';
 
 import MKV from '../../melosyskodeverk';
-import * as KV from '../../kodeverk';
 
 import { doThenDispatch } from '../../services/utils';
 import { formSelectors } from '../form';
@@ -46,9 +45,7 @@ export function send(bid, behandlingsgrunnlag) {
   );
 }
 
-const hentOvergangsregelbestemmelser = values =>
-  values && values.overgangsregelbestemmelser.map(overgangsregelbestemmelse =>
-    KV.kodeTilObjekt(overgangsregelbestemmelse, MKV.KTObjects.lovvalgsbestemmelser.overgangsregelbestemmelser));
+const hentOvergangsregelbestemmelser = values => (values ? values.overgangsregelbestemmelser : []);
 
 const temaForSedGrunnlag = behandlingstema => [
   MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE,


### PR DESCRIPTION
Backend klarer ikke å lagre behandlingsgrunnlaget når overgangsregelbestemmelser blir sendt inn som kode/term, selv om det er formatet det blir sendt ut på (grunnet mangel av dto og bruk av serializer). Dette ble den enkleste måten å fikse det på frem til vi har dtoer for behandlingsgrunnlagene (https://jira.adeo.no/browse/MELOSYS-4178).

Må også gjøres en liten endring i schema for overgabgsregelbestemmelser: https://github.com/navikt/melosys-schema/pull/184