### PR TITLE
Melosys 4433 generelle datofelt feilmeldinger

### DIFF
--- a/src/ducks/form/selectors.js
+++ b/src/ducks/form/selectors.js
@@ -384,6 +384,16 @@ export const SoknadErrorsSelector = createSelector(
   }
 );
 
+export const SoknadsperiodeTomErrorsSelector = createSelector(
+  (state) => SoknadenFormSelector(state).syncErrors || {},
+  (errors) => errors?.soknadsperiodeTom?.melding
+);
+
+export const SoknadsperiodeFomErrorsSelector = createSelector(
+  (state) => SoknadenFormSelector(state).syncErrors || {},
+  (errors) => errors?.soknadsperiodeFom?.melding
+);
+
 const finnPanelFeil = (errors) => {
   const panelerOgFeil = Utils.finnVerdierMedKey(errors, "panel", true);
   const unikePanelerMedFeilNavn = Utils._uniqBy(panelerOgFeil, "panel").map(({ panel }) => panel);

--- a/src/ducks/form/selectors.test.js
+++ b/src/ducks/form/selectors.test.js
@@ -25,6 +25,8 @@ describe("FormSelectors", () => {
                   orgnr: "12341234123412341234123412341234",
                 },
               ],
+              soknadsperiodeFom: "01.01.2010",
+              soknadsperiodeTom: "10.01.2020",
             },
             syncErrors: {
               oppgittAdresseGatenavn: {

--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -4,13 +4,13 @@ import * as KV from "../../kodeverk";
 
 import MKV, { Utils as MKVUtils } from "../../melosyskodeverk";
 
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
+
 const lagMelding = (panel, undertittel, melding) => ({
   panel,
   undertittel,
   melding,
 });
-
-const SLUTTDATO_ER_APEN = lagMelding(KV.Menypunkter.Periode.tittel, null, "Sluttdato er åpen");
 
 const erIkkeBeslutningLovvalgAnnetLand = (behandlingstema) =>
   behandlingstema !== MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND;
@@ -183,10 +183,15 @@ const soknad = object().when("$behandlingstema", {
             lagMelding(KV.Menypunkter.Person.tittel, KV.Menypunkter.Person.undertitler.annenAdresse, "Land kreves")
           ),
       }),
-    soknadsperiodeTom: string().when("$behandlingstema", {
-      is: MKVUtils.erUtsendt,
-      then: string().required(SLUTTDATO_ER_APEN),
-    }),
+    soknadsperiodeFom: string().erGyldigDato().required(MAA_FYLLES_UT),
+    soknadsperiodeTom: string()
+      .erGyldigDato()
+      .erEtterDatofelt("soknadsperiodeFom")
+      .when("$behandlingstema", {
+        is: MKVUtils.erUtsendt,
+        then: string().required(MAA_FYLLES_UT),
+      })
+      .nullable(),
     utenlandskIdent: array().of(utenlandskIdent),
     medfolgendeBarn: array().of(medfolgendeBarn),
   }),

--- a/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiode.js
+++ b/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiode.js
@@ -8,6 +8,7 @@ import * as Nav from "../../../../../utils/navFrontend";
 import * as Symboler from "../../symboler";
 
 import { behandlingsgrunnlagSelectors, behandlingsgrunnlagOperations } from "../../../../../ducks/behandlingsgrunnlag";
+import { formSelectors } from "../../../../../ducks/form";
 
 import SoknadsperiodeEndring from "./soknadsperiodeEndring";
 
@@ -16,101 +17,69 @@ import "./soknadsperiode.css";
 export class Soknadsperiode extends Component {
   state = {
     erEndrePeriodeSynlig: false,
-    erPeriodeOppdatertOgGyldig: false,
-    soknadsperiodeNyFom: "",
-    soknadsperiodeNyTom: "",
+    soknadsperiodeFom: this.props.soknadsperiodeFom,
+    soknadsperiodeTom: this.props.soknadsperiodeTom,
+    soknadsperiodeGammelFom: this.props.soknadsperiodeFom,
+    soknadsperiodeGammelTom: this.props.soknadsperiodeTom,
   };
 
-  componentDidUpdate(prevProps) {
-    const { soknadsperiodeFom, soknadsperiodeTom } = this.props;
-    if (prevProps.soknadsperiodeFom === soknadsperiodeFom && prevProps.soknadsperiodeTom === soknadsperiodeTom) {
-      return;
-    }
-
-    this.kopierPeriodeTilLokalState(soknadsperiodeFom, soknadsperiodeTom);
+  componentDidUpdate() {
+    this.oppdaterPeriode(this.state.soknadsperiodeFom, this.state.soknadsperiodeTom);
   }
 
-  kopierPeriodeTilLokalState = (soknadsperiodeNyFom, soknadsperiodeNyTom) => {
-    this.setState((state) => ({
-      ...state,
-      soknadsperiodeNyFom,
-      soknadsperiodeNyTom,
-    }));
-  };
+  componentWillUnmount() {
+    this.oppdaterPeriode(this.state.soknadsperiodeGammelFom, this.state.soknadsperiodeGammelTom);
+  }
 
-  visEndrePeriode = () => {
-    const { soknadsperiodeFom, soknadsperiodeTom } = this.props;
-
-    this.kopierPeriodeTilLokalState(soknadsperiodeFom, soknadsperiodeTom);
-    this.setState({ erEndrePeriodeSynlig: true });
-  };
+  visEndrePeriode = () => this.setState({ erEndrePeriodeSynlig: true });
 
   skjulEndrePeriode = () => this.setState({ erEndrePeriodeSynlig: false });
 
-  oppdaterFelt = (feltNavn, verdi) => {
-    this.setState({ [feltNavn]: verdi });
+  oppdaterFelt = (feltNavn, verdi) => this.setState({ [feltNavn]: verdi });
 
-    const erPeriodeOppdatertOgGyldig =
-      this.validerDato("soknadsperiodeNyFom") && this.validerDato("soknadsperiodeNyTom");
-    this.setState({ erPeriodeOppdatertOgGyldig });
+  oppdaterPeriode = (fom, tom) => {
+    this.props.oppdaterPeriode({
+      fom: fom ? Utils.dato.formatterDatoTilISO(fom) : "",
+      tom: tom ? Utils.dato.formatterDatoTilISO(tom) : "",
+    });
   };
 
-  validerDato = (feltNavn) => {
-    const verdi = this.state[feltNavn];
-    const vasketVerdi = Utils.dato.vaskInputDato(verdi);
-    return vasketVerdi !== false;
+  resetLokalPeriode = () => {
+    const { soknadsperiodeGammelFom, soknadsperiodeGammelTom } = this.state;
+    this.setState({
+      soknadsperiodeFom: soknadsperiodeGammelFom,
+      soknadsperiodeTom: soknadsperiodeGammelTom,
+    });
   };
 
-  validerFelter = () => {
-    const erPeriodeOppdatertOgGyldig =
-      this.vaskOgValiderDato("soknadsperiodeNyFom") &&
-      this.vaskOgValiderDato("soknadsperiodeNyTom") &&
-      Utils.dato.erGyldigPeriode(this.state.soknadsperiodeNyFom, this.state.soknadsperiodeNyTom);
-
-    this.setState({ erPeriodeOppdatertOgGyldig });
-  };
-
-  vaskOgValiderDato = (feltNavn) => {
-    const gyldigDato = this.validerDato(feltNavn);
-    if (gyldigDato) {
-      const verdi = this.state[feltNavn];
-      const vasketVerdi = Utils.dato.vaskInputDato(verdi);
-      this.setState({ [feltNavn]: vasketVerdi });
-    } else {
-      this.setState({ [feltNavn]: "Ugyldig" });
-    }
-    return gyldigDato;
-  };
-
-  oppdaterPeriode = (event) => {
-    event.preventDefault();
-    const { soknadsperiodeNyFom, soknadsperiodeNyTom } = this.state;
-    const periode = {
-      fom: Utils.dato.formatterDatoTilISO(soknadsperiodeNyFom),
-      tom: Utils.dato.formatterDatoTilISO(soknadsperiodeNyTom),
-    };
-    this.props.oppdaterPeriode(periode);
+  lagre = () => {
+    const { soknadsperiodeFom, soknadsperiodeTom } = this.state;
+    this.setState({
+      soknadsperiodeGammelFom: soknadsperiodeFom,
+      soknadsperiodeGammelTom: soknadsperiodeTom,
+    });
+    this.oppdaterPeriode(soknadsperiodeFom, soknadsperiodeTom);
     // Todo: Denne er hacky. Bakgrunn: oppdatert soknad rekker ikke å re-propagate til parent før
     // funksjonen nedenfor kalles. Vurder å skrive om til en async await-aktig løsning.
     setTimeout(() => this.props.lagreSoknadOgOppfriskSaksopplysninger(), 0);
   };
 
-  avbryt = (event) => {
-    event.preventDefault();
-    const { soknadsperiodeFom, soknadsperiodeTom } = this.props;
-    this.setState((state) => ({
-      ...state,
-      soknadsperiodeNyFom: soknadsperiodeFom,
-      soknadsperiodeNyTom: soknadsperiodeTom,
-    }));
+  avbryt = () => {
+    this.resetLokalPeriode();
     this.skjulEndrePeriode();
   };
 
   render() {
-    const { redigerbart, soknadsperiodeFom, soknadsperiodeTom } = this.props;
-    const { visEndrePeriode, skjulEndrePeriode, validerFelter, oppdaterPeriode, oppdaterFelt, avbryt } = this;
+    const {
+      redigerbart,
+      soknadsperiodeFom,
+      soknadsperiodeTom,
+      soknadsperiodeFomErrors,
+      soknadsperiodeTomErrors,
+    } = this.props;
+    const { visEndrePeriode, skjulEndrePeriode, lagre, oppdaterFelt, avbryt } = this;
 
-    const { erEndrePeriodeSynlig, soknadsperiodeNyFom, soknadsperiodeNyTom } = this.state;
+    const { erEndrePeriodeSynlig } = this.state;
 
     return (
       <div className="soknadsperiode">
@@ -125,13 +94,13 @@ export class Soknadsperiode extends Component {
         )}
         {erEndrePeriodeSynlig && (
           <SoknadsperiodeEndring
-            soknadsperiodeNyFom={soknadsperiodeNyFom}
-            soknadsperiodeNyTom={soknadsperiodeNyTom}
+            soknadsperiodeFom={soknadsperiodeFom}
+            soknadsperiodeTom={soknadsperiodeTom}
+            soknadsperiodeFomErrors={soknadsperiodeFomErrors}
+            soknadsperiodeTomErrors={soknadsperiodeTomErrors}
             skjulEndrePeriode={skjulEndrePeriode}
-            oppdaterPeriode={oppdaterPeriode}
+            lagre={lagre}
             vedFeltEndring={oppdaterFelt}
-            vedFeltFokusUt={validerFelter}
-            erDatoerGyldig={this.state.erPeriodeOppdatertOgGyldig}
             avbryt={avbryt}
           />
         )}
@@ -146,11 +115,20 @@ Soknadsperiode.propTypes = {
   lagreSoknadOgOppfriskSaksopplysninger: PT.func.isRequired,
   soknadsperiodeFom: PT.string.isRequired,
   soknadsperiodeTom: PT.string.isRequired,
+  soknadsperiodeFomErrors: PT.string,
+  soknadsperiodeTomErrors: PT.string,
+};
+
+Soknadsperiode.defaultProps = {
+  soknadsperiodeFomErrors: undefined,
+  soknadsperiodeTomErrors: undefined,
 };
 
 const mapStateToProps = (state) => ({
   soknadsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingsgrunnlagSelectors.PeriodeSelector(state).fom),
   soknadsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingsgrunnlagSelectors.PeriodeSelector(state).tom),
+  soknadsperiodeFomErrors: formSelectors.SoknadsperiodeFomErrorsSelector(state),
+  soknadsperiodeTomErrors: formSelectors.SoknadsperiodeTomErrorsSelector(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiode.test.js
+++ b/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiode.test.js
@@ -39,7 +39,7 @@ describe("Soknadsperiode", () => {
 
     expect(soknadsperiodeEndring).toHaveLength(1);
 
-    expect(soknadsperiodeEndringProps.soknadsperiodeNyFom).toBe(props.soknadsperiodeFom);
-    expect(soknadsperiodeEndringProps.soknadsperiodeNyTom).toBe(props.soknadsperiodeTom);
+    expect(soknadsperiodeEndringProps.soknadsperiodeFom).toBe(props.soknadsperiodeFom);
+    expect(soknadsperiodeEndringProps.soknadsperiodeTom).toBe(props.soknadsperiodeTom);
   });
 });

--- a/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiodeEndring.js
+++ b/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiodeEndring.js
@@ -13,19 +13,17 @@ import * as Utils from "../../../../../utils/dato";
 
 const SoknadsperiodeEndring = (props) => {
   const {
-    soknadsperiodeNyFom,
-    soknadsperiodeNyTom,
+    soknadsperiodeFom,
+    soknadsperiodeTom,
+    soknadsperiodeFomErrors,
+    soknadsperiodeTomErrors,
     vedFeltEndring,
     avbryt,
-    oppdaterPeriode,
-    vedFeltFokusUt,
-    erDatoerGyldig,
+    lagre,
   } = props;
 
-  const vedFomEndring = (nyDato) => vedFeltEndring("soknadsperiodeNyFom", Utils.dateTilNorskString(nyDato));
-  const vedTomEndring = (nyDato) => vedFeltEndring("soknadsperiodeNyTom", Utils.dateTilNorskString(nyDato));
-  const vedFomFokusUt = () => vedFeltFokusUt("soknadsperiodeNyFom");
-  const vedTomFokusUt = () => vedFeltFokusUt("soknadsperiodeNyTom");
+  const vedFomEndring = (nyDato) => vedFeltEndring("soknadsperiodeFom", Utils.dateTilNorskString(nyDato));
+  const vedTomEndring = (nyDato) => vedFeltEndring("soknadsperiodeTom", Utils.dateTilNorskString(nyDato));
 
   return (
     <Nav.Fieldset legend="">
@@ -36,19 +34,19 @@ const SoknadsperiodeEndring = (props) => {
               status === "enabled" ? (
                 <Datovelger
                   label="Fra og med:"
-                  value={Utils.norskStringTilDate(soknadsperiodeNyFom)}
+                  value={Utils.norskStringTilDate(soknadsperiodeFom)}
                   onChange={vedFomEndring}
-                  onBlur={vedFomFokusUt}
                   bredde="S"
-                  maxDate={Utils.norskStringTilDate(soknadsperiodeNyTom)}
+                  maxDate={Utils.norskStringTilDate(soknadsperiodeTom)}
+                  feil={soknadsperiodeFomErrors}
                 />
               ) : (
                 <Nav.Input
                   bredde="S"
                   label="Fra og med:"
-                  value={soknadsperiodeNyFom}
-                  onChange={(event) => vedFeltEndring("soknadsperiodeNyFom", event.target.value)}
-                  onBlur={() => vedFeltFokusUt("soknadsperiodeNyFom")}
+                  value={soknadsperiodeFom}
+                  onChange={(event) => vedFeltEndring("soknadsperiodeFom", event.target.value)}
+                  feil={soknadsperiodeFomErrors && { feilmelding: soknadsperiodeFomErrors }}
                 />
               )
             }
@@ -60,19 +58,19 @@ const SoknadsperiodeEndring = (props) => {
               status === "enabled" ? (
                 <Datovelger
                   label="Til og med:"
-                  value={Utils.norskStringTilDate(soknadsperiodeNyTom)}
+                  value={Utils.norskStringTilDate(soknadsperiodeTom)}
                   onChange={vedTomEndring}
-                  onBlur={vedTomFokusUt}
                   bredde="S"
-                  minDate={Utils.norskStringTilDate(soknadsperiodeNyFom)}
+                  minDate={Utils.norskStringTilDate(soknadsperiodeFom)}
+                  feil={soknadsperiodeTomErrors}
                 />
               ) : (
                 <Nav.Input
                   bredde="S"
                   label="Til og med:"
-                  value={soknadsperiodeNyTom}
-                  onChange={(event) => vedFeltEndring("soknadsperiodeNyTom", event.target.value)}
-                  onBlur={() => vedFeltFokusUt("soknadsperiodeNyTom")}
+                  value={soknadsperiodeTom}
+                  onChange={(event) => vedFeltEndring("soknadsperiodeTom", event.target.value)}
+                  feil={soknadsperiodeTomErrors && { feilmelding: soknadsperiodeTomErrors }}
                 />
               )
             }
@@ -85,10 +83,10 @@ const SoknadsperiodeEndring = (props) => {
             capitalCase
             avbryt={avbryt}
             avbrytTekst="Avbryt"
-            bekreft={oppdaterPeriode}
+            bekreft={lagre}
             bekreftTekst="Lagre"
             redigerbart
-            bekreftRedigerbart={erDatoerGyldig}
+            bekreftRedigerbart={!soknadsperiodeTomErrors && !soknadsperiodeFomErrors}
           />
         </Nav.Column>
       </Nav.Row>
@@ -98,12 +96,17 @@ const SoknadsperiodeEndring = (props) => {
 
 SoknadsperiodeEndring.propTypes = {
   avbryt: PT.func.isRequired,
-  oppdaterPeriode: PT.func.isRequired,
-  soknadsperiodeNyFom: PT.string.isRequired,
-  soknadsperiodeNyTom: PT.string.isRequired,
+  lagre: PT.func.isRequired,
+  soknadsperiodeFom: PT.string.isRequired,
+  soknadsperiodeTom: PT.string.isRequired,
+  soknadsperiodeFomErrors: PT.string,
+  soknadsperiodeTomErrors: PT.string,
   vedFeltEndring: PT.func.isRequired,
-  vedFeltFokusUt: PT.func.isRequired,
-  erDatoerGyldig: PT.bool.isRequired,
+};
+
+SoknadsperiodeEndring.defaultProps = {
+  soknadsperiodeFomErrors: undefined,
+  soknadsperiodeTomErrors: undefined,
 };
 
 export default SoknadsperiodeEndring;

--- a/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiodeEndring.test.js
+++ b/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiodeEndring.test.js
@@ -7,12 +7,12 @@ import SoknadsperiodeEndring from "./soknadsperiodeEndring";
 describe("SoknadsperiodeEndring", () => {
   const lagProps = () => ({
     avbryt: jest.fn(),
-    oppdaterPeriode: jest.fn(),
-    soknadsperiodeNyFom: "11.12.2030",
-    soknadsperiodeNyTom: "11.12.2035",
+    lagre: jest.fn(),
+    soknadsperiodeFom: "11.12.2030",
+    soknadsperiodeTom: "11.12.2035",
+    soknadsperiodeFomErrors: undefined,
+    soknadsperiodeTomErrors: undefined,
     vedFeltEndring: jest.fn(),
-    vedFeltFokusUt: jest.fn(),
-    erDatoerGyldig: true,
   });
 
   // TODO: Fjern kommentar etter featuretoggle melosys.input.DATOFELT er fjernet. (Skip funket ikke for some reason)
@@ -26,23 +26,15 @@ describe("SoknadsperiodeEndring", () => {
 
     it("vises", () => {
       expect(fomInput).toHaveLength(1);
-      expect(fomInputProps.value).toBe(props.soknadsperiodeNyFom);
+      expect(fomInputProps.value).toStrictEqual(Utils.dato.norskStringTilDate(props.soknadsperiodeFom));
     });
 
     it("kaller vedFeltEndring ved change", () => {
-      const event = { target: { value: "Verdi" } };
-      fomInput.simulate("change", event);
+      const nyDato = "01.01.2011"
+      fomInput.simulate("change", Utils.dato.norskStringTilDate(nyDato));
 
       expect(props.vedFeltEndring).toHaveBeenCalledTimes(1);
-      expect(props.vedFeltEndring).toHaveBeenLastCalledWith("soknadsperiodeNyFom", "Verdi");
-    });
-
-    it("kaller vedFeltFokusUt ved blur", () => {
-      const event = { target: { value: "Verdi" } };
-      fomInput.simulate("blur", event);
-
-      expect(props.vedFeltFokusUt).toHaveBeenCalledTimes(1);
-      expect(props.vedFeltFokusUt).toHaveBeenLastCalledWith("soknadsperiodeNyFom");
+      expect(props.vedFeltEndring).toHaveBeenLastCalledWith("soknadsperiodeFom", nyDato);
     });
   });
 
@@ -56,23 +48,15 @@ describe("SoknadsperiodeEndring", () => {
 
     it("vises", () => {
       expect(tomInput).toHaveLength(1);
-      expect(tomInputProps.value).toBe(props.soknadsperiodeNyTom);
+      expect(tomInputProps.value).toStrictEqual(Utils.dato.norskStringTilDate(props.soknadsperiodeTom));
     });
 
     it("kaller vedFeltEndring ved change", () => {
-      const event = { target: { value: "Verdi" } };
-      tomInput.simulate("change", event);
+      const nyDato = "02.02.2012"
+      tomInput.simulate("change", Utils.dato.norskStringTilDate(nyDato));
 
       expect(props.vedFeltEndring).toHaveBeenCalledTimes(1);
-      expect(props.vedFeltEndring).toHaveBeenLastCalledWith("soknadsperiodeNyTom", "Verdi");
-    });
-
-    it("kaller vedFeltFokusUt ved blur", () => {
-      const event = { target: { value: "Verdi" } };
-      tomInput.simulate("blur", event);
-
-      expect(props.vedFeltFokusUt).toHaveBeenCalledTimes(1);
-      expect(props.vedFeltFokusUt).toHaveBeenLastCalledWith("soknadsperiodeNyTom");
+      expect(props.vedFeltEndring).toHaveBeenLastCalledWith("soknadsperiodeTom", nyDato);
     });
   }); */
 
@@ -86,13 +70,43 @@ describe("SoknadsperiodeEndring", () => {
       expect(knappeRad).toHaveLength(1);
     });
 
-    it("får props for å oppdatere periode", () => {
-      expect(knapperadProps.bekreft).toBe(props.oppdaterPeriode);
-      expect(knapperadProps.bekreftRedigerbart).toBe(props.erDatoerGyldig);
+    it("får props for å lagre periode", () => {
+      expect(knapperadProps.bekreft).toBe(props.lagre);
     });
 
     it("får props for å avbryte endring av periode", () => {
       expect(knapperadProps.avbryt).toBe(props.avbryt);
+    });
+  });
+
+  describe("Lagreknapp", () => {
+    it("kan trykkes på", () => {
+      const props = lagProps();
+      const soknadsperiodeEndring = shallow(<SoknadsperiodeEndring {...props} />);
+      const knappeRad = soknadsperiodeEndring.find(Knapperad);
+      const knapperadProps = knappeRad.props();
+
+      expect(knapperadProps.bekreftRedigerbart).toBe(true);
+    });
+
+    it("kan ikke trykkes på når fom har errors", () => {
+      const props = lagProps();
+      props.soknadsperiodeFomErrors = "Feil skjedde";
+      const soknadsperiodeEndring = shallow(<SoknadsperiodeEndring {...props} />);
+      const knappeRad = soknadsperiodeEndring.find(Knapperad);
+      const knapperadProps = knappeRad.props();
+
+      expect(knapperadProps.bekreftRedigerbart).toBe(false);
+    });
+
+    it("kan ikke trykkes på når tom har errors", () => {
+      const props = lagProps();
+      props.soknadsperiodeTomErrors = "Feil skjedde";
+      const soknadsperiodeEndring = shallow(<SoknadsperiodeEndring {...props} />);
+      const knappeRad = soknadsperiodeEndring.find(Knapperad);
+      const knapperadProps = knappeRad.props();
+
+      expect(knapperadProps.bekreftRedigerbart).toBe(false);
     });
   });
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingPerioderSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingPerioderSchema.js
@@ -30,17 +30,9 @@ const erFeilAktivPaaPerioder = (medlemskapsperioder) =>
 
 const erDatoGyldig = (dato) => (Utils._isEmpty(dato) ? true : Utils.dato.vaskInputDato(dato));
 
-const gyldigFomDatoTest = {
-  name: "Gyldig fomDato",
-  message: "Dato er utenfor søknadsperioden",
-  test: (dato, schema) =>
-    erDatoGyldig(dato) &&
-    Utils.dato.erGyldigPeriode(Utils.dato.formatterDatoTilNorsk(schema.options.context.soknadsperiode.fom), dato),
-};
-
 const gyldigTomDatoTest = {
   name: "Gyldig tomDato",
-  message: "Dato er utenfor søknadsperioden",
+  message: "Utenfor søknadsperioden",
   test: (tomDato, schema) => {
     const tomDatoFraSoknadsperiode = schema.options.context.soknadsperiode.tom;
     const medlemskapsperioder = schema.options.context.formValues?.medlemskapsperioder;
@@ -61,7 +53,7 @@ const vurdering_perioder = object().shape({
       object().shape({
         id: string().required(),
         arbeidsland: string(),
-        fomDato: string().erGyldigDato().test(gyldigFomDatoTest).required(MAA_FYLLES_UT),
+        fomDato: string().erGyldigDato().erInnenforSoknadsperioden().required(MAA_FYLLES_UT),
         tomDato: string().erGyldigDato().erEtterDatofelt("fomDato").test(gyldigTomDatoTest).nullable(),
         bestemmelse: string(),
         innvilgelsesResultat: string().required(INNGILGELSESRESULTAT_FELT_KREVES),

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingPerioderSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingPerioderSchema.js
@@ -2,7 +2,7 @@ import { object, string, array } from "yup";
 import * as KV from "../../../../kodeverk";
 import * as Utils from "../../../../utils";
 
-const FOM_FELT_KREVES = { melding: "Må fylles ut" };
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 const INNGILGELSESRESULTAT_FELT_KREVES = { melding: "Du må velge innvilgelsesresultat" };
 const TRYGDEDEKNING_FELT_KREVES = { melding: "Du må velge trygdedekning" };
 
@@ -29,12 +29,6 @@ const erFeilAktivPaaPerioder = (medlemskapsperioder) =>
   medlemskapsperioder && medlemskapsperioder.some((medlemskapsperiode) => !!medlemskapsperiode.feil);
 
 const erDatoGyldig = (dato) => (Utils._isEmpty(dato) ? true : Utils.dato.vaskInputDato(dato));
-
-const gyldigDatoTest = {
-  name: "Gyldig dato",
-  message: "Skriv inn en gyldig dato",
-  test: (dato) => erDatoGyldig(dato),
-};
 
 const gyldigFomDatoTest = {
   name: "Gyldig fomDato",
@@ -67,8 +61,8 @@ const vurdering_perioder = object().shape({
       object().shape({
         id: string().required(),
         arbeidsland: string(),
-        fomDato: string().test(gyldigDatoTest).test(gyldigFomDatoTest).required(FOM_FELT_KREVES),
-        tomDato: string().test(gyldigDatoTest).test(gyldigTomDatoTest).nullable(),
+        fomDato: string().erGyldigDato().test(gyldigFomDatoTest).required(MAA_FYLLES_UT),
+        tomDato: string().erGyldigDato().erEtterDatofelt("fomDato").test(gyldigTomDatoTest).nullable(),
         bestemmelse: string(),
         innvilgelsesResultat: string().required(INNGILGELSESRESULTAT_FELT_KREVES),
         trygdedekning: string().required(TRYGDEDEKNING_FELT_KREVES),

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingStartSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingStartSchema.js
@@ -1,33 +1,13 @@
 import { object, string } from "yup";
-import * as Utils from "../../../../utils";
+import * as KV from "../../../../kodeverk";
 
-const FOM_FELT_KREVES = { melding: "Må fylles ut" };
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 const ARBEIDSLAND_FELT_KREVES = { melding: "Du må velge arbeidsland" };
 const TRYGDEDEKNING_FELT_KREVES = { melding: "Du må velge trygdedekning" };
 
-const erDatoGyldig = (dato) => (Utils._isEmpty(dato) ? true : Utils.dato.vaskInputDato(dato));
-
-const gyldigDatoTest = {
-  name: "Gyldig dato",
-  message: "Skriv inn en gyldig dato",
-  test: erDatoGyldig,
-};
-
-function erPeriodeGyldig(tom) {
-  const { fom } = this.options.parent;
-  if (!erDatoGyldig(fom) || !erDatoGyldig(tom)) return true;
-  return !fom || !tom || Utils.dato.erGyldigPeriode(fom, tom);
-}
-
-const gyldigPeriodeTest = {
-  name: "Gyldig periode",
-  message: "Tidligere enn f.o.m.-dato",
-  test: erPeriodeGyldig,
-};
-
 const vurdering_start = object().shape({
-  fom: string().test(gyldigDatoTest).required(FOM_FELT_KREVES),
-  tom: string().test(gyldigDatoTest).test(gyldigPeriodeTest).nullable(),
+  fom: string().erGyldigDato().required(MAA_FYLLES_UT),
+  tom: string().erGyldigDato().erEtterDatofelt("fom").nullable(),
   land: string().required(ARBEIDSLAND_FELT_KREVES),
   trygdedekning: string().required(TRYGDEDEKNING_FELT_KREVES),
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtakSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtakSchema.js
@@ -16,9 +16,13 @@ const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 const arbeid_ett_land_ovrig_vedtak = object().shape({
   lovvalgsbestemmelse: string().nullable().required(VELG_EN_BESTEMMELSE),
   forkortLovvalgsperiode: bool().required(),
+  fomDato: string().when("forkortLovvalgsperiode", {
+    is: true,
+    then: string().erInnenforSoknadsperioden().erGyldigDato().required(MAA_FYLLES_UT),
+  }),
   tomDato: string().when("forkortLovvalgsperiode", {
     is: true,
-    then: string().erInnenforSoknadsperioden().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
+    then: string().erInnenforSoknadsperioden().erEtterDatofelt("fomDato").erGyldigDato().required(MAA_FYLLES_UT),
   }),
   vedtakstype: string()
     .nullable()

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtakSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtakSchema.js
@@ -18,7 +18,7 @@ const arbeid_ett_land_ovrig_vedtak = object().shape({
   forkortLovvalgsperiode: bool().required(),
   tomDato: string().when("forkortLovvalgsperiode", {
     is: true,
-    then: string().endretPeriodeErGyldig().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
+    then: string().erInnenforSoknadsperioden().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
   }),
   vedtakstype: string()
     .nullable()

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtakSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidEttLandOvrigVedtakSchema.js
@@ -1,6 +1,7 @@
 import { object, string, bool, array } from "yup";
 
 import MKV from "../../../melosyskodeverk";
+import * as KV from "../../../kodeverk";
 
 const VELG_EN_BESTEMMELSE = "Velg en bestemmelse.";
 const VELG_EN_VEDTAKSTYPE = { melding: "Velg en vedtakstype" };
@@ -10,16 +11,14 @@ const VELG_OM_UTENLANDSK_TRYGDEMYNDIGHET_SKAL_INFORMERES = {
   melding: "Velg om utenlandsk trygdemyndighet skal informeres",
 };
 const VELG_LAND = { melding: "Velg land" };
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 
 const arbeid_ett_land_ovrig_vedtak = object().shape({
   lovvalgsbestemmelse: string().nullable().required(VELG_EN_BESTEMMELSE),
   forkortLovvalgsperiode: bool().required(),
   tomDato: string().when("forkortLovvalgsperiode", {
     is: true,
-    then: string()
-      .endretPeriodeErGyldig({ melding: "Ugyldig periode" })
-      .erGyldigDato({ melding: "Gyldig dato kreves" })
-      .required({ melding: "Dato kreves" }),
+    then: string().endretPeriodeErGyldig().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
   }),
   vedtakstype: string()
     .nullable()

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13UtpekLandSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13UtpekLandSchema.js
@@ -1,17 +1,16 @@
 import { object, string, bool, array } from "yup";
+import * as KV from "../../../kodeverk";
 
 const MOTTAKERINSTITUSJON_KREVES = { melding: "Mottakerinstitusjon kreves" };
 const LOVVALGSLAND_KREVES = { melding: "Lovvalgsland kreves" };
 const OPPGI_ET_LAND = { melding: "Oppgi et land." };
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 
 const artikkel13_utpek = object().shape({
   forkortUtpekingsperiode: bool().required(),
   tomDato: string().when("forkortUtpekingsperiode", {
     is: true,
-    then: string()
-      .endretPeriodeErGyldig({ melding: "Ugyldig periode" })
-      .erGyldigDato({ melding: "Gyldig dato kreves" })
-      .required({ melding: "Dato kreves" }),
+    then: string().endretPeriodeErGyldig().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
   }),
   kreverMottakerinstitusjon: bool().required(),
   mottakerinstitusjoner: array().of(

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13UtpekLandSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13UtpekLandSchema.js
@@ -10,7 +10,7 @@ const artikkel13_utpek = object().shape({
   forkortUtpekingsperiode: bool().required(),
   tomDato: string().when("forkortUtpekingsperiode", {
     is: true,
-    then: string().endretPeriodeErGyldig().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
+    then: string().erInnenforSoknadsperioden().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
   }),
   kreverMottakerinstitusjon: bool().required(),
   mottakerinstitusjoner: array().of(

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13UtpekLandSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13UtpekLandSchema.js
@@ -8,9 +8,13 @@ const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 
 const artikkel13_utpek = object().shape({
   forkortUtpekingsperiode: bool().required(),
+  fomDato: string().when("forkortUtpekingsperiode", {
+    is: true,
+    then: string().erInnenforSoknadsperioden().erGyldigDato().required(MAA_FYLLES_UT),
+  }),
   tomDato: string().when("forkortUtpekingsperiode", {
     is: true,
-    then: string().erInnenforSoknadsperioden().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
+    then: string().erInnenforSoknadsperioden().erEtterDatofelt("fomDato").erGyldigDato().required(MAA_FYLLES_UT),
   }),
   kreverMottakerinstitusjon: bool().required(),
   mottakerinstitusjoner: array().of(

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13_x_vedtakSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13_x_vedtakSchema.js
@@ -10,9 +10,13 @@ const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 
 const artikkel13_x_vedtak = object().shape({
   forkortLovvalgsperiode: bool().required(),
+  fomDato: string().when("forkortLovvalgsperiode", {
+    is: true,
+    then: string().erInnenforSoknadsperioden().erGyldigDato().required(MAA_FYLLES_UT),
+  }),
   tomDato: string().when("forkortLovvalgsperiode", {
     is: true,
-    then: string().erInnenforSoknadsperioden().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
+    then: string().erInnenforSoknadsperioden().erEtterDatofelt("fomDato").erGyldigDato().required(MAA_FYLLES_UT),
   }),
   vedtakstype: string()
     .nullable()

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13_x_vedtakSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13_x_vedtakSchema.js
@@ -1,19 +1,18 @@
 import { object, string, bool, array } from "yup";
 
 import MKV from "../../../melosyskodeverk";
+import * as KV from "../../../kodeverk";
 
 const VELG_EN_VEDTAKSTYPE = { melding: "Velg en vedtakstype" };
 const OPPGI_BEGRUNNELSE = { melding: "Oppgi begrunnelse" };
 const MOTTAKERINSTITUSJON_KREVES = { melding: "Mottaker institusjon kreves" };
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 
 const artikkel13_x_vedtak = object().shape({
   forkortLovvalgsperiode: bool().required(),
   tomDato: string().when("forkortLovvalgsperiode", {
     is: true,
-    then: string()
-      .endretPeriodeErGyldig({ melding: "Ugyldig periode" })
-      .erGyldigDato({ melding: "Gyldig dato kreves" })
-      .required({ melding: "Dato kreves" }),
+    then: string().endretPeriodeErGyldig().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
   }),
   vedtakstype: string()
     .nullable()

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13_x_vedtakSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel13_x_vedtakSchema.js
@@ -12,7 +12,7 @@ const artikkel13_x_vedtak = object().shape({
   forkortLovvalgsperiode: bool().required(),
   tomDato: string().when("forkortLovvalgsperiode", {
     is: true,
-    then: string().endretPeriodeErGyldig().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
+    then: string().erInnenforSoknadsperioden().erEtterDatofelt().erGyldigDato().required(MAA_FYLLES_UT),
   }),
   vedtakstype: string()
     .nullable()

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16MottaSvarSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16MottaSvarSchema.js
@@ -5,18 +5,13 @@ import * as KV from "../../../kodeverk";
 
 const { DELVIS_INNVILGELSE } = MKV.Koder.anmodningsperiodesvartyper;
 const { MAA_FYLLES_UT } = KV.Feilmeldinger;
-const UGYLDIG_PERIODE = { melding: "Endret periode er utenfor opprinnelig periode" };
 
 const artikkel16_motta_svar = object().shape({
   endretPeriode: object().when("$anmodningsperiodeSvarType", {
     is: DELVIS_INNVILGELSE,
     then: object().shape({
-      fom: string().erGyldigDato().endretPeriodeErGyldig(UGYLDIG_PERIODE).required(MAA_FYLLES_UT),
-      tom: string()
-        .erGyldigDato()
-        .endretPeriodeErGyldig(UGYLDIG_PERIODE)
-        .erEtterDatofelt("fom")
-        .required(MAA_FYLLES_UT),
+      fom: string().erGyldigDato().erInnenforSoknadsperioden().required(MAA_FYLLES_UT),
+      tom: string().erGyldigDato().erInnenforSoknadsperioden().erEtterDatofelt("fom").required(MAA_FYLLES_UT),
     }),
   }),
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16MottaSvarSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16MottaSvarSchema.js
@@ -1,43 +1,22 @@
 import { object, string } from "yup";
 
-import * as Utils from "../../../utils";
-
 import MKV from "../../../melosyskodeverk";
+import * as KV from "../../../kodeverk";
 
 const { DELVIS_INNVILGELSE } = MKV.Koder.anmodningsperiodesvartyper;
-
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 const UGYLDIG_PERIODE = { melding: "Endret periode er utenfor opprinnelig periode" };
 
 const artikkel16_motta_svar = object().shape({
   endretPeriode: object().when("$anmodningsperiodeSvarType", {
     is: DELVIS_INNVILGELSE,
     then: object().shape({
-      fom: string()
-        .test("Er innenfor soknadsperiode", UGYLDIG_PERIODE, (value, { options }) => {
-          const { soknadsperiode } = options.context;
-
-          return Utils.dato.erIPeriode(
-            soknadsperiode.fom,
-            soknadsperiode.tom,
-            Utils.dato.formatterDatoTilISO(value),
-            "[]"
-          );
-        })
-        .erGyldigDato({ melding: "Ugyldig dato" })
-        .required({ melding: "dato kreves" }),
+      fom: string().erGyldigDato().endretPeriodeErGyldig(UGYLDIG_PERIODE).required(MAA_FYLLES_UT),
       tom: string()
-        .test("Er innenfor soknadsperiode", UGYLDIG_PERIODE, (value, { options }) => {
-          const { soknadsperiode } = options.context;
-
-          return Utils.dato.erIPeriode(
-            soknadsperiode.fom,
-            soknadsperiode.tom,
-            Utils.dato.formatterDatoTilISO(value),
-            "[]"
-          );
-        })
-        .erGyldigDato({ melding: "Ugyldig dato" })
-        .required({ melding: "dato kreves" }),
+        .erGyldigDato()
+        .endretPeriodeErGyldig(UGYLDIG_PERIODE)
+        .erEtterDatofelt("fom")
+        .required(MAA_FYLLES_UT),
     }),
   }),
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16VedtakSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArtikkel16VedtakSchema.js
@@ -7,8 +7,7 @@ import MKV from "../../../melosyskodeverk";
 
 const VELG_EN_VEDTAKSTYPE = { melding: "Velg en vedtakstype" };
 const OPPGI_BEGRUNNELSE = { melding: "Oppgi begrunnelse" };
-const SKRIV_INN_GYLDIG_DATO = { melding: "Skriv inn en gyldig dato" };
-const MAA_FYLLES_UT = { melding: "Må fylles ut" };
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 
 const {
   TIDLIGERE_ENN_OPPRINNELIG_FOM,
@@ -75,7 +74,7 @@ const artikkel16_vedtak = object().shape({
       .test(erEtterOpprinneligFomTest)
       .test(erFoerOpprinneligTomTest)
       .test(erFoerTomTest)
-      .erGyldigDato(SKRIV_INN_GYLDIG_DATO)
+      .erGyldigDato()
       .required(MAA_FYLLES_UT),
   }),
   tomDato: string().when("forkortLovvalgsperiode", {
@@ -84,7 +83,7 @@ const artikkel16_vedtak = object().shape({
       .test(erEtterOpprinneligFomTest)
       .test(erFoerOpprinneligTomTest)
       .test(erEtterFomTest)
-      .erGyldigDato(SKRIV_INN_GYLDIG_DATO)
+      .erGyldigDato()
       .required(MAA_FYLLES_UT),
   }),
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpektSchema.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingUtpektSchema.js
@@ -1,11 +1,11 @@
 import { string, object } from "yup";
+import * as KV from "../../../kodeverk";
 
-const TAST_INN_DATO = { melding: "Tast inn dato" };
-const SKRIV_INN_EN_GYLDIG_DATO = { melding: "Skriv inn en gyldig dato" };
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 
 const vurder_utpeking = object().shape({
-  fom: string().erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO).required(TAST_INN_DATO),
-  tom: string().erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO).required(TAST_INN_DATO),
+  fom: string().erGyldigDato().required(MAA_FYLLES_UT),
+  tom: string().erGyldigDato().erEtterDatofelt("fom").required(MAA_FYLLES_UT),
 });
 
 export default vurder_utpeking;

--- a/src/kodeverk/feilmeldinger.js
+++ b/src/kodeverk/feilmeldinger.js
@@ -3,5 +3,5 @@ export const SENERE_ENN_OPPRINNELIG_TOM = { melding: "Senere enn opprinnelig t.o
 export const TIDLIGERE_ENN_FOM = { melding: "Tidligere enn f.o.m.-dato" };
 export const SENERE_ENN_TOM = { melding: "Senere enn t.o.m.-dato" };
 export const GYLDIG_DATO = { melding: "Skriv inn en gyldig dato" };
-export const UGYLDIG_PERIODE = { melding: "Ugyldig periode" };
+export const UTENFOR_SOKNADSPERIODEN = { melding: "Utenfor søknadsperioden" };
 export const MAA_FYLLES_UT = { melding: "Må fylles ut" };

--- a/src/kodeverk/feilmeldinger.js
+++ b/src/kodeverk/feilmeldinger.js
@@ -2,3 +2,6 @@ export const TIDLIGERE_ENN_OPPRINNELIG_FOM = { melding: "Tidligere enn opprinnel
 export const SENERE_ENN_OPPRINNELIG_TOM = { melding: "Senere enn opprinnelig t.o.m.-dato" };
 export const TIDLIGERE_ENN_FOM = { melding: "Tidligere enn f.o.m.-dato" };
 export const SENERE_ENN_TOM = { melding: "Senere enn t.o.m.-dato" };
+export const GYLDIG_DATO = { melding: "Skriv inn en gyldig dato" };
+export const UGYLDIG_PERIODE = { melding: "Ugyldig periode" };
+export const MAA_FYLLES_UT = { melding: "Må fylles ut" };

--- a/src/setupYup.js
+++ b/src/setupYup.js
@@ -5,7 +5,7 @@ import * as Utils from "./utils";
 import MKV from "./melosyskodeverk";
 import * as KV from "./kodeverk";
 
-const { TIDLIGERE_ENN_FOM, GYLDIG_DATO, UGYLDIG_PERIODE } = KV.Feilmeldinger;
+const { TIDLIGERE_ENN_FOM, GYLDIG_DATO, UTENFOR_SOKNADSPERIODEN } = KV.Feilmeldinger;
 
 /* eslint-disable func-names */
 /* eslint-disable prefer-arrow-callback */
@@ -40,21 +40,22 @@ addMethod(string, "erGyldigDato", function (message = GYLDIG_DATO) {
   });
 });
 
-addMethod(string, "endretPeriodeErGyldig", function (message = UGYLDIG_PERIODE) {
-  return this.test("periode er gyldig", message, function (value) {
+addMethod(string, "erInnenforSoknadsperioden", function (message = UTENFOR_SOKNADSPERIODEN) {
+  return this.test("dato er innenfor soknadsperioden", message, function (value) {
     const { soknadsperiode } = this.options.context;
 
-    /** Hvis åpen periode, ikke valider perioden */
-    if (!soknadsperiode.tom) return true;
+    if (Utils._isEmpty(value) || !Utils.dato.vaskInputDato(value)) return true;
 
-    if (value === "") return false;
+    if (Utils._isEmpty(soknadsperiode.tom)) {
+      return Utils.dato.erGyldigPeriode(Utils.dato.formatterDatoTilNorsk(soknadsperiode.fom), value);
+    }
 
     return Utils.dato.erIPeriode(soknadsperiode.fom, soknadsperiode.tom, Utils.dato.formatterDatoTilISO(value));
   });
 });
 
 addMethod(string, "erEtterDatofelt", function (felt = "fomDato", message = TIDLIGERE_ENN_FOM) {
-  return this.test("erEtterFraDato", message, function (value) {
+  return this.test("er etter dato", message, function (value) {
     const { [felt]: fomDato } = this.parent;
     const tomDato = value;
     if (!Utils.dato.vaskInputDato(tomDato)) return true;

--- a/src/setupYup.js
+++ b/src/setupYup.js
@@ -3,6 +3,9 @@ import { addMethod, object, string } from "yup";
 import * as Utils from "./utils";
 
 import MKV from "./melosyskodeverk";
+import * as KV from "./kodeverk";
+
+const { TIDLIGERE_ENN_FOM, GYLDIG_DATO, UGYLDIG_PERIODE } = KV.Feilmeldinger;
 
 /* eslint-disable func-names */
 /* eslint-disable prefer-arrow-callback */
@@ -30,13 +33,14 @@ addMethod(object, "uniqueProperty", function (propertyName, message) {
   });
 });
 
-addMethod(string, "erGyldigDato", function (message) {
+addMethod(string, "erGyldigDato", function (message = GYLDIG_DATO) {
   return this.test("er gyldig dato", message, function (value) {
+    if (Utils._isEmpty(value)) return true;
     return Boolean(Utils.dato.vaskInputDato(value));
   });
 });
 
-addMethod(string, "endretPeriodeErGyldig", function (message) {
+addMethod(string, "endretPeriodeErGyldig", function (message = UGYLDIG_PERIODE) {
   return this.test("periode er gyldig", message, function (value) {
     const { soknadsperiode } = this.options.context;
 
@@ -49,10 +53,11 @@ addMethod(string, "endretPeriodeErGyldig", function (message) {
   });
 });
 
-addMethod(string, "erEtterDatofelt", function (felt, message) {
+addMethod(string, "erEtterDatofelt", function (felt = "fomDato", message = TIDLIGERE_ENN_FOM) {
   return this.test("erEtterFraDato", message, function (value) {
     const { [felt]: fomDato } = this.parent;
     const tomDato = value;
+    if (!Utils.dato.vaskInputDato(tomDato)) return true;
 
     return Utils.dato.erGyldigPeriode(fomDato, tomDato);
   });

--- a/src/sider/journalforing/komponenter/journalforingSchema.js
+++ b/src/sider/journalforing/komponenter/journalforingSchema.js
@@ -17,14 +17,12 @@ const VELG_DOKUMENTTITTEL_FRA_LISTEN_ELLER_SKRIV_DIN_EGEN = {
 const VELG_HVILKEN_SAK_DU_ONSKER_A_KNYTTE_JOURNALFORINGEN_MOT = {
   melding: "Velg hvilken sak du ønsker å knytte journalføringen mot.",
 };
-const SKRIV_INN_EN_GYLDIG_DATO = { melding: "Skriv inn en gyldig dato" };
-const TAST_INN_DATO = { melding: "Tast inn dato" };
 const VELG_MINST_ETT_LAND = { melding: "Velg minst ett land." };
 const VELG_ETT_LAND = { melding: "Velg ett land." };
 const VELG_EN_AVSENDER = { melding: "Velg en avsender" };
 const VELG_EN_BESTEMMELSE = "Velg en bestemmelse.";
-const DATO_MA_VAERE_ETTER_FOM = { melding: "Dato må være lik eller senere enn fra." };
 const VELG_REPRESENTERER = { melding: "Velg hvem fullmektig representerer" };
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 
 const kreverPeriodeOgLand = (journalforingHensikt, behandlingstema) =>
   journalforingHensikt === Konstanter.JOURNALFORING_HENSIKT.OPPRETT &&
@@ -94,17 +92,14 @@ const journalforing = object().shape({
   }),
   journalforingPeriodeFraOgMed: string().when(["journalforingHensikt", "opprettnysak_behandlingstema"], {
     is: kreverPeriodeOgLand,
-    then: string().erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO).required(TAST_INN_DATO),
+    then: string().erGyldigDato().required(MAA_FYLLES_UT),
   }),
   journalforingPeriodeTilOgMed: lazy((value) =>
     !value
       ? string().ensure()
       : string().when(["journalforingHensikt", "opprettnysak_behandlingstema"], {
           is: kreverPeriodeOgLand,
-          then: string()
-            .erEtterDatofelt("journalforingPeriodeFraOgMed", DATO_MA_VAERE_ETTER_FOM)
-            .erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO)
-            .required(TAST_INN_DATO),
+          then: string().erEtterDatofelt("journalforingPeriodeFraOgMed").erGyldigDato().required(MAA_FYLLES_UT),
         })
   ),
   journalforingSoknadsland: array()
@@ -138,7 +133,7 @@ const journalforing = object().shape({
     is: false,
     then: string().ensure().required(VELG_EN_AVSENDER),
   }),
-  mottattDato: string().erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO).required(TAST_INN_DATO),
+  mottattDato: string().erGyldigDato().required(MAA_FYLLES_UT),
 
   /* Følgene felter viser ingen feilmeldinger til bruker, men må være en del av skjemaet for å kunne benytte .when() for andre felter. */
   journalforingHensikt: string(),

--- a/src/sider/opprettnysak/opprettnysakSchema.js
+++ b/src/sider/opprettnysak/opprettnysakSchema.js
@@ -1,6 +1,7 @@
 import { object, string, mixed, array, lazy } from "yup";
 
 import * as Utils from "../../utils";
+import * as KV from "../../kodeverk";
 
 import { Utils as MKVUtils } from "../../melosyskodeverk";
 
@@ -8,18 +9,17 @@ const SKRIV_INN_FNR_ELLER_DNR = { melding: "Skriv inn f.nr eller d.nr" };
 const SKRIV_INN_KUN_NUMMER = { melding: "Skriv inn kun nummer." };
 const SKRIV_INN_GYLDIG_FNR_ELLER_DNR = { melding: "Skriv inn gyldig f.nr eller d.nr" };
 const FANT_INGEN_NAVN_PA_FNR_ELLER_DNR = { melding: "Fant ingen navn på dette f.nr eller d.nr." };
-const TAST_INN_DATO = { melding: "Tast inn dato" };
-const SKRIV_INN_EN_GYLDIG_DATO = { melding: "Skriv inn en gyldig dato" };
 const VELG_SAKSTYPE = { melding: "Velg sakstype" };
 const VELG_BEHANDLINGSTEMA = { melding: "Velg behandlingstema" };
 const VELG_LAND = { melding: "Velg land" };
 const VELG_EN_OPPGAVE = { melding: "Velg en oppgave" };
 const MANGLER_JOURNALPOST = { melding: "Den valgte oppgaven har ingen journalpost" };
+const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 
 const soknadsinfo = object().shape({
-  fom: string().erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO).required(TAST_INN_DATO),
+  fom: string().erGyldigDato().required(MAA_FYLLES_UT),
   tom: lazy((value) =>
-    !value ? string().ensure() : string().erGyldigDato(SKRIV_INN_EN_GYLDIG_DATO).required(TAST_INN_DATO)
+    !value ? string().ensure() : string().erGyldigDato().erEtterDatofelt("fom").required(MAA_FYLLES_UT)
   ),
   land: array().of(string()).required({ _error: VELG_LAND }).min(1, { _error: VELG_LAND }),
 });


### PR DESCRIPTION
- Generell endring av schema som har fom og tom-datoer. Validerer gyldig dato og periode, og bruker konsekvente feilmeldinger.
- Større endring på soknadsperiode.js - Periode-steget under menypanelet. Istedenfor å ha validering og oppdatert state lokalt, brukes redux og yup for validering. 


[MELOSYS-4433](https://jira.adeo.no/browse/MELOSYS-4433#)