### PR TITLE
Melosys 4340 kombinasjoner på trygdeavgift steget

### DIFF
--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingTrygdeavgift.less
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingTrygdeavgift.less
@@ -5,7 +5,6 @@
     padding-left: 0.5rem;
     padding-right: 0.5rem;
   }
-
   .extra_left_margin {
     margin-left: 1rem;
   }
@@ -71,5 +70,8 @@
   }
   .liten_margin_bottom {
     margin-bottom: 0.5rem;
+  }
+  .ja_nei {
+    margin-left: 1rem;
   }
 }

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingTrygdeavgift.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingTrygdeavgift.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState, ChangeEvent } from "react";
+import React, { useEffect, useState, ChangeEvent, Fragment } from "react";
 import { RootState } from "AppTypes";
 import { connect, ConnectedProps } from "react-redux";
 import { KTObject } from "@navikt/melosys-kodeverk";
 import { change, getFormValues, reduxForm } from "redux-form";
 import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
-import { Avgiftsgrunnlag, Avgiftsberegning, Avgiftsperiode, AvgiftsgrunnlagInfo } from "Domene";
+import { Avgiftsgrunnlag, Avgiftsberegning, AvgiftsgrunnlagInfo } from "Domene";
 
 import MKV from "../../../../melosyskodeverk";
 import * as Nav from "../../../../utils/navFrontend";
@@ -101,7 +101,10 @@ const TrygdeavgiftsgrunnlagComponent = ({
     </Nav.Hjelpetekst>
   );
 
-  function mapTabell(avgiftsperioder: Avgiftsperiode[] | undefined) {
+  function mapTabell() {
+    const avgiftsperioder = erVirksomhetNorsk
+      ? formValues?.avgiftsberegning?.avgiftsperioderNorge
+      : formValues?.avgiftsberegning?.avgiftsperioderUtland;
     return (
       avgiftsperioder &&
       avgiftsperioder.map((avgiftsperiode) => [
@@ -134,58 +137,95 @@ const TrygdeavgiftsgrunnlagComponent = ({
                 )}
           </Nav.AlertStripeInfo>
         )}
-        {!erVirksomhetNorsk &&
-          formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland &&
-          formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland.betalerArbeidsgiverAvgift && (
-            <Nav.AlertStripeAdvarsel className="stor_margin_bottom">
-              Du har oppgitt at utenlandsk virksomhet betaler arbeidsavgift.
-            </Nav.AlertStripeAdvarsel>
-          )}
+        {!erVirksomhetNorsk && formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland?.betalerArbeidsgiverAvgift && (
+          <Nav.AlertStripeAdvarsel className="stor_margin_bottom">
+            Du har oppgitt at utenlandsk virksomhet betaler arbeidsavgift.
+          </Nav.AlertStripeAdvarsel>
+        )}
       </div>
     );
   };
 
   if (!formValues.avgiftsgrunnlag) return null;
+
+  const virksomhetType = erVirksomhetNorsk
+    ? VurderingTrygdeavgiftVirksomhetTyper.NORSK
+    : VurderingTrygdeavgiftVirksomhetTyper.UTENLANDSK;
+  const feltNavnBase = erVirksomhetNorsk
+    ? "avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge"
+    : "avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland";
+  const ingenTrygdeavgiftBetalesTilNAV = erVirksomhetNorsk
+    ? formValues.avgiftsgrunnlag.vurderingTrygdeavgiftNorskInntekt ===
+      MKV.Koder.vurderingsutfall_trygdeavgift_norsk_inntekt.NORSK_INNTEKT_INGEN_TRYGDEAVGIFT_NAV
+    : formValues.avgiftsgrunnlag.vurderingTrygdeavgiftUtenlandskInntekt ===
+      MKV.Koder.vurderingsutfall_trygdeavgift_utenlandsk_inntekt.UTENLANDSK_INNTEKT_INGEN_TRYGDEAVGIFT_NAV;
+  const trygdeavgiftBetalesTilNAV = erVirksomhetNorsk
+    ? formValues.avgiftsgrunnlag.vurderingTrygdeavgiftNorskInntekt ===
+      MKV.Koder.vurderingsutfall_trygdeavgift_norsk_inntekt.NORSK_INNTEKT_TRYGDEAVGIFT_NAV
+    : formValues.avgiftsgrunnlag.vurderingTrygdeavgiftUtenlandskInntekt ===
+      MKV.Koder.vurderingsutfall_trygdeavgift_utenlandsk_inntekt.UTENLANDSK_INNTEKT_TRYGDEAVGIFT_NAV;
+
   return (
     <div className="vurderingTrygdeavgift__overstrek vurderingTrygdeavgift">
       <Nav.Row>
         <Nav.typo.Undertittel className="sub_undertittel">
           {erVirksomhetNorsk ? "Fra Norge" : "Fra utlandet"}
         </Nav.typo.Undertittel>
+
         <Nav.Column xs="4">
-          <Nav.Fieldset legend="Er søker skattepliktig?">
-            <Skjema.Radio
+          <Nav.Fieldset
+            legend={
+              <Fragment>
+                Tilhører søker en spesiell gruppe?
+                <Hjelpetekst />
+              </Fragment>
+            }
+          >
+            <Nav.Radio
               className="column"
               label="Ja"
-              feltNavn={
-                erVirksomhetNorsk
-                  ? "avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.erSkattepliktig"
-                  : "avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland.erSkattepliktig"
-              }
-              value={BOOLSK.SANN}
+              name={`${virksomhetType}særligAvgiftsgruppe`}
+              onChange={(event) => handleSærligAvgiftsgruppeRadioChange(event, erVirksomhetNorsk)}
+              checked={erSaerligAvgiftsGruppeValgt.get(virksomhetType) === true}
+              value={BOOLSK_STRING.SANN}
               disabled={!redigerbart}
-              id={
-                erVirksomhetNorsk
-                  ? "trygdeavgiftsgrunnlagNorge.erSkattepliktig"
-                  : "trygdeavgiftsgrunnlagUtland.erSkattepliktig"
-              }
             />
-            <Skjema.Radio
+            <Nav.Radio
               className="column"
               label="Nei"
-              feltNavn={
-                erVirksomhetNorsk
-                  ? "avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.erSkattepliktig"
-                  : "avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland.erSkattepliktig"
-              }
-              value={BOOLSK.USANN}
+              name={`${virksomhetType}særligAvgiftsgruppe`}
+              onChange={(event) => handleSærligAvgiftsgruppeRadioChange(event, erVirksomhetNorsk)}
+              checked={erSaerligAvgiftsGruppeValgt.get(virksomhetType) === false}
+              value={BOOLSK_STRING.USANN}
               disabled={!redigerbart}
-              id={
-                erVirksomhetNorsk
-                  ? "trygdeavgiftsgrunnlagNorge.erIkkeSkattepliktig"
-                  : "trygdeavgiftsgrunnlagUtland.erIkkeSkattepliktig"
-              }
             />
+            {erSaerligAvgiftsGruppeValgt.get(virksomhetType) === true && (
+              <Skjema.Select
+                label=""
+                disabled={!redigerbart}
+                feltNavn={`${feltNavnBase}.særligAvgiftsgruppe`}
+                emptyFieldText="Velg gruppe"
+                emptyFieldDisabled={
+                  (erVirksomhetNorsk
+                    ? formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe
+                    : formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.særligAvgiftsgruppe) !== "TRUE"
+                }
+              >
+                {saerligeavgiftsgrupper
+                  .filter(
+                    (avgiftsgruppe) =>
+                      avgiftsgruppe.kode !==
+                      (erVirksomhetNorsk
+                        ? MKV.Koder.saerligeavgiftsgrupper.FN
+                        : MKV.Koder.saerligeavgiftsgrupper.MISJONÆR)
+                  )
+                  .map((saerligavgiftsgruppe: KTObject) => (
+                    <option key={saerligavgiftsgruppe.kode} value={saerligavgiftsgruppe.kode}>
+                      {saerligavgiftsgruppe.term}
+                    </option>
+                  ))}
+              </Skjema.Select>
+            )}
           </Nav.Fieldset>
         </Nav.Column>
 
@@ -194,132 +234,53 @@ const TrygdeavgiftsgrunnlagComponent = ({
             <Skjema.Radio
               className="column"
               label="Ja"
-              feltNavn={
-                erVirksomhetNorsk
-                  ? "avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.betalerArbeidsgiverAvgift"
-                  : "avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland.betalerArbeidsgiverAvgift"
-              }
+              feltNavn={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
               value={BOOLSK.SANN}
               disabled={!redigerbart}
-              id={
-                erVirksomhetNorsk
-                  ? "trygdeavgiftsgrunnlagNorge.betalerArbeidsgiverAvgift"
-                  : "trygdeavgiftsgrunnlagUtland.betalerArbeidsgiverAvgift"
-              }
+              id={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
             />
             <Skjema.Radio
               className="column"
               label="Nei"
-              feltNavn={
-                erVirksomhetNorsk
-                  ? "avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.betalerArbeidsgiverAvgift"
-                  : "avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland.betalerArbeidsgiverAvgift"
-              }
+              feltNavn={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
               value={BOOLSK.USANN}
               disabled={!redigerbart}
-              id={
-                erVirksomhetNorsk
-                  ? "trygdeavgiftsgrunnlagNorge.betalerIkkeArbeidsgiverAvgift"
-                  : "trygdeavgiftsgrunnlagUtland.betalerIkkeArbeidsgiverAvgift"
-              }
+              id={`${feltNavnBase}.betalerIkkeArbeidsgiverAvgift`}
             />
           </Nav.Fieldset>
         </Nav.Column>
 
         <Nav.Column xs="4">
-          <Nav.Fieldset
-            legend={
-              <div>
-                Tilhører søker en spesiell gruppe?
-                <Hjelpetekst />
-              </div>
-            }
-          >
-            <Nav.Radio
+          <Nav.Fieldset legend="Er søker skattepliktig?">
+            <Skjema.Radio
               className="column"
               label="Ja"
-              name={`${
-                erVirksomhetNorsk
-                  ? VurderingTrygdeavgiftVirksomhetTyper.NORSK
-                  : VurderingTrygdeavgiftVirksomhetTyper.UTENLANDSK
-              }særligAvgiftsgruppe`}
-              onChange={(event) => handleSærligAvgiftsgruppeRadioChange(event, erVirksomhetNorsk)}
-              checked={
-                erVirksomhetNorsk
-                  ? erSaerligAvgiftsGruppeValgt.get(VurderingTrygdeavgiftVirksomhetTyper.NORSK) === true
-                  : erSaerligAvgiftsGruppeValgt.get(VurderingTrygdeavgiftVirksomhetTyper.UTENLANDSK) === true
-              }
-              value={BOOLSK_STRING.SANN}
+              feltNavn={`${feltNavnBase}.erSkattepliktig`}
+              value={BOOLSK.SANN}
               disabled={!redigerbart}
+              id={`${feltNavnBase}.erSkattepliktig`}
             />
-            <Nav.Radio
+            <Skjema.Radio
               className="column"
               label="Nei"
-              name={`${
-                erVirksomhetNorsk
-                  ? VurderingTrygdeavgiftVirksomhetTyper.NORSK
-                  : VurderingTrygdeavgiftVirksomhetTyper.UTENLANDSK
-              }særligAvgiftsgruppe`}
-              onChange={(event) => handleSærligAvgiftsgruppeRadioChange(event, erVirksomhetNorsk)}
-              checked={
-                erVirksomhetNorsk
-                  ? erSaerligAvgiftsGruppeValgt.get(VurderingTrygdeavgiftVirksomhetTyper.NORSK) === false
-                  : erSaerligAvgiftsGruppeValgt.get(VurderingTrygdeavgiftVirksomhetTyper.UTENLANDSK) === false
-              }
-              value={BOOLSK_STRING.USANN}
+              feltNavn={`${feltNavnBase}.erSkattepliktig`}
+              value={BOOLSK.USANN}
               disabled={!redigerbart}
+              id={`${feltNavnBase}.erIkkeSkattepliktig`}
             />
-            {(erVirksomhetNorsk
-              ? erSaerligAvgiftsGruppeValgt.get(VurderingTrygdeavgiftVirksomhetTyper.NORSK) === true
-              : erSaerligAvgiftsGruppeValgt.get(VurderingTrygdeavgiftVirksomhetTyper.UTENLANDSK) === true) && (
-              <Skjema.Select
-                label=""
-                disabled={!redigerbart}
-                feltNavn={
-                  erVirksomhetNorsk
-                    ? "avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.særligAvgiftsgruppe"
-                    : "avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland.særligAvgiftsgruppe"
-                }
-                emptyFieldText="Velg gruppe"
-                emptyFieldDisabled={
-                  (erVirksomhetNorsk
-                    ? formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge &&
-                      formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.særligAvgiftsgruppe
-                    : formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland &&
-                      formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland.særligAvgiftsgruppe) !== "TRUE"
-                }
-              >
-                {saerligeavgiftsgrupper.map((saerligavgiftsgruppe: KTObject) => (
-                  <option key={saerligavgiftsgruppe.kode} value={saerligavgiftsgruppe.kode}>
-                    {saerligavgiftsgruppe.term}
-                  </option>
-                ))}
-              </Skjema.Select>
-            )}
           </Nav.Fieldset>
         </Nav.Column>
       </Nav.Row>
 
-      {(erVirksomhetNorsk
-        ? formValues.avgiftsgrunnlag.vurderingTrygdeavgiftNorskInntekt ===
-          MKV.Koder.vurderingsutfall_trygdeavgift_norsk_inntekt.NORSK_INNTEKT_INGEN_TRYGDEAVGIFT_NAV
-        : formValues.avgiftsgrunnlag.vurderingTrygdeavgiftUtenlandskInntekt ===
-          MKV.Koder.vurderingsutfall_trygdeavgift_utenlandsk_inntekt.UTENLANDSK_INNTEKT_INGEN_TRYGDEAVGIFT_NAV) && (
-        <VurderingsutfallIngenTrygdeavgift />
-      )}
-      {(erVirksomhetNorsk
-        ? formValues.avgiftsgrunnlag.vurderingTrygdeavgiftNorskInntekt ===
-          MKV.Koder.vurderingsutfall_trygdeavgift_norsk_inntekt.NORSK_INNTEKT_TRYGDEAVGIFT_NAV
-        : formValues.avgiftsgrunnlag.vurderingTrygdeavgiftUtenlandskInntekt ===
-          MKV.Koder.vurderingsutfall_trygdeavgift_utenlandsk_inntekt.UTENLANDSK_INNTEKT_TRYGDEAVGIFT_NAV) && (
+      {ingenTrygdeavgiftBetalesTilNAV && <VurderingsutfallIngenTrygdeavgift />}
+
+      {trygdeavgiftBetalesTilNAV && (
         <div>
-          {!erVirksomhetNorsk &&
-            formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland &&
-            formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland.betalerArbeidsgiverAvgift && (
-              <Nav.AlertStripeAdvarsel className="stor_margin_bottom">
-                Du har oppgitt at utenlandsk virksomhet betaler arbeidsavgift.
-              </Nav.AlertStripeAdvarsel>
-            )}
+          {!erVirksomhetNorsk && formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland?.betalerArbeidsgiverAvgift && (
+            <Nav.AlertStripeAdvarsel className="stor_margin_bottom">
+              Du har oppgitt at utenlandsk virksomhet betaler arbeidsavgift.
+            </Nav.AlertStripeAdvarsel>
+          )}
           {(erVirksomhetNorsk ? !erTrygdeavgiftsgrunnlagNorgeUgyldig : !erTrygdeavgiftsgrunnlagUtlandUgyldig) && (
             <Nav.Row>
               <Nav.Column xs="4">
@@ -360,22 +321,13 @@ const TrygdeavgiftsgrunnlagComponent = ({
         </div>
       )}
 
-      {(erVirksomhetNorsk
-        ? erTabellApen.get(VurderingTrygdeavgiftVirksomhetTyper.NORSK)
-        : erTabellApen.get(VurderingTrygdeavgiftVirksomhetTyper.UTENLANDSK)) &&
-        formValues.avgiftsberegning && (
-          <Nav.Row>
-            <Nav.Column xs="12">
-              <PeriodeTabellComponent
-                perioder={mapTabell(
-                  erVirksomhetNorsk
-                    ? formValues.avgiftsberegning.avgiftsperioderNorge
-                    : formValues.avgiftsberegning.avgiftsperioderUtland
-                )}
-              />
-            </Nav.Column>
-          </Nav.Row>
-        )}
+      {erTabellApen.get(virksomhetType) && formValues.avgiftsberegning && (
+        <Nav.Row>
+          <Nav.Column xs="12">
+            <PeriodeTabellComponent perioder={mapTabell()} />
+          </Nav.Column>
+        </Nav.Row>
+      )}
     </div>
   );
 };
@@ -433,19 +385,13 @@ const VurderingTrygdeavgift = ({
   useEffect(() => {
     Api.Trygdeavgift.hentGrunnlag(behandlingID)
       .then((response) => {
-        if (
-          response.trygdeavgiftsgrunnlagNorge &&
-          response.trygdeavgiftsgrunnlagNorge.særligAvgiftsgruppe !== undefined
-        ) {
+        if (response?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe !== undefined) {
           erSaerligAvgiftsGruppeValgt.set(
             VurderingTrygdeavgiftVirksomhetTyper.NORSK,
             !!response.trygdeavgiftsgrunnlagNorge.særligAvgiftsgruppe
           );
         }
-        if (
-          response.trygdeavgiftsgrunnlagUtland &&
-          response.trygdeavgiftsgrunnlagUtland.særligAvgiftsgruppe !== undefined
-        ) {
+        if (response?.trygdeavgiftsgrunnlagUtland?.særligAvgiftsgruppe !== undefined) {
           erSaerligAvgiftsGruppeValgt.set(
             VurderingTrygdeavgiftVirksomhetTyper.UTENLANDSK,
             !!response.trygdeavgiftsgrunnlagUtland.særligAvgiftsgruppe
@@ -523,7 +469,7 @@ const VurderingTrygdeavgift = ({
   }
 
   useEffect(() => {
-    if (formValues && formValues.avgiftsgrunnlag && erAvgiftsgrunnlagGyldig(formValues.avgiftsgrunnlag)) {
+    if (formValues?.avgiftsgrunnlag && erAvgiftsgrunnlagGyldig(formValues.avgiftsgrunnlag)) {
       Api.Trygdeavgift.sendGrunnlag(behandlingID, {
         lønnsforhold: formValues.avgiftsgrunnlag.lønnsforhold,
         trygdeavgiftsgrunnlagNorge: formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge || null,
@@ -535,7 +481,7 @@ const VurderingTrygdeavgift = ({
         })
         .catch(Utils.logger.error);
     }
-  }, [formValues && formValues.avgiftsgrunnlag]);
+  }, [formValues?.avgiftsgrunnlag]);
 
   function handleSærligAvgiftsgruppeRadioChange(event: ChangeEvent<HTMLInputElement>, erNorskVirksomhet: boolean) {
     const erSærligAvgiftsgruppe = Utils.streng.tryParseBool(event.target.value);
@@ -578,6 +524,12 @@ const VurderingTrygdeavgift = ({
     );
   }
 
+  const lønnsforholdErLønnFraNorge =
+    formValues?.avgiftsgrunnlag?.lønnsforhold === MKV.Koder.loenn_forhold.LØNN_FRA_NORGE;
+  const lønnsforholdErLønnFraUtlandet =
+    formValues?.avgiftsgrunnlag?.lønnsforhold === MKV.Koder.loenn_forhold.LØNN_FRA_UTLANDET;
+  const lønnsforholdErDeltLønn = formValues?.avgiftsgrunnlag?.lønnsforhold === MKV.Koder.loenn_forhold.DELT_LØNN;
+
   return (
     <div className="vurderingTrygdeavgift">
       <Nav.typo.Undertittel className="undertittel">Trygdeavgift</Nav.typo.Undertittel>
@@ -591,11 +543,7 @@ const VurderingTrygdeavgift = ({
               value={MKV.Koder.loenn_forhold.LØNN_FRA_NORGE}
               id={MKV.Koder.loenn_forhold.LØNN_FRA_NORGE}
               disabled={!redigerbart}
-              defaultChecked={
-                formValues &&
-                formValues.avgiftsgrunnlag &&
-                formValues.avgiftsgrunnlag.lønnsforhold === MKV.Koder.loenn_forhold.LØNN_FRA_NORGE
-              }
+              defaultChecked={lønnsforholdErLønnFraNorge}
             />
             <Skjema.Radio
               feltNavn="avgiftsgrunnlag.lønnsforhold"
@@ -603,11 +551,7 @@ const VurderingTrygdeavgift = ({
               value={MKV.Koder.loenn_forhold.LØNN_FRA_UTLANDET}
               id={MKV.Koder.loenn_forhold.LØNN_FRA_UTLANDET}
               disabled={!redigerbart}
-              defaultChecked={
-                formValues &&
-                formValues.avgiftsgrunnlag &&
-                formValues.avgiftsgrunnlag.lønnsforhold === MKV.Koder.loenn_forhold.LØNN_FRA_UTLANDET
-              }
+              defaultChecked={lønnsforholdErLønnFraUtlandet}
             />
             <Skjema.Radio
               label="Norsk og utenlandsk virksomhet"
@@ -615,54 +559,44 @@ const VurderingTrygdeavgift = ({
               value={MKV.Koder.loenn_forhold.DELT_LØNN}
               id={MKV.Koder.loenn_forhold.DELT_LØNN}
               disabled={!redigerbart}
-              defaultChecked={
-                formValues &&
-                formValues.avgiftsgrunnlag &&
-                formValues.avgiftsgrunnlag.lønnsforhold === MKV.Koder.loenn_forhold.DELT_LØNN
-              }
+              defaultChecked={lønnsforholdErDeltLønn}
             />
           </Nav.Fieldset>
         </Nav.Column>
       </Nav.Row>
 
-      {formValues &&
-        formValues.avgiftsgrunnlag &&
-        (formValues.avgiftsgrunnlag.lønnsforhold === MKV.Koder.loenn_forhold.LØNN_FRA_NORGE ||
-          formValues.avgiftsgrunnlag.lønnsforhold === MKV.Koder.loenn_forhold.DELT_LØNN) && (
-          <TrygdeavgiftsgrunnlagComponent
-            erVirksomhetNorsk
-            formValues={formValues}
-            oppdatertAvgiftsberegning={oppdatertAvgiftsberegning}
-            erTabellApen={erTabellApen}
-            erSaerligAvgiftsGruppeValgt={erSaerligAvgiftsGruppeValgt}
-            handleBeregnClick={handleBeregnClick}
-            handleSærligAvgiftsgruppeRadioChange={handleSærligAvgiftsgruppeRadioChange}
-            handleAvgiftspliktigLønnInputChange={handleAvgiftspliktigLønnInputChange}
-            redigerbart={redigerbart}
-            erTrygdeavgiftsgrunnlagNorgeUgyldig={erTrygdeavgiftsgrunnlagNorgeUgyldig}
-            erTrygdeavgiftsgrunnlagUtlandUgyldig={erTrygdeavgiftsgrunnlagUtlandUgyldig}
-            saerligeavgiftsgrupper={saerligeavgiftsgrupper}
-          />
-        )}
-      {formValues &&
-        formValues.avgiftsgrunnlag &&
-        (formValues.avgiftsgrunnlag.lønnsforhold === MKV.Koder.loenn_forhold.LØNN_FRA_UTLANDET ||
-          formValues.avgiftsgrunnlag.lønnsforhold === MKV.Koder.loenn_forhold.DELT_LØNN) && (
-          <TrygdeavgiftsgrunnlagComponent
-            erVirksomhetNorsk={false}
-            formValues={formValues}
-            oppdatertAvgiftsberegning={oppdatertAvgiftsberegning}
-            erTabellApen={erTabellApen}
-            erSaerligAvgiftsGruppeValgt={erSaerligAvgiftsGruppeValgt}
-            handleBeregnClick={handleBeregnClick}
-            handleSærligAvgiftsgruppeRadioChange={handleSærligAvgiftsgruppeRadioChange}
-            handleAvgiftspliktigLønnInputChange={handleAvgiftspliktigLønnInputChange}
-            redigerbart={redigerbart}
-            erTrygdeavgiftsgrunnlagNorgeUgyldig={erTrygdeavgiftsgrunnlagNorgeUgyldig}
-            erTrygdeavgiftsgrunnlagUtlandUgyldig={erTrygdeavgiftsgrunnlagUtlandUgyldig}
-            saerligeavgiftsgrupper={saerligeavgiftsgrupper}
-          />
-        )}
+      {(lønnsforholdErLønnFraNorge || lønnsforholdErDeltLønn) && (
+        <TrygdeavgiftsgrunnlagComponent
+          erVirksomhetNorsk
+          formValues={formValues}
+          oppdatertAvgiftsberegning={oppdatertAvgiftsberegning}
+          erTabellApen={erTabellApen}
+          erSaerligAvgiftsGruppeValgt={erSaerligAvgiftsGruppeValgt}
+          handleBeregnClick={handleBeregnClick}
+          handleSærligAvgiftsgruppeRadioChange={handleSærligAvgiftsgruppeRadioChange}
+          handleAvgiftspliktigLønnInputChange={handleAvgiftspliktigLønnInputChange}
+          redigerbart={redigerbart}
+          erTrygdeavgiftsgrunnlagNorgeUgyldig={erTrygdeavgiftsgrunnlagNorgeUgyldig}
+          erTrygdeavgiftsgrunnlagUtlandUgyldig={erTrygdeavgiftsgrunnlagUtlandUgyldig}
+          saerligeavgiftsgrupper={saerligeavgiftsgrupper}
+        />
+      )}
+      {(lønnsforholdErLønnFraUtlandet || lønnsforholdErDeltLønn) && (
+        <TrygdeavgiftsgrunnlagComponent
+          erVirksomhetNorsk={false}
+          formValues={formValues}
+          oppdatertAvgiftsberegning={oppdatertAvgiftsberegning}
+          erTabellApen={erTabellApen}
+          erSaerligAvgiftsGruppeValgt={erSaerligAvgiftsGruppeValgt}
+          handleBeregnClick={handleBeregnClick}
+          handleSærligAvgiftsgruppeRadioChange={handleSærligAvgiftsgruppeRadioChange}
+          handleAvgiftspliktigLønnInputChange={handleAvgiftspliktigLønnInputChange}
+          redigerbart={redigerbart}
+          erTrygdeavgiftsgrunnlagNorgeUgyldig={erTrygdeavgiftsgrunnlagNorgeUgyldig}
+          erTrygdeavgiftsgrunnlagUtlandUgyldig={erTrygdeavgiftsgrunnlagUtlandUgyldig}
+          saerligeavgiftsgrupper={saerligeavgiftsgrupper}
+        />
+      )}
 
       <div className="fane__knapplinje">
         <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingTrygdeavgift.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingTrygdeavgift.tsx
@@ -146,6 +146,82 @@ const TrygdeavgiftsgrunnlagComponent = ({
     );
   };
 
+  const betalerArbeidsgiverAvgiftDisabled = () => {
+    if (erVirksomhetNorsk) {
+      const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe;
+      const erSkattepliktig = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.erSkattepliktig;
+
+      return (
+        (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA && erSkattepliktig === true) ||
+        særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.MISJONÆR
+      );
+    }
+    return true;
+  };
+
+  const betalerIkkeArbeidsgiverAvgiftDisabled = () => {
+    if (erVirksomhetNorsk) {
+      return [null, MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA].includes(
+        formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe
+      );
+    }
+    const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.særligAvgiftsgruppe;
+    const erSkattepliktig = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.erSkattepliktig;
+
+    return (
+      (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA && erSkattepliktig === true) ||
+      (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.FN && erSkattepliktig === true)
+    );
+  };
+
+  const erSkattepliktigDisabled = () => {
+    if (erVirksomhetNorsk) {
+      const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe;
+      const betalerArbeidsgiverAvgift =
+        formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.betalerArbeidsgiverAvgift;
+
+      return (
+        (særligAvgiftsgruppe === null && betalerArbeidsgiverAvgift === false) ||
+        særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA ||
+        (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.MISJONÆR && betalerArbeidsgiverAvgift === true)
+      );
+    }
+    const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.særligAvgiftsgruppe;
+    const betalerArbeidsgiverAvgift =
+      formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.betalerArbeidsgiverAvgift;
+
+    return (
+      (særligAvgiftsgruppe === null && betalerArbeidsgiverAvgift === true) ||
+      særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA ||
+      særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.FN
+    );
+  };
+
+  const erIkkeSkattepliktigDisabled = () => {
+    if (erVirksomhetNorsk) {
+      const betalerArbeidsgiverAvgift =
+        formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.betalerArbeidsgiverAvgift;
+      const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe;
+
+      return (
+        (særligAvgiftsgruppe === null && betalerArbeidsgiverAvgift === false) ||
+        (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA &&
+          betalerArbeidsgiverAvgift === false) ||
+        (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.MISJONÆR && betalerArbeidsgiverAvgift === true)
+      );
+    }
+    const betalerArbeidsgiverAvgift =
+      formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.betalerArbeidsgiverAvgift;
+    const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.særligAvgiftsgruppe;
+
+    return (
+      (særligAvgiftsgruppe === null && betalerArbeidsgiverAvgift === true) ||
+      (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA &&
+        betalerArbeidsgiverAvgift === true) ||
+      (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.FN && betalerArbeidsgiverAvgift === true)
+    );
+  };
+
   if (!formValues.avgiftsgrunnlag) return null;
 
   const virksomhetType = erVirksomhetNorsk
@@ -164,6 +240,14 @@ const TrygdeavgiftsgrunnlagComponent = ({
       MKV.Koder.vurderingsutfall_trygdeavgift_norsk_inntekt.NORSK_INNTEKT_TRYGDEAVGIFT_NAV
     : formValues.avgiftsgrunnlag.vurderingTrygdeavgiftUtenlandskInntekt ===
       MKV.Koder.vurderingsutfall_trygdeavgift_utenlandsk_inntekt.UTENLANDSK_INNTEKT_TRYGDEAVGIFT_NAV;
+  const trygdeavgiftsgrunnlag = erVirksomhetNorsk
+    ? formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge
+    : formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland;
+  const visBetalerArbeidsgiverAvgift =
+    trygdeavgiftsgrunnlag?.særligAvgiftsgruppe !== undefined &&
+    trygdeavgiftsgrunnlag?.særligAvgiftsgruppe !== BOOLSK_STRING.SANN;
+  const visErSøkerSkattepliktig =
+    visBetalerArbeidsgiverAvgift && trygdeavgiftsgrunnlag?.betalerArbeidsgiverAvgift !== undefined;
 
   return (
     <div className="vurderingTrygdeavgift__overstrek vurderingTrygdeavgift">
@@ -229,47 +313,51 @@ const TrygdeavgiftsgrunnlagComponent = ({
           </Nav.Fieldset>
         </Nav.Column>
 
-        <Nav.Column xs="4">
-          <Nav.Fieldset legend="Betaler virksomheten arbeideravgift?">
-            <Skjema.Radio
-              className="column"
-              label="Ja"
-              feltNavn={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
-              value={BOOLSK.SANN}
-              disabled={!redigerbart}
-              id={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
-            />
-            <Skjema.Radio
-              className="column"
-              label="Nei"
-              feltNavn={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
-              value={BOOLSK.USANN}
-              disabled={!redigerbart}
-              id={`${feltNavnBase}.betalerIkkeArbeidsgiverAvgift`}
-            />
-          </Nav.Fieldset>
-        </Nav.Column>
+        {visBetalerArbeidsgiverAvgift && (
+          <Nav.Column xs="4">
+            <Nav.Fieldset legend="Betaler virksomheten arbeideravgift?">
+              <Skjema.Radio
+                className="column"
+                label="Ja"
+                feltNavn={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
+                value={BOOLSK.SANN}
+                disabled={!redigerbart || betalerArbeidsgiverAvgiftDisabled()}
+                id={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
+              />
+              <Skjema.Radio
+                className="column"
+                label="Nei"
+                feltNavn={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
+                value={BOOLSK.USANN}
+                disabled={!redigerbart || betalerIkkeArbeidsgiverAvgiftDisabled()}
+                id={`${feltNavnBase}.betalerIkkeArbeidsgiverAvgift`}
+              />
+            </Nav.Fieldset>
+          </Nav.Column>
+        )}
 
-        <Nav.Column xs="4">
-          <Nav.Fieldset legend="Er søker skattepliktig?">
-            <Skjema.Radio
-              className="column"
-              label="Ja"
-              feltNavn={`${feltNavnBase}.erSkattepliktig`}
-              value={BOOLSK.SANN}
-              disabled={!redigerbart}
-              id={`${feltNavnBase}.erSkattepliktig`}
-            />
-            <Skjema.Radio
-              className="column"
-              label="Nei"
-              feltNavn={`${feltNavnBase}.erSkattepliktig`}
-              value={BOOLSK.USANN}
-              disabled={!redigerbart}
-              id={`${feltNavnBase}.erIkkeSkattepliktig`}
-            />
-          </Nav.Fieldset>
-        </Nav.Column>
+        {visErSøkerSkattepliktig && (
+          <Nav.Column xs="4">
+            <Nav.Fieldset legend="Er søker skattepliktig?">
+              <Skjema.Radio
+                className="column"
+                label="Ja"
+                feltNavn={`${feltNavnBase}.erSkattepliktig`}
+                value={BOOLSK.SANN}
+                disabled={!redigerbart || erSkattepliktigDisabled()}
+                id={`${feltNavnBase}.erSkattepliktig`}
+              />
+              <Skjema.Radio
+                className="column"
+                label="Nei"
+                feltNavn={`${feltNavnBase}.erSkattepliktig`}
+                value={BOOLSK.USANN}
+                disabled={!redigerbart || erIkkeSkattepliktigDisabled()}
+                id={`${feltNavnBase}.erIkkeSkattepliktig`}
+              />
+            </Nav.Fieldset>
+          </Nav.Column>
+        )}
       </Nav.Row>
 
       {ingenTrygdeavgiftBetalesTilNAV && <VurderingsutfallIngenTrygdeavgift />}
@@ -490,13 +578,23 @@ const VurderingTrygdeavgift = ({
       erSærligAvgiftsgruppe
     );
     setErSaerligAvgiftsGruppeValgt(new Map(erSaerligAvgiftsGruppeValgt));
-    changeField(
-      erNorskVirksomhet
-        ? "avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.særligAvgiftsgruppe"
-        : "avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland.særligAvgiftsgruppe",
-      erSærligAvgiftsgruppe ? "TRUE" : null
-    );
+    const fieldBase = erNorskVirksomhet
+      ? "avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge"
+      : "avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland";
+    changeField(`${fieldBase}.særligAvgiftsgruppe`, erSærligAvgiftsgruppe ? "TRUE" : null);
+    changeField(`${fieldBase}.betalerArbeidsgiverAvgift`, erNorskVirksomhet ? BOOLSK.SANN : BOOLSK.USANN);
+    changeField(`${fieldBase}.erSkattepliktig`, undefined);
   }
+
+  useEffect(() => {
+    const særligAvgiftsgruppe = formValues?.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe;
+    if (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.MISJONÆR) {
+      changeField("avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.betalerArbeidsgiverAvgift", BOOLSK.USANN);
+    }
+    if (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA) {
+      changeField("avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.betalerArbeidsgiverAvgift", BOOLSK.SANN);
+    }
+  }, [formValues?.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe]);
 
   function handleAvgiftspliktigLønnInputChange(event: ChangeEvent<HTMLInputElement>, erNorskVirksomhet: boolean) {
     setOppdatertAvgiftsberegning(

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingTrygdeavgift.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingTrygdeavgift.tsx
@@ -146,82 +146,6 @@ const TrygdeavgiftsgrunnlagComponent = ({
     );
   };
 
-  const betalerArbeidsgiverAvgiftDisabled = () => {
-    if (erVirksomhetNorsk) {
-      const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe;
-      const erSkattepliktig = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.erSkattepliktig;
-
-      return (
-        (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA && erSkattepliktig === true) ||
-        særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.MISJONÆR
-      );
-    }
-    return true;
-  };
-
-  const betalerIkkeArbeidsgiverAvgiftDisabled = () => {
-    if (erVirksomhetNorsk) {
-      return [null, MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA].includes(
-        formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe
-      );
-    }
-    const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.særligAvgiftsgruppe;
-    const erSkattepliktig = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.erSkattepliktig;
-
-    return (
-      (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA && erSkattepliktig === true) ||
-      (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.FN && erSkattepliktig === true)
-    );
-  };
-
-  const erSkattepliktigDisabled = () => {
-    if (erVirksomhetNorsk) {
-      const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe;
-      const betalerArbeidsgiverAvgift =
-        formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.betalerArbeidsgiverAvgift;
-
-      return (
-        (særligAvgiftsgruppe === null && betalerArbeidsgiverAvgift === false) ||
-        særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA ||
-        (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.MISJONÆR && betalerArbeidsgiverAvgift === true)
-      );
-    }
-    const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.særligAvgiftsgruppe;
-    const betalerArbeidsgiverAvgift =
-      formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.betalerArbeidsgiverAvgift;
-
-    return (
-      (særligAvgiftsgruppe === null && betalerArbeidsgiverAvgift === true) ||
-      særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA ||
-      særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.FN
-    );
-  };
-
-  const erIkkeSkattepliktigDisabled = () => {
-    if (erVirksomhetNorsk) {
-      const betalerArbeidsgiverAvgift =
-        formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.betalerArbeidsgiverAvgift;
-      const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe;
-
-      return (
-        (særligAvgiftsgruppe === null && betalerArbeidsgiverAvgift === false) ||
-        (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA &&
-          betalerArbeidsgiverAvgift === false) ||
-        (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.MISJONÆR && betalerArbeidsgiverAvgift === true)
-      );
-    }
-    const betalerArbeidsgiverAvgift =
-      formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.betalerArbeidsgiverAvgift;
-    const særligAvgiftsgruppe = formValues.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.særligAvgiftsgruppe;
-
-    return (
-      (særligAvgiftsgruppe === null && betalerArbeidsgiverAvgift === true) ||
-      (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA &&
-        betalerArbeidsgiverAvgift === true) ||
-      (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.FN && betalerArbeidsgiverAvgift === true)
-    );
-  };
-
   if (!formValues.avgiftsgrunnlag) return null;
 
   const virksomhetType = erVirksomhetNorsk
@@ -244,10 +168,22 @@ const TrygdeavgiftsgrunnlagComponent = ({
     ? formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge
     : formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland;
   const visBetalerArbeidsgiverAvgift =
-    trygdeavgiftsgrunnlag?.særligAvgiftsgruppe !== undefined &&
-    trygdeavgiftsgrunnlag?.særligAvgiftsgruppe !== BOOLSK_STRING.SANN;
+    !erVirksomhetNorsk ||
+    (trygdeavgiftsgrunnlag?.særligAvgiftsgruppe !== undefined &&
+      trygdeavgiftsgrunnlag?.særligAvgiftsgruppe !== BOOLSK_STRING.SANN);
   const visErSøkerSkattepliktig =
-    visBetalerArbeidsgiverAvgift && trygdeavgiftsgrunnlag?.betalerArbeidsgiverAvgift !== undefined;
+    trygdeavgiftsgrunnlag?.særligAvgiftsgruppe !== undefined &&
+    trygdeavgiftsgrunnlag?.særligAvgiftsgruppe !== BOOLSK_STRING.SANN &&
+    trygdeavgiftsgrunnlag?.betalerArbeidsgiverAvgift !== undefined;
+
+  const erSkattepliktigFastsatt = () => {
+    if (erVirksomhetNorsk) {
+      return trygdeavgiftsgrunnlag?.særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA;
+    }
+    return [MKV.Koder.saerligeavgiftsgrupper.FN, MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA].includes(
+      trygdeavgiftsgrunnlag?.særligAvgiftsgruppe
+    );
+  };
 
   return (
     <div className="vurderingTrygdeavgift__overstrek vurderingTrygdeavgift">
@@ -316,22 +252,9 @@ const TrygdeavgiftsgrunnlagComponent = ({
         {visBetalerArbeidsgiverAvgift && (
           <Nav.Column xs="4">
             <Nav.Fieldset legend="Betaler virksomheten arbeideravgift?">
-              <Skjema.Radio
-                className="column"
-                label="Ja"
-                feltNavn={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
-                value={BOOLSK.SANN}
-                disabled={!redigerbart || betalerArbeidsgiverAvgiftDisabled()}
-                id={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
-              />
-              <Skjema.Radio
-                className="column"
-                label="Nei"
-                feltNavn={`${feltNavnBase}.betalerArbeidsgiverAvgift`}
-                value={BOOLSK.USANN}
-                disabled={!redigerbart || betalerIkkeArbeidsgiverAvgiftDisabled()}
-                id={`${feltNavnBase}.betalerIkkeArbeidsgiverAvgift`}
-              />
+              <Nav.typo.Normaltekst className="ja_nei">
+                {trygdeavgiftsgrunnlag?.betalerArbeidsgiverAvgift ? "Ja" : "Nei"}
+              </Nav.typo.Normaltekst>
             </Nav.Fieldset>
           </Nav.Column>
         )}
@@ -339,22 +262,30 @@ const TrygdeavgiftsgrunnlagComponent = ({
         {visErSøkerSkattepliktig && (
           <Nav.Column xs="4">
             <Nav.Fieldset legend="Er søker skattepliktig?">
-              <Skjema.Radio
-                className="column"
-                label="Ja"
-                feltNavn={`${feltNavnBase}.erSkattepliktig`}
-                value={BOOLSK.SANN}
-                disabled={!redigerbart || erSkattepliktigDisabled()}
-                id={`${feltNavnBase}.erSkattepliktig`}
-              />
-              <Skjema.Radio
-                className="column"
-                label="Nei"
-                feltNavn={`${feltNavnBase}.erSkattepliktig`}
-                value={BOOLSK.USANN}
-                disabled={!redigerbart || erIkkeSkattepliktigDisabled()}
-                id={`${feltNavnBase}.erIkkeSkattepliktig`}
-              />
+              {erSkattepliktigFastsatt() ? (
+                <Nav.typo.Normaltekst className="ja_nei">
+                  {trygdeavgiftsgrunnlag?.erSkattepliktig ? "Ja" : "Nei"}
+                </Nav.typo.Normaltekst>
+              ) : (
+                <Fragment>
+                  <Skjema.Radio
+                    className="column"
+                    label="Ja"
+                    feltNavn={`${feltNavnBase}.erSkattepliktig`}
+                    value={BOOLSK.SANN}
+                    disabled={!redigerbart}
+                    id={`${feltNavnBase}.erSkattepliktig`}
+                  />
+                  <Skjema.Radio
+                    className="column"
+                    label="Nei"
+                    feltNavn={`${feltNavnBase}.erSkattepliktig`}
+                    value={BOOLSK.USANN}
+                    disabled={!redigerbart}
+                    id={`${feltNavnBase}.erIkkeSkattepliktig`}
+                  />
+                </Fragment>
+              )}
             </Nav.Fieldset>
           </Nav.Column>
         )}
@@ -593,8 +524,20 @@ const VurderingTrygdeavgift = ({
     }
     if (særligAvgiftsgruppe === MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA) {
       changeField("avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.betalerArbeidsgiverAvgift", BOOLSK.SANN);
+      changeField("avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge.erSkattepliktig", BOOLSK.USANN);
     }
   }, [formValues?.avgiftsgrunnlag?.trygdeavgiftsgrunnlagNorge?.særligAvgiftsgruppe]);
+
+  useEffect(() => {
+    const særligAvgiftsgruppe = formValues?.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.særligAvgiftsgruppe;
+    if (
+      [MKV.Koder.saerligeavgiftsgrupper.FN, MKV.Koder.saerligeavgiftsgrupper.ARBEIDSTAKER_MALAYSIA].includes(
+        særligAvgiftsgruppe
+      )
+    ) {
+      changeField("avgiftsgrunnlag.trygdeavgiftsgrunnlagUtland.erSkattepliktig", BOOLSK.USANN);
+    }
+  }, [formValues?.avgiftsgrunnlag?.trygdeavgiftsgrunnlagUtland?.særligAvgiftsgruppe]);
 
   function handleAvgiftspliktigLønnInputChange(event: ChangeEvent<HTMLInputElement>, erNorskVirksomhet: boolean) {
     setOppdatertAvgiftsberegning(


### PR DESCRIPTION
Skal være en viss logikk på hvilke kombinasjoner som er gyldige på steget.
- Bytter om rekkefølgen og viser kun neste spørsmål når det forrige er svart(med unntak utland `BetalerArbeidsgiverAvgift` siden det alltid er **nei**)
- `BetalerArbeidsgiverAvgift` er alltid fastsatt (for norsk varierer det etter særlige grupper, mens det for utland alltid er nei)
- `ErSkattepliktig` er fastsatt noen ganger, basert på valgt særlige grupper.

[Gyldige kombinasjoner](https://confluence.adeo.no/display/TEESSI/Lovlige+og+ulovlige+kombinasjoner+for+trygdeavgift+FTRL)
[MELOSYS-4340](https://jira.adeo.no/browse/MELOSYS-4340)