### PR TITLE
MELOSYS-4549 - Registrering revurder

### DIFF
--- a/src/felleskomponenter/dialogboks/revurderFagsak/dialogboksRevurderFagsak.js
+++ b/src/felleskomponenter/dialogboks/revurderFagsak/dialogboksRevurderFagsak.js
@@ -17,7 +17,7 @@ export const DialogboksRevurderFagsak = ({ bekreft, avbryt, ariaHideApp, spinner
     shouldCloseOnOverlayClick
     ariaHideApp={ariaHideApp}
   >
-    <Nav.Typo.Systemtittel className="overskrift">Vurder vedtak på nytt</Nav.Typo.Systemtittel>
+    <Nav.Typo.Systemtittel className="overskrift">Vurder saken på nytt</Nav.Typo.Systemtittel>
     <Knapperad
       bekreft={bekreft}
       bekreftTekst="BEKREFT"

--- a/src/felleskomponenter/dialogboks/revurderFagsak/dialogboksRevurderFagsak.js
+++ b/src/felleskomponenter/dialogboks/revurderFagsak/dialogboksRevurderFagsak.js
@@ -11,7 +11,7 @@ export const DialogboksRevurderFagsak = ({ bekreft, avbryt, ariaHideApp, spinner
   <Nav.Modal
     className="dialogboksRevurderFagsak"
     isOpen
-    contentLabel="Revurder vedtak"
+    contentLabel="Revurder fagsak"
     onRequestClose={avbryt}
     closeButton={false}
     shouldCloseOnOverlayClick

--- a/src/sider/eu_eøs/registrering/komponenter/behandlingsmeny.js
+++ b/src/sider/eu_eøs/registrering/komponenter/behandlingsmeny.js
@@ -10,6 +10,8 @@ const Behandlingsmeny = (props) => {
     apneTidligereBehandlinger,
     tilbakeleggeHandle,
     oppfriskSaksopplysningerHandle,
+    visRevurderFagsak,
+    visRevurderFagsakDialogHandle,
   } = props;
 
   return (
@@ -33,6 +35,11 @@ const Behandlingsmeny = (props) => {
         <Nav.Knapp mini className="innhold__element" onClick={apneTidligereBehandlinger}>
           Vis alle behandlinger
         </Nav.Knapp>
+        {visRevurderFagsak && (
+          <Nav.Knapp mini className="innhold__element" onClick={visRevurderFagsakDialogHandle}>
+            Vurder saken på nytt
+          </Nav.Knapp>
+        )}
       </div>
     </Nav.EkspanderbartpanelBase>
   );
@@ -44,6 +51,8 @@ Behandlingsmeny.propTypes = {
   oppfriskSaksopplysningerHandle: PT.func.isRequired,
   apneTidligereBehandlinger: PT.func.isRequired,
   redigerbart: PT.bool.isRequired,
+  visRevurderFagsakDialogHandle: PT.func.isRequired,
+  visRevurderFagsak: PT.bool.isRequired,
 };
 
 export default Behandlingsmeny;

--- a/src/sider/eu_eøs/registrering/registrering.js
+++ b/src/sider/eu_eøs/registrering/registrering.js
@@ -30,6 +30,8 @@ const {
   REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE,
 } = MKV.Koder.behandlinger.behandlingstema;
 
+const { AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Koder.behandlinger.behandlingsstatus;
+
 const behandlingsstatusMap = {
   [MKV.Koder.behandlinger.behandlingsstatus.VURDER_DOKUMENT]: [
     {
@@ -94,6 +96,7 @@ export const Registrering = (props) => {
     redigerbart,
     Saksopplysninger,
     behandlingstema,
+    behandlingsstatus,
     fagsak,
     oppsummering,
     person,
@@ -151,10 +154,10 @@ export const Registrering = (props) => {
 
   if (Utils._isNil(redigerbart)) return null;
 
+  const behandlingErAvsluttet = [AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING].includes(behandlingsstatus);
   const visRevurderFagsak =
-    !redigerbart &&
-    (behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING ||
-      behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE);
+    behandlingErAvsluttet &&
+    [REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING, REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE].includes(behandlingstema);
 
   return (
     <div className="registrering">
@@ -245,6 +248,7 @@ Registrering.propTypes = {
   dokumenter: PT.array.isRequired,
   startOgVisOppfriskModal: PT.func.isRequired,
   visRevurderFagsakDialogHandle: PT.func.isRequired,
+  behandlingsstatus: PT.string.isRequired,
 };
 Registrering.defaultProps = {
   redigerbart: null,
@@ -266,6 +270,7 @@ const mapStateToProps = (state) => ({
   person: behandlingerSelectors.PersonSelector(state),
   sed: behandlingerSelectors.SEDSelector(state),
   behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
+  behandlingsstatus: behandlingerSelectors.BehandlingsstatusKodeSelector(state),
   lovvalgsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeFomSelector(state)),
   lovvalgsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeTomSelector(state)),
   lovvalgsland: behandlingerSelectors.LovvalgslandSelector(state),

--- a/src/sider/eu_eøs/registrering/registrering.js
+++ b/src/sider/eu_eøs/registrering/registrering.js
@@ -25,6 +25,11 @@ import { dokumenterSelectors } from "../../../ducks/dokumenter";
 
 import "./registrering.css";
 
+const {
+  REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING,
+  REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE,
+} = MKV.Koder.behandlinger.behandlingstema;
+
 const behandlingsstatusMap = {
   [MKV.Koder.behandlinger.behandlingsstatus.VURDER_DOKUMENT]: [
     {
@@ -72,7 +77,7 @@ const behandlingsstatusMap = {
   ],
 };
 
-const Registrering = (props) => {
+export const Registrering = (props) => {
   const {
     match: {
       params: { snr },
@@ -100,6 +105,7 @@ const Registrering = (props) => {
     dokumentOversikt,
     dokumenter,
     startOgVisOppfriskModal,
+    visRevurderFagsakDialogHandle,
   } = props;
 
   const saksnummer = snr;
@@ -145,6 +151,11 @@ const Registrering = (props) => {
 
   if (Utils._isNil(redigerbart)) return null;
 
+  const visRevurderFagsak =
+    !redigerbart &&
+    (behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING ||
+      behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE);
+
   return (
     <div className="registrering">
       <Nav.Container fluid>
@@ -177,6 +188,8 @@ const Registrering = (props) => {
                   tilbakeleggeHandle={tilbakeleggHandle}
                   apneTidligereBehandlinger={apneTidligereBehandlinger}
                   oppfriskSaksopplysningerHandle={visOppfriskModal}
+                  visRevurderFagsakDialogHandle={visRevurderFagsakDialogHandle}
+                  visRevurderFagsak={visRevurderFagsak}
                 />
               )}
               renderBehandlingsstatus={() => (
@@ -231,6 +244,7 @@ Registrering.propTypes = {
   dokumentOversikt: PT.array.isRequired,
   dokumenter: PT.array.isRequired,
   startOgVisOppfriskModal: PT.func.isRequired,
+  visRevurderFagsakDialogHandle: PT.func.isRequired,
 };
 Registrering.defaultProps = {
   redigerbart: null,

--- a/src/sider/eu_eøs/registrering/registrering.test.js
+++ b/src/sider/eu_eøs/registrering/registrering.test.js
@@ -10,6 +10,8 @@ const {
   REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE,
 } = MKV.Koder.behandlinger.behandlingstema;
 
+const { AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING, UNDER_BEHANDLING } = MKV.Koder.behandlinger.behandlingsstatus;
+
 describe("Registrering", () => {
   let props = null;
 
@@ -35,6 +37,7 @@ describe("Registrering", () => {
       },
       location: {},
       behandlingstema: "",
+      behandlingsstatus: "",
       lovvalgsperiodeFom: "",
       lovvalgsperiodeTom: "PT.string",
       tilForsiden: jest.fn(),
@@ -48,9 +51,8 @@ describe("Registrering", () => {
     };
   });
 
-  it("Revurder fagsak vises ikke dersom behandling er redigerbar", () => {
-    props.redigerbart = true;
-
+  it(`Revurder fagsak vises ikke dersom behandlingsstatus er ${UNDER_BEHANDLING}`, () => {
+    props.behandlingsstatus = UNDER_BEHANDLING;
     const registrering = shallow(<Registrering {...props} />);
 
     const sideOppsummering = registrering.find(SideOppsummering);
@@ -58,8 +60,8 @@ describe("Registrering", () => {
     expect(behandlingsmeny.props.visRevurderFagsak).toBe(false);
   });
 
-  it(`Revurder fagsak vises dersom behandling ikke er redigerbar og behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING}`, () => {
-    props.redigerbart = false;
+  it(`Revurder fagsak vises dersom behandlingsstatus er ${AVSLUTTET} og behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING}`, () => {
+    props.behandlingsstatus = AVSLUTTET;
     props.behandlingstema = REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING;
 
     const registrering = shallow(<Registrering {...props} />);
@@ -69,8 +71,30 @@ describe("Registrering", () => {
     expect(behandlingsmeny.props.visRevurderFagsak).toBe(true);
   });
 
-  it(`Revurder fagsak vises dersom behandling ikke er redigerbar og behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE}`, () => {
-    props.redigerbart = false;
+  it(`Revurder fagsak vises dersom behandlingsstatus er ${MIDLERTIDIG_LOVVALGSBESLUTNING} og behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING}`, () => {
+    props.behandlingsstatus = MIDLERTIDIG_LOVVALGSBESLUTNING;
+    props.behandlingstema = REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING;
+
+    const registrering = shallow(<Registrering {...props} />);
+
+    const sideOppsummering = registrering.find(SideOppsummering);
+    const behandlingsmeny = sideOppsummering.props().renderBehandlingsmeny();
+    expect(behandlingsmeny.props.visRevurderFagsak).toBe(true);
+  });
+
+  it(`Revurder fagsak vises dersom behandlingsstatus er ${AVSLUTTET} og behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE}`, () => {
+    props.behandlingsstatus = AVSLUTTET;
+    props.behandlingstema = REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE;
+
+    const registrering = shallow(<Registrering {...props} />);
+
+    const sideOppsummering = registrering.find(SideOppsummering);
+    const behandlingsmeny = sideOppsummering.props().renderBehandlingsmeny();
+    expect(behandlingsmeny.props.visRevurderFagsak).toBe(true);
+  });
+
+  it(`Revurder fagsak vises dersom behandlingsstatus er ${MIDLERTIDIG_LOVVALGSBESLUTNING} og behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE}`, () => {
+    props.behandlingsstatus = MIDLERTIDIG_LOVVALGSBESLUTNING;
     props.behandlingstema = REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE;
 
     const registrering = shallow(<Registrering {...props} />);

--- a/src/sider/eu_eøs/registrering/registrering.test.js
+++ b/src/sider/eu_eøs/registrering/registrering.test.js
@@ -1,0 +1,82 @@
+import React from "react";
+
+import { Registrering } from "./registrering";
+import SideOppsummering from "../../../felleskomponenter/oppsummering/sideOppsummering";
+
+import MKV from "../../../melosyskodeverk";
+
+const {
+  REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING,
+  REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE,
+} = MKV.Koder.behandlinger.behandlingstema;
+
+describe("Registrering", () => {
+  let props = null;
+
+  beforeEach(() => {
+    props = {
+      Saksopplysninger: () => <span />,
+      hentAvklartefakta: jest.fn(),
+      hentBehandling: jest.fn(),
+      hentFagsaker: jest.fn(),
+      hentLovvalgsperioder: jest.fn(),
+      resetFagsakState: jest.fn(),
+      tilbakeleggOppgave: jest.fn(),
+      redigerbart: true,
+      avklartefakta: [],
+      vurderingBegrunnelser: [],
+      fagsak: {},
+      lovvalgsperioder: [], // TODO lag proptype
+      oppsummering: {},
+      person: {},
+      sed: {},
+      match: {
+        params: { snr: "" },
+      },
+      location: {},
+      behandlingstema: "",
+      lovvalgsperiodeFom: "",
+      lovvalgsperiodeTom: "PT.string",
+      tilForsiden: jest.fn(),
+      lovvalgsland: {},
+      visOppfriskModal: jest.fn(),
+      behandlingOppfriskes: false,
+      dokumentOversikt: [],
+      dokumenter: [],
+      startOgVisOppfriskModal: jest.fn(),
+      visRevurderFagsakDialogHandle: jest.fn(),
+    };
+  });
+
+  it("Revurder fagsak vises ikke dersom behandling er redigerbar", () => {
+    props.redigerbart = true;
+
+    const registrering = shallow(<Registrering {...props} />);
+
+    const sideOppsummering = registrering.find(SideOppsummering);
+    const behandlingsmeny = sideOppsummering.props().renderBehandlingsmeny();
+    expect(behandlingsmeny.props.visRevurderFagsak).toBe(false);
+  });
+
+  it(`Revurder fagsak vises dersom behandling ikke er redigerbar og behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING}`, () => {
+    props.redigerbart = false;
+    props.behandlingstema = REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING;
+
+    const registrering = shallow(<Registrering {...props} />);
+
+    const sideOppsummering = registrering.find(SideOppsummering);
+    const behandlingsmeny = sideOppsummering.props().renderBehandlingsmeny();
+    expect(behandlingsmeny.props.visRevurderFagsak).toBe(true);
+  });
+
+  it(`Revurder fagsak vises dersom behandling ikke er redigerbar og behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE}`, () => {
+    props.redigerbart = false;
+    props.behandlingstema = REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE;
+
+    const registrering = shallow(<Registrering {...props} />);
+
+    const sideOppsummering = registrering.find(SideOppsummering);
+    const behandlingsmeny = sideOppsummering.props().renderBehandlingsmeny();
+    expect(behandlingsmeny.props.visRevurderFagsak).toBe(true);
+  });
+});

--- a/src/sider/eu_eøs/saksbehandling/komponenter/behandlingsmeny.js
+++ b/src/sider/eu_eøs/saksbehandling/komponenter/behandlingsmeny.js
@@ -60,7 +60,7 @@ const Behandlingsmeny = ({
       </Nav.Knapp>
       {visRevurderFagsak && (
         <Nav.Knapp mini className="innhold__element" onClick={visRevurderFagsakDialogHandle}>
-          Vurder vedtak på nytt
+          Vurder saken på nytt
         </Nav.Knapp>
       )}
     </div>

--- a/src/sider/eu_eøs/saksbehandling/saksbehandling.js
+++ b/src/sider/eu_eøs/saksbehandling/saksbehandling.js
@@ -32,6 +32,8 @@ import { datalastingOperations } from "../../../ducks/datalasting";
 import "./saksbehandling.css";
 import { dokumenterOperations, dokumenterSelectors } from "../../../ducks/dokumenter";
 
+const { AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Koder.behandlinger.behandlingsstatus;
+
 const behandlingsstatusMap = {
   [MKV.Koder.behandlinger.behandlingsstatus.VURDER_DOKUMENT]: [
     {
@@ -227,6 +229,7 @@ class Saksbehandling extends Component {
       startOgVisOppfriskModal,
       dokumentOversikt,
       dokumenter,
+      behandlingsstatus,
     } = this.props;
     const {
       params: { snr: saksnummer },
@@ -236,9 +239,10 @@ class Saksbehandling extends Component {
     if (Utils._isNil(redigerbart)) return null;
     if (!saksopplysningerLastet) return null;
 
+    const behandlingErAvsluttet = [AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING].includes(behandlingsstatus);
     const visRevurderFagsak =
       anmodningsperioderErSendtUtlandet ||
-      (!redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE);
+      (behandlingErAvsluttet && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE);
 
     const visOppfriskSaksopplysninger =
       behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE && !anmodningsperioderErSendtUtlandet;
@@ -387,6 +391,7 @@ Saksbehandling.propTypes = {
   hentDokumentOversikt: PT.func.isRequired,
   dokumentOversikt: PT.array.isRequired,
   dokumenter: PT.array.isRequired,
+  behandlingsstatus: PT.string.isRequired,
 };
 
 Saksbehandling.defaultProps = {
@@ -436,6 +441,7 @@ const mapStateToProps = (state) => ({
   behandlingsmenyRedigerbart: redigerbartSelectors.BehandlingsmenyRedigerbartSelector(state),
   dokumenter: dokumenterSelectors.AlleFysiskeDokumentSelector(state),
   dokumentOversikt: dokumenterSelectors.DokumentOversiktSelector(state),
+  behandlingsstatus: behandlingerSelectors.BehandlingsstatusKodeSelector(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/sider/eu_eøs/vurderutpeking/komponenter/behandlingsmeny.js
+++ b/src/sider/eu_eøs/vurderutpeking/komponenter/behandlingsmeny.js
@@ -57,7 +57,7 @@ const Behandlingsmeny = ({
       <Nav.Knapp mini className="innhold__element" onClick={apneTidligereBehandlinger}>
         Vis alle behandlinger
       </Nav.Knapp>
-      {!redigerbart && visRevurderFagsak && (
+      {visRevurderFagsak && (
         <Nav.Knapp mini className="innhold__element" onClick={visRevurderFagsakDialogHandle}>
           Vurder saken på nytt
         </Nav.Knapp>

--- a/src/sider/eu_eøs/vurderutpeking/komponenter/behandlingsmeny.js
+++ b/src/sider/eu_eøs/vurderutpeking/komponenter/behandlingsmeny.js
@@ -59,7 +59,7 @@ const Behandlingsmeny = ({
       </Nav.Knapp>
       {!redigerbart && visRevurderFagsak && (
         <Nav.Knapp mini className="innhold__element" onClick={visRevurderFagsakDialogHandle}>
-          Vurder vedtak på nytt
+          Vurder saken på nytt
         </Nav.Knapp>
       )}
     </div>

--- a/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
+++ b/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
@@ -34,6 +34,8 @@ import { dokumenterSelectors } from "../../../ducks/dokumenter";
 
 import "./vurderutpeking.css";
 
+const { AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Koder.behandlinger.behandlingsstatus;
+
 const behandlingsstatusMap = {
   [MKV.Koder.behandlinger.behandlingsstatus.VURDER_DOKUMENT]: [
     {
@@ -123,6 +125,7 @@ const Vurderutpeking = ({
   dokumentOversikt,
   dokumenter,
   vurderUtpekingFormValues,
+  behandlingsstatus,
 }) => {
   const {
     params: { snr: saksnummer },
@@ -156,6 +159,10 @@ const Vurderutpeking = ({
   const lovvalgslandKTOBject = visLovvalgsland
     ? KV.kodeTilObjekt(lovvalgslandFraForm, MKV.KTObjects.landkoder)
     : undefined;
+
+  const behandlingErAvsluttet = [AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING].includes(behandlingsstatus);
+  const visRevurderFagsak =
+    behandlingErAvsluttet && behandlingstema !== MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND;
 
   return (
     <div className="vurderutpeking">
@@ -209,9 +216,7 @@ const Vurderutpeking = ({
                   visOppfriskSaksopplysninger
                   oppfriskSaksopplysningerHandle={visOppfriskModal}
                   visRevurderFagsakDialogHandle={visRevurderFagsakDialogHandle}
-                  visRevurderFagsak={
-                    behandlingstema !== MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND
-                  }
+                  visRevurderFagsak={visRevurderFagsak}
                 />
               )}
               renderBehandlingsstatus={() => (
@@ -244,6 +249,7 @@ Vurderutpeking.propTypes = {
   match: PT.object.isRequired,
   location: PT.object.isRequired,
   behandlingstema: PT.string.isRequired,
+  behandlingsstatus: PT.string.isRequired,
   redigerbart: PT.bool.isRequired,
   fagsak: MPT.Fagsak.isRequired,
   oppsummering: MPT.Behandlinger.Oppsummering.isRequired,
@@ -289,6 +295,7 @@ Vurderutpeking.defaultProps = {
 
 const mapStateToProps = (state) => ({
   behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
+  behandlingsstatus: behandlingerSelectors.BehandlingsstatusKodeSelector(state),
   redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   fagsak: fagsakSelectors.FagsakSelector(state),
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),

--- a/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
+++ b/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
@@ -161,8 +161,7 @@ const Vurderutpeking = ({
     : undefined;
 
   const behandlingErAvsluttet = [AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING].includes(behandlingsstatus);
-  const visRevurderFagsak =
-    behandlingErAvsluttet && behandlingstema !== MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND;
+  const visRevurderFagsak = behandlingErAvsluttet;
 
   return (
     <div className="vurderutpeking">

--- a/src/sider/ftrl/saksbehandling/behandlingsmeny.tsx
+++ b/src/sider/ftrl/saksbehandling/behandlingsmeny.tsx
@@ -72,7 +72,7 @@ const Behandlingsmeny = ({
       {(anmodningsperioderErSendtUtlandet ||
         (!redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE)) && (
         <Nav.Knapp mini className="element" onClick={visRevurderFagsakDialogHandle}>
-          Vurder vedtak på nytt
+          Vurder saken på nytt
         </Nav.Knapp>
       )}
     </div>

--- a/src/sider/ftrl/saksbehandling/behandlingsmeny.tsx
+++ b/src/sider/ftrl/saksbehandling/behandlingsmeny.tsx
@@ -8,7 +8,6 @@ const { AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Koder.behandlinger.beh
 interface Props {
   redigerbart: boolean;
   behandlingsstatus: string;
-  anmodningsperioderErSendtUtlandet: boolean;
   lagreOgLukkHandle: () => void;
   tilbakeleggeHandle: () => void;
   oppfriskSaksopplysningerHandle: () => void;
@@ -21,7 +20,6 @@ interface Props {
 const Behandlingsmeny = ({
   redigerbart,
   behandlingsstatus,
-  anmodningsperioderErSendtUtlandet,
   lagreOgLukkHandle,
   tilbakeleggeHandle,
   oppfriskSaksopplysningerHandle,
@@ -48,7 +46,7 @@ const Behandlingsmeny = ({
         <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={tilbakeleggeHandle}>
           Legg tilbake i kø
         </Nav.Knapp>
-        {!anmodningsperioderErSendtUtlandet && (
+        {redigerbart && (
           <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={oppfriskSaksopplysningerHandle}>
             Oppdater registeropplysninger
           </Nav.Knapp>
@@ -71,7 +69,7 @@ const Behandlingsmeny = ({
         <Nav.Knapp mini className="element" onClick={apneTidligereBehandlinger}>
           Vis alle behandlinger
         </Nav.Knapp>
-        {(anmodningsperioderErSendtUtlandet || behandlingErAvsluttet) && (
+        {behandlingErAvsluttet && (
           <Nav.Knapp mini className="element" onClick={visRevurderFagsakDialogHandle}>
             Vurder saken på nytt
           </Nav.Knapp>

--- a/src/sider/ftrl/saksbehandling/behandlingsmeny.tsx
+++ b/src/sider/ftrl/saksbehandling/behandlingsmeny.tsx
@@ -7,7 +7,6 @@ const { AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Koder.behandlinger.beh
 
 interface Props {
   redigerbart: boolean;
-  behandlingstype: string;
   behandlingsstatus: string;
   anmodningsperioderErSendtUtlandet: boolean;
   lagreOgLukkHandle: () => void;
@@ -21,7 +20,6 @@ interface Props {
 }
 const Behandlingsmeny = ({
   redigerbart,
-  behandlingstype,
   behandlingsstatus,
   anmodningsperioderErSendtUtlandet,
   lagreOgLukkHandle,
@@ -50,23 +48,22 @@ const Behandlingsmeny = ({
         <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={tilbakeleggeHandle}>
           Legg tilbake i kø
         </Nav.Knapp>
-        {behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE &&
-          !anmodningsperioderErSendtUtlandet && (
-            <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={oppfriskSaksopplysningerHandle}>
-              Oppdater registeropplysninger
-            </Nav.Knapp>
-          )}
-        {redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE && (
+        {!anmodningsperioderErSendtUtlandet && (
+          <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={oppfriskSaksopplysningerHandle}>
+            Oppdater registeropplysninger
+          </Nav.Knapp>
+        )}
+        {redigerbart && (
           <Nav.Knapp mini className="element" onClick={visHenleggDialogHandle}>
             Henlegg sak
           </Nav.Knapp>
         )}
-        {redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE && (
+        {redigerbart && (
           <Nav.Knapp mini className="element" onClick={visAvsluttSakSomBortfaltDialogHandle}>
             Avslutt sak som bortfalt
           </Nav.Knapp>
         )}
-        {redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING && (
+        {redigerbart && (
           <Nav.Knapp mini className="element" onClick={visAvslagSoknadDialogHandle}>
             Avslå søknad pga. manglende opplysninger
           </Nav.Knapp>
@@ -74,8 +71,7 @@ const Behandlingsmeny = ({
         <Nav.Knapp mini className="element" onClick={apneTidligereBehandlinger}>
           Vis alle behandlinger
         </Nav.Knapp>
-        {(anmodningsperioderErSendtUtlandet ||
-          (behandlingErAvsluttet && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE)) && (
+        {(anmodningsperioderErSendtUtlandet || behandlingErAvsluttet) && (
           <Nav.Knapp mini className="element" onClick={visRevurderFagsakDialogHandle}>
             Vurder saken på nytt
           </Nav.Knapp>

--- a/src/sider/ftrl/saksbehandling/behandlingsmeny.tsx
+++ b/src/sider/ftrl/saksbehandling/behandlingsmeny.tsx
@@ -43,9 +43,11 @@ const Behandlingsmeny = ({
             Lagre og lukk
           </Nav.Knapp>
         )}
-        <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={tilbakeleggeHandle}>
-          Legg tilbake i kø
-        </Nav.Knapp>
+        {redigerbart && (
+          <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={tilbakeleggeHandle}>
+            Legg tilbake i kø
+          </Nav.Knapp>
+        )}
         {redigerbart && (
           <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={oppfriskSaksopplysningerHandle}>
             Oppdater registeropplysninger

--- a/src/sider/ftrl/saksbehandling/behandlingsmeny.tsx
+++ b/src/sider/ftrl/saksbehandling/behandlingsmeny.tsx
@@ -3,11 +3,13 @@ import MKV from "../../../melosyskodeverk";
 import * as Nav from "../../../utils/navFrontend";
 import "./behandlingsmeny.css";
 
+const { AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Koder.behandlinger.behandlingsstatus;
+
 interface Props {
   redigerbart: boolean;
   behandlingstype: string;
+  behandlingsstatus: string;
   anmodningsperioderErSendtUtlandet: boolean;
-
   lagreOgLukkHandle: () => void;
   tilbakeleggeHandle: () => void;
   oppfriskSaksopplysningerHandle: () => void;
@@ -20,8 +22,8 @@ interface Props {
 const Behandlingsmeny = ({
   redigerbart,
   behandlingstype,
+  behandlingsstatus,
   anmodningsperioderErSendtUtlandet,
-
   lagreOgLukkHandle,
   tilbakeleggeHandle,
   oppfriskSaksopplysningerHandle,
@@ -30,53 +32,57 @@ const Behandlingsmeny = ({
   visAvslagSoknadDialogHandle,
   apneTidligereBehandlinger,
   visRevurderFagsakDialogHandle,
-}: Props) => (
-  <Nav.EkspanderbartpanelBase
-    ariaTittel="Behandlingsmeny"
-    className="behandlingsmeny"
-    heading={<div className="title">Behandlingsmeny</div>}
-  >
-    <div className="innhold">
-      {redigerbart && (
-        <Nav.Knapp mini className="element" onClick={lagreOgLukkHandle}>
-          Lagre og lukk
-        </Nav.Knapp>
-      )}
-      <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={tilbakeleggeHandle}>
-        Legg tilbake i kø
-      </Nav.Knapp>
-      {behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE &&
-        !anmodningsperioderErSendtUtlandet && (
-          <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={oppfriskSaksopplysningerHandle}>
-            Oppdater registeropplysninger
+}: Props) => {
+  const behandlingErAvsluttet = [AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING].includes(behandlingsstatus);
+
+  return (
+    <Nav.EkspanderbartpanelBase
+      ariaTittel="Behandlingsmeny"
+      className="behandlingsmeny"
+      heading={<div className="title">Behandlingsmeny</div>}
+    >
+      <div className="innhold">
+        {redigerbart && (
+          <Nav.Knapp mini className="element" onClick={lagreOgLukkHandle}>
+            Lagre og lukk
           </Nav.Knapp>
         )}
-      {redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE && (
-        <Nav.Knapp mini className="element" onClick={visHenleggDialogHandle}>
-          Henlegg sak
+        <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={tilbakeleggeHandle}>
+          Legg tilbake i kø
         </Nav.Knapp>
-      )}
-      {redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE && (
-        <Nav.Knapp mini className="element" onClick={visAvsluttSakSomBortfaltDialogHandle}>
-          Avslutt sak som bortfalt
+        {behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE &&
+          !anmodningsperioderErSendtUtlandet && (
+            <Nav.Knapp disabled={!redigerbart} mini className="element" onClick={oppfriskSaksopplysningerHandle}>
+              Oppdater registeropplysninger
+            </Nav.Knapp>
+          )}
+        {redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE && (
+          <Nav.Knapp mini className="element" onClick={visHenleggDialogHandle}>
+            Henlegg sak
+          </Nav.Knapp>
+        )}
+        {redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE && (
+          <Nav.Knapp mini className="element" onClick={visAvsluttSakSomBortfaltDialogHandle}>
+            Avslutt sak som bortfalt
+          </Nav.Knapp>
+        )}
+        {redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING && (
+          <Nav.Knapp mini className="element" onClick={visAvslagSoknadDialogHandle}>
+            Avslå søknad pga. manglende opplysninger
+          </Nav.Knapp>
+        )}
+        <Nav.Knapp mini className="element" onClick={apneTidligereBehandlinger}>
+          Vis alle behandlinger
         </Nav.Knapp>
-      )}
-      {redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING && (
-        <Nav.Knapp mini className="element" onClick={visAvslagSoknadDialogHandle}>
-          Avslå søknad pga. manglende opplysninger
-        </Nav.Knapp>
-      )}
-      <Nav.Knapp mini className="element" onClick={apneTidligereBehandlinger}>
-        Vis alle behandlinger
-      </Nav.Knapp>
-      {(anmodningsperioderErSendtUtlandet ||
-        (!redigerbart && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE)) && (
-        <Nav.Knapp mini className="element" onClick={visRevurderFagsakDialogHandle}>
-          Vurder saken på nytt
-        </Nav.Knapp>
-      )}
-    </div>
-  </Nav.EkspanderbartpanelBase>
-);
+        {(anmodningsperioderErSendtUtlandet ||
+          (behandlingErAvsluttet && behandlingstype !== MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE)) && (
+          <Nav.Knapp mini className="element" onClick={visRevurderFagsakDialogHandle}>
+            Vurder saken på nytt
+          </Nav.Knapp>
+        )}
+      </div>
+    </Nav.EkspanderbartpanelBase>
+  );
+};
 
 export default Behandlingsmeny;

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -103,6 +103,7 @@ const Saksbehandling = ({
   behandlingsgrunnlagMottaksdato,
   behandlingsresultat,
   behandlingstema,
+  behandlingsstatus,
   brevBestillingRedigerbart,
   brevBestillingRedigerbartIArtikkel13,
   dokumenter,
@@ -295,6 +296,7 @@ const Saksbehandling = ({
                   visAvslagSoknadDialogHandle={visAvslagSoknadDialogHandle}
                   apneTidligereBehandlinger={apneTidligereBehandlinger}
                   visRevurderFagsakDialogHandle={visRevurderFagsakDialogHandle}
+                  behandlingsstatus={behandlingsstatus}
                 />
               )}
               renderBehandlingsstatus={() => (
@@ -333,6 +335,7 @@ Saksbehandling.propTypes = {
   behandlingsgrunnlagMottaksdato: PT.string.isRequired,
   behandlingsresultat: MPT.Behandlingsresultat.isRequired,
   behandlingstema: PT.string.isRequired,
+  behandlingsstatus: PT.string.isRequired,
   brevBestillingRedigerbart: PT.bool.isRequired,
   brevBestillingRedigerbartIArtikkel13: PT.bool.isRequired,
   dokumenter: PT.array.isRequired,
@@ -401,6 +404,7 @@ const mapStateToProps = (state) => ({
   ),
   behandlingsresultat: behandlingsresultatSelectors.BehandlingsresultatSelector(state),
   behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
+  behandlingsstatus: behandlingerSelectors.BehandlingsstatusKodeSelector(state),
   brevBestillingRedigerbart: redigerbartSelectors.BrevBestillingRedigerbartSelector(state),
   brevBestillingRedigerbartIArtikkel13: redigerbartSelectors.BrevBestillingRedigerbartIArtikkel13Selector(state),
   dokumenter: dokumenterSelectors.AlleFysiskeDokumentSelector(state),

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -103,7 +103,6 @@ const Saksbehandling = ({
   behandlingsgrunnlagMottaksdato,
   behandlingsresultat,
   behandlingstema,
-  behandlingstype,
   brevBestillingRedigerbart,
   brevBestillingRedigerbartIArtikkel13,
   dokumenter,
@@ -287,7 +286,6 @@ const Saksbehandling = ({
               renderBehandlingsmeny={() => (
                 <Behandlingsmeny
                   redigerbart={redigerbart}
-                  behandlingstype={behandlingstype}
                   anmodningsperioderErSendtUtlandet={anmodningsperioderErSendtUtlandet}
                   lagreOgLukkHandle={lagreOgLukk}
                   tilbakeleggeHandle={tilbakeleggOppgave}
@@ -335,7 +333,6 @@ Saksbehandling.propTypes = {
   behandlingsgrunnlagMottaksdato: PT.string.isRequired,
   behandlingsresultat: MPT.Behandlingsresultat.isRequired,
   behandlingstema: PT.string.isRequired,
-  behandlingstype: PT.string.isRequired,
   brevBestillingRedigerbart: PT.bool.isRequired,
   brevBestillingRedigerbartIArtikkel13: PT.bool.isRequired,
   dokumenter: PT.array.isRequired,
@@ -404,7 +401,6 @@ const mapStateToProps = (state) => ({
   ),
   behandlingsresultat: behandlingsresultatSelectors.BehandlingsresultatSelector(state),
   behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
-  behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
   brevBestillingRedigerbart: redigerbartSelectors.BrevBestillingRedigerbartSelector(state),
   brevBestillingRedigerbartIArtikkel13: redigerbartSelectors.BrevBestillingRedigerbartIArtikkel13Selector(state),
   dokumenter: dokumenterSelectors.AlleFysiskeDokumentSelector(state),


### PR DESCRIPTION
- Legger til mulighet for å revurdere behandlinger med behandlingstema REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING og REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE
- "Vurder vedtak på nytt" -> "Vurder saken på nytt"
- Viser bare revurderingsknapp dersom behandlingsstatus er AVSLUTTET eller MIDLERTIDIG_LOVVALGSBESLUTNING.
- Fikser litt forskjellig i FTRL-behandlingsmeny