### PR TITLE
Melosys 4422 endringer

### DIFF
--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -13,6 +13,8 @@ import { anmodningsperioderOperations } from "../anmodningsperioder";
 import { anmodningsperiodesvarOperations } from "../anmodningsperiodesvar";
 import { utpekingsperioderOperations } from "../utpekingsperioder";
 import { dokumenterOperations } from "../dokumenter";
+import { oppsummertfaktaOperations } from "../oppsummertfakta";
+import { medlemskapsperioderOperations } from "../medlemskapsperioder";
 
 export const lastInnSaksopplysninger = (sakstype, saksnummer, behandlingID) => (dispatch) => {
   try {
@@ -21,6 +23,8 @@ export const lastInnSaksopplysninger = (sakstype, saksnummer, behandlingID) => (
       dispatch(behandlingerOperations.hentBehandling(behandlingID));
       dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
       dispatch(behandlingsresultatOperations.hent(behandlingID));
+      dispatch(oppsummertfaktaOperations.hentOppsummertFakta(behandlingID));
+      dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
       dispatch(vilkarOperations.hent(behandlingID));
       dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
     } else {

--- a/src/ducks/form/selectors.js
+++ b/src/ducks/form/selectors.js
@@ -51,6 +51,16 @@ export const VurderStartFormValid = createSelector(
   (errors) => Utils._isEmpty(errors)
 );
 
+export const VurderVirksomhetFormSelector = createSelector(
+  (state) => getFormState(state, KV.Form.VIRKSOMHET, {}),
+  (start) => start
+);
+
+export const VurderVirksomhetFormValid = createSelector(
+  (state) => VurderVirksomhetFormSelector(state).syncErrors || {},
+  (errors) => Utils._isEmpty(errors)
+);
+
 export const VurderStartPeriodeValid = createSelector(
   (state) => VurderStartFormSelector(state).syncErrors || {},
   (errors) => !("erPeriodeGyldig" in errors)

--- a/src/ducks/medlemskapsperioder/actions.ts
+++ b/src/ducks/medlemskapsperioder/actions.ts
@@ -6,3 +6,7 @@ export function oppdaterBestemmelse(bestemmelse: string): Types.OppdaterBestemme
     data: bestemmelse,
   };
 }
+
+export function resetMedlemskapsperioder(): Types.ResetAction {
+  return { type: Types.RESET };
+}

--- a/src/ducks/medlemskapsperioder/operations.js
+++ b/src/ducks/medlemskapsperioder/operations.js
@@ -36,3 +36,7 @@ export function opprettMedlemskapsperiodeFraBestemmelse() {
     dispatch(opprettMedlemskapsperiode(bid, bestemmelse));
   };
 }
+
+export function resetMedlemskapsperioder() {
+  return Actions.resetMedlemskapsperioder();
+}

--- a/src/ducks/medlemskapsperioder/reducers.ts
+++ b/src/ducks/medlemskapsperioder/reducers.ts
@@ -33,6 +33,8 @@ export default function reducer(state = initialState, action: Types.Action): Sta
           bestemmelse: action.data,
         },
       };
+    case Types.RESET:
+      return { ...initialState };
     default:
       return state;
   }

--- a/src/ducks/medlemskapsperioder/types.ts
+++ b/src/ducks/medlemskapsperioder/types.ts
@@ -3,6 +3,7 @@ import { Medlemskapsperiode } from "Domene";
 export const OK = "medlemskapsperioder/OK";
 export const FEILET = "medlemskapsperioder/FEILET";
 export const PENDING = "medlemskapsperioder/PENDING";
+export const RESET = "medlemskapsperioder/RESET";
 
 export const OPPDATER_BESTEMMELSE = "medlemskapsperioder/OPPDATER_BESTEMMELSE";
 
@@ -20,6 +21,10 @@ export interface PendingAction {
   type: typeof PENDING;
 }
 
+export interface ResetAction {
+  type: typeof RESET;
+}
+
 export interface OkAction {
   type: typeof OK;
   data: Medlemskapsperiode[];
@@ -30,4 +35,4 @@ export interface OppdaterBestemmelseAction {
   data: string;
 }
 
-export type Action = FeiletAction | PendingAction | OkAction | OppdaterBestemmelseAction;
+export type Action = FeiletAction | PendingAction | ResetAction | OkAction | OppdaterBestemmelseAction;

--- a/src/felleskomponenter/stegvelger/Stegvelger.js
+++ b/src/felleskomponenter/stegvelger/Stegvelger.js
@@ -84,7 +84,8 @@ class Stegvelger extends Component {
 
     if (
       this.props.oppsummering.behandlingsstatus !== prevProps.oppsummering.behandlingsstatus ||
-      this.props.artikkel12_vedtak_skjema !== prevProps.artikkel12_vedtak_skjema
+      this.props.artikkel12_vedtak_skjema !== prevProps.artikkel12_vedtak_skjema ||
+      this.props.vurder_virksomhet_valid !== prevProps.vurder_virksomhet_valid
     ) {
       this.oppdaterAktuelleSteg(aktivtStegNummer);
     }
@@ -436,6 +437,7 @@ class Stegvelger extends Component {
       bestemmelser: props.bestemmelser,
       medlemskapsperioder: props.medlemskapsperioder,
       vurder_start_valid: props.vurder_start_valid,
+      vurder_virksomhet_valid: props.vurder_virksomhet_valid,
       vurder_periode_valid: props.vurder_periode_valid,
       vurder_trygdeavgift_valid: props.vurder_trygdeavgift_valid,
       vurder_familie_valid: props.vurder_familie_valid,
@@ -618,6 +620,7 @@ Stegvelger.propTypes = {
   medlemskapsperioder: PT.object.isRequired,
   sakstype: PT.string,
   vurder_start_valid: PT.bool.isRequired,
+  vurder_virksomhet_valid: PT.bool.isRequired,
   vurder_periode_valid: PT.bool.isRequired,
   vurder_trygdeavgift_valid: PT.bool.isRequired,
   vurder_familie_valid: PT.bool.isRequired,
@@ -673,6 +676,7 @@ const mapStateToProps = (state) => ({
   artikkel16_motta_svar_skjema: formSelectors.Artikkel16MottaSvarFormSelector(state).values,
   vurder_utpeking_skjema: formSelectors.VurderUtpekingFormSelector(state).values,
   vurder_start_valid: formSelectors.VurderStartFormValid(state),
+  vurder_virksomhet_valid: formSelectors.VurderVirksomhetFormValid(state),
   vurder_periode_valid: formSelectors.VurderPerioderValid(state),
   vurder_trygdeavgift_valid: formSelectors.VurderTrygdeavgiftFormValid(state),
   vurder_familie_valid: formSelectors.VurderFamilieFormValid(state),

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVirksomhet.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVirksomhet.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
+import { change, getFormValues, reduxForm } from "redux-form";
 import { RootState } from "AppTypes";
 import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
@@ -7,25 +8,32 @@ import { OppsummertFaktaVirksomheter } from "Domene";
 
 import * as Nav from "../../../../utils/navFrontend";
 import * as Mui from "../../../../felleskomponenter/ui";
+import * as KV from "../../../../kodeverk";
 
+import { lagYupToReduxformErrorMapper, Skjemaer as YupSkjemaer } from "../../../../yup";
 import { behandlingerSelectors } from "../../../../ducks/behandlinger";
-import { oppsummertfaktaOperations } from "../../../../ducks/oppsummertfakta";
+import { oppsummertfaktaOperations, oppsummertfaktaSelectors } from "../../../../ducks/oppsummertfakta";
 import { behandlingsgrunnlagOperations } from "../../../../ducks/behandlingsgrunnlag";
 
 import "./vurderingVirksomhet.css";
+import { formSelectors } from "../../../../ducks/form";
 
 const mapStateToProps = (state: RootState) => ({
   virksomheterListe: behandlingerSelectors.AlleVirksomheterSelector(state),
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
+  formValues: getFormValues(KV.Form.VIRKSOMHET)(state),
+  initialValues: {
+    valgteVirksomheter: oppsummertfaktaSelectors.VirksomhetIDerSelector(state),
+  },
+  formIsValid: formSelectors.VurderVirksomhetFormValid(state),
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
   hentOppsummertFakta: (behandlingID: number) => dispatch(oppsummertfaktaOperations.hentOppsummertFakta(behandlingID)),
-  oppdaterVirksomheterState: (virksomheter: OppsummertFaktaVirksomheter) =>
-    dispatch(oppsummertfaktaOperations.oppdaterVirksomheterState(virksomheter)),
   sendVirksomheter: (behandlingID: number, virksomheter: OppsummertFaktaVirksomheter) =>
     dispatch(oppsummertfaktaOperations.sendVirksomheter(behandlingID, virksomheter)),
   hentBehandlingsgrunnlag: (behandlingID: number) => dispatch(behandlingsgrunnlagOperations.hent(behandlingID)),
+  changeValgteVirksomheter: (data: string[]) => dispatch(change(KV.Form.VIRKSOMHET, "valgteVirksomheter", data)),
 });
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -34,27 +42,26 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 
 interface Props {
   bekreft: () => void;
-  lagredeVirksomheter: string[];
-  oppdater: () => void;
   redigerbart: boolean;
   tilbake: () => void;
+  formValues: {
+    valgteVirksomheter?: string[];
+  };
 }
 
 const VurderingVirksomhet = ({
   behandlingID,
   bekreft,
+  changeValgteVirksomheter,
+  formIsValid,
+  formValues,
   hentBehandlingsgrunnlag,
   hentOppsummertFakta,
-  lagredeVirksomheter,
-  oppdater,
-  oppdaterVirksomheterState,
   redigerbart,
   sendVirksomheter,
   tilbake,
   virksomheterListe,
 }: Props & PropsFromRedux) => {
-  const [valgteVirksomheter, setValgteVirksomheter] = useState(lagredeVirksomheter);
-  const [erValgtVirksomheterGyldig, setErValgtVirksomheterGyldig] = useState(false);
   const [erBehandlingsgrunnlagLastetInn, setErBehandlingsgrunnlagLastetInn] = useState(false);
   const hjelpetekst =
     "Velg virksomhet søker er ansatt av og arbeider for i søknadsperioden. Det er mulig å velge flere virksomheter om søker har mer enn ett arbeidsforhold. " +
@@ -72,22 +79,14 @@ const VurderingVirksomhet = ({
     };
   }, []);
 
-  const oppdaterVirksomheterOgStegvelger = async () => {
-    await oppdaterVirksomheterState({ virksomhetIDer: valgteVirksomheter });
-    oppdater();
-  };
-
-  useEffect(() => {
-    setErValgtVirksomheterGyldig(valgteVirksomheter.length > 0);
-    oppdaterVirksomheterOgStegvelger();
-  }, [valgteVirksomheter]);
-
   const handleFortsett = () => {
-    sendVirksomheter(behandlingID, { virksomhetIDer: valgteVirksomheter });
-    bekreft();
+    if (formValues && formValues.valgteVirksomheter) {
+      sendVirksomheter(behandlingID, { virksomhetIDer: formValues.valgteVirksomheter });
+      bekreft();
+    }
   };
 
-  if (!erBehandlingsgrunnlagLastetInn) {
+  if (!erBehandlingsgrunnlagLastetInn || !formValues) {
     return null;
   }
 
@@ -102,21 +101,16 @@ const VurderingVirksomhet = ({
 
       <Mui.Checkboxgruppe
         muligeValg={virksomheterListe}
-        onChange={(checkedVirksomheter) => setValgteVirksomheter(checkedVirksomheter)}
+        onChange={(checkedVirksomheter) => changeValgteVirksomheter(checkedVirksomheter)}
         disabled={!redigerbart}
-        defaultValg={valgteVirksomheter}
+        defaultValg={formValues.valgteVirksomheter}
       />
 
       <div className="fane__knapplinje">
         <Nav.Knapp mini className="fane__navigasjonsknapp" onClick={tilbake}>
           Tilbake
         </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={!erValgtVirksomheterGyldig}
-          className="fane__navigasjonsknapp"
-          onClick={handleFortsett}
-        >
+        <Nav.Hovedknapp mini disabled={!formIsValid} className="fane__navigasjonsknapp" onClick={handleFortsett}>
           Fortsett
         </Nav.Hovedknapp>
       </div>
@@ -124,4 +118,12 @@ const VurderingVirksomhet = ({
   );
 };
 
-export default connector(VurderingVirksomhet);
+const VurderingVirksomhetForm = reduxForm<{}, PropsFromRedux & Props>({
+  form: KV.Form.VIRKSOMHET,
+  destroyOnUnmount: true,
+  keepDirtyOnReinitialize: true,
+  updateUnregisteredFields: true,
+  validate: (values) => lagYupToReduxformErrorMapper(YupSkjemaer.vurdering_virksomhet)(values),
+})(VurderingVirksomhet);
+
+export default connector(VurderingVirksomhetForm);

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVirksomhet.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVirksomhet.tsx
@@ -18,15 +18,19 @@ import { behandlingsgrunnlagOperations } from "../../../../ducks/behandlingsgrun
 import "./vurderingVirksomhet.css";
 import { formSelectors } from "../../../../ducks/form";
 
-const mapStateToProps = (state: RootState) => ({
-  virksomheterListe: behandlingerSelectors.AlleVirksomheterSelector(state),
-  behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
-  formValues: getFormValues(KV.Form.VIRKSOMHET)(state),
-  initialValues: {
-    valgteVirksomheter: oppsummertfaktaSelectors.VirksomhetIDerSelector(state),
-  },
-  formIsValid: formSelectors.VurderVirksomhetFormValid(state),
-});
+const mapStateToProps = (state: RootState) => {
+  const lagredeValgtevirksomheter = oppsummertfaktaSelectors.VirksomhetIDerSelector(state);
+  return {
+    virksomheterListe: behandlingerSelectors.AlleVirksomheterSelector(state),
+    behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
+    lagredeValgtevirksomheter,
+    formValues: getFormValues(KV.Form.VIRKSOMHET)(state),
+    initialValues: {
+      valgteVirksomheter: lagredeValgtevirksomheter,
+    },
+    formIsValid: formSelectors.VurderVirksomhetFormValid(state),
+  };
+};
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
   hentOppsummertFakta: (behandlingID: number) => dispatch(oppsummertfaktaOperations.hentOppsummertFakta(behandlingID)),
@@ -61,6 +65,7 @@ const VurderingVirksomhet = ({
   sendVirksomheter,
   tilbake,
   virksomheterListe,
+  lagredeValgtevirksomheter,
 }: Props & PropsFromRedux) => {
   const [erBehandlingsgrunnlagLastetInn, setErBehandlingsgrunnlagLastetInn] = useState(false);
   const hjelpetekst =
@@ -78,6 +83,10 @@ const VurderingVirksomhet = ({
       hentOppsummertFakta(behandlingID);
     };
   }, []);
+
+  useEffect(() => {
+    changeValgteVirksomheter(lagredeValgtevirksomheter);
+  }, [lagredeValgtevirksomheter]);
 
   const handleFortsett = () => {
     if (formValues && formValues.valgteVirksomheter) {
@@ -103,7 +112,7 @@ const VurderingVirksomhet = ({
         muligeValg={virksomheterListe}
         onChange={(checkedVirksomheter) => changeValgteVirksomheter(checkedVirksomheter)}
         disabled={!redigerbart}
-        defaultValg={formValues.valgteVirksomheter}
+        defaultValg={lagredeValgtevirksomheter}
       />
 
       <div className="fane__knapplinje">

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVirksomhet.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVirksomhet.tsx
@@ -44,13 +44,15 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
+interface FormValuesProps {
+  valgteVirksomheter?: string[];
+}
+
 interface Props {
   bekreft: () => void;
   redigerbart: boolean;
   tilbake: () => void;
-  formValues: {
-    valgteVirksomheter?: string[];
-  };
+  formValues: FormValuesProps;
 }
 
 const VurderingVirksomhet = ({
@@ -127,12 +129,12 @@ const VurderingVirksomhet = ({
   );
 };
 
-const VurderingVirksomhetForm = reduxForm<{}, PropsFromRedux & Props>({
+const VurderingVirksomhetForm = reduxForm<FormValuesProps, PropsFromRedux & Props>({
   form: KV.Form.VIRKSOMHET,
   destroyOnUnmount: true,
   keepDirtyOnReinitialize: true,
   updateUnregisteredFields: true,
-  validate: (values) => lagYupToReduxformErrorMapper(YupSkjemaer.vurdering_virksomhet)(values),
+  validate: lagYupToReduxformErrorMapper(YupSkjemaer.vurdering_virksomhet),
 })(VurderingVirksomhet);
 
 export default connector(VurderingVirksomhetForm);

--- a/src/felleskomponenter/ui/checkboxgruppe.js
+++ b/src/felleskomponenter/ui/checkboxgruppe.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PT from "prop-types";
 
 import * as Nav from "../../utils/navFrontend";
@@ -9,6 +9,10 @@ const Checkboxgruppe = ({ legend, muligeValg, defaultValg, onChange, disabled })
   const [valgteCheckboxer, setValgteCheckboxer] = useState(
     muligeValg.map((valg) => valg.kode).filter((kode) => defaultValg.includes(kode))
   );
+
+  useEffect(() => {
+    setValgteCheckboxer(muligeValg.map((valg) => valg.kode).filter((kode) => defaultValg.includes(kode)));
+  }, [defaultValg]);
 
   const onChangeHandler = ({ value }) => {
     const verdi = value;

--- a/src/kodeverk/form.ts
+++ b/src/kodeverk/form.ts
@@ -78,6 +78,7 @@ export interface RegistreringPanelerFormData {
 }
 export const ARBEID_ETT_LAND_OVRIG_VEDTAK = "arbeid_ett_land_ovrig_vedtak";
 export const START = "start";
+export const VIRKSOMHET = "virksomhet";
 export const PERIODER = "perioder";
 export const TRYGDEAVGIFT = "trygdeavgift";
 export const FTRL_VEDTAK = "ftrl_vedtak";

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -209,7 +209,6 @@ const Saksbehandling = ({
       .catch(Utils.logger.error);
 
     return () => {
-      console.log("boom");
       resetFagsakState();
       resetVilkarState();
       resetOppsummertFaktaState();

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -131,6 +131,9 @@ const Saksbehandling = ({
   resetBehandlingerState,
   resetBehandlingsgrunnlagState,
   resetFagsakState,
+  resetVilkarState,
+  resetOppsummertFaktaState,
+  resetMedlemskapsperiodeState,
   skjulMenypanel,
   soknadForm,
   tilbakeleggOppgave,
@@ -206,7 +209,11 @@ const Saksbehandling = ({
       .catch(Utils.logger.error);
 
     return () => {
+      console.log("boom");
       resetFagsakState();
+      resetVilkarState();
+      resetOppsummertFaktaState();
+      resetMedlemskapsperiodeState();
       resetBehandlingerState();
       resetBehandlingsgrunnlagState();
       skjulMenypanel();
@@ -359,6 +366,9 @@ Saksbehandling.propTypes = {
   resetBehandlingerState: PT.func.isRequired,
   resetBehandlingsgrunnlagState: PT.func.isRequired,
   resetFagsakState: PT.func.isRequired,
+  resetVilkarState: PT.func.isRequired,
+  resetOppsummertFaktaState: PT.func.isRequired,
+  resetMedlemskapsperiodeState: PT.func.isRequired,
   startOgVisOppfriskModal: PT.func.isRequired,
   skjulMenypanel: PT.func.isRequired,
   tilbakeleggOppgave: PT.func.isRequired,
@@ -416,6 +426,9 @@ const mapDispatchToProps = (dispatch) => ({
   lagreAvklartefakta: () => dispatch(avklartefaktaOperations.lagre()),
   lagreVilkar: () => dispatch(vilkarOperations.lagre()),
   oppdaterBehandlingsgrunnlag: () => dispatch(behandlingsgrunnlagOperations.oppdaterState()),
+  resetVilkarState: () => dispatch(vilkarOperations.resetState()),
+  resetOppsummertFaktaState: () => dispatch(oppsummertfaktaOperations.resetOppsummertFakta()),
+  resetMedlemskapsperiodeState: () => dispatch(medlemskapsperioderOperations.resetMedlemskapsperioder()),
   resetFagsakState: () => dispatch(fagsakOperations.resetFagsakState()),
   resetBehandlingerState: () => dispatch(behandlingerOperations.resetBehandlingerState()),
   resetBehandlingsgrunnlagState: () => dispatch(behandlingsgrunnlagOperations.resetState()),

--- a/src/sider/ftrl/saksbehandling/stegMap/virksomhet.js
+++ b/src/sider/ftrl/saksbehandling/stegMap/virksomhet.js
@@ -5,7 +5,7 @@ import VurderingVirksomhet from "../../../../felleskomponenter/stegvelger/stegKo
 class Virksomhet extends Steg {
   constructor(propsLight, stegPosisjon) {
     super(propsLight, stegPosisjon);
-    const harAvklaring = propsLight.lagredeVirksomheter.length > 0;
+    const harAvklaring = propsLight.vurder_virksomhet_valid;
     this.kriterier = [
       {
         exec: () => harAvklaring,
@@ -16,14 +16,12 @@ class Virksomhet extends Steg {
     this.tittel = "Virksomhet";
     this.komponent = VurderingVirksomhet;
     this.samleRelevanteData = (_propsLight) => ({
-      lagredeVirksomheter: _propsLight.lagredeVirksomheter,
       redigerbart: _propsLight.redigerbart,
     });
     this.beregnRelevantUI = (_propsLight) => ({ harAvklaring });
     this.handlers = {
       bekreft: propsLight.tilgjengeligeHandlers.bekreft,
       tilbake: propsLight.tilgjengeligeHandlers.tilbake,
-      oppdater: propsLight.tilgjengeligeHandlers.oppdater,
     };
     this.status = FANE_STATUS.OK;
   }

--- a/src/yup/skjemaer/index.js
+++ b/src/yup/skjemaer/index.js
@@ -15,6 +15,7 @@ export { avslaa_utpeking } from "./avslaa_utpeking";
 export { sed } from "./sed";
 export { soknad } from "./soknad";
 export { vurdering_start } from "./vurdering_start";
+export { vurdering_virksomhet } from "./vurdering_virksomhet";
 export { vurdering_perioder } from "./vurdering_perioder";
 export { vurdering_trygdeavgift } from "./vurdering_trygdeavgift";
 export { vurdering_familie } from "./vurdering_familie";

--- a/src/yup/skjemaer/vurdering_virksomhet.js
+++ b/src/yup/skjemaer/vurdering_virksomhet.js
@@ -1,0 +1,9 @@
+import { object, array } from "yup";
+
+const VIRKSOMHET_KREVES = { melding: "Du må velge minst én virksomhet" };
+
+const vurdering_virksomhet = object().shape({
+  valgteVirksomheter: array().min(1).required(VIRKSOMHET_KREVES),
+});
+
+export { vurdering_virksomhet };


### PR DESCRIPTION
Merket mangler når jeg testet endringene i [oppfriskning](https://github.com/navikt/melosys-web/pull/1131) :
- Resetter ikke alle saksoplysninger på unmount av saksbehandling.js
- Virksomhet-steget (og som følge bestemmelse-steget) ble ikke oppdatert når data ble oppdatert
- Manglet også henting/oppdatering av noen saksopplysninger etter oppfriskning

Denne PR-en skal ha fikset alle de over, og skrev liksågodt `vurderingVirksomhet` over til reduxForms i samme sleng.