### PR TITLE
Bruker sedLovvalgsperiode der relevant og tar hendsyn til annerledes datoformat

### DIFF
--- a/src/sider/eu_eøs/registrering/anmodningunntak/saksopplysninger.js
+++ b/src/sider/eu_eøs/registrering/anmodningunntak/saksopplysninger.js
@@ -73,7 +73,8 @@ const Saksopplysninger = ({
   const [durationWarningMessage, setDurationWarningMessage] = useState(null);
   const [registreringPending, setRegistreringPending] = useState(false);
 
-  const erGyldigLovvalgsperiode = () => Utils.dato.erGyldigPeriode(sed?.lovvalgsperiode?.fom, sed?.lovvalgsperiode?.tom);
+  const erGyldigLovvalgsperiode = () =>
+    Utils.dato.erGyldigPeriode(sed?.lovvalgsperiode?.fom, sed?.lovvalgsperiode?.tom);
 
   useEffect(() => {
     lastInnSaksopplysninger(saksnummer, behandlingID);

--- a/src/sider/eu_eøs/registrering/anmodningunntak/saksopplysninger.js
+++ b/src/sider/eu_eøs/registrering/anmodningunntak/saksopplysninger.js
@@ -73,7 +73,7 @@ const Saksopplysninger = ({
   const [durationWarningMessage, setDurationWarningMessage] = useState(null);
   const [registreringPending, setRegistreringPending] = useState(false);
 
-  const erGyldigLovvalgsperiode = () => Utils.dato.erGyldigPeriode(sed.lovvalgsperiode);
+  const erGyldigLovvalgsperiode = () => Utils.dato.erGyldigPeriode(sed?.lovvalgsperiode?.fom, sed?.lovvalgsperiode?.tom);
 
   useEffect(() => {
     lastInnSaksopplysninger(saksnummer, behandlingID);

--- a/src/sider/eu_eøs/registrering/unntaksperioder/saksopplysninger.js
+++ b/src/sider/eu_eøs/registrering/unntaksperioder/saksopplysninger.js
@@ -72,7 +72,10 @@ const Saksopplysninger = ({
     lastInnSaksopplysninger(saksnummer, behandlingID);
   }, []);
 
-  const erGyldigLovvalgsperiode = () => Utils.dato.erGyldigPeriode(lovvalgsperiode.fomDato, lovvalgsperiode.tomDato);
+  const erGyldigLovvalgsperiode = () =>
+    !Utils._isEmpty(lovvalgsperiode)
+      ? Utils.dato.erGyldigPeriode(lovvalgsperiode?.fomDato, lovvalgsperiode?.tomDato)
+      : Utils.dato.erGyldigPeriode(sedLovvalgsperiode?.fom, sedLovvalgsperiode?.tom);
 
   const settEndretPeriodeOpplysninger = async (avklartFakta) => {
     setUnntaksperiodeVurdering(KV.Koder.Unntaksperiode.DELVIS_GODKJENT);
@@ -297,7 +300,6 @@ const Saksopplysninger = ({
   };
 
   const endreUnntaksperiodeVurdering = (e) => setUnntaksperiodeVurdering(e.target.value);
-
   const unikRadioButtonGruppeID = uuid();
   return (
     <div>

--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -99,8 +99,8 @@ function formatterKortDatoTilNorsk(kortDato) {
 }
 
 function erGyldigPeriode(fom, tom) {
-  const inputFormat = ["DD.MM.YYYY"];
-  return moment(fom, inputFormat).isSameOrBefore(moment(tom, inputFormat));
+  const inputFormats = ["DD.MM.YYYY", "YYYY-MM-DD"];
+  return moment(fom, inputFormats).isSameOrBefore(moment(tom, inputFormats));
 }
 
 function erIPeriode(fom, tom, dato, inclusivity) {


### PR DESCRIPTION
Validerte alltid feil om SED da periode vil bli lagret som sedLovvalgsperiode

Validerte alltid feil i og med at erGyldigPeriode bare aksepterte formatet vi bruker for visning, men ikke formatet vi i hovedsak behandler datoer på (ISO standard)