### PR TITLE
Sett feilmelding i menypanelet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13259,6 +13259,11 @@
       "resolved": "https://registry.npmjs.org/nav-frontend-ikoner-assets/-/nav-frontend-ikoner-assets-1.0.5.tgz",
       "integrity": "sha512-SPXDdvz8dhamhImf2aLQ3jOdXeNPedgnc/5MAd9RRr8T/EBjoZIWHCCg88GiXk6HC1T5MgjohHSFntkk5/phGg=="
     },
+    "nav-frontend-ikonknapper": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/nav-frontend-ikonknapper/-/nav-frontend-ikonknapper-1.0.25.tgz",
+      "integrity": "sha512-gXAzR1EtR0EjEyMVuNj9gseTgAaWVPxq6Q2kqdhPrR0mZMw+E7aKuXrEWyZWxWjqs4zXQWNM/7IUtuQLdjT6fA=="
+    },
     "nav-frontend-js-utils": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/nav-frontend-js-utils/-/nav-frontend-js-utils-1.0.15.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "nav-frontend-hjelpetekst": "^2.0.43",
     "nav-frontend-hjelpetekst-style": "^2.0.33",
     "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikonknapper": "^1.0.25",
     "nav-frontend-js-utils": "^1.0.15",
     "nav-frontend-knapper": "^1.0.37",
     "nav-frontend-knapper-style": "^0.3.32",

--- a/src/felleskomponenter/menypanel/menypanel.less
+++ b/src/felleskomponenter/menypanel/menypanel.less
@@ -7,23 +7,24 @@
   }
 }
 
-.alertstripe {
+.menypanel__feilmelding {
   padding: 5px 20px 0;
+
   svg {
     margin: 5px;
   }
-}
 
-.alertstripe__tekst {
-  max-width: none !important;
-  line-height: 35px;
+  .alertstripe__tekst {
+    max-width: none;
+    line-height: 35px;
 
-  .knapp {
-    float: right;
-    color: #ba3a26 !important;
-    border: none !important;
-    svg {
-      fill: #ba3a26 !important;
+    .knapp {
+      float: right;
+      border: none;
+
+      svg {
+        fill: #ba3a26;
+      }
     }
   }
 }

--- a/src/felleskomponenter/menypanel/menypanel.less
+++ b/src/felleskomponenter/menypanel/menypanel.less
@@ -6,3 +6,24 @@
     width: 80%;
   }
 }
+
+.alertstripe {
+  padding: 5px 20px 0;
+  svg {
+    margin: 5px;
+  }
+}
+
+.alertstripe__tekst {
+  max-width: none !important;
+  line-height: 35px;
+
+  .knapp {
+    float: right;
+    color: #ba3a26 !important;
+    border: none !important;
+    svg {
+      fill: #ba3a26 !important;
+    }
+  }
+}

--- a/src/felleskomponenter/menypanel/menypanel.tsx
+++ b/src/felleskomponenter/menypanel/menypanel.tsx
@@ -1,7 +1,6 @@
 import React, { useState, ReactNode } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from 'AppTypes';
-import { Xknapp } from 'nav-frontend-ikonknapper';
 
 import * as Nav from '../../utils/navFrontend';
 
@@ -256,9 +255,9 @@ export const Menypanel = ({
   return (
     <>
       { menypanelFeilmelding &&
-      <Nav.AlertStripe type="feil" className="varsel">
+      <Nav.AlertStripe type="feil" className="varsel menypanel__feilmelding">
         {menypanelFeilmelding}
-        <Xknapp form="kompakt" onClick={() => { setMenypanelFeilmelding(''); }} />
+        <Nav.Xknapp form="kompakt" onClick={() => { setMenypanelFeilmelding(''); }} />
       </Nav.AlertStripe> }
       <div className="menypanel">
         <Sidemeny

--- a/src/felleskomponenter/menypanel/menypanel.tsx
+++ b/src/felleskomponenter/menypanel/menypanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, ReactNode } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { RootState } from 'AppTypes';
+import { Xknapp } from 'nav-frontend-ikonknapper';
 
 import * as Nav from '../../utils/navFrontend';
 
@@ -214,6 +215,7 @@ export const Menypanel = ({
 
   const handleClick = (groupIndex: number, linkIndex: number) => {
     setActive([groupIndex, linkIndex]);
+    setMenypanelFeilmelding('');
   };
 
   const filteredLinkGroups = defaultLinkGroups
@@ -253,7 +255,11 @@ export const Menypanel = ({
 
   return (
     <>
-      { menypanelFeilmelding && <Nav.AlertStripe type="feil" className="varsel">{menypanelFeilmelding}</Nav.AlertStripe> }
+      { menypanelFeilmelding &&
+      <Nav.AlertStripe type="feil" className="varsel">
+        {menypanelFeilmelding}
+        <Xknapp form="kompakt" onClick={() => { setMenypanelFeilmelding(''); }} />
+      </Nav.AlertStripe> }
       <div className="menypanel">
         <Sidemeny
           heading="Opplysninger"

--- a/src/felleskomponenter/menypanel/menypanel.tsx
+++ b/src/felleskomponenter/menypanel/menypanel.tsx
@@ -95,6 +95,7 @@ export const Menypanel = ({
   lagreSoknadOgOppfriskSaksopplysninger,
 }: MenypanelProps) => {
   const [[activeGroupIndex, activeLinkIndex], setActive] = useState<[number, number]>([0, 0]);
+  const [menypanelFeilmelding, setMenypanelFeilmelding] = useState('');
 
   const visArbeidsforholdRolleEtiketter = behandlingsgrunnlagtype === SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS;
 
@@ -116,6 +117,7 @@ export const Menypanel = ({
           content: <Familieforhold
             visArbeidsforholdRolleEtiketter={visArbeidsforholdRolleEtiketter}
             redigerbart={redigerbart}
+            setMenypanelFeilmelding={setMenypanelFeilmelding}
           />,
         },
       ],
@@ -250,16 +252,19 @@ export const Menypanel = ({
     }));
 
   return (
-    <div className="menypanel">
-      <Sidemeny
-        heading="Opplysninger"
-        linkGroups={linkGroups}
-        onClick={handleClick}
-      />
-      <Nav.Panel className="content">
-        { activeContent }
-      </Nav.Panel>
-    </div>
+    <>
+      { menypanelFeilmelding && <Nav.AlertStripe type="feil" className="varsel">{menypanelFeilmelding}</Nav.AlertStripe> }
+      <div className="menypanel">
+        <Sidemeny
+          heading="Opplysninger"
+          linkGroups={linkGroups}
+          onClick={handleClick}
+        />
+        <Nav.Panel className="content">
+          { activeContent }
+        </Nav.Panel>
+      </div>
+    </>
   );
 };
 

--- a/src/felleskomponenter/menypanel/menypunkter/familieforhold/familieforholdContainer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/familieforhold/familieforholdContainer.tsx
@@ -15,11 +15,13 @@ import './familieforholdContainer.css';
 interface FamilieforholdContainerProps {
   redigerbart: boolean,
   visArbeidsforholdRolleEtiketter: boolean,
+  setMenypanelFeilmelding: (feilmelding: string) => void
 }
 
 const FamilieforholdContainer = ({
   redigerbart,
   visArbeidsforholdRolleEtiketter,
+  setMenypanelFeilmelding,
 }: FamilieforholdContainerProps) => (
   <Nav.Container fluid className="familieforhold-container">
     <Nav.Row>
@@ -29,7 +31,7 @@ const FamilieforholdContainer = ({
     </Nav.Row>
     <Nav.Row className="familiemedlemmer-row">
       <Nav.Column xs="12">
-        <Familiemedlemmer />
+        <Familiemedlemmer setMenypanelFeilmelding={setMenypanelFeilmelding} />
       </Nav.Column>
     </Nav.Row>
     <Nav.Row>

--- a/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmer.tsx
@@ -106,16 +106,17 @@ const mapDispatchToProps = (dispatch: any) => ({
 });
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
-type PropsFromRedux = ConnectedProps<typeof connector> & {
+type PropsFromRedux = ConnectedProps<typeof connector>;
+type FamiliemedlemmerProps = PropsFromRedux & {
   setMenypanelFeilmelding: (feilmelding: string) => void
-};
+}
 
 const Familiemedlemmer = ({
   behandlingID,
   familiemedlemmer,
   oppdaterBehandling,
   setMenypanelFeilmelding,
-}: PropsFromRedux) => {
+}: FamiliemedlemmerProps) => {
   const [harOppfrisket, setHarOppfrisket] = useState(false);
 
   const oppfrisk = async () => {

--- a/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmer.tsx
@@ -106,23 +106,27 @@ const mapDispatchToProps = (dispatch: any) => ({
 });
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
-type PropsFromRedux = ConnectedProps<typeof connector>;
+type PropsFromRedux = ConnectedProps<typeof connector> & {
+  setMenypanelFeilmelding: (feilmelding: string) => void
+};
 
 const Familiemedlemmer = ({
   behandlingID,
   familiemedlemmer,
   oppdaterBehandling,
+  setMenypanelFeilmelding,
 }: PropsFromRedux) => {
-  const [feilmelding, setFeilmelding] = useState('');
+  const [harOppfrisket, setHarOppfrisket] = useState(false);
 
   const oppfrisk = async () => {
     try {
       await Api.Saksopplysninger.oppfrisk(behandlingID, { medFamilierelasjoner: true });
       oppdaterBehandling();
+      setHarOppfrisket(true);
     } catch (e) {
       Utils.logger.error(e);
-      if (e.status >= 500) setFeilmelding('Kunne ikke hente familierelasjoner');
-      else if (e.status >= 400) setFeilmelding(e.body.message);
+      if (e.status >= 500) setMenypanelFeilmelding('Ikke svar fra TPS. Prøv igjen senere.');
+      else if (e.status >= 400) setMenypanelFeilmelding(e.body.message);
     }
   };
 
@@ -134,12 +138,12 @@ const Familiemedlemmer = ({
   return (
     <div className="familiemedlemmer">
       <Etiketter.FraRegister style={{ float: 'right' }} />
-      { feilmelding &&
-        <Nav.AlertStripe type="advarsel" className="varsel">{feilmelding}</Nav.AlertStripe>}
       { familiemedlemmer.length === 0 &&
         <div className="familiemedlemmer__gruppeoverskrift">
           <Mui.Knappelenke ikon={Ikoner.HentOpplysninger} onClick={oppfrisk}>Hent opplysninger</Mui.Knappelenke>
         </div>}
+      { harOppfrisket && familiemedlemmer.length === 0 &&
+        <div style={{ paddingLeft: '16px', fontStyle: 'italic' }}>Fant ingen familieforhold</div>}
       { familiemedlemmer.length !== 0 &&
       <FamiliemedlemmerGruppe
         familiemedlemmer={barn}

--- a/src/utils/navFrontend.js
+++ b/src/utils/navFrontend.js
@@ -17,6 +17,7 @@ import Tekstomrade from 'nav-frontend-tekstomrade';
 import Chevron from 'nav-frontend-chevron';
 import { LenkepanelBase } from 'nav-frontend-lenkepanel';
 import { PopoverOrientering } from 'nav-frontend-popover';
+import { Xknapp } from 'nav-frontend-ikonknapper';
 
 export {
   AlertStripeAdvarsel, AlertStripe, AlertStripeInfo,
@@ -37,4 +38,5 @@ export {
   Chevron,
   LenkepanelBase,
   PopoverOrientering,
+  Xknapp,
 };


### PR DESCRIPTION
Denne feilmeldinga må vel nødvendigvis ligge i menypanel-komponenten, siden den skal ligge over menyen og panelet. Har på følelsen at jeg har sett tilsvarende "Fant ingen familieforhold"-varselet et annet sted, så vi har kanskje en komponent for den, men klarte ikke å finne noe. Det blir litt mer rom over den enn i skissene, på grunn av at labelen til høyre tar opp en del plass.