### PR TITLE
MELOSYS-4321 - Arbeidssteder oppforsel fiks

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/enRedigeringsknappListe.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/enRedigeringsknappListe.tsx
@@ -63,6 +63,29 @@ function EnRedigeringsKnappListe<T>({
 
   const elementer = fields.getAll();
 
+  const ingenDataRender = IngenDataKomponent ?
+    (apneRedigering: () => void) => (
+      <>
+        <div className="ingen__data__container">
+          <IngenDataKomponent />
+        </div>
+        {
+          redigerbart &&
+          <Mui.Knappelenke
+            onClick={() => {
+              apneRedigering();
+              leggTil();
+            }}
+            ikon={Ikoner.Add}
+          >
+            {leggTilTekst}
+          </Mui.Knappelenke>
+        }
+      </>
+    )
+    :
+    undefined;
+
   return (
     <EditerbartElement
       className="en__redigeringsknapp__liste"
@@ -114,28 +137,7 @@ function EnRedigeringsKnappListe<T>({
       redigeringUtfortRender={() => <RedigeringUtfortKomponent
         verdier={elementer}
       />}
-      ingenDataRender={apneRedigering => (
-        <>
-          {
-            IngenDataKomponent &&
-            <div className="ingen__data__container">
-              <IngenDataKomponent />
-            </div>
-          }
-          {
-            redigerbart &&
-            <Mui.Knappelenke
-              onClick={() => {
-                apneRedigering();
-                leggTil();
-              }}
-              ikon={Ikoner.Add}
-            >
-              {leggTilTekst}
-            </Mui.Knappelenke>
-          }
-        </>
-      )}
+      ingenDataRender={ingenDataRender}
     />
   );
 }

--- a/src/felleskomponenter/skjema/landvelger/enkeltLand.js
+++ b/src/felleskomponenter/skjema/landvelger/enkeltLand.js
@@ -19,16 +19,28 @@ export class EnkeltLand extends Component {
   };
 
   componentDidMount = () => {
-    const { value } = this.props.input;
-    const { landkoder } = this.props;
-    const landkodeObjekt = value && KV.kodeTilObjekt(value, landkoder);
-    const inputVerdi = landkodeObjekt ? landTekstFormat(landkodeObjekt) : '';
+    const inputVerdi = this.lagInputVerdi();
     this.setInputVerdi(inputVerdi);
   };
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.input.value !== this.props.input.value) {
+      const inputVerdi = this.lagInputVerdi();
+      this.setInputVerdi(inputVerdi);
+    }
+  }
 
   setInputVerdi = verdi => {
     this.setState({ inputVerdi: verdi });
   };
+
+  lagInputVerdi = () => {
+    const { value } = this.props.input;
+    const { landkoder } = this.props;
+    const landkodeObjekt = value && KV.kodeTilObjekt(value, landkoder);
+    const inputVerdi = landkodeObjekt ? landTekstFormat(landkodeObjekt) : '';
+    return inputVerdi;
+  }
 
   reduxOppdaterLand = landkode => {
     if (!landkode) {


### PR DESCRIPTION
Fikser to bugs:
- Når man hadde et arbeidssted utfylt og trykket "Legg til arbeidssted..", forsvant alle arbeidsstedene man hadde fylt inn. Skjedde fordi  `EnRedigeringsKnappListe` manglet sjekk på om `IngenDataKomponent` var satt(arbeidssteder setter ikke `IngenDataKomponent`)
- `inputVerdi`-state i `EnkeltLand` oppdaterte seg ikke dersom tilsvarende prop endret seg. Førte til at når man slettet et arbeidssted, dukket land fra det slettede arbeidsstedet opp i eventuelle arbeidssted som lå igjen i samme liste(inntil man endrer menypunkt).