### PR TITLE
Fjern @navikt/fnrvalidator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1752,11 +1752,6 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
-    "@navikt/fnrvalidator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@navikt/fnrvalidator/-/fnrvalidator-1.1.3.tgz",
-      "integrity": "sha512-xBwlPOI08kbByUWI4Yyd6NbIYLFs78I0h05mlHPjmrPPikyM89IQRbMac+6ovkgpi2s63OV6ryv3w4QqPubwiw=="
-    },
     "@navikt/melosys-kodeverk": {
       "version": "5.15.45",
       "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.45/8e7b1c5dcd8215d508ec23f1ac446689944b9ce9a5829181c009ebeb9c70ae97",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "readme": "README.md",
   "dependencies": {
     "@loadable/component": "^5.10.3",
-    "@navikt/fnrvalidator": "^1.1.3",
     "@types/classnames": "^2.2.10",
     "@types/react-select": "^3.0.20",
     "babel-polyfill": "^6.26.0",

--- a/src/ducks/sok/operations.js
+++ b/src/ducks/sok/operations.js
@@ -6,14 +6,13 @@
  * når det asynkrone kallet, feks fra API'et er ferdigkjørt.
  *
  */
-import FnrValidator from '@navikt/fnrvalidator';
-
 import { doThenDispatch } from '../../services/utils';
+import * as Utils from '../../utils';
 import * as Api from '../../services/api';
 import * as Types from './types';
 
 export function sok(sokefrase) {
-  const sokefraseErIdnr = FnrValidator.idnr(sokefrase).status === 'valid';
+  const sokefraseErIdnr = Utils.person.erGyldigFnr(sokefrase);
 
   const body = {
     ident: sokefraseErIdnr ? sokefrase : null,

--- a/src/felleskomponenter/paneler/personopplysninger/medfolgendeAndre.js
+++ b/src/felleskomponenter/paneler/personopplysninger/medfolgendeAndre.js
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import PT from 'prop-types';
 
 import * as Nav from '../../../utils/navFrontend';
+import * as Utils from '../../../utils';
 import * as Skjema from '../../skjema';
 import * as MPT from '../../../proptypes';
-import * as PersonValidering from '../../skjema/validering/generisk/person';
 
 import { beregnAlder } from '../../../utils/dato';
 import GeneriskAdresse from '../../adresser/generiskAdresse';
@@ -18,7 +18,7 @@ function MedfolgendeAndre(props) {
   const sokHandle = () => {
     const { sjekkPerson } = props;
 
-    if (PersonValidering.erGyldigFnr(fnr) || PersonValidering.erGyldigDnr(fnr)) {
+    if (Utils.person.erGyldigFnr(fnr) || Utils.person.erGyldigDnr(fnr)) {
       setDirty(false);
       sjekkPerson(fnr);
     }

--- a/src/felleskomponenter/skjema/validering/index.js
+++ b/src/felleskomponenter/skjema/validering/index.js
@@ -1,6 +1,5 @@
 import { adresseKreves, norskPostNummer } from './generisk/adresse';
 import { minLengde, erPakrevet, kunTall, erDato, avhengerAvSann } from './generisk';
-import { fulltNavn, erGyldigDnr, erGyldigFnr } from './generisk/person';
 import Felles from './felles';
 
 export {
@@ -8,9 +7,6 @@ export {
   norskPostNummer,
   minLengde,
   erPakrevet,
-  fulltNavn,
-  erGyldigDnr,
-  erGyldigFnr,
   kunTall,
   erDato,
   avhengerAvSann,

--- a/src/setupYup.js
+++ b/src/setupYup.js
@@ -1,7 +1,6 @@
 import { addMethod, object, string } from 'yup';
 
 import * as Utils from './utils';
-import * as Person from './felleskomponenter/skjema/validering/generisk/person';
 import * as Organisasjon from './felleskomponenter/skjema/validering/generisk/organisasjon';
 
 import MKV from './melosyskodeverk';
@@ -90,13 +89,13 @@ addMethod(string, 'erNummer', function(message) {
 
 addMethod(string, 'erFnrEllerDnr', function(message) {
   return this.test('er et Fnr eller Dnr', message, function(value) {
-    return Person.erGyldigFnr(value) || Person.erGyldigDnr(value);
+    return Utils.person.erGyldigFnr(value) || Utils.person.erGyldigDnr(value);
   });
 });
 
 addMethod(string, 'erFnrEllerDnrEllerOrgnr', function(message) {
   return this.test('er et Fnr, Dnr eller Orgnr', message, function(value) {
-    return Person.erGyldigFnr(value) || Person.erGyldigDnr(value) || Organisasjon.erOrgnrLengde(value);
+    return Utils.person.erGyldigFnr(value) || Utils.person.erGyldigDnr(value) || Organisasjon.erOrgnrLengde(value);
   });
 });
 
@@ -125,7 +124,7 @@ addMethod(string, 'harIkkeFnrEllerDnrLengde', function(message) {
   return this.test('er fnr eller dnr lengde', message, function(value) {
     const { path, createError } = this;
 
-    if (Person.erFnrLengde(value) || Person.erDnrLengde(value)) {
+    if (Utils.person.erFnrLengde(value) || Utils.person.erDnrLengde(value)) {
       throw createError({
         path,
         message,

--- a/src/sider/journalforing/journalforing.js
+++ b/src/sider/journalforing/journalforing.js
@@ -13,8 +13,6 @@ import * as Nav from '../../utils/navFrontend';
 import * as Api from '../../services/api';
 import { JOURNALFORING_HENSIKT, ANTALL_TALL_I_ORGNR } from '../../constants';
 
-import * as Person from '../../felleskomponenter/skjema/validering/generisk/person';
-
 import Sticky from '../../felleskomponenter/sticky';
 import PDFDokument from './komponenter/pdfdokument';
 import JournalforingSED from './komponenter/journalforingsed';
@@ -249,7 +247,7 @@ class Journalforing extends Component {
    * @param brukerID {string} Verdien vi ønsker å sjekke på.
    */
   hentOgVisBruker = async brukerID => {
-    if (!Person.erGyldigFnr(brukerID) && !Person.erGyldigDnr(brukerID)) { return; }
+    if (!Utils.person.erGyldigFnr(brukerID) && !Utils.person.erGyldigDnr(brukerID)) { return; }
 
     const { sokFnrDnr, settFeltInnhold, hentFagsakListe } = this.props;
     settFeltInnhold('brukerNavn', '');
@@ -279,7 +277,7 @@ class Journalforing extends Component {
       settFeltInnhold('avsenderNavn', navn);
     }
 
-    if (Person.erGyldigFnr(value) || Person.erGyldigDnr(value)) {
+    if (Utils.person.erGyldigFnr(value) || Utils.person.erGyldigDnr(value)) {
       settFeltInnhold('avsenderNavn', '');
       const response = await sokFnrDnr(value);
       if (!response || !response.data) { return false; }

--- a/src/sider/journalforing/komponenter/informasjon.js
+++ b/src/sider/journalforing/komponenter/informasjon.js
@@ -10,7 +10,6 @@ import * as MPT from '../../../proptypes/';
 import * as Konstanter from '../../../constants';
 import * as Api from '../../../services/api';
 import * as Ikoner from '../../../resources/images';
-import * as Person from '../../../felleskomponenter/skjema/validering/generisk/person';
 import * as Mui from '../../../felleskomponenter/ui';
 import AvsenderVelger from './avsendervelger';
 import LenkeListeVelger from './lenkelistevelger';
@@ -102,7 +101,7 @@ class Informasjon extends Component {
     const { settFeltInnhold, hentOgVisBruker } = this.props;
     const { erBrukerAvsender } = this.props.journalforingSkjemaVerdier;
 
-    if (Person.erGyldigFnr(verdi)) {
+    if (Utils.person.erGyldigFnr(verdi)) {
       await this.spinner('brukerNavn');
       const response = await hentOgVisBruker(verdi);
       if (!response) return;

--- a/src/sider/opprettnysak/opprettnysak.js
+++ b/src/sider/opprettnysak/opprettnysak.js
@@ -5,7 +5,6 @@ import { reduxForm, getFormValues, FormSection, SubmissionError } from 'redux-fo
 
 import * as Nav from '../../utils/navFrontend';
 import * as Skjema from '../../felleskomponenter/skjema';
-import * as Validering from '../../felleskomponenter/skjema/validering';
 import * as Mui from '../../felleskomponenter/ui';
 import * as Ikoner from '../../resources/images';
 import * as KV from '../../kodeverk';
@@ -36,7 +35,7 @@ const OpprettNySak = ({
   const soknadErValgt = MKVUtils.erSoknad(behandlingstema);
 
   const hentOppgaver = async brukerID => {
-    if (Validering.erGyldigFnr(brukerID) || Validering.erGyldigDnr(brukerID)) {
+    if (Utils.person.erGyldigFnr(brukerID) || Utils.person.erGyldigDnr(brukerID)) {
       try {
         const oppgaverResponse = await Api.Oppgaver.sok(brukerID);
         setOppgaver(oppgaverResponse);

--- a/src/sider/sok/sok.js
+++ b/src/sider/sok/sok.js
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
-import FnrValidator from '@navikt/fnrvalidator';
 
 import withErrorHandling from '../../felleskomponenter/withErrorHandling';
 import * as Nav from '../../utils/navFrontend';
 import * as MPT from '../../proptypes';
+import * as Utils from '../../utils';
 import Fagsak from '../../felleskomponenter/oppgaveliste/fagsak';
 import SorterbarListe from '../../felleskomponenter/sorterbarListe/sorterbarListe';
 
@@ -32,7 +32,7 @@ export const Sok = ({
 
   if (!sokResultat) return null;
 
-  const sokeFraseErFnrDnr = FnrValidator.idnr(sokefrase).status === 'valid';
+  const sokeFraseErFnrDnr = Utils.person.erGyldigFnr(sokefrase);
   const ingenTreff = <Nav.Panel>Fant ingen saker knyttet til {sokeFraseErFnrDnr ? 'f.nr./d-nr.' : 'saksnummer' } {sokefrase}.</Nav.Panel>;
 
   return (

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,6 +9,7 @@ import * as logger from './logger';
 import * as queryString from './queryString';
 import * as testhelpers from './testhelpers';
 import * as mapping from './mapping';
+import * as person from './person';
 
 import { buildinfo, delay, fn, isJSON, verdiSomNullable, queryParamsTilObjekt, erPropertyUnik, finnVerdierMedKey } from './utils';
 
@@ -22,6 +23,7 @@ export {
   queryString,
   testhelpers,
   mapping,
+  person,
   isUndefined as _isUndefined,
   isFunction as _isFunction,
   isNil as _isNil,

--- a/src/utils/panelFelter.js
+++ b/src/utils/panelFelter.js
@@ -1,4 +1,5 @@
 import * as Skjema from '../felleskomponenter/skjema';
+import * as Person from './person';
 
 /** Definer alle felter med validering. Dette objektet brukes også i validForm decorator.
  */
@@ -6,7 +7,7 @@ export const feltGrupper = {
   personOpplysninger: {
     medfolgendeAndre: [value => {
       if (!value) { return null; }
-      return (Skjema.Validering.erGyldigFnr(value) || Skjema.Validering.erGyldigDnr(value)) ? null : 'Ugyldig fnr eller dnr';
+      return (Person.erGyldigFnr(value) || Person.erGyldigDnr(value)) ? null : 'Ugyldig fnr eller dnr';
     }],
   },
   inntekt: {

--- a/src/utils/person.js
+++ b/src/utils/person.js
@@ -1,8 +1,3 @@
-const fulltNavn = value => {
-  const regex = /^[a-zA-Z.'-]{2,50}(?: [a-zA-Z.'-]{2,50})+$/;
-  return value && value.search(regex) ? 'Du må skrive inn både fornavn og etternavn.' : null;
-};
-
 const erFnrLengde = verdi => {
   const regex = RegExp(/^\d{11,11}$/);
   return regex.test(verdi);
@@ -51,7 +46,6 @@ const erGyldigFnr = verdi => {
 const erGyldigDnr = verdi => erGyldigFnr(verdi);
 
 export {
-  fulltNavn,
   erFnrLengde,
   erDnrLengde,
   erGyldigFnr,

--- a/src/utils/person.test.js
+++ b/src/utils/person.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import * as Person from './person';
-import * as Utils from '../../../../utils';
+import * as testhelpers from './testhelpers';
 
 describe('Tester person.js:', () => {
   describe('erGyldigFnr', () => {
@@ -15,7 +15,7 @@ describe('Tester person.js:', () => {
     });
 
     test('returnerer true ved riktig fødselsnummer', () => {
-      const generator = new Utils.testhelpers.Generator();
+      const generator = new testhelpers.Generator();
       const mockData1 = generator.generateBirthNumber();
       const mockData2 = generator.generateBirthNumber();
       const mockData3 = generator.generateBirthNumber();
@@ -75,7 +75,7 @@ describe('Tester person.js:', () => {
     });
 
     test('returnerer true ved riktig dnr', () => {
-      const generator = new Utils.testhelpers.Generator();
+      const generator = new testhelpers.Generator();
       const mockData1 = generator.generateDNumber();
       const mockData2 = generator.generateDNumber();
       const mockData3 = generator.generateDNumber();

--- a/src/utils/person.test.js
+++ b/src/utils/person.test.js
@@ -3,22 +3,6 @@ import * as Person from './person';
 import * as Utils from '../../../../utils';
 
 describe('Tester person.js:', () => {
-  describe('fulltNavn', () => {
-    test('feiler dersom mellomrom i navn mangler', () => {
-      const mockData = 'OlaNordmann';
-      expect(Person.fulltNavn(mockData)).toBe('Du må skrive inn både fornavn og etternavn.');
-    });
-
-    test('returnerer null (dvs ingen feilmelding) dersom navnet har ett eller flere mellomrom', () => {
-      const mockData1 = 'Ola Nordmann';
-      const mockData2 = 'Ola Jensenius Nordmann';
-      const mockData3 = 'Ola Jensenius Hansen Nordmann';
-      expect(Person.fulltNavn(mockData1)).toBe(null);
-      expect(Person.fulltNavn(mockData2)).toBe(null);
-      expect(Person.fulltNavn(mockData3)).toBe(null);
-    })
-  });
-
   describe('erGyldigFnr', () => {
     test('returnerer false ved feil fødselsnummer', () => {
       const mockData1 = '22222222222';

--- a/src/utils/testhelpers/generator.js
+++ b/src/utils/testhelpers/generator.js
@@ -1,4 +1,4 @@
-import FnrValidator from '@navikt/fnrvalidator';
+import * as Utils from '../../utils';
 
 class Generator {
   static MALE = 1;
@@ -102,7 +102,7 @@ class Generator {
     }
 
     const birthNumber = `${partialBirthNumber}${k1}${k2}`;
-    if (FnrValidator.idnr(birthNumber).status !== 'valid') {
+    if (!Utils.person.erGyldigFnr(birthNumber)) {
       return this.generateBirthNumber();
     }
 
@@ -120,7 +120,7 @@ class Generator {
     }
 
     const dNumber = `${partialDNumber}${k1}${k2}`;
-    if (FnrValidator.idnr(dNumber).status !== 'valid') {
+    if (!Utils.person.erGyldigDnr(dNumber)) {
       return this.generateDNumber();
     }
 

--- a/src/utils/testhelpers/generator.js
+++ b/src/utils/testhelpers/generator.js
@@ -1,4 +1,4 @@
-import * as Utils from '../../utils';
+import * as person from '../person';
 
 class Generator {
   static MALE = 1;
@@ -102,7 +102,7 @@ class Generator {
     }
 
     const birthNumber = `${partialBirthNumber}${k1}${k2}`;
-    if (!Utils.person.erGyldigFnr(birthNumber)) {
+    if (!person.erGyldigFnr(birthNumber)) {
       return this.generateBirthNumber();
     }
 
@@ -120,7 +120,7 @@ class Generator {
     }
 
     const dNumber = `${partialDNumber}${k1}${k2}`;
-    if (!Utils.person.erGyldigDnr(dNumber)) {
+    if (!person.erGyldigDnr(dNumber)) {
       return this.generateDNumber();
     }
 


### PR DESCRIPTION
Npm tillater ikke [enda](https://github.com/npm/rfcs/pull/217) å hente pakker fra samme org fra forskjellige registry. Det skaper noe trøbbel når vi henter ned pakker med `npm install`. Fjerner derfor `@navikt/fnrvalidator` siden vi har egendefinert funksjon for å validere fnr.