### PR TITLE
soknadsperiode.fom kan være likt fom, soknadsperiode.tom kan være likt tom

### DIFF
--- a/src/setupYup.js
+++ b/src/setupYup.js
@@ -45,7 +45,7 @@ addMethod(string, "endretPeriodeErGyldig", function (message) {
 
     if (value === "") return false;
 
-    return Utils.dato.erIPeriode(soknadsperiode.fom, soknadsperiode.tom, Utils.dato.formatterDatoTilISO(value));
+    return Utils.dato.erIPeriode(soknadsperiode.fom, soknadsperiode.tom, Utils.dato.formatterDatoTilISO(value), true);
   });
 });
 

--- a/src/setupYup.js
+++ b/src/setupYup.js
@@ -45,7 +45,7 @@ addMethod(string, "endretPeriodeErGyldig", function (message) {
 
     if (value === "") return false;
 
-    return Utils.dato.erIPeriode(soknadsperiode.fom, soknadsperiode.tom, Utils.dato.formatterDatoTilISO(value), true);
+    return Utils.dato.erIPeriode(soknadsperiode.fom, soknadsperiode.tom, Utils.dato.formatterDatoTilISO(value), "[]");
   });
 });
 


### PR DESCRIPTION
Legger til inclusivity, da jeg antar det skal være tillatt at `soknadsperiode.fom === fomDato` og `soknadsperiode.tom === tomDato`.

~~Skal dobbeltsjekke med fag.~~ Fag er enig.