### PR TITLE
NOJIRA - Ikke obfusker feil i schema som ikke er valideringsfeil

### DIFF
--- a/src/yup/lagYupToReduxformErrorMapper.js
+++ b/src/yup/lagYupToReduxformErrorMapper.js
@@ -8,10 +8,14 @@ const lagYupToReduxformErrorMapper = (schema, settings) => {
 
     try {
       schema.validateSync(values, { abortEarly: false, ...settings });
-    } catch (errors) {
-      errors.inner.forEach((error) => {
-        Utils._set(formErrors, error.path, error.message);
-      });
+    } catch (error) {
+      if (error.inner) {
+        error.inner.forEach((e) => {
+          Utils._set(formErrors, e.path, e.message);
+        });
+      } else {
+        throw error;
+      }
     }
 
     return formErrors;

--- a/src/yup/lagYupToReduxformErrorMapper.test.js
+++ b/src/yup/lagYupToReduxformErrorMapper.test.js
@@ -1,4 +1,4 @@
-import { object, array, number } from "yup";
+import { object, array, number, mixed } from "yup";
 
 import { lagYupToReduxformErrorMapper } from "./lagYupToReduxformErrorMapper";
 
@@ -24,11 +24,23 @@ describe("lagYupToReduxformErrorMapper", () => {
       ).toHaveLength(1);
     });
 
-    it("returnerer ingen feilmeldinger for et tomt schema", () => {
-      const schema = object().shape({});
+    it("returnerer ingen feilmeldinger for et schema som matcher verdiene", () => {
+      const schema = mixed();
       const mapYupToReduxformError = lagYupToReduxformErrorMapper(schema);
 
       expect(mapYupToReduxformError({})).toEqual({});
+    });
+
+    it("obfuskerer ikke errors som ikke er valideringsfeil(error.inner er undefined)", () => {
+      const schema = mixed();
+      schema.validateSync = () => {
+        throw new Error("Feil");
+      };
+      const mapYupToReduxformError = lagYupToReduxformErrorMapper(schema);
+
+      expect(() => {
+        mapYupToReduxformError({});
+      }).toThrowError(new Error("Feil"));
     });
   });
 });


### PR DESCRIPTION
Errors fra schema som ikke er valideringsfeil blir obfuskert/gjemt, ved at de ikke har `error.inner` satt. Det blir derfor kastet en TypeError, og den faktiske erroren blir "svelget". Denne PRen fikser dette.