### PR TITLE
Familiemedlemmer flyttes under hverandre

### DIFF
--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingFamilie.less
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingFamilie.less
@@ -7,9 +7,18 @@
   }
   .familiemedlem_radio {
     margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0;
   }
   .fritekst {
     margin-top: 0.5rem;
+  }
+  .barn {
+    margin-bottom: 0;
+    .barnet {
+      margin-bottom: 1.75rem;
+    }
+  }
+  .ektefelleSamboeren {
+    margin-bottom: 1.75rem;
   }
 }

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingFamilie.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingFamilie.tsx
@@ -203,8 +203,8 @@ const VurderingFamilie = ({
         <div>
           <Nav.Fieldset legend="Barn" className="barn">
             {medfolgendeBarn.map((barn: MedfolgendeFamilie) => (
-              <Nav.Row key={Utils._uuid()} className="barnet">
-                <Nav.Column xs="8" key={barn.uuid}>
+              <Nav.Row key={barn.uuid} className="barnet">
+                <Nav.Column xs="8">
                   <Nav.typo.Normaltekst>{`${Utils.streng.storeForbokstaver(barn.navn)} (F.nr: ${
                     barn.fnr
                   })`}</Nav.typo.Normaltekst>
@@ -258,8 +258,8 @@ const VurderingFamilie = ({
           </Nav.Fieldset>
           <Nav.Fieldset legend="Ektefelle/partner/samboer">
             {medfolgendeEktefelleSamboer.map((ektefelleSamboer: MedfolgendeFamilie) => (
-              <Nav.Row key={Utils._uuid()} className="ektefelleSamboeren">
-                <Nav.Column xs="8" key={ektefelleSamboer.uuid}>
+              <Nav.Row key={ektefelleSamboer.uuid} className="ektefelleSamboeren">
+                <Nav.Column xs="8">
                   <Nav.typo.Normaltekst>{`${Utils.streng.storeForbokstaver(ektefelleSamboer.navn)} (F.nr: ${
                     ektefelleSamboer.fnr
                   })`}</Nav.typo.Normaltekst>

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingFamilie.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingFamilie.tsx
@@ -201,10 +201,10 @@ const VurderingFamilie = ({
 
       {medfolgendeFamilie && medfolgendeFamilie.length > 0 ? (
         <div>
-          <Nav.Fieldset legend="Barn">
-            <Nav.Row>
-              {medfolgendeBarn.map((barn: MedfolgendeFamilie) => (
-                <Nav.Column xs="6" key={barn.uuid}>
+          <Nav.Fieldset legend="Barn" className="barn">
+            {medfolgendeBarn.map((barn: MedfolgendeFamilie) => (
+              <Nav.Row key={Utils._uuid()} className="barnet">
+                <Nav.Column xs="8" key={barn.uuid}>
                   <Nav.typo.Normaltekst>{`${Utils.streng.storeForbokstaver(barn.navn)} (F.nr: ${
                     barn.fnr
                   })`}</Nav.typo.Normaltekst>
@@ -244,22 +244,22 @@ const VurderingFamilie = ({
                     </Skjema.Select>
                   )}
                 </Nav.Column>
-              ))}
-            </Nav.Row>
+              </Nav.Row>
+            ))}
             {medfolgendeBarn.some(
               (barn: MedfolgendeFamilie) =>
                 formValues.barn && formValues.barn[barn.uuid].innvilget === BOOLSK_STRING.USANN
             ) && (
-              <div>
+              <div style={{ marginBottom: "2rem" }}>
                 <Nav.typo.Element>Fritekst til avsnitt om barn i vedtaksbrev</Nav.typo.Element>
                 <Skjema.HTMLEditor feltNavn="barn.fritekst" className="fritekst" />
               </div>
             )}
           </Nav.Fieldset>
           <Nav.Fieldset legend="Ektefelle/partner/samboer">
-            <Nav.Row>
-              {medfolgendeEktefelleSamboer.map((ektefelleSamboer: MedfolgendeFamilie) => (
-                <Nav.Column xs="6" key={ektefelleSamboer.uuid}>
+            {medfolgendeEktefelleSamboer.map((ektefelleSamboer: MedfolgendeFamilie) => (
+              <Nav.Row key={Utils._uuid()} className="ektefelleSamboeren">
+                <Nav.Column xs="8" key={ektefelleSamboer.uuid}>
                   <Nav.typo.Normaltekst>{`${Utils.streng.storeForbokstaver(ektefelleSamboer.navn)} (F.nr: ${
                     ektefelleSamboer.fnr
                   })`}</Nav.typo.Normaltekst>
@@ -302,8 +302,8 @@ const VurderingFamilie = ({
                       </Skjema.Select>
                     )}
                 </Nav.Column>
-              ))}
-            </Nav.Row>
+              </Nav.Row>
+            ))}
             {medfolgendeEktefelleSamboer.some(
               (ektefelleSamboer: MedfolgendeFamilie) =>
                 formValues.ektefelle_samboer &&


### PR DESCRIPTION
Se kommentarer på [MELOSYS-4447](https://jira.adeo.no/browse/MELOSYS-4447). 

Det var ønskelig å ha familiemedlemmene(når det er flere enn én) under hverandre, istedenfor på siden av hverandre.