### PR TITLE
MELOSYS-4436 - Får ikke forhåndsvist i art13

### DIFF
--- a/src/felleskomponenter/mottakerinstitusjonvelger.js
+++ b/src/felleskomponenter/mottakerinstitusjonvelger.js
@@ -36,10 +36,6 @@ export const MottakerinstitusjonvelgerSchema = ({
     };
   }, [mottakerinstitusjoner]);
 
-  if (landkode === MKV.Koder.landkoder.NO) {
-    return null;
-  }
-
   if (Utils._isEmpty(mottakerinstitusjoner) || !redigerbart) {
     return null;
   }
@@ -74,19 +70,20 @@ MottakerinstitusjonvelgerSchema.defaultProps = {
   label: "Velg utenlandsk institusjon som skal motta SED",
 };
 
-const Mottakerinstitusjonvelger = ({ redigerbart, landkode, bucType, oppdaterKreverMottakerinstitusjon, data_cy }) => (
-  <Field
-    name={MOTTAKERINSTITUSJON}
-    component={MottakerinstitusjonvelgerSchema}
-    props={{
-      redigerbart,
-      landkode,
-      bucType,
-      oppdaterKreverMottakerinstitusjon,
-      data_cy,
-    }}
-  />
-);
+const Mottakerinstitusjonvelger = ({ redigerbart, landkode, bucType, oppdaterKreverMottakerinstitusjon, data_cy }) =>
+  landkode !== MKV.Koder.landkoder.NO ? (
+    <Field
+      name={MOTTAKERINSTITUSJON}
+      component={MottakerinstitusjonvelgerSchema}
+      props={{
+        redigerbart,
+        landkode,
+        bucType,
+        oppdaterKreverMottakerinstitusjon,
+        data_cy,
+      }}
+    />
+  ) : null;
 
 Mottakerinstitusjonvelger.propTypes = {
   form: PT.string.isRequired,
@@ -128,24 +125,27 @@ const MottakerinstitusjonvelgerFlervalgInner = ({
   bucType,
   data_cy,
 }) =>
-  fields.map((mottakerinstitusjon) => (
-    <Field
-      key={`${mottakerinstitusjon}.id`}
-      name={`${mottakerinstitusjon}.id`}
-      component={MottakerinstitusjonvelgerSchema}
-      props={{
-        redigerbart,
-        bucType,
-        landkode: hentFelt(`${mottakerinstitusjon}.kode`),
-        label: `Velg institusjon i ${hentFelt(`${mottakerinstitusjon}.term`)} som skal motta SED`,
-        oppdaterKreverMottakerinstitusjon: oppdaterKreverMottakerinstitusjon(
-          form,
-          `${mottakerinstitusjon}.kreverMottakerinstitusjon`
-        ),
-        data_cy,
-      }}
-    />
-  ));
+  fields
+    .map((mottakerinstitusjon) => mottakerinstitusjon)
+    .filter((mottakerinstitusjon) => hentFelt(`${mottakerinstitusjon}.kode`) !== MKV.Koder.landkoder.NO)
+    .map((mottakerinstitusjon) => (
+      <Field
+        key={`${mottakerinstitusjon}.id`}
+        name={`${mottakerinstitusjon}.id`}
+        component={MottakerinstitusjonvelgerSchema}
+        props={{
+          redigerbart,
+          bucType,
+          landkode: hentFelt(`${mottakerinstitusjon}.kode`),
+          label: `Velg institusjon i ${hentFelt(`${mottakerinstitusjon}.term`)} som skal motta SED`,
+          oppdaterKreverMottakerinstitusjon: oppdaterKreverMottakerinstitusjon(
+            form,
+            `${mottakerinstitusjon}.kreverMottakerinstitusjon`
+          ),
+          data_cy,
+        }}
+      />
+    ));
 
 MottakerinstitusjonvelgerFlervalgInner.propTypes = {
   oppdaterKreverMottakerinstitusjon: PT.func.isRequired,

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingForretningssted.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingForretningssted.js
@@ -40,8 +40,6 @@ const Forretningsstedet = (props) => {
     return cleanup;
   }, []);
 
-  if (!forretningsstedet) return null;
-
   const { navn, virksomhetId } = forretningsstedet;
   const landEndretHandler = (landKode) => {
     oppdaterData(lagAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSGIVERS_FORRETNINGSSTED, virksomhetId, landKode));
@@ -84,23 +82,25 @@ export const Forretningssteder = (props) => {
 
   return (
     <div>
-      {valgteVirksomheter.map((valgtVirksomhet) => {
-        const key = `forretningssted${valgtVirksomhet.virksomhetId}-${valgtVirksomhet.navn}`;
-        const avklartForretningsland = avklarteForretningsland.find(
-          (enkeltAvklaring) => enkeltAvklaring.subjektID === valgtVirksomhet.virksomhetId
-        );
+      {valgteVirksomheter
+        .filter((valgtVirksomhet) => valgtVirksomhet !== null)
+        .map((valgtVirksomhet) => {
+          const key = `forretningssted${valgtVirksomhet.virksomhetId}-${valgtVirksomhet.navn}`;
+          const avklartForretningsland = avklarteForretningsland.find(
+            (enkeltAvklaring) => enkeltAvklaring.subjektID === valgtVirksomhet.virksomhetId
+          );
 
-        return (
-          <Forretningsstedet
-            key={key}
-            forretningsstedet={valgtVirksomhet}
-            avklartForretningsland={avklartForretningsland}
-            oppdaterData={props.oppdaterData}
-            slettData={props.slettData}
-            redigerbart={redigerbart}
-          />
-        );
-      })}
+          return (
+            <Forretningsstedet
+              key={key}
+              forretningsstedet={valgtVirksomhet}
+              avklartForretningsland={avklartForretningsland}
+              oppdaterData={props.oppdaterData}
+              slettData={props.slettData}
+              redigerbart={redigerbart}
+            />
+          );
+        })}
       {ingenValgteVirksomheterVarsel}
     </div>
   );

--- a/src/yup/skjemaer/arbeid_ett_land_ovrig_vedtak.js
+++ b/src/yup/skjemaer/arbeid_ett_land_ovrig_vedtak.js
@@ -21,14 +21,18 @@ const arbeid_ett_land_ovrig_vedtak = object().shape({
       .erGyldigDato({ melding: "Gyldig dato kreves" })
       .required({ melding: "Dato kreves" }),
   }),
-  vedtakstype: string().when("$behandlingstype", {
-    is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
-    then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
-  }),
-  vedtakstypebegrunnelse: string().when("$behandlingstype", {
-    is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
-    then: string().required(OPPGI_BEGRUNNELSE),
-  }),
+  vedtakstype: string()
+    .nullable()
+    .when("$behandlingstype", {
+      is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
+      then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
+    }),
+  vedtakstypebegrunnelse: string()
+    .nullable()
+    .when("$behandlingstype", {
+      is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
+      then: string().nullable().required(OPPGI_BEGRUNNELSE),
+    }),
   mottakerinstitusjoner: array().of(
     object().shape({
       kreverMottakerinstitusjon: bool(),

--- a/src/yup/skjemaer/artikkel12vedtak.js
+++ b/src/yup/skjemaer/artikkel12vedtak.js
@@ -7,14 +7,18 @@ const OPPGI_BEGRUNNELSE = { melding: "Oppgi begrunnelse" };
 const MOTTAKERINSTITUSJON_KREVES = { melding: "Mottakerinstitusjon kreves" };
 
 const artikkel12_vedtak = object().shape({
-  vedtakstype: string().when("$behandlingstype", {
-    is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
-    then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
-  }),
-  vedtakstypebegrunnelse: string().when("$behandlingstype", {
-    is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
-    then: string().required(OPPGI_BEGRUNNELSE),
-  }),
+  vedtakstype: string()
+    .nullable()
+    .when("$behandlingstype", {
+      is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
+      then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
+    }),
+  vedtakstypebegrunnelse: string()
+    .nullable()
+    .when("$behandlingstype", {
+      is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
+      then: string().nullable().required(OPPGI_BEGRUNNELSE),
+    }),
   kreverMottakerinstitusjon: bool().required(),
   mottakerinstitusjon: string().when("kreverMottakerinstitusjon", {
     is: true,

--- a/src/yup/skjemaer/artikkel13_x_vedtak.js
+++ b/src/yup/skjemaer/artikkel13_x_vedtak.js
@@ -21,10 +21,12 @@ const artikkel13_x_vedtak = object().shape({
       is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
       then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
     }),
-  vedtakstypebegrunnelse: string().when("$behandlingstype", {
-    is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
-    then: string().required(OPPGI_BEGRUNNELSE),
-  }),
+  vedtakstypebegrunnelse: string()
+    .nullable()
+    .when("$behandlingstype", {
+      is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
+      then: string().nullable().required(OPPGI_BEGRUNNELSE),
+    }),
   mottakerinstitusjoner: array().of(
     object().shape({
       kreverMottakerinstitusjon: bool(),

--- a/src/yup/skjemaer/artikkel13_x_vedtak.js
+++ b/src/yup/skjemaer/artikkel13_x_vedtak.js
@@ -15,10 +15,12 @@ const artikkel13_x_vedtak = object().shape({
       .erGyldigDato({ melding: "Gyldig dato kreves" })
       .required({ melding: "Dato kreves" }),
   }),
-  vedtakstype: string().when("$behandlingstype", {
-    is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
-    then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
-  }),
+  vedtakstype: string()
+    .nullable()
+    .when("$behandlingstype", {
+      is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
+      then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
+    }),
   vedtakstypebegrunnelse: string().when("$behandlingstype", {
     is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
     then: string().required(OPPGI_BEGRUNNELSE),

--- a/src/yup/skjemaer/artikkel16vedtak.js
+++ b/src/yup/skjemaer/artikkel16vedtak.js
@@ -6,14 +6,18 @@ const VELG_EN_VEDTAKSTYPE = { melding: "Velg en vedtakstype" };
 const OPPGI_BEGRUNNELSE = { melding: "Oppgi begrunnelse" };
 
 const artikkel16_vedtak = object().shape({
-  vedtakstype: string().when("$behandlingstype", {
-    is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
-    then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
-  }),
-  vedtakstypebegrunnelse: string().when("$behandlingstype", {
-    is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
-    then: string().required(OPPGI_BEGRUNNELSE),
-  }),
+  vedtakstype: string()
+    .nullable()
+    .when("$behandlingstype", {
+      is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
+      then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
+    }),
+  vedtakstypebegrunnelse: string()
+    .nullable()
+    .when("$behandlingstype", {
+      is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
+      then: string().nullable().required(OPPGI_BEGRUNNELSE),
+    }),
 });
 
 export { artikkel16_vedtak };

--- a/src/yup/skjemaer/avslagartikkel12og16.js
+++ b/src/yup/skjemaer/avslagartikkel12og16.js
@@ -6,14 +6,18 @@ const VELG_EN_VEDTAKSTYPE = { melding: "Velg en vedtakstype" };
 const OPPGI_BEGRUNNELSE = { melding: "Oppgi begrunnelse" };
 
 const avslag_artikkel_12_og_16 = object().shape({
-  vedtakstype: string().when("$behandlingstype", {
-    is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
-    then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
-  }),
-  vedtakstypebegrunnelse: string().when("$behandlingstype", {
-    is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
-    then: string().required(OPPGI_BEGRUNNELSE),
-  }),
+  vedtakstype: string()
+    .nullable()
+    .when("$behandlingstype", {
+      is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
+      then: string().nullable().required(VELG_EN_VEDTAKSTYPE),
+    }),
+  vedtakstypebegrunnelse: string()
+    .nullable()
+    .when("$behandlingstype", {
+      is: MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
+      then: string().nullable().required(OPPGI_BEGRUNNELSE),
+    }),
 });
 
 export { avslag_artikkel_12_og_16 };


### PR DESCRIPTION
Kunne ikke forhåndsvise vedtak for art13 pga:
- vedtakstype ble sendt til yup-schema med verdi null, yup ga type error fordi schemaet ikke hadde `nullable()`
- Mottakerinstitusjonvelger gjorde sjekk på Norge litt sent, slik at `oppdaterKreverMottakerinstitusjon()` ble kalt selv om NO var landkode. Førte til at schemaet ikke ble validert ordentlig. Denne feilen ble introdusert ved oppgradering av react-scripts.

@sigbjorn-myhre Setter deg på review siden jeg endrer i Mottakerinstitusjonsvelger