### PR TITLE
MELOSYS-4405 - Slett lovvalgsperioder ved avslag pga. manglende opplysninger

### DIFF
--- a/src/contexts/fellesHandlers.js
+++ b/src/contexts/fellesHandlers.js
@@ -16,6 +16,7 @@ import { saksopplysningerOperations } from "../ducks/saksopplysninger";
 import { behandlingerOperations } from "../ducks/behandlinger";
 import { modalerOperations, modalerSelectors } from "../ducks/modaler";
 import { navigeringOperations } from "../ducks/navigering";
+import { lovvalgsperioderOperations } from "../ducks/lovvalgsperioder";
 
 const FellesHandlersContext = React.createContext({});
 export default FellesHandlersContext;
@@ -46,6 +47,7 @@ const FellesHandlersProviderUnconnected = ({
   fjernBehandlingOppfriskes,
   behandlingUnderOppfriskning,
   tilForsiden,
+  resetLovvalgsperioder,
 }) => {
   const [venterPaRevurderFagsak, setVenterPaRevurderFagsak] = useState(false);
   const behandlingID = Utils._toInteger(Utils.queryString.getParam(location, "behandlingID"));
@@ -126,6 +128,8 @@ const FellesHandlersProviderUnconnected = ({
 
   const avslaaSoknadHandle = async (data) => {
     try {
+      // Hvis lovvalgsperioden er blitt opprettet må den fjernes før avslag.
+      await resetLovvalgsperioder();
       await lagreAllData();
       avslaSoknad(behandlingID, data);
     } catch (e) {
@@ -196,6 +200,7 @@ FellesHandlersProviderUnconnected.propTypes = {
   fjernBehandlingOppfriskes: PT.func.isRequired,
   behandlingUnderOppfriskning: PT.number,
   tilForsiden: PT.func.isRequired,
+  resetLovvalgsperioder: PT.func.isRequired,
 };
 
 FellesHandlersProviderUnconnected.defaultProps = {
@@ -234,6 +239,7 @@ const mapDispatchToProps = (dispatch) => ({
   visRevurderFagsakDialogHandle: () => dispatch(modalerOperations.visRevurderFagsak()),
   visValideringModalDialogHandle: () => dispatch(modalerOperations.visValidering()),
   tilForsiden: () => dispatch(navigeringOperations.tilForsiden()),
+  resetLovvalgsperioder: () => dispatch(lovvalgsperioderOperations.resetLovvalgsperioderState()),
 });
 
 export const FellesHandlersProvider = withRouter(

--- a/src/contexts/fellesHandlers.js
+++ b/src/contexts/fellesHandlers.js
@@ -17,6 +17,8 @@ import { behandlingerOperations } from "../ducks/behandlinger";
 import { modalerOperations, modalerSelectors } from "../ducks/modaler";
 import { navigeringOperations } from "../ducks/navigering";
 import { lovvalgsperioderOperations } from "../ducks/lovvalgsperioder";
+import { anmodningsperioderOperations } from "../ducks/anmodningsperioder";
+import { utpekingsperioderOperations } from "../ducks/utpekingsperioder";
 
 const FellesHandlersContext = React.createContext({});
 export default FellesHandlersContext;
@@ -48,6 +50,8 @@ const FellesHandlersProviderUnconnected = ({
   behandlingUnderOppfriskning,
   tilForsiden,
   resetLovvalgsperioder,
+  resetAnmodningsperioder,
+  resetUtpekingsperioder,
 }) => {
   const [venterPaRevurderFagsak, setVenterPaRevurderFagsak] = useState(false);
   const behandlingID = Utils._toInteger(Utils.queryString.getParam(location, "behandlingID"));
@@ -128,8 +132,11 @@ const FellesHandlersProviderUnconnected = ({
 
   const avslaaSoknadHandle = async (data) => {
     try {
-      // Hvis lovvalgsperioden er blitt opprettet må den fjernes før avslag.
+      // Hvis perioden er blitt opprettet må den fjernes før avslag.
       await resetLovvalgsperioder();
+      await resetAnmodningsperioder();
+      await resetUtpekingsperioder();
+
       await lagreAllData();
       avslaSoknad(behandlingID, data);
     } catch (e) {
@@ -201,6 +208,8 @@ FellesHandlersProviderUnconnected.propTypes = {
   behandlingUnderOppfriskning: PT.number,
   tilForsiden: PT.func.isRequired,
   resetLovvalgsperioder: PT.func.isRequired,
+  resetAnmodningsperioder: PT.func.isRequired,
+  resetUtpekingsperioder: PT.func.isRequired,
 };
 
 FellesHandlersProviderUnconnected.defaultProps = {
@@ -240,6 +249,8 @@ const mapDispatchToProps = (dispatch) => ({
   visValideringModalDialogHandle: () => dispatch(modalerOperations.visValidering()),
   tilForsiden: () => dispatch(navigeringOperations.tilForsiden()),
   resetLovvalgsperioder: () => dispatch(lovvalgsperioderOperations.resetLovvalgsperioderState()),
+  resetAnmodningsperioder: () => dispatch(anmodningsperioderOperations.resetAnmodningsperioderState()),
+  resetUtpekingsperioder: () => dispatch(utpekingsperioderOperations.resetUtpekingsperioderState()),
 });
 
 export const FellesHandlersProvider = withRouter(


### PR DESCRIPTION
Hvis saksbehandler nesten behandler en sak ferdig (til et punkt hvor en lovvalgsperiode opprettes) og så velger å avslå pga. manglende opplysninger vil avslaget enten feile i backend eller resultere i en feilaktig periode i MEDL. Legger derfor inn sletting/reset av lovvalgsperiodene ved avslag.