### PR TITLE
Viser underordnet virksomhet istedenfor juridisk virksomhet

### DIFF
--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -284,6 +284,30 @@ export const ArbeidsforholdeneSelector = createSelector(
       return arbeid;
     })
 );
+
+export const AlleVirksomheterSelector = createSelector(
+  (state) => ArbeidsforholdeneSelector(state),
+  (state) => behandlingsgrunnlagSelectors.SelvstendigNaringsvirksomhetSelector(state),
+  (state) => behandlingsgrunnlagSelectors.ForetakUtlandSelector(state),
+  (state) => behandlingsgrunnlagSelectors.ValiderteEkstraArbeidsgivereSelector(state),
+  (arbeidsforholdene, selvstendigNaringsvirksomhet, foretakUtland, ekstraArbeidsgivere) => {
+    const virksomhetsListe = [];
+    arbeidsforholdene.forEach((arbeidsforhold) => {
+      virksomhetsListe.push({ kode: arbeidsforhold.arbeidsgiver.orgnr, term: arbeidsforhold.arbeidsgiver.navn });
+    });
+    selvstendigNaringsvirksomhet.forEach((selvstendigForetak) => {
+      virksomhetsListe.push({ kode: selvstendigForetak.orgnr, term: selvstendigForetak.navn });
+    });
+    foretakUtland.forEach((foretak) => {
+      virksomhetsListe.push({ kode: foretak.uuid, term: foretak.navn });
+    });
+    ekstraArbeidsgivere.forEach((ekstraArbeidsgiver) => {
+      virksomhetsListe.push({ kode: ekstraArbeidsgiver.orgnr, term: ekstraArbeidsgiver.navn });
+    });
+    return virksomhetsListe;
+  }
+);
+
 /** Finner alle organisasjonsnummer som er listet i arbeidsforhold.
  * Det er range i arbeidsforhold som avgjør hvilke organisasjoner som selectoren
  * regner som relevante å vise.

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVirksomhet.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVirksomhet.tsx
@@ -10,13 +10,12 @@ import * as Mui from "../../../../felleskomponenter/ui";
 
 import { behandlingerSelectors } from "../../../../ducks/behandlinger";
 import { oppsummertfaktaOperations } from "../../../../ducks/oppsummertfakta";
-
-import "./vurderingVirksomhet.css";
-import { avklartefaktaSelectors } from "../../../../ducks/avklartefakta";
 import { behandlingsgrunnlagOperations } from "../../../../ducks/behandlingsgrunnlag";
 
+import "./vurderingVirksomhet.css";
+
 const mapStateToProps = (state: RootState) => ({
-  virksomheterListe: avklartefaktaSelectors.VirksomheterIPeriodenSelector(state),
+  virksomheterListe: behandlingerSelectors.AlleVirksomheterSelector(state),
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
 });
 
@@ -102,7 +101,7 @@ const VurderingVirksomhet = ({
       </Nav.typo.Undertittel>
 
       <Mui.Checkboxgruppe
-        muligeValg={virksomheterListe.map((virksomhet) => ({ kode: virksomhet.virksomhetId, term: virksomhet.navn }))}
+        muligeValg={virksomheterListe}
         onChange={(checkedVirksomheter) => setValgteVirksomheter(checkedVirksomheter)}
         disabled={!redigerbart}
         defaultValg={valgteVirksomheter}


### PR DESCRIPTION
FTRL er forskjellig fra EØS i at det er underordnet virksomhet som skal vises som valg av virksomheter istedenfor den juridiske virksomheten. 
Hentet opp "gammel" selector fra tidligere PR