### PR TITLE
Gjør lastInnSaksopplysninger og lagreAllData forskjellig for EU_EOS/FTRL

### DIFF
--- a/src/contexts/fellesHandlers.js
+++ b/src/contexts/fellesHandlers.js
@@ -33,6 +33,7 @@ const FellesHandlersProviderUnconnected = ({
   oppfriskSaksopplysninger,
   lagreBehandlingsgrunnlag,
   saksnummer,
+  sakstype,
   apneTidligereBehandlinger,
   avslaSoknad,
   skjulOppfriskDialogHandle,
@@ -61,7 +62,7 @@ const FellesHandlersProviderUnconnected = ({
     await lagreBehandlingsgrunnlag();
     await oppfriskSaksopplysninger(behandlingID);
     await fjernBehandlingOppfriskes();
-    await lastInnSaksopplysninger(saksnummer, behandlingID);
+    await lastInnSaksopplysninger(sakstype, saksnummer, behandlingID);
   };
 
   const startOgVisOppfriskModal = async () => {
@@ -69,7 +70,7 @@ const FellesHandlersProviderUnconnected = ({
     visOppfriskDialogHandle();
     await oppfriskSaksopplysninger(behandlingID);
     await fjernBehandlingOppfriskes();
-    await lastInnSaksopplysninger(saksnummer, behandlingID);
+    await lastInnSaksopplysninger(sakstype, saksnummer, behandlingID);
   };
 
   const behandlingOppfriskes = behandlingUnderOppfriskning === behandlingID;
@@ -86,7 +87,7 @@ const FellesHandlersProviderUnconnected = ({
   };
 
   const lagreOgLukk = async () => {
-    await lagreAllData();
+    await lagreAllData(sakstype);
     tilForsiden();
   };
 
@@ -100,7 +101,7 @@ const FellesHandlersProviderUnconnected = ({
       const { behandlingID: nyBehandlingID } = res;
 
       history.replace(`${location.pathname}?${stringify({ behandlingID: nyBehandlingID })}`);
-      lastInnSaksopplysninger(saksnummer, nyBehandlingID);
+      lastInnSaksopplysninger(sakstype, saksnummer, nyBehandlingID);
     } catch (e) {
       Utils.logger.error(e);
     }
@@ -121,7 +122,7 @@ const FellesHandlersProviderUnconnected = ({
 
   const henleggHandle = async (data) => {
     try {
-      await lagreAllData();
+      await lagreAllData(sakstype);
       await henleggSak(data);
       skjulHenleggDialogHandle();
       tilForsiden();
@@ -137,7 +138,7 @@ const FellesHandlersProviderUnconnected = ({
       await resetAnmodningsperioder();
       await resetUtpekingsperioder();
 
-      await lagreAllData();
+      await lagreAllData(sakstype);
       avslaSoknad(behandlingID, data);
     } catch (e) {
       Utils.logger.error(e);
@@ -191,6 +192,7 @@ FellesHandlersProviderUnconnected.propTypes = {
   oppfriskSaksopplysninger: PT.func.isRequired,
   lagreBehandlingsgrunnlag: PT.func.isRequired,
   saksnummer: PT.string,
+  sakstype: PT.string,
   apneTidligereBehandlinger: PT.func.isRequired,
   avslaSoknad: PT.func.isRequired,
   skjulOppfriskDialogHandle: PT.func.isRequired,
@@ -218,21 +220,23 @@ FellesHandlersProviderUnconnected.defaultProps = {
 
 FellesHandlersProviderUnconnected.defaultProps = {
   saksnummer: undefined,
+  sakstype: undefined,
 };
 
 const mapStateToProps = (state) => ({
   saksnummer: fagsakSelectors.SaksnummerSelector(state),
+  sakstype: fagsakSelectors.SakstypeKodeSelector(state),
   behandlingUnderOppfriskning: modalerSelectors.BehandlingUnderOppfriskningSelector(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  lagreAllData: () => dispatch(datalastingOperations.lagreAllData()),
+  lagreAllData: (sakstype) => dispatch(datalastingOperations.lagreAllData(sakstype)),
   lagreBehandlingsgrunnlag: () => dispatch(behandlingsgrunnlagOperations.lagre()),
   tilbakeleggeOppgave: (oppgaveID, venterPaaDokumentasjon) =>
     oppgaverOperations.tilbakelegg(oppgaveID, venterPaaDokumentasjon),
   avslaSoknad: (behandlingID, data) => dispatch(vedtakOperations.avslaSoknad(behandlingID, data)),
-  lastInnSaksopplysninger: (saksnummer, behandlingID) =>
-    dispatch(datalastingOperations.lastInnSaksopplysninger(saksnummer, behandlingID)),
+  lastInnSaksopplysninger: (sakstype, saksnummer, behandlingID) =>
+    dispatch(datalastingOperations.lastInnSaksopplysninger(sakstype, saksnummer, behandlingID)),
   oppfriskSaksopplysninger: (behandlingID) => saksopplysningerOperations.oppfrisk(behandlingID),
   leggTilBehandlingOppfriskes: (behandlingID) => dispatch(modalerOperations.leggTilBehandlingOppfriskes(behandlingID)),
   fjernBehandlingOppfriskes: () => dispatch(modalerOperations.fjernBehandlingOppfriskes()),

--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -1,4 +1,5 @@
 import * as Utils from "../../utils";
+import MKV from "../../melosyskodeverk";
 
 import { avklartefaktaOperations } from "../avklartefakta";
 import { fagsakOperations } from "../fagsaker";
@@ -13,19 +14,28 @@ import { anmodningsperiodesvarOperations } from "../anmodningsperiodesvar";
 import { utpekingsperioderOperations } from "../utpekingsperioder";
 import { dokumenterOperations } from "../dokumenter";
 
-export const lastInnSaksopplysninger = (saksnummer, behandlingID) => (dispatch) => {
+export const lastInnSaksopplysninger = (sakstype, saksnummer, behandlingID) => (dispatch) => {
   try {
-    dispatch(anmodningsperioderOperations.hent(behandlingID));
-    dispatch(fagsakOperations.hent(saksnummer));
-    dispatch(behandlingerOperations.hentBehandling(behandlingID));
-    dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
-    dispatch(behandlingsresultatOperations.hent(behandlingID));
-    dispatch(avklartefaktaOperations.hent(behandlingID));
-    dispatch(vilkarOperations.hent(behandlingID));
-    dispatch(lovvalgsperioderOperations.hent(behandlingID));
-    dispatch(utpekingsperioderOperations.hent(behandlingID));
-    dispatch(behandlingsperioderOperations.hentMedlemsPerioder(behandlingID));
-    dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
+    if (sakstype === MKV.Koder.sakstyper.FTRL) {
+      dispatch(fagsakOperations.hent(saksnummer));
+      dispatch(behandlingerOperations.hentBehandling(behandlingID));
+      dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
+      dispatch(behandlingsresultatOperations.hent(behandlingID));
+      dispatch(vilkarOperations.hent(behandlingID));
+      dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
+    } else {
+      dispatch(anmodningsperioderOperations.hent(behandlingID));
+      dispatch(fagsakOperations.hent(saksnummer));
+      dispatch(behandlingerOperations.hentBehandling(behandlingID));
+      dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
+      dispatch(behandlingsresultatOperations.hent(behandlingID));
+      dispatch(avklartefaktaOperations.hent(behandlingID));
+      dispatch(vilkarOperations.hent(behandlingID));
+      dispatch(lovvalgsperioderOperations.hent(behandlingID));
+      dispatch(utpekingsperioderOperations.hent(behandlingID));
+      dispatch(behandlingsperioderOperations.hentMedlemsPerioder(behandlingID));
+      dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
+    }
   } catch (e) {
     Utils.logger.error(e);
   }
@@ -70,7 +80,11 @@ export const resetSaksopplysninger = () => (dispatch) => {
   dispatch(dokumenterOperations.resetDokument());
 };
 
-export const lagreAllData = () => async (dispatch) => {
+export const lagreAllData = (sakstype) => async (dispatch) => {
+  if (sakstype === MKV.Koder.sakstyper.FTRL) {
+    return Promise.all([dispatch(behandlingsgrunnlagOperations.lagre()), dispatch(vilkarOperations.lagre())]);
+  }
+
   await Promise.all([
     dispatch(behandlingsgrunnlagOperations.lagre()),
     dispatch(vilkarOperations.lagre()),

--- a/src/sider/eu_eøs/saksbehandling/saksbehandling.js
+++ b/src/sider/eu_eøs/saksbehandling/saksbehandling.js
@@ -453,7 +453,7 @@ const mapDispatchToProps = (dispatch) => ({
   sendLovvalgsperioder: (behandlingID, body) => dispatch(lovvalgsperioderOperations.send(behandlingID, body)),
   lagrePerioder: () => dispatch(behandlingsperioderOperations.lagre()),
   sendAnmodningsperioder: (behandlingID, body) => dispatch(anmodningsperioderOperations.send(behandlingID, body)),
-  lagreAllData: () => dispatch(datalastingOperations.lagreAllData()),
+  lagreAllData: () => dispatch(datalastingOperations.lagreAllData(MKV.Koder.sakstyper.EU_EOS)),
   resetSaksopplysninger: () => dispatch(datalastingOperations.resetSaksopplysninger()),
 });
 

--- a/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
+++ b/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
@@ -312,7 +312,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   lastInnSaksopplysninger: (saksnummer, behandlingID) =>
-    dispatch(datalastingOperations.lastInnSaksopplysninger(saksnummer, behandlingID)),
+    dispatch(datalastingOperations.lastInnSaksopplysninger(MKV.Koder.sakstyper.EU_EOS, saksnummer, behandlingID)),
   resetSaksopplysninger: () => dispatch(datalastingOperations.resetSaksopplysninger()),
   oppdaterBehandlingsgrunnlag: () => dispatch(behandlingsgrunnlagOperations.oppdaterState()),
   lagreVilkar: () => dispatch(vilkarOperations.lagre()),
@@ -320,7 +320,7 @@ const mapDispatchToProps = (dispatch) => ({
   lagreLovvalgsperioder: () => dispatch(lovvalgsperioderOperations.lagre()),
   lagreAnmodningsperioder: () => dispatch(anmodningsperioderOperations.lagre()),
   oppdaterOgLagreBehandlingsperioder: () => dispatch(behandlingsperioderOperations.oppdaterOgLagre()),
-  lagreAllData: () => dispatch(datalastingOperations.lagreAllData()),
+  lagreAllData: () => dispatch(datalastingOperations.lagreAllData(MKV.Koder.sakstyper.EU_EOS)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Vurderutpeking);

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -403,7 +403,7 @@ const mapDispatchToProps = (dispatch) => ({
   hentFolketrygdenKodeverk: () => dispatch(folketrygdenkodeverkOperations.hentKodeverkForFolketrygden()),
   hentMedlemskapsperioder: (bid) => dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(bid)),
   hentOppsummertFakta: (bid) => dispatch(oppsummertfaktaOperations.hentOppsummertFakta(bid)),
-  lagreAllData: () => dispatch(datalastingOperations.lagreAllData()),
+  lagreAllData: () => dispatch(datalastingOperations.lagreAllData(MKV.Koder.sakstyper.FTRL)),
   lagreAvklartefakta: () => dispatch(avklartefaktaOperations.lagre()),
   lagreVilkar: () => dispatch(vilkarOperations.lagre()),
   oppdaterBehandlingsgrunnlag: () => dispatch(behandlingsgrunnlagOperations.oppdaterState()),


### PR DESCRIPTION
Fjerner kall som har med anmodningsperioder, avklartefakta, tidligeremedlemskapsperioder, utpekingsperioder, og lovvalgsperioder for FTRL-sakstypen