### PR TITLE
MELOSYS-4320 - Begrens valg av artikler ved vurdering av Utpeking av Norge(A003)

### DIFF
--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.js
@@ -24,6 +24,18 @@ import { lagYupToReduxformErrorMapper, Skjemaer as YupSkjemaer } from '../../../
 
 import './vurderingUtpekt.css';
 
+const lovvalgsbestemmelserStottetAvBrevVedNorgeUtpekt = MKV.Kodekombinasjoner.alleLovvalg.filter(({ kode }) => (
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1A ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B1 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B2 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B3 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B4 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_2A ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_2B ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_3 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_4
+));
+
 export const VurderingUtpekt = ({
   vurderingBegrunnelser,
   slettData,
@@ -77,7 +89,7 @@ export const VurderingUtpekt = ({
   const visLovvalgsland = lovvalgslandFraForm && lovvalgslandFraForm !== MKV.Koder.landkoder.NO;
   const lovvalgslandTerm = KV.kodeTilTerm(lovvalgslandFraForm, MKV.KTObjects.landkoder);
   const lovvalgsbestemmelser = behandlingstema === MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE ?
-    MKV.Kodekombinasjoner.valgbareLovvalgsbestemmelserSEDA003
+    lovvalgsbestemmelserStottetAvBrevVedNorgeUtpekt
     :
     MKV.Kodekombinasjoner.alleLovvalg;
 

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.js
@@ -38,6 +38,7 @@ export const VurderingUtpekt = ({
   formValues,
   lovvalgsperiode,
   ytterligereInformasjon,
+  behandlingstema,
 }) => {
   useEffect(() => {
     if (lovvalgsland) {
@@ -75,6 +76,10 @@ export const VurderingUtpekt = ({
   const lovvalgslandFraForm = formValues.lovvalgsland;
   const visLovvalgsland = lovvalgslandFraForm && lovvalgslandFraForm !== MKV.Koder.landkoder.NO;
   const lovvalgslandTerm = KV.kodeTilTerm(lovvalgslandFraForm, MKV.KTObjects.landkoder);
+  const lovvalgsbestemmelser = behandlingstema === MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE ?
+    MKV.Kodekombinasjoner.valgbareLovvalgsbestemmelserSEDA003
+    :
+    MKV.Kodekombinasjoner.alleLovvalg;
 
   return (
     <form onSubmit={handleSubmit}>
@@ -109,7 +114,7 @@ export const VurderingUtpekt = ({
           >
             <option disabled key="VELG" value="">Velg</option>
             {
-              MKV.Kodekombinasjoner.alleLovvalg.map(kodeObjekt => (
+              lovvalgsbestemmelser.map(kodeObjekt => (
                 <option key={Utils._uuid()} value={kodeObjekt.kode}>{kodeObjekt.term}</option>
               ))
             }
@@ -210,6 +215,7 @@ VurderingUtpekt.propTypes = {
   formValues: PT.object,
   lovvalgsperiode: MPT.Periode.isRequired,
   ytterligereInformasjon: PT.string,
+  behandlingstema: PT.string.isRequired,
 };
 
 VurderingUtpekt.defaultProps = {
@@ -234,6 +240,7 @@ const mapStateToProps = (state, ownProps) => ({
   },
   vurderingBegrunnelser: behandlingsresultatSelectors.KontrollresultatBegrunnelseKoderSelector(state),
   ytterligereInformasjon: behandlingsgrunnlagSelectors.YtterligereInformasjonSelector(state),
+  behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
 });
 
 const nesteSteg = (values, dispatch, props) => {

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpekt.test.js
@@ -2,6 +2,8 @@ import React from 'react';
 
 import * as Skjema from '../../skjema';
 
+import MKV from '../../../melosyskodeverk';
+
 import RegisterKontrollTreff from '../../registerkontrollTreff';
 import { VurderingUtpekt } from './vurderingUtpekt';
 
@@ -22,6 +24,7 @@ describe('VurderingUtpekt', () => {
       handleSubmit: jest.fn(),
       formValues: {},
       lovvalgsperiode: { fom: '', tom: '' },
+      behandlingstema: MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE,
     };
   });
 

--- a/src/melosyskodeverk/kodekombinasjoner.js
+++ b/src/melosyskodeverk/kodekombinasjoner.js
@@ -7,21 +7,6 @@ export const alleLovvalg = [
   ...MKV.KTObjects.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004,
 ];
 
-export const valgbareLovvalgsbestemmelserSEDA003 = alleLovvalg.filter(({ kode }) => (
-  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1A ||
-  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B1 ||
-  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B2 ||
-  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B3 ||
-  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B4 ||
-  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_2A ||
-  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_2B ||
-  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_3 ||
-  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_4 ||
-  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_987_2009.FO_987_2009_ART14_11 ||
-  kode === MKV.Koder.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004.FO_883_2004_ART87_8 ||
-  kode === MKV.Koder.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004.FO_883_2004_ART87A
-));
-
 const bestemmelserIkkeRelevanteForUnntak = [
   MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_1,
   MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_3B,

--- a/src/melosyskodeverk/kodekombinasjoner.js
+++ b/src/melosyskodeverk/kodekombinasjoner.js
@@ -7,6 +7,21 @@ export const alleLovvalg = [
   ...MKV.KTObjects.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004,
 ];
 
+export const valgbareLovvalgsbestemmelserSEDA003 = alleLovvalg.filter(({ kode }) => (
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1A ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B1 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B2 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B3 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1B4 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_2A ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_2B ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_3 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_4 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_987_2009.FO_987_2009_ART14_11 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004.FO_883_2004_ART87_8 ||
+  kode === MKV.Koder.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004.FO_883_2004_ART87A
+));
+
 const bestemmelserIkkeRelevanteForUnntak = [
   MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_1,
   MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_3B,


### PR DESCRIPTION
I flyt for Utpeking av Norge(mottatt A003): Skal bare være mulig å velge artikler som er mulig å velge i SED A003 punkt 10.