### PR TITLE
Journalforing ftrl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1753,9 +1753,9 @@
       }
     },
     "@navikt/melosys-kodeverk": {
-      "version": "5.15.45",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.45/8e7b1c5dcd8215d508ec23f1ac446689944b9ce9a5829181c009ebeb9c70ae97",
-      "integrity": "sha512-2NjDYFHqGJOhmY6va82O913ViLGLi7pxhWj34+Q7LQidi4YdEuQsrH49tlOHJ3G/LCTHM214Lo6l3TMxfJUgZw=="
+      "version": "5.15.55",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.55/230c1b7eaaabc13a339706a8c10689f4f54d7c9fe0bbbb0e23d7889777e2bb34",
+      "integrity": "sha512-d9lLoAleCNUsmvWDRMEcfiHSZiTD1CLoKAgvCrVId8Hho1vUafM/wfAW6hG7eoHIv/bATEONH/eZ6cfNdFOOXA=="
     },
     "@navikt/textparser": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "readme": "README.md",
   "dependencies": {
     "@loadable/component": "^5.10.3",
-    "@navikt/melosys-kodeverk": "5.15.45",
+    "@navikt/melosys-kodeverk": "5.15.55",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.6",
     "connected-react-router": "^6.6.1",

--- a/src/sider/forside/komponenter/behandling.tsx
+++ b/src/sider/forside/komponenter/behandling.tsx
@@ -53,6 +53,7 @@ export const Behandling = ({
 
   const ikkePlukkbareBehandlingstemaer = [
     MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND,
+    'ARBEID_I_UTLANDET',
   ];
   const behandlingstemaErPlukkbart = (behandlingtemaKTObject: KTObject) => !ikkePlukkbareBehandlingstemaer.includes(behandlingtemaKTObject.kode);
 

--- a/src/sider/forside/komponenter/behandling.tsx
+++ b/src/sider/forside/komponenter/behandling.tsx
@@ -53,7 +53,7 @@ export const Behandling = ({
 
   const ikkePlukkbareBehandlingstemaer = [
     MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND,
-    'ARBEID_I_UTLANDET',
+    MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET,
   ];
   const behandlingstemaErPlukkbart = (behandlingtemaKTObject: KTObject) => !ikkePlukkbareBehandlingstemaer.includes(behandlingtemaKTObject.kode);
 

--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -112,13 +112,15 @@ const OpprettFagsak = props => {
               </Nav.Column>
             </Nav.Row>
           </Nav.Fieldset>
-          <Nav.Fieldset legend="Land:">
-            <Nav.Row className="">
-              <Nav.Column xs="12">
-                <Skjema.LandVelger feltNavn="journalforingSoknadsland" multiLand errorConfig={{ submitFailed: true }} />
-              </Nav.Column>
-            </Nav.Row>
-          </Nav.Fieldset>
+          { valgtBehandlingstema !== 'ARBEID_I_UTLANDET' &&
+            <Nav.Fieldset legend="Land:">
+              <Nav.Row className="">
+                <Nav.Column xs="12">
+                  <Skjema.LandVelger feltNavn="journalforingSoknadsland" multiLand errorConfig={{ submitFailed: true }} />
+                </Nav.Column>
+              </Nav.Row>
+            </Nav.Fieldset>
+          }
         </Fragment>
       }
     </div>

--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -24,7 +24,7 @@ const OpprettFagsak = props => {
   const { journalforingSkjemaVerdier } = props;
   const { opprettnysak_behandlingstema: valgtBehandlingstema } = journalforingSkjemaVerdier;
 
-  const [folketrygdenToggle] = Hooks.useFeatureToggle('melosys.folketrygden');
+  const [folketrygdenToggle] = Hooks.useFeatureToggle('melosys.folketrygden.mvp');
 
   if (folketrygdenToggle === 'fetching') return null;
 

--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -8,6 +8,7 @@ import * as Nav from '../../../utils/navFrontend';
 import * as MPT from '../../../proptypes/';
 import * as Utils from '../../../utils';
 import * as KV from '../../../kodeverk';
+import * as Hooks from '../../../hooks';
 import { formSelectors } from '../../../ducks/form';
 import MKV from '../../../melosyskodeverk';
 
@@ -22,6 +23,25 @@ const OpprettFagsak = props => {
   const { sakstyper, behandlingstemaer } = props;
   const { journalforingSkjemaVerdier } = props;
   const { opprettnysak_behandlingstema: valgtBehandlingstema } = journalforingSkjemaVerdier;
+
+  const [sidemenyToggle] = Hooks.useFeatureToggle('melosys.folketrygden');
+
+  if (sidemenyToggle === 'fetching') return null;
+
+  if (sidemenyToggle === 'enabled') {
+    if (sakstyper.findIndex(sakstype => sakstype.kode === 'FTRL') === -1) {
+      sakstyper.push({
+        kode: 'FTRL',
+        term: 'Folketrygdloven',
+      });
+    }
+    if (behandlingstemaer.findIndex(behandlingstema => behandlingstema.kode === 'ARBEID_I_UTLANDET') === -1) {
+      behandlingstemaer.push({
+        kode: 'ARBEID_I_UTLANDET',
+        term: 'Arbeid i utlandet',
+      });
+    }
+  }
 
   const art16 = [
     KV.kodeTilObjekt(

--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -24,11 +24,11 @@ const OpprettFagsak = props => {
   const { journalforingSkjemaVerdier } = props;
   const { opprettnysak_behandlingstema: valgtBehandlingstema } = journalforingSkjemaVerdier;
 
-  const [sidemenyToggle] = Hooks.useFeatureToggle('melosys.folketrygden');
+  const [folketrygdenToggle] = Hooks.useFeatureToggle('melosys.folketrygden');
 
-  if (sidemenyToggle === 'fetching') return null;
+  if (folketrygdenToggle === 'fetching') return null;
 
-  if (sidemenyToggle === 'enabled') {
+  if (folketrygdenToggle === 'enabled') {
     if (sakstyper.findIndex(sakstype => sakstype.kode === 'FTRL') === -1) {
       sakstyper.push({
         kode: 'FTRL',

--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import { change } from 'redux-form';
+import { change, getFormValues } from 'redux-form';
 import PT from 'prop-types';
 
 import * as Skjema from '../../../felleskomponenter/skjema/';
@@ -22,6 +22,7 @@ export const OpprettSakTittel = () => (
 const OpprettFagsak = props => {
   const { sakstyper, behandlingstemaer } = props;
   const { journalforingSkjemaVerdier } = props;
+  const { formValues } = props;
   const { opprettnysak_behandlingstema: valgtBehandlingstema } = journalforingSkjemaVerdier;
 
   const [folketrygdenToggle] = Hooks.useFeatureToggle('melosys.folketrygden.mvp');
@@ -64,7 +65,11 @@ const OpprettFagsak = props => {
       <Skjema.Select feltNavn="opprettnysak_behandlingstema" bredde="fullbredde" label="Behandlingstema">
         {
           behandlingstemaer &&
-          behandlingstemaer.map(elem => (<option key={elem.kode} value={elem.kode}>{elem.term}</option>))
+          behandlingstemaer
+            .filter(elem => (formValues && formValues.sakstype === MKV.Koder.sakstyper.FTRL
+              ? elem.kode === MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET
+              : elem.kode !== MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET))
+            .map(elem => (<option key={elem.kode} value={elem.kode}>{elem.term}</option>))
         }
       </Skjema.Select>
       {skalViseSoknadsperiodeOgLand(valgtBehandlingstema) &&
@@ -128,13 +133,16 @@ OpprettFagsak.propTypes = {
   behandlingstemaer: PT.arrayOf(MPT.Kodeverk).isRequired,
   sakstyper: PT.arrayOf(MPT.Kodeverk).isRequired,
   journalforingSkjemaVerdier: PT.object,
+  formValues: PT.object,
 };
 
 OpprettFagsak.defaultProps = {
   journalforingSkjemaVerdier: {},
+  formValues: {},
 };
 const mapStateToProps = state => ({
   journalforingSkjemaVerdier: formSelectors.JournalforingFormSelector(state).values,
+  formValues: getFormValues('journalforing')(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -29,17 +29,13 @@ const OpprettFagsak = props => {
   if (folketrygdenToggle === 'fetching') return null;
 
   if (folketrygdenToggle === 'enabled') {
-    if (sakstyper.findIndex(sakstype => sakstype.kode === 'FTRL') === -1) {
-      sakstyper.push({
-        kode: 'FTRL',
-        term: 'Folketrygdloven',
-      });
+    if (sakstyper.findIndex(sakstype => sakstype.kode === MKV.Koder.sakstyper.FTRL) === -1) {
+      sakstyper.push(MKV.KTObjects.sakstyper.find(({ kode }) =>
+        kode === MKV.Koder.sakstyper.FTRL));
     }
-    if (behandlingstemaer.findIndex(behandlingstema => behandlingstema.kode === 'ARBEID_I_UTLANDET') === -1) {
-      behandlingstemaer.push({
-        kode: 'ARBEID_I_UTLANDET',
-        term: 'Arbeid i utlandet',
-      });
+    if (behandlingstemaer.findIndex(behandlingstema => behandlingstema.kode === MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET) === -1) {
+      behandlingstemaer.push(MKV.KTObjects.behandlinger.behandlingstema.find(({ kode }) =>
+        kode === MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET));
     }
   }
 
@@ -112,7 +108,7 @@ const OpprettFagsak = props => {
               </Nav.Column>
             </Nav.Row>
           </Nav.Fieldset>
-          { valgtBehandlingstema !== 'ARBEID_I_UTLANDET' &&
+          { valgtBehandlingstema !== MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET &&
             <Nav.Fieldset legend="Land:">
               <Nav.Row className="">
                 <Nav.Column xs="12">

--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -1,6 +1,6 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import { connect } from 'react-redux';
-import { change, getFormValues } from 'redux-form';
+import { change } from 'redux-form';
 import PT from 'prop-types';
 
 import * as Skjema from '../../../felleskomponenter/skjema/';
@@ -22,8 +22,17 @@ export const OpprettSakTittel = () => (
 const OpprettFagsak = props => {
   const { sakstyper, behandlingstemaer } = props;
   const { journalforingSkjemaVerdier } = props;
-  const { formValues } = props;
-  const { opprettnysak_behandlingstema: valgtBehandlingstema } = journalforingSkjemaVerdier;
+  const { settFeltInnhold } = props;
+  const { opprettnysak_behandlingstema: valgtBehandlingstema, sakstype: valgtSakstype } = journalforingSkjemaVerdier;
+
+  useEffect(() => {
+    settFeltInnhold(
+      'opprettnysak_behandlingstema',
+      valgtSakstype === MKV.Koder.sakstyper.FTRL
+        ? MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET
+        : MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER
+    );
+  }, [valgtSakstype]);
 
   const [folketrygdenToggle] = Hooks.useFeatureToggle('melosys.folketrygden.mvp');
 
@@ -66,7 +75,7 @@ const OpprettFagsak = props => {
         {
           behandlingstemaer &&
           behandlingstemaer
-            .filter(elem => (formValues && formValues.sakstype === MKV.Koder.sakstyper.FTRL
+            .filter(elem => (valgtSakstype === MKV.Koder.sakstyper.FTRL
               ? elem.kode === MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET
               : elem.kode !== MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET))
             .map(elem => (<option key={elem.kode} value={elem.kode}>{elem.term}</option>))
@@ -133,16 +142,14 @@ OpprettFagsak.propTypes = {
   behandlingstemaer: PT.arrayOf(MPT.Kodeverk).isRequired,
   sakstyper: PT.arrayOf(MPT.Kodeverk).isRequired,
   journalforingSkjemaVerdier: PT.object,
-  formValues: PT.object,
+  settFeltInnhold: PT.func.isRequired,
 };
 
 OpprettFagsak.defaultProps = {
   journalforingSkjemaVerdier: {},
-  formValues: {},
 };
 const mapStateToProps = state => ({
   journalforingSkjemaVerdier: formSelectors.JournalforingFormSelector(state).values,
-  formValues: getFormValues('journalforing')(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -98,24 +98,26 @@ const OpprettFagsak = props => {
             </Nav.Fieldset>
           </Fragment>
           }
-          <Nav.Fieldset legend="Søknadsperiode:" className="opprettnysak__soknadsperiode">
-            <Nav.Row className="">
-              <Nav.Column xs="6">
-                <Skjema.Input datoFelt label="Fra" feltNavn="journalforingPeriodeFraOgMed" />
-              </Nav.Column>
-              <Nav.Column xs="6">
-                <Skjema.Input datoFelt label="Til" feltNavn="journalforingPeriodeTilOgMed" />
-              </Nav.Column>
-            </Nav.Row>
-          </Nav.Fieldset>
           { valgtBehandlingstema !== MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET &&
-            <Nav.Fieldset legend="Land:">
-              <Nav.Row className="">
-                <Nav.Column xs="12">
-                  <Skjema.LandVelger feltNavn="journalforingSoknadsland" multiLand errorConfig={{ submitFailed: true }} />
-                </Nav.Column>
-              </Nav.Row>
-            </Nav.Fieldset>
+            <Fragment>
+              <Nav.Fieldset legend="Søknadsperiode:" className="opprettnysak__soknadsperiode">
+                <Nav.Row className="">
+                  <Nav.Column xs="6">
+                    <Skjema.Input datoFelt label="Fra" feltNavn="journalforingPeriodeFraOgMed" />
+                  </Nav.Column>
+                  <Nav.Column xs="6">
+                    <Skjema.Input datoFelt label="Til" feltNavn="journalforingPeriodeTilOgMed" />
+                  </Nav.Column>
+                </Nav.Row>
+              </Nav.Fieldset>
+              <Nav.Fieldset legend="Land:">
+                <Nav.Row className="">
+                  <Nav.Column xs="12">
+                    <Skjema.LandVelger feltNavn="journalforingSoknadsland" multiLand errorConfig={{ submitFailed: true }} />
+                  </Nav.Column>
+                </Nav.Row>
+              </Nav.Fieldset>
+            </Fragment>
           }
         </Fragment>
       }

--- a/src/yup/skjemaer/journalforing.js
+++ b/src/yup/skjemaer/journalforing.js
@@ -35,6 +35,15 @@ const kreverPeriodeOgLand = (journalforingHensikt, behandlingstema) => (
   ].includes(behandlingstema)
 );
 
+const kreverLand = (journalforingHensikt, behandlingstema) => (
+  journalforingHensikt === Konstanter.JOURNALFORING_HENSIKT.OPPRETT && ![
+    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
+    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
+    MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
+    'ARBEID_I_UTLANDET',
+  ].includes(behandlingstema)
+);
+
 const anmodningOmUnntak = (journalforingHensikt, behandlingstema) =>
   kreverPeriodeOgLand(journalforingHensikt, behandlingstema) &&
   journalforingHensikt === Konstanter.JOURNALFORING_HENSIKT.OPPRETT &&
@@ -115,7 +124,7 @@ const journalforing = object().shape({
   journalforingSoknadsland: array().of(string())
     .ensure()
     .when(['journalforingHensikt', 'opprettnysak_behandlingstema'], {
-      is: kreverPeriodeOgLand,
+      is: kreverLand,
       then: array().of(string())
         .min(1, { _error: VELG_MINST_ETT_LAND }),
     }),

--- a/src/yup/skjemaer/journalforing.js
+++ b/src/yup/skjemaer/journalforing.js
@@ -32,14 +32,6 @@ const kreverPeriodeOgLand = (journalforingHensikt, behandlingstema) => (
     MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
     MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
     MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
-  ].includes(behandlingstema)
-);
-
-const kreverLand = (journalforingHensikt, behandlingstema) => (
-  journalforingHensikt === Konstanter.JOURNALFORING_HENSIKT.OPPRETT && ![
-    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
-    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
-    MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
     MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET,
   ].includes(behandlingstema)
 );
@@ -124,7 +116,7 @@ const journalforing = object().shape({
   journalforingSoknadsland: array().of(string())
     .ensure()
     .when(['journalforingHensikt', 'opprettnysak_behandlingstema'], {
-      is: kreverLand,
+      is: kreverPeriodeOgLand,
       then: array().of(string())
         .min(1, { _error: VELG_MINST_ETT_LAND }),
     }),

--- a/src/yup/skjemaer/journalforing.js
+++ b/src/yup/skjemaer/journalforing.js
@@ -40,7 +40,7 @@ const kreverLand = (journalforingHensikt, behandlingstema) => (
     MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
     MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
     MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
-    'ARBEID_I_UTLANDET',
+    MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET,
   ].includes(behandlingstema)
 );
 


### PR DESCRIPTION
Setter feature-toggles på journalføring slik at man ikke kan velge FTLR-sakstype eller -behandlingstema. Merk at behandlingstemaer og sakstyper som kommer inn som props i `opprettsak.js` allerede blir filtrert lengre opp. 

Legger også til FTLR-behandlingstemaet i temaene som ikke skal plukkes.

Oppdaterer kodeverk-versjon.