### PR TITLE
Sidemeny for FTRL-kode

### DIFF
--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
@@ -51,7 +51,7 @@ class LinkGroupsFactory {
           )
           .addFraSoknad(
             new LinksBuilder(contentProps)
-              .addArbeidsgiverEllervirksomhet()
+              .addArbeidsgiverEllerVirksomhet()
               .addFullmektig()
               .addPeriode()
               .addArbeidssteder()
@@ -92,7 +92,7 @@ class LinkGroupsFactory {
           )
           .addFraSED(
             new LinksBuilder(contentProps)
-              .addArbeidsgiverEllervirksomhet()
+              .addArbeidsgiverEllerVirksomhet()
               .addFullmektig()
               .addPeriode()
               .addArbeidssteder()
@@ -106,7 +106,7 @@ class LinkGroupsFactory {
           .addFraRegister(
             new LinksBuilder(contentProps).addMedlemskap().addEUEOSBarnetrygd().addArbeidsforholdOgInntekt().build()
           )
-          .addFraSoknad(new LinksBuilder(contentProps).addArbeidsgiverEllervirksomhet().addFullmektig().build())
+          .addFraSoknad(new LinksBuilder(contentProps).addArbeidsgiverEllerVirksomhet().addFullmektig().build())
           .build();
       }
       default:

--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
@@ -19,6 +19,7 @@ const {
   ØVRIGE_SED_MED,
   ØVRIGE_SED_UFM,
   TRYGDETID,
+  ARBEID_I_UTLANDET,
 } = MKV.Koder.behandlinger.behandlingstema;
 
 export interface LinkGroupsFactoryConfig {
@@ -97,6 +98,15 @@ class LinkGroupsFactory {
               .addArbeidssteder()
               .build()
           )
+          .build();
+      }
+      case ARBEID_I_UTLANDET: {
+        return new LinkgroupsBuilder()
+          .addFraRegisterOgSoknad(new LinksBuilder(contentProps).addPerson().addFamilieForhold().build())
+          .addFraRegister(
+            new LinksBuilder(contentProps).addMedlemskap().addEUEOSBarnetrygd().addArbeidsforholdOgInntekt().build()
+          )
+          .addFraSoknad(new LinksBuilder(contentProps).addArbeidsgiverEllervirksomhet().addFullmektig().build())
           .build();
       }
       default:

--- a/src/felleskomponenter/menypanel/linkgroups/linksBuilder.test.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linksBuilder.test.tsx
@@ -17,7 +17,7 @@ describe("LinksBuilder", () => {
 
     const links = linksBuilder
       .addArbeidsforholdOgInntekt()
-      .addArbeidsgiverEllervirksomhet()
+      .addArbeidsgiverEllerVirksomhet()
       .addArbeidssteder()
       .addEUEOSBarnetrygd()
       .addFamilieForhold()

--- a/src/felleskomponenter/menypanel/linkgroups/linksBuilder.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linksBuilder.tsx
@@ -20,7 +20,7 @@ interface ILinksBuilder {
   addMedlemskap: () => ILinksBuilder;
   addEUEOSBarnetrygd: () => ILinksBuilder;
   addArbeidsforholdOgInntekt: () => ILinksBuilder;
-  addArbeidsgiverEllervirksomhet: () => ILinksBuilder;
+  addArbeidsgiverEllerVirksomhet: () => ILinksBuilder;
   addFullmektig: () => ILinksBuilder;
   addPeriode: () => ILinksBuilder;
   // addUtenlandsoppdraget: () => ILinksBuilder,

--- a/src/felleskomponenter/menypanel/linkgroups/linksBuilder.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linksBuilder.tsx
@@ -99,7 +99,7 @@ class LinksBuilder implements ILinksBuilder {
     return this;
   }
 
-  public addArbeidsgiverEllervirksomhet() {
+  public addArbeidsgiverEllerVirksomhet() {
     this.links.push({
       label: "Arbeidsgiver/virksomhet",
       active: false,

--- a/src/felleskomponenter/menypanel/menypanel.test.tsx
+++ b/src/felleskomponenter/menypanel/menypanel.test.tsx
@@ -35,6 +35,7 @@ const {
   ØVRIGE_SED_MED,
   ØVRIGE_SED_UFM,
   TRYGDETID,
+  ARBEID_I_UTLANDET,
 } = MKV.Koder.behandlinger.behandlingstema;
 
 describe("MenyPanel", () => {
@@ -136,6 +137,29 @@ describe("MenyPanel", () => {
     expect(sidemenyLinkGroups[2].links[1].label).toBe("Fullmektig");
     expect(sidemenyLinkGroups[2].links[2].label).toBe("Periode");
     expect(sidemenyLinkGroups[2].links[3].label).toBe("Arbeidssted(er)");
+  });
+
+  each([ARBEID_I_UTLANDET]).it("Viser korrekte menypunkter for behandlingstema %p", (behandlingstema) => {
+    props.behandlingstema = behandlingstema;
+    const menypanel = shallow(<Menypanel {...props} />);
+    const sidemeny = menypanel.find(Sidemeny);
+    const sidemenyLinkGroups = sidemeny.props().linkGroups;
+
+    expect(sidemenyLinkGroups[0].label).toBe("FRA REGISTER OG SØKNAD");
+    expect(sidemenyLinkGroups[0].links).toHaveLength(2);
+    expect(sidemenyLinkGroups[0].links[0].label).toBe("Person");
+    expect(sidemenyLinkGroups[0].links[1].label).toBe("Familieforhold");
+
+    expect(sidemenyLinkGroups[1].label).toBe("FRA REGISTER");
+    expect(sidemenyLinkGroups[1].links).toHaveLength(3);
+    expect(sidemenyLinkGroups[1].links[0].label).toBe("Medlemskap");
+    expect(sidemenyLinkGroups[1].links[1].label).toBe("EU/EØS-barnetrygd");
+    expect(sidemenyLinkGroups[1].links[2].label).toBe("Arbeidsforhold og inntekt");
+
+    expect(sidemenyLinkGroups[2].label).toBe("FRA SØKNAD");
+    expect(sidemenyLinkGroups[2].links).toHaveLength(2);
+    expect(sidemenyLinkGroups[2].links[0].label).toBe("Arbeidsgiver/virksomhet");
+    expect(sidemenyLinkGroups[2].links[1].label).toBe("Fullmektig");
   });
 
   it("hvis behandlingsgrunnlagtype er SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS vises arbeidsforholdrolleetiketter", () => {


### PR DESCRIPTION
Legger til enkel sidemeny for FTRL, med felt som beskrevet i confluence: [MELOSYS-4234].(https://jira.adeo.no/browse/MELOSYS-4234).
Etikkene `Fra SED` og `Arbeidsgivers del`/`Arbeidstakers del` var allerede fikset slik at de ikke vises her, basert på hhv. behandlingstype og behandlingssgrunnlagtype.