### PR TITLE
MELOSYS-4480 - Dokumentliste lastes ikke ved registrering av svar på anmodning om unntak(ANMODNING_OM_UNNTAK_HOVEDREGEL)

### DIFF
--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -1,4 +1,3 @@
-import * as Utils from "../../utils";
 import MKV from "../../melosyskodeverk";
 
 import { avklartefaktaOperations } from "../avklartefakta";
@@ -17,47 +16,39 @@ import { oppsummertfaktaOperations } from "../oppsummertfakta";
 import { medlemskapsperioderOperations } from "../medlemskapsperioder";
 
 export const lastInnSaksopplysninger = (sakstype, saksnummer, behandlingID) => (dispatch) => {
-  try {
-    if (sakstype === MKV.Koder.sakstyper.FTRL) {
-      dispatch(fagsakOperations.hent(saksnummer));
-      dispatch(behandlingerOperations.hentBehandling(behandlingID));
-      dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
-      dispatch(behandlingsresultatOperations.hent(behandlingID));
-      dispatch(oppsummertfaktaOperations.hentOppsummertFakta(behandlingID));
-      dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
-      dispatch(vilkarOperations.hent(behandlingID));
-      dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
-    } else {
-      dispatch(anmodningsperioderOperations.hent(behandlingID));
-      dispatch(fagsakOperations.hent(saksnummer));
-      dispatch(behandlingerOperations.hentBehandling(behandlingID));
-      dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
-      dispatch(behandlingsresultatOperations.hent(behandlingID));
-      dispatch(avklartefaktaOperations.hent(behandlingID));
-      dispatch(vilkarOperations.hent(behandlingID));
-      dispatch(lovvalgsperioderOperations.hent(behandlingID));
-      dispatch(utpekingsperioderOperations.hent(behandlingID));
-      dispatch(behandlingsperioderOperations.hentMedlemsPerioder(behandlingID));
-      dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
-    }
-  } catch (e) {
-    Utils.logger.error(e);
-  }
-};
-
-export const lastInnSaksopplysningerSedBehandling = (saksnummer, behandlingID) => (dispatch) => {
-  try {
+  if (sakstype === MKV.Koder.sakstyper.FTRL) {
     dispatch(fagsakOperations.hent(saksnummer));
     dispatch(behandlingerOperations.hentBehandling(behandlingID));
+    dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
+    dispatch(behandlingsresultatOperations.hent(behandlingID));
+    dispatch(oppsummertfaktaOperations.hentOppsummertFakta(behandlingID));
+    dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
+    dispatch(vilkarOperations.hent(behandlingID));
+    dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
+  } else {
+    dispatch(anmodningsperioderOperations.hent(behandlingID));
+    dispatch(fagsakOperations.hent(saksnummer));
+    dispatch(behandlingerOperations.hentBehandling(behandlingID));
+    dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
     dispatch(behandlingsresultatOperations.hent(behandlingID));
     dispatch(avklartefaktaOperations.hent(behandlingID));
     dispatch(vilkarOperations.hent(behandlingID));
     dispatch(lovvalgsperioderOperations.hent(behandlingID));
+    dispatch(utpekingsperioderOperations.hent(behandlingID));
     dispatch(behandlingsperioderOperations.hentMedlemsPerioder(behandlingID));
     dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
-  } catch (e) {
-    Utils.logger.error(e);
   }
+};
+
+export const lastInnSaksopplysningerSedBehandling = (saksnummer, behandlingID) => (dispatch) => {
+  dispatch(fagsakOperations.hent(saksnummer));
+  dispatch(behandlingerOperations.hentBehandling(behandlingID));
+  dispatch(behandlingsresultatOperations.hent(behandlingID));
+  dispatch(avklartefaktaOperations.hent(behandlingID));
+  dispatch(vilkarOperations.hent(behandlingID));
+  dispatch(lovvalgsperioderOperations.hent(behandlingID));
+  dispatch(behandlingsperioderOperations.hentMedlemsPerioder(behandlingID));
+  dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
 };
 
 export const lastInnSaksopplysningerBehandleMottattAOU = (saksnummer, behandlingID) => (dispatch, getState) => {

--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -9,7 +9,7 @@ import { behandlingsgrunnlagOperations } from "../behandlingsgrunnlag";
 import { lovvalgsperioderOperations } from "../lovvalgsperioder";
 import { vilkarOperations } from "../vilkar";
 import { behandlingsperioderOperations } from "../behandlingsperioder";
-import { anmodningsperioderOperations } from "../anmodningsperioder";
+import { anmodningsperioderOperations, anmodningsperioderSelectors } from "../anmodningsperioder";
 import { anmodningsperiodesvarOperations } from "../anmodningsperiodesvar";
 import { utpekingsperioderOperations } from "../utpekingsperioder";
 import { dokumenterOperations } from "../dokumenter";
@@ -60,15 +60,14 @@ export const lastInnSaksopplysningerSedBehandling = (saksnummer, behandlingID) =
   }
 };
 
-export const lastInnSaksopplysningerBehandleMottattAOU = (behandlingID, anmodningsperiodeID) => (dispatch) => {
-  try {
-    dispatch(behandlingerOperations.hentBehandling(behandlingID));
-    dispatch(behandlingsresultatOperations.hent(behandlingID));
-    dispatch(anmodningsperioderOperations.hent(behandlingID));
+export const lastInnSaksopplysningerBehandleMottattAOU = (saksnummer, behandlingID) => (dispatch, getState) => {
+  dispatch(behandlingerOperations.hentBehandling(behandlingID));
+  dispatch(behandlingsresultatOperations.hent(behandlingID));
+  dispatch(anmodningsperioderOperations.hent(behandlingID)).then(() => {
+    const anmodningsperiodeID = anmodningsperioderSelectors.AnmodningsperiodeIDSelector(getState());
     dispatch(anmodningsperiodesvarOperations.hent(anmodningsperiodeID));
-  } catch (e) {
-    Utils.logger.error(e);
-  }
+  });
+  dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
 };
 
 export const resetSaksopplysninger = () => (dispatch) => {

--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -16,27 +16,22 @@ import { oppsummertfaktaOperations } from "../oppsummertfakta";
 import { medlemskapsperioderOperations } from "../medlemskapsperioder";
 
 export const lastInnSaksopplysninger = (sakstype, saksnummer, behandlingID) => (dispatch) => {
+  dispatch(fagsakOperations.hent(saksnummer));
+  dispatch(vilkarOperations.hent(behandlingID));
+  dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
+  dispatch(behandlingerOperations.hentBehandling(behandlingID));
+  dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
+  dispatch(behandlingsresultatOperations.hent(behandlingID));
+
   if (sakstype === MKV.Koder.sakstyper.FTRL) {
-    dispatch(fagsakOperations.hent(saksnummer));
-    dispatch(behandlingerOperations.hentBehandling(behandlingID));
-    dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
-    dispatch(behandlingsresultatOperations.hent(behandlingID));
     dispatch(oppsummertfaktaOperations.hentOppsummertFakta(behandlingID));
     dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
-    dispatch(vilkarOperations.hent(behandlingID));
-    dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
   } else {
     dispatch(anmodningsperioderOperations.hent(behandlingID));
-    dispatch(fagsakOperations.hent(saksnummer));
-    dispatch(behandlingerOperations.hentBehandling(behandlingID));
-    dispatch(behandlingsgrunnlagOperations.hent(behandlingID));
-    dispatch(behandlingsresultatOperations.hent(behandlingID));
     dispatch(avklartefaktaOperations.hent(behandlingID));
-    dispatch(vilkarOperations.hent(behandlingID));
     dispatch(lovvalgsperioderOperations.hent(behandlingID));
     dispatch(utpekingsperioderOperations.hent(behandlingID));
     dispatch(behandlingsperioderOperations.hentMedlemsPerioder(behandlingID));
-    dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
   }
 };
 

--- a/src/sider/eu_eøs/registrering/anmodningunntak/saksopplysninger.js
+++ b/src/sider/eu_eøs/registrering/anmodningunntak/saksopplysninger.js
@@ -60,6 +60,7 @@ const Saksopplysninger = ({
   lovvalgsperiode,
   tilForsiden,
   startOgVisOppfriskModal,
+  saksnummer,
 }) => {
   const [anmodningsperiodeSvarType, setAnmodningsperiodeSvarType] = useState(
     MKV.Koder.anmodningsperiodesvartyper.INNVILGELSE
@@ -73,8 +74,8 @@ const Saksopplysninger = ({
   const [registreringPending, setRegistreringPending] = useState(false);
 
   useEffect(() => {
-    lastInnSaksopplysninger(behandlingID, anmodningsperiodeID);
-  }, [anmodningsperiodeID]);
+    lastInnSaksopplysninger(saksnummer, behandlingID);
+  }, [saksnummer, behandlingID]);
 
   const setEndretPeriode = () => {
     if (sed.lovvalgsperiode) {
@@ -424,6 +425,7 @@ Saksopplysninger.propTypes = {
   lovvalgsperiode: MPT.Lovvalgsperiode.isRequired,
   tilForsiden: PT.func.isRequired,
   startOgVisOppfriskModal: PT.func.isRequired,
+  saksnummer: PT.string.isRequired,
 };
 
 Saksopplysninger.defaultProps = {
@@ -442,8 +444,8 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   oppdaterAvklartefakta: (behandlingID, avklartefaktaListe) =>
     dispatch(avklartefaktaOperations.send(behandlingID, avklartefaktaListe)),
-  lastInnSaksopplysninger: (behandlingID, anmodningsperiodeID) =>
-    datalastingOperations.lastInnSaksopplysningerBehandleMottattAOU(behandlingID, anmodningsperiodeID)(dispatch),
+  lastInnSaksopplysninger: (saksnummer, behandlingID) =>
+    dispatch(datalastingOperations.lastInnSaksopplysningerBehandleMottattAOU(saksnummer, behandlingID)),
 });
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Saksopplysninger));

--- a/src/sider/eu_eøs/registrering/registrering.js
+++ b/src/sider/eu_eøs/registrering/registrering.js
@@ -153,6 +153,7 @@ const Registrering = (props) => {
             <Saksopplysninger
               redigerbart={redigerbart}
               behandlingID={behandlingID}
+              saksnummer={saksnummer}
               sed={sed}
               vurderingBegrunnelser={vurderingBegrunnelser}
               tilForsiden={tilForsiden}


### PR DESCRIPTION
- Fikser bug https://jira.adeo.no/browse/MELOSYS-4480. Manglet et kall for å hente dokumentoversikt. Fikset også kall til `/api/anmodningsperioder/undefined/svar`.
- Litt refaktorering