### PR TITLE
Bug i periode-panelet

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiode.js
+++ b/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiode.js
@@ -70,16 +70,10 @@ export class Soknadsperiode extends Component {
   };
 
   render() {
-    const {
-      redigerbart,
-      soknadsperiodeFom,
-      soknadsperiodeTom,
-      soknadsperiodeFomErrors,
-      soknadsperiodeTomErrors,
-    } = this.props;
+    const { redigerbart, soknadsperiodeFomErrors, soknadsperiodeTomErrors } = this.props;
     const { visEndrePeriode, skjulEndrePeriode, lagre, oppdaterFelt, avbryt } = this;
 
-    const { erEndrePeriodeSynlig } = this.state;
+    const { erEndrePeriodeSynlig, soknadsperiodeFom, soknadsperiodeTom } = this.state;
 
     return (
       <div className="soknadsperiode">

--- a/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiodeEndring.js
+++ b/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiodeEndring.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import PT from "prop-types";
 
@@ -22,11 +22,30 @@ const SoknadsperiodeEndring = (props) => {
     lagre,
   } = props;
 
+  const [fomHarFokus, setFomHarFokus] = useState(false);
+  const [tomHarFokus, setTomHarFokus] = useState(false);
+
   const vedFomEndring = (nyDato) => vedFeltEndring("soknadsperiodeFom", Utils.dateTilNorskString(nyDato));
   const vedTomEndring = (nyDato) => vedFeltEndring("soknadsperiodeTom", Utils.dateTilNorskString(nyDato));
 
-  const vedFomBlur = (nyDato) => vedFeltEndring("soknadsperiodeFom", Utils.vaskInputDato(nyDato) || nyDato);
-  const vedTomBlur = (nyDato) => vedFeltEndring("soknadsperiodeTom", Utils.vaskInputDato(nyDato) || nyDato);
+  const vedFomFokus = () => {
+    setFomHarFokus(true);
+  };
+  const vedTomFokus = () => {
+    setTomHarFokus(true);
+  };
+
+  const vedFomBlur = (nyDato) => {
+    setFomHarFokus(false);
+    vedFeltEndring("soknadsperiodeFom", Utils.vaskInputDato(nyDato) || nyDato);
+  };
+  const vedTomBlur = (nyDato) => {
+    setTomHarFokus(false);
+    vedFeltEndring("soknadsperiodeTom", Utils.vaskInputDato(nyDato) || nyDato);
+  };
+
+  const fomFeil = !fomHarFokus && soknadsperiodeFomErrors ? { feilmelding: soknadsperiodeFomErrors } : undefined;
+  const tomFeil = !tomHarFokus && soknadsperiodeTomErrors ? { feilmelding: soknadsperiodeTomErrors } : undefined;
 
   return (
     <Nav.Fieldset legend="">
@@ -50,7 +69,8 @@ const SoknadsperiodeEndring = (props) => {
                   value={soknadsperiodeFom}
                   onChange={(event) => vedFeltEndring("soknadsperiodeFom", event.target.value)}
                   onBlur={(event) => event.target.value && vedFomBlur(event.target.value)}
-                  feil={soknadsperiodeFomErrors && { feilmelding: soknadsperiodeFomErrors }}
+                  onFocus={vedFomFokus}
+                  feil={fomFeil}
                 />
               )
             }
@@ -75,7 +95,8 @@ const SoknadsperiodeEndring = (props) => {
                   value={soknadsperiodeTom}
                   onChange={(event) => vedFeltEndring("soknadsperiodeTom", event.target.value)}
                   onBlur={(event) => event.target.value && vedTomBlur(event.target.value)}
-                  feil={soknadsperiodeTomErrors && { feilmelding: soknadsperiodeTomErrors }}
+                  onFocus={vedTomFokus}
+                  feil={tomFeil}
                 />
               )
             }

--- a/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiodeEndring.js
+++ b/src/felleskomponenter/menypanel/menypunkter/periode/soknadsperiode/soknadsperiodeEndring.js
@@ -25,6 +25,9 @@ const SoknadsperiodeEndring = (props) => {
   const vedFomEndring = (nyDato) => vedFeltEndring("soknadsperiodeFom", Utils.dateTilNorskString(nyDato));
   const vedTomEndring = (nyDato) => vedFeltEndring("soknadsperiodeTom", Utils.dateTilNorskString(nyDato));
 
+  const vedFomBlur = (nyDato) => vedFeltEndring("soknadsperiodeFom", Utils.vaskInputDato(nyDato) || nyDato);
+  const vedTomBlur = (nyDato) => vedFeltEndring("soknadsperiodeTom", Utils.vaskInputDato(nyDato) || nyDato);
+
   return (
     <Nav.Fieldset legend="">
       <Nav.Row>
@@ -46,6 +49,7 @@ const SoknadsperiodeEndring = (props) => {
                   label="Fra og med:"
                   value={soknadsperiodeFom}
                   onChange={(event) => vedFeltEndring("soknadsperiodeFom", event.target.value)}
+                  onBlur={(event) => event.target.value && vedFomBlur(event.target.value)}
                   feil={soknadsperiodeFomErrors && { feilmelding: soknadsperiodeFomErrors }}
                 />
               )
@@ -70,6 +74,7 @@ const SoknadsperiodeEndring = (props) => {
                   label="Til og med:"
                   value={soknadsperiodeTom}
                   onChange={(event) => vedFeltEndring("soknadsperiodeTom", event.target.value)}
+                  onBlur={(event) => event.target.value && vedTomBlur(event.target.value)}
                   feil={soknadsperiodeTomErrors && { feilmelding: soknadsperiodeTomErrors }}
                 />
               )


### PR DESCRIPTION
Når datovelger var togglet av, ble dato auto-utfylt for tidlig med leading zeroes når årstall ikke hadde "nok" tall. Dette gjorde at periode-feltet opplevdes buggy.

La på en fix der steget bruker state-perioden istedenfor direkte redux-perioden, og la på en onblur som vasket input.

Er fortsatt en bug der feil feilmelding vises. Dette er fordi panelet oppdaterer behandlingsgrunnlag-perioden ved å formattere lokal state til ISO -> som ignorerer endel feil format. Ser ikke ut til å være lett løsning her, men skal se litt mer på det. 