### PR TITLE
Legg til paneler for registrering-behandlingstemaer

### DIFF
--- a/src/sider/registrering/anmodningunntak/saksopplysninger.js
+++ b/src/sider/registrering/anmodningunntak/saksopplysninger.js
@@ -390,6 +390,8 @@ const Saksopplysninger = ({
         <RegistreringMenypanelForm
           menypunkter={[
             'Person',
+            'Medlemskap',
+            'EU/EØS-barnetrygd',
             'Arbeidsforhold og inntekt',
           ]}
           startOgVisOppfriskModal={startOgVisOppfriskModal}

--- a/src/sider/registrering/unntaksperioder/saksopplysninger.js
+++ b/src/sider/registrering/unntaksperioder/saksopplysninger.js
@@ -379,6 +379,8 @@ const Saksopplysninger = ({
         <RegistreringMenypanelForm
           menypunkter={[
             'Person',
+            'Medlemskap',
+            'EU/EØS-barnetrygd',
           ]}
           startOgVisOppfriskModal={startOgVisOppfriskModal}
         />


### PR DESCRIPTION
Informasjon om Medlemskap og EU/EØS-barnetrygd var før del av person-panel for registrering av unntaksperioder og anmodning om unntak, så det burde være med nå også.

(Avventer svar fra Yvonne på om vi skal vise inntektsopplysninger for registrering av unntaksperioder også(vises allerede for registrering av anmodning om unntak))