### PR TITLE
Fiks jest coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "build:javalocal": "npm-run-all -s patch:init patch:env patch:javalocal echo:env -p build:css build:js",
     "test": "npm run patch:init && npm run patch:env && npm run build:css && react-scripts test",
     "test:ci": "npm run patch:init && npm run patch:env && npm run build:css && react-scripts test --coverage --coverageDirectory=test/coverage",
-    "coverage": "npm test -- --coverage",
+    "coverage": "npm test -- --coverage --watchAll=false",
     "eject": "react-scripts eject",
     "eslint:src": "eslint src --ext .js,.ts,.tsx",
     "eslint:scripts": "eslint scripts --ext .js,.ts,.tsx",


### PR DESCRIPTION
Jest har en bug hvor det ikke genereres coverage uten "--watchAll=false" - https://github.com/facebook/create-react-app/issues/10033

Jeg er litt usikker på når dette oppstod. Ser det er noen issues på facebook/create-react-app fra så tidlig som 2019 om dette, men tror nok det har brukket senere for oss.