### PR TITLE
MELOSYS-4579 - Kommer ikke videre i stegvelger med åpen periode

### DIFF
--- a/src/ducks/form/selectors.js
+++ b/src/ducks/form/selectors.js
@@ -14,6 +14,7 @@ import soknadSchema from "./soknadSchema";
 import { lagYupToReduxformErrorMapper } from "../../yup";
 
 import { behandlingerSelectors } from "../behandlinger";
+import { behandlingsgrunnlagSelectors } from "../behandlingsgrunnlag";
 
 const getFormState = (state, formName, defaultValue = {}) =>
   state.form[formName] ? state.form[formName] : defaultValue;
@@ -365,6 +366,7 @@ export const SoknadErrorsSelector = createSelector(
   (state) => ({
     skalOppgittAdresseValideres: SoknadOppgittAdresseHarVerdierSelector(state),
     behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
+    behandlingsgrunnlagtype: behandlingsgrunnlagSelectors.BehandlingsgrunnlagtypeSelector(state),
   }),
   (soknadformSyncErrors, soknadformValues, context) => {
     const settings = {

--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -27,6 +27,32 @@ const erIkkeBeslutningLovvalgAnnetLand = (behandlingstema) =>
 const erElektroniskSoknad = (behandlingsgrunnlagtype) =>
   behandlingsgrunnlagtype === MKV.Koder.behandlingsgrunnlagtyper.SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS;
 
+const lagSoknadsperiodeSchema = (behandlingsgrunnlagtype) => {
+  const menypunkt = erElektroniskSoknad(behandlingsgrunnlagtype)
+    ? KV.Menypunkter.Utenlandsoppdraget.tittel
+    : KV.Menypunkter.Periode.tittel;
+  const periodeUndertittel = erElektroniskSoknad(behandlingsgrunnlagtype)
+    ? KV.Menypunkter.Utenlandsoppdraget.undertitler.periode
+    : KV.Menypunkter.Periode.undertitler.periode;
+
+  return object().shape({
+    soknadsperiodeFom: string()
+      .erGyldigDato(lagMelding(menypunkt, periodeUndertittel, SKRIV_INN_GYLDIG_DATO.melding))
+      .required(lagMelding(menypunkt, periodeUndertittel, `Fra og med ${MAA_FYLLES_UT.melding}`)),
+    soknadsperiodeTom: string()
+      .erGyldigDato(lagMelding(menypunkt, periodeUndertittel, SKRIV_INN_GYLDIG_DATO.melding))
+      .erEtterDatofelt(
+        "soknadsperiodeFom",
+        lagMelding(menypunkt, periodeUndertittel, `Til og med ${TIDLIGERE_ENN_FOM.melding}`)
+      )
+      .when("$behandlingstema", {
+        is: MKVUtils.erUtsendt,
+        then: string().required(lagMelding(menypunkt, periodeUndertittel, `Til og med ${MAA_FYLLES_UT.melding}`)),
+      })
+      .nullable(),
+  });
+};
+
 const utenlandskIdent = object().shape({
   ident: string()
     .nullable()
@@ -286,97 +312,7 @@ const soknad = object().when("$behandlingstema", {
         }),
       }),
     })
-    .when("$behandlingsgrunnlagtype", {
-      is: erElektroniskSoknad,
-      then: object().shape({
-        soknadsperiodeFom: string()
-          .erGyldigDato(
-            lagMelding(
-              KV.Menypunkter.Utenlandsoppdraget.tittel,
-              KV.Menypunkter.Utenlandsoppdraget.undertitler.periode,
-              SKRIV_INN_GYLDIG_DATO.melding
-            )
-          )
-          .required(
-            lagMelding(
-              KV.Menypunkter.Utenlandsoppdraget.tittel,
-              KV.Menypunkter.Utenlandsoppdraget.undertitler.periode,
-              `Fra og med ${MAA_FYLLES_UT.melding}`
-            )
-          ),
-        soknadsperiodeTom: string()
-          .erGyldigDato(
-            lagMelding(
-              KV.Menypunkter.Utenlandsoppdraget.tittel,
-              KV.Menypunkter.Utenlandsoppdraget.undertitler.periode,
-              SKRIV_INN_GYLDIG_DATO.melding
-            )
-          )
-          .erEtterDatofelt(
-            "soknadsperiodeFom",
-            lagMelding(
-              KV.Menypunkter.Utenlandsoppdraget.tittel,
-              KV.Menypunkter.Utenlandsoppdraget.undertitler.periode,
-              `Til og med ${TIDLIGERE_ENN_FOM.melding}`
-            )
-          )
-          .when("$behandlingstema", {
-            is: MKVUtils.erUtsendt,
-            then: string().required(
-              lagMelding(
-                KV.Menypunkter.Utenlandsoppdraget.tittel,
-                KV.Menypunkter.Utenlandsoppdraget.undertitler.periode,
-                `Til og med ${MAA_FYLLES_UT.melding}`
-              )
-            ),
-          })
-          .nullable(),
-      }),
-      otherwise: object().shape({
-        soknadsperiodeFom: string()
-          .erGyldigDato(
-            lagMelding(
-              KV.Menypunkter.Periode.tittel,
-              KV.Menypunkter.Periode.undertitler.periode,
-              SKRIV_INN_GYLDIG_DATO.melding
-            )
-          )
-          .required(
-            lagMelding(
-              KV.Menypunkter.Periode.tittel,
-              KV.Menypunkter.Periode.undertitler.periode,
-              `Fra og med ${MAA_FYLLES_UT.melding}`
-            )
-          ),
-        soknadsperiodeTom: string()
-          .erGyldigDato(
-            lagMelding(
-              KV.Menypunkter.Periode.tittel,
-              KV.Menypunkter.Periode.undertitler.periode,
-              SKRIV_INN_GYLDIG_DATO.melding
-            )
-          )
-          .erEtterDatofelt(
-            "soknadsperiodeFom",
-            lagMelding(
-              KV.Menypunkter.Periode.tittel,
-              KV.Menypunkter.Periode.undertitler.periode,
-              `Til og med ${TIDLIGERE_ENN_FOM.melding}`
-            )
-          )
-          .when("$behandlingstema", {
-            is: MKVUtils.erUtsendt,
-            then: string().required(
-              lagMelding(
-                KV.Menypunkter.Periode.tittel,
-                KV.Menypunkter.Periode.undertitler.periode,
-                `Til og med ${MAA_FYLLES_UT.melding}`
-              )
-            ),
-          })
-          .nullable(),
-      }),
-    }),
+    .when("$behandlingsgrunnlagtype", lagSoknadsperiodeSchema),
 });
 
 export default soknad;

--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -38,16 +38,13 @@ const lagSoknadsperiodeSchema = (behandlingsgrunnlagtype) => {
   return object().shape({
     soknadsperiodeFom: string()
       .erGyldigDato(lagMelding(menypunkt, periodeUndertittel, SKRIV_INN_GYLDIG_DATO.melding))
-      .required(lagMelding(menypunkt, periodeUndertittel, `Fra og med ${MAA_FYLLES_UT.melding}`)),
+      .required(lagMelding(menypunkt, periodeUndertittel, MAA_FYLLES_UT.melding)),
     soknadsperiodeTom: string()
       .erGyldigDato(lagMelding(menypunkt, periodeUndertittel, SKRIV_INN_GYLDIG_DATO.melding))
-      .erEtterDatofelt(
-        "soknadsperiodeFom",
-        lagMelding(menypunkt, periodeUndertittel, `Til og med ${TIDLIGERE_ENN_FOM.melding}`)
-      )
+      .erEtterDatofelt("soknadsperiodeFom", lagMelding(menypunkt, periodeUndertittel, TIDLIGERE_ENN_FOM.melding))
       .when("$behandlingstema", {
         is: MKVUtils.erUtsendt,
-        then: string().required(lagMelding(menypunkt, periodeUndertittel, `Til og med ${MAA_FYLLES_UT.melding}`)),
+        then: string().required(lagMelding(menypunkt, periodeUndertittel, MAA_FYLLES_UT.melding)),
       })
       .nullable(),
   });

--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -24,31 +24,40 @@ const tomStringTilNull = (value, originalValue) => (originalValue === "" ? null 
 const erIkkeBeslutningLovvalgAnnetLand = (behandlingstema) =>
   behandlingstema !== MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND;
 
-const erElektroniskSoknad = (behandlingsgrunnlagtype) =>
+const erAltinnsøknad = (behandlingsgrunnlagtype) =>
   behandlingsgrunnlagtype === MKV.Koder.behandlingsgrunnlagtyper.SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS;
 
-const lagSoknadsperiodeSchema = (behandlingsgrunnlagtype) => {
-  const menypunkt = erElektroniskSoknad(behandlingsgrunnlagtype)
+const hentSoknadsperiodeMeldingtekst = (behandlingsgrunnlagtype) => {
+  const menypunkt = erAltinnsøknad(behandlingsgrunnlagtype)
     ? KV.Menypunkter.Utenlandsoppdraget.tittel
     : KV.Menypunkter.Periode.tittel;
-  const periodeUndertittel = erElektroniskSoknad(behandlingsgrunnlagtype)
+  const periodeUndertittel = erAltinnsøknad(behandlingsgrunnlagtype)
     ? KV.Menypunkter.Utenlandsoppdraget.undertitler.periode
     : KV.Menypunkter.Periode.undertitler.periode;
 
-  return object().shape({
-    soknadsperiodeFom: string()
-      .erGyldigDato(lagMelding(menypunkt, periodeUndertittel, SKRIV_INN_GYLDIG_DATO.melding))
-      .required(lagMelding(menypunkt, periodeUndertittel, MAA_FYLLES_UT.melding)),
-    soknadsperiodeTom: string()
-      .erGyldigDato(lagMelding(menypunkt, periodeUndertittel, SKRIV_INN_GYLDIG_DATO.melding))
-      .erEtterDatofelt("soknadsperiodeFom", lagMelding(menypunkt, periodeUndertittel, TIDLIGERE_ENN_FOM.melding))
-      .when("$behandlingstema", {
-        is: MKVUtils.erUtsendt,
-        then: string().required(lagMelding(menypunkt, periodeUndertittel, MAA_FYLLES_UT.melding)),
-      })
-      .nullable(),
-  });
+  return { menypunkt, periodeUndertittel };
 };
+
+const soknadsperiodeFomSchema = string().when("$behandlingsgrunnlagtype", (behandlingsgrunnlagtype) => {
+  const { menypunkt, periodeUndertittel } = hentSoknadsperiodeMeldingtekst(behandlingsgrunnlagtype);
+
+  return string()
+    .erGyldigDato(lagMelding(menypunkt, periodeUndertittel, SKRIV_INN_GYLDIG_DATO.melding))
+    .required(lagMelding(menypunkt, periodeUndertittel, MAA_FYLLES_UT.melding));
+});
+
+const soknadsperiodeTomSchema = string().when("$behandlingsgrunnlagtype", (behandlingsgrunnlagtype) => {
+  const { menypunkt, periodeUndertittel } = hentSoknadsperiodeMeldingtekst(behandlingsgrunnlagtype);
+
+  return string()
+    .erGyldigDato(lagMelding(menypunkt, periodeUndertittel, SKRIV_INN_GYLDIG_DATO.melding))
+    .erEtterDatofelt("soknadsperiodeFom", lagMelding(menypunkt, periodeUndertittel, TIDLIGERE_ENN_FOM.melding))
+    .when("$behandlingstema", {
+      is: MKVUtils.erUtsendt,
+      then: string().required(lagMelding(menypunkt, periodeUndertittel, MAA_FYLLES_UT.melding)),
+    })
+    .nullable();
+});
 
 const utenlandskIdent = object().shape({
   ident: string()
@@ -113,203 +122,195 @@ const medfolgendeBarn = object().shape({
 
 const soknad = object().when("$behandlingstema", {
   is: erIkkeBeslutningLovvalgAnnetLand,
-  then: object()
-    .shape({
-      arbeidsforholdUtland: array().of(
-        object().shape({
-          navn: string()
+  then: object().shape({
+    arbeidsforholdUtland: array().of(
+      object().shape({
+        navn: string()
+          .nullable()
+          .required(
+            lagMelding(
+              KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
+              KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.arbeidsforholdIUtlandet,
+              "Navn kreves"
+            )
+          ),
+        orgnr: string()
+          .nullable()
+          .max(
+            25,
+            lagMelding(
+              KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
+              KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.arbeidsforholdIUtlandet,
+              "Registreringsnummer kan ikke være lenger enn 25 tegn"
+            )
+          ),
+      })
+    ),
+    selvstendigNaeringsvirksomhetUtland: array().of(
+      object().shape({
+        navn: string()
+          .nullable()
+          .required(
+            lagMelding(
+              KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
+              KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.selvstendigNaeringsdrivendeIUtlandet,
+              "Navn kreves"
+            )
+          ),
+        orgnr: string()
+          .nullable()
+          .max(
+            25,
+            lagMelding(
+              KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
+              KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.selvstendigNaeringsdrivendeIUtlandet,
+              "Registreringsnummer kan ikke være lenger enn 25 tegn"
+            )
+          ),
+      })
+    ),
+    arbeidsstedOffshore: array().of(
+      object()
+        .shape({
+          enhetNavn: string()
             .nullable()
             .required(
               lagMelding(
-                KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
-                KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.arbeidsforholdIUtlandet,
+                KV.Menypunkter.Arbeidssteder.tittel,
+                KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedOffshore,
                 "Navn kreves"
               )
             ),
-          orgnr: string()
-            .nullable()
-            .max(
-              25,
-              lagMelding(
-                KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
-                KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.arbeidsforholdIUtlandet,
-                "Registreringsnummer kan ikke være lenger enn 25 tegn"
-              )
-            ),
         })
-      ),
-      selvstendigNaeringsvirksomhetUtland: array().of(
-        object().shape({
-          navn: string()
+        .uniqueProperty(
+          "enhetNavn",
+          lagMelding(
+            KV.Menypunkter.Arbeidssteder.tittel,
+            KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedOffshore,
+            "Navn på enhet må være unikt"
+          )
+        )
+    ),
+    arbeidsstedSkip: array().of(
+      object()
+        .shape({
+          enhetNavn: string()
             .nullable()
             .required(
               lagMelding(
-                KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
-                KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.selvstendigNaeringsdrivendeIUtlandet,
+                KV.Menypunkter.Arbeidssteder.tittel,
+                KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedSkip,
                 "Navn kreves"
               )
             ),
-          orgnr: string()
-            .nullable()
-            .max(
-              25,
-              lagMelding(
-                KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
-                KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.selvstendigNaeringsdrivendeIUtlandet,
-                "Registreringsnummer kan ikke være lenger enn 25 tegn"
-              )
-            ),
         })
-      ),
-      arbeidsstedOffshore: array().of(
-        object()
-          .shape({
-            enhetNavn: string()
-              .nullable()
-              .required(
-                lagMelding(
-                  KV.Menypunkter.Arbeidssteder.tittel,
-                  KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedOffshore,
-                  "Navn kreves"
-                )
-              ),
-          })
-          .uniqueProperty(
-            "enhetNavn",
-            lagMelding(
-              KV.Menypunkter.Arbeidssteder.tittel,
-              KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedOffshore,
-              "Navn på enhet må være unikt"
-            )
+        .uniqueProperty(
+          "enhetNavn",
+          lagMelding(
+            KV.Menypunkter.Arbeidssteder.tittel,
+            KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedSkip,
+            "Navn på enhet må være unikt"
           )
-      ),
-      arbeidsstedSkip: array().of(
-        object()
-          .shape({
-            enhetNavn: string()
-              .nullable()
-              .required(
-                lagMelding(
-                  KV.Menypunkter.Arbeidssteder.tittel,
-                  KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedSkip,
-                  "Navn kreves"
-                )
-              ),
-          })
-          .uniqueProperty(
-            "enhetNavn",
+        )
+    ),
+    oppgittAdresseGatenavn: string()
+      .nullable()
+      .when("$skalOppgittAdresseValideres", {
+        is: true,
+        then: string()
+          .nullable()
+          .required(
+            lagMelding(KV.Menypunkter.Person.tittel, KV.Menypunkter.Person.undertitler.annenAdresse, "Gatenavn kreves")
+          ),
+      }),
+    oppgittAdressePostnummer: string()
+      .nullable()
+      .when("$skalOppgittAdresseValideres", {
+        is: true,
+        then: string()
+          .nullable()
+          .required(
             lagMelding(
-              KV.Menypunkter.Arbeidssteder.tittel,
-              KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedSkip,
-              "Navn på enhet må være unikt"
+              KV.Menypunkter.Person.tittel,
+              KV.Menypunkter.Person.undertitler.annenAdresse,
+              "Postnummer kreves"
             )
-          )
-      ),
-      oppgittAdresseGatenavn: string()
-        .nullable()
-        .when("$skalOppgittAdresseValideres", {
-          is: true,
-          then: string()
-            .nullable()
-            .required(
-              lagMelding(
-                KV.Menypunkter.Person.tittel,
-                KV.Menypunkter.Person.undertitler.annenAdresse,
-                "Gatenavn kreves"
-              )
-            ),
-        }),
-      oppgittAdressePostnummer: string()
-        .nullable()
-        .when("$skalOppgittAdresseValideres", {
-          is: true,
-          then: string()
-            .nullable()
-            .required(
-              lagMelding(
-                KV.Menypunkter.Person.tittel,
-                KV.Menypunkter.Person.undertitler.annenAdresse,
-                "Postnummer kreves"
-              )
-            ),
-        }),
-      oppgittAdressePoststed: string()
-        .nullable()
-        .when("$skalOppgittAdresseValideres", {
-          is: true,
-          then: string()
-            .nullable()
-            .required(
-              lagMelding(
-                KV.Menypunkter.Person.tittel,
-                KV.Menypunkter.Person.undertitler.annenAdresse,
-                "Poststed kreves"
-              )
-            ),
-        }),
-      oppgittAdresseLand: string()
-        .nullable()
-        .when("$skalOppgittAdresseValideres", {
-          is: true,
-          then: string()
-            .nullable()
-            .required(
-              lagMelding(KV.Menypunkter.Person.tittel, KV.Menypunkter.Person.undertitler.annenAdresse, "Land kreves")
-            ),
-        }),
-      utenlandskIdent: array().of(utenlandskIdent),
-      medfolgendeBarn: array().of(medfolgendeBarn),
-      juridiskArbeidsgiverNorge: object().shape({
-        antallAnsatte: number().transform(tomStringTilNull).nullable(),
-        antallAdmAnsatte: number().transform(tomStringTilNull).nullable(),
-        antallUtsendte: number().transform(tomStringTilNull).nullable(),
-        andelRekruttertINorge: number()
-          .min(0, lagAndelMellomNullOgHundreMelding("ansatte rekruttert i Norge"))
-          .max(100, lagAndelMellomNullOgHundreMelding("ansatte rekruttert i Norge"))
-          .transform(tomStringTilNull)
-          .nullable(),
-        andelOmsetningINorge: number()
-          .min(0, lagAndelMellomNullOgHundreMelding("omsetning opptjent i Norge"))
-          .max(100, lagAndelMellomNullOgHundreMelding("omsetning opptjent i Norge"))
-          .transform(tomStringTilNull)
-          .nullable(),
-        andelKontrakterINorge: number()
-          .min(0, lagAndelMellomNullOgHundreMelding("oppdragskontrakter inngått i Norge"))
-          .max(100, lagAndelMellomNullOgHundreMelding("oppdragskontrakter inngått i Norge"))
-          .transform(tomStringTilNull)
-          .nullable(),
-        andelOppdragINorge: number()
-          .min(0, lagAndelMellomNullOgHundreMelding("oppdrag utført i Norge"))
-          .max(100, lagAndelMellomNullOgHundreMelding("oppdrag utført i Norge"))
-          .transform(tomStringTilNull)
-          .nullable(),
+          ),
       }),
-      utenlandsoppdraget: object().shape({
-        samletUtsendingsperiode: object().shape({
-          fom: string()
-            .nullable()
-            .test(erFoerTomTest)
-            .erGyldigDato(
-              lagMelding(
-                KV.Menypunkter.Utenlandsoppdraget.tittel,
-                KV.Menypunkter.Utenlandsoppdraget.undertitler.tilleggsopplysninger,
-                SKRIV_INN_GYLDIG_DATO.melding
-              )
-            ),
-          tom: string()
-            .nullable()
-            .test(erEtterFomTest)
-            .erGyldigDato(
-              lagMelding(
-                KV.Menypunkter.Utenlandsoppdraget.tittel,
-                KV.Menypunkter.Utenlandsoppdraget.undertitler.tilleggsopplysninger,
-                SKRIV_INN_GYLDIG_DATO.melding
-              )
-            ),
-        }),
+    oppgittAdressePoststed: string()
+      .nullable()
+      .when("$skalOppgittAdresseValideres", {
+        is: true,
+        then: string()
+          .nullable()
+          .required(
+            lagMelding(KV.Menypunkter.Person.tittel, KV.Menypunkter.Person.undertitler.annenAdresse, "Poststed kreves")
+          ),
       }),
-    })
-    .when("$behandlingsgrunnlagtype", lagSoknadsperiodeSchema),
+    oppgittAdresseLand: string()
+      .nullable()
+      .when("$skalOppgittAdresseValideres", {
+        is: true,
+        then: string()
+          .nullable()
+          .required(
+            lagMelding(KV.Menypunkter.Person.tittel, KV.Menypunkter.Person.undertitler.annenAdresse, "Land kreves")
+          ),
+      }),
+    soknadsperiodeFom: soknadsperiodeFomSchema,
+    soknadsperiodeTom: soknadsperiodeTomSchema,
+    utenlandskIdent: array().of(utenlandskIdent),
+    medfolgendeBarn: array().of(medfolgendeBarn),
+    juridiskArbeidsgiverNorge: object().shape({
+      antallAnsatte: number().transform(tomStringTilNull).nullable(),
+      antallAdmAnsatte: number().transform(tomStringTilNull).nullable(),
+      antallUtsendte: number().transform(tomStringTilNull).nullable(),
+      andelRekruttertINorge: number()
+        .min(0, lagAndelMellomNullOgHundreMelding("ansatte rekruttert i Norge"))
+        .max(100, lagAndelMellomNullOgHundreMelding("ansatte rekruttert i Norge"))
+        .transform(tomStringTilNull)
+        .nullable(),
+      andelOmsetningINorge: number()
+        .min(0, lagAndelMellomNullOgHundreMelding("omsetning opptjent i Norge"))
+        .max(100, lagAndelMellomNullOgHundreMelding("omsetning opptjent i Norge"))
+        .transform(tomStringTilNull)
+        .nullable(),
+      andelKontrakterINorge: number()
+        .min(0, lagAndelMellomNullOgHundreMelding("oppdragskontrakter inngått i Norge"))
+        .max(100, lagAndelMellomNullOgHundreMelding("oppdragskontrakter inngått i Norge"))
+        .transform(tomStringTilNull)
+        .nullable(),
+      andelOppdragINorge: number()
+        .min(0, lagAndelMellomNullOgHundreMelding("oppdrag utført i Norge"))
+        .max(100, lagAndelMellomNullOgHundreMelding("oppdrag utført i Norge"))
+        .transform(tomStringTilNull)
+        .nullable(),
+    }),
+    utenlandsoppdraget: object().shape({
+      samletUtsendingsperiode: object().shape({
+        fom: string()
+          .nullable()
+          .test(erFoerTomTest)
+          .erGyldigDato(
+            lagMelding(
+              KV.Menypunkter.Utenlandsoppdraget.tittel,
+              KV.Menypunkter.Utenlandsoppdraget.undertitler.tilleggsopplysninger,
+              SKRIV_INN_GYLDIG_DATO.melding
+            )
+          ),
+        tom: string()
+          .nullable()
+          .test(erEtterFomTest)
+          .erGyldigDato(
+            lagMelding(
+              KV.Menypunkter.Utenlandsoppdraget.tittel,
+              KV.Menypunkter.Utenlandsoppdraget.undertitler.tilleggsopplysninger,
+              SKRIV_INN_GYLDIG_DATO.melding
+            )
+          ),
+      }),
+    }),
+  }),
 });
 
 export default soknad;

--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -24,6 +24,9 @@ const tomStringTilNull = (value, originalValue) => (originalValue === "" ? null 
 const erIkkeBeslutningLovvalgAnnetLand = (behandlingstema) =>
   behandlingstema !== MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND;
 
+const erElektroniskSoknad = (behandlingsgrunnlagtype) =>
+  behandlingsgrunnlagtype === MKV.Koder.behandlingsgrunnlagtyper.SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS;
+
 const utenlandskIdent = object().shape({
   ident: string()
     .nullable()
@@ -87,202 +90,293 @@ const medfolgendeBarn = object().shape({
 
 const soknad = object().when("$behandlingstema", {
   is: erIkkeBeslutningLovvalgAnnetLand,
-  then: object().shape({
-    arbeidsforholdUtland: array().of(
-      object().shape({
-        navn: string()
-          .nullable()
-          .required(
-            lagMelding(
-              KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
-              KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.arbeidsforholdIUtlandet,
-              "Navn kreves"
-            )
-          ),
-        orgnr: string()
-          .nullable()
-          .max(
-            25,
-            lagMelding(
-              KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
-              KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.arbeidsforholdIUtlandet,
-              "Registreringsnummer kan ikke være lenger enn 25 tegn"
-            )
-          ),
-      })
-    ),
-    selvstendigNaeringsvirksomhetUtland: array().of(
-      object().shape({
-        navn: string()
-          .nullable()
-          .required(
-            lagMelding(
-              KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
-              KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.selvstendigNaeringsdrivendeIUtlandet,
-              "Navn kreves"
-            )
-          ),
-        orgnr: string()
-          .nullable()
-          .max(
-            25,
-            lagMelding(
-              KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
-              KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.selvstendigNaeringsdrivendeIUtlandet,
-              "Registreringsnummer kan ikke være lenger enn 25 tegn"
-            )
-          ),
-      })
-    ),
-    arbeidsstedOffshore: array().of(
-      object()
-        .shape({
-          enhetNavn: string()
+  then: object()
+    .shape({
+      arbeidsforholdUtland: array().of(
+        object().shape({
+          navn: string()
             .nullable()
             .required(
               lagMelding(
-                KV.Menypunkter.Arbeidssteder.tittel,
-                KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedOffshore,
+                KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
+                KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.arbeidsforholdIUtlandet,
                 "Navn kreves"
               )
             ),
+          orgnr: string()
+            .nullable()
+            .max(
+              25,
+              lagMelding(
+                KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
+                KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.arbeidsforholdIUtlandet,
+                "Registreringsnummer kan ikke være lenger enn 25 tegn"
+              )
+            ),
         })
-        .uniqueProperty(
-          "enhetNavn",
-          lagMelding(
-            KV.Menypunkter.Arbeidssteder.tittel,
-            KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedOffshore,
-            "Navn på enhet må være unikt"
-          )
-        )
-    ),
-    arbeidsstedSkip: array().of(
-      object()
-        .shape({
-          enhetNavn: string()
+      ),
+      selvstendigNaeringsvirksomhetUtland: array().of(
+        object().shape({
+          navn: string()
             .nullable()
             .required(
               lagMelding(
-                KV.Menypunkter.Arbeidssteder.tittel,
-                KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedSkip,
+                KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
+                KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.selvstendigNaeringsdrivendeIUtlandet,
                 "Navn kreves"
               )
             ),
+          orgnr: string()
+            .nullable()
+            .max(
+              25,
+              lagMelding(
+                KV.Menypunkter.ArbeidsgiverOgVirksomhet.tittel,
+                KV.Menypunkter.ArbeidsgiverOgVirksomhet.undertitler.selvstendigNaeringsdrivendeIUtlandet,
+                "Registreringsnummer kan ikke være lenger enn 25 tegn"
+              )
+            ),
         })
-        .uniqueProperty(
-          "enhetNavn",
-          lagMelding(
-            KV.Menypunkter.Arbeidssteder.tittel,
-            KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedSkip,
-            "Navn på enhet må være unikt"
+      ),
+      arbeidsstedOffshore: array().of(
+        object()
+          .shape({
+            enhetNavn: string()
+              .nullable()
+              .required(
+                lagMelding(
+                  KV.Menypunkter.Arbeidssteder.tittel,
+                  KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedOffshore,
+                  "Navn kreves"
+                )
+              ),
+          })
+          .uniqueProperty(
+            "enhetNavn",
+            lagMelding(
+              KV.Menypunkter.Arbeidssteder.tittel,
+              KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedOffshore,
+              "Navn på enhet må være unikt"
+            )
           )
-        )
-    ),
-    oppgittAdresseGatenavn: string()
-      .nullable()
-      .when("$skalOppgittAdresseValideres", {
-        is: true,
-        then: string()
-          .nullable()
-          .required(
-            lagMelding(KV.Menypunkter.Person.tittel, KV.Menypunkter.Person.undertitler.annenAdresse, "Gatenavn kreves")
-          ),
-      }),
-    oppgittAdressePostnummer: string()
-      .nullable()
-      .when("$skalOppgittAdresseValideres", {
-        is: true,
-        then: string()
-          .nullable()
-          .required(
+      ),
+      arbeidsstedSkip: array().of(
+        object()
+          .shape({
+            enhetNavn: string()
+              .nullable()
+              .required(
+                lagMelding(
+                  KV.Menypunkter.Arbeidssteder.tittel,
+                  KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedSkip,
+                  "Navn kreves"
+                )
+              ),
+          })
+          .uniqueProperty(
+            "enhetNavn",
             lagMelding(
-              KV.Menypunkter.Person.tittel,
-              KV.Menypunkter.Person.undertitler.annenAdresse,
-              "Postnummer kreves"
+              KV.Menypunkter.Arbeidssteder.tittel,
+              KV.Menypunkter.Arbeidssteder.undertitler.arbeidsstedSkip,
+              "Navn på enhet må være unikt"
             )
-          ),
+          )
+      ),
+      oppgittAdresseGatenavn: string()
+        .nullable()
+        .when("$skalOppgittAdresseValideres", {
+          is: true,
+          then: string()
+            .nullable()
+            .required(
+              lagMelding(
+                KV.Menypunkter.Person.tittel,
+                KV.Menypunkter.Person.undertitler.annenAdresse,
+                "Gatenavn kreves"
+              )
+            ),
+        }),
+      oppgittAdressePostnummer: string()
+        .nullable()
+        .when("$skalOppgittAdresseValideres", {
+          is: true,
+          then: string()
+            .nullable()
+            .required(
+              lagMelding(
+                KV.Menypunkter.Person.tittel,
+                KV.Menypunkter.Person.undertitler.annenAdresse,
+                "Postnummer kreves"
+              )
+            ),
+        }),
+      oppgittAdressePoststed: string()
+        .nullable()
+        .when("$skalOppgittAdresseValideres", {
+          is: true,
+          then: string()
+            .nullable()
+            .required(
+              lagMelding(
+                KV.Menypunkter.Person.tittel,
+                KV.Menypunkter.Person.undertitler.annenAdresse,
+                "Poststed kreves"
+              )
+            ),
+        }),
+      oppgittAdresseLand: string()
+        .nullable()
+        .when("$skalOppgittAdresseValideres", {
+          is: true,
+          then: string()
+            .nullable()
+            .required(
+              lagMelding(KV.Menypunkter.Person.tittel, KV.Menypunkter.Person.undertitler.annenAdresse, "Land kreves")
+            ),
+        }),
+      utenlandskIdent: array().of(utenlandskIdent),
+      medfolgendeBarn: array().of(medfolgendeBarn),
+      juridiskArbeidsgiverNorge: object().shape({
+        antallAnsatte: number().transform(tomStringTilNull).nullable(),
+        antallAdmAnsatte: number().transform(tomStringTilNull).nullable(),
+        antallUtsendte: number().transform(tomStringTilNull).nullable(),
+        andelRekruttertINorge: number()
+          .min(0, lagAndelMellomNullOgHundreMelding("ansatte rekruttert i Norge"))
+          .max(100, lagAndelMellomNullOgHundreMelding("ansatte rekruttert i Norge"))
+          .transform(tomStringTilNull)
+          .nullable(),
+        andelOmsetningINorge: number()
+          .min(0, lagAndelMellomNullOgHundreMelding("omsetning opptjent i Norge"))
+          .max(100, lagAndelMellomNullOgHundreMelding("omsetning opptjent i Norge"))
+          .transform(tomStringTilNull)
+          .nullable(),
+        andelKontrakterINorge: number()
+          .min(0, lagAndelMellomNullOgHundreMelding("oppdragskontrakter inngått i Norge"))
+          .max(100, lagAndelMellomNullOgHundreMelding("oppdragskontrakter inngått i Norge"))
+          .transform(tomStringTilNull)
+          .nullable(),
+        andelOppdragINorge: number()
+          .min(0, lagAndelMellomNullOgHundreMelding("oppdrag utført i Norge"))
+          .max(100, lagAndelMellomNullOgHundreMelding("oppdrag utført i Norge"))
+          .transform(tomStringTilNull)
+          .nullable(),
       }),
-    oppgittAdressePoststed: string()
-      .nullable()
-      .when("$skalOppgittAdresseValideres", {
-        is: true,
-        then: string()
-          .nullable()
-          .required(
-            lagMelding(KV.Menypunkter.Person.tittel, KV.Menypunkter.Person.undertitler.annenAdresse, "Poststed kreves")
-          ),
+      utenlandsoppdraget: object().shape({
+        samletUtsendingsperiode: object().shape({
+          fom: string()
+            .nullable()
+            .test(erFoerTomTest)
+            .erGyldigDato(
+              lagMelding(
+                KV.Menypunkter.Utenlandsoppdraget.tittel,
+                KV.Menypunkter.Utenlandsoppdraget.undertitler.tilleggsopplysninger,
+                SKRIV_INN_GYLDIG_DATO.melding
+              )
+            ),
+          tom: string()
+            .nullable()
+            .test(erEtterFomTest)
+            .erGyldigDato(
+              lagMelding(
+                KV.Menypunkter.Utenlandsoppdraget.tittel,
+                KV.Menypunkter.Utenlandsoppdraget.undertitler.tilleggsopplysninger,
+                SKRIV_INN_GYLDIG_DATO.melding
+              )
+            ),
+        }),
       }),
-    oppgittAdresseLand: string()
-      .nullable()
-      .when("$skalOppgittAdresseValideres", {
-        is: true,
-        then: string()
-          .nullable()
-          .required(
-            lagMelding(KV.Menypunkter.Person.tittel, KV.Menypunkter.Person.undertitler.annenAdresse, "Land kreves")
-          ),
-      }),
-    soknadsperiodeFom: string().erGyldigDato().required(MAA_FYLLES_UT),
-    soknadsperiodeTom: string()
-      .erGyldigDato()
-      .erEtterDatofelt("soknadsperiodeFom")
-      .when("$behandlingstema", {
-        is: MKVUtils.erUtsendt,
-        then: string().required(MAA_FYLLES_UT),
-      })
-      .nullable(),
-    utenlandskIdent: array().of(utenlandskIdent),
-    medfolgendeBarn: array().of(medfolgendeBarn),
-    juridiskArbeidsgiverNorge: object().shape({
-      antallAnsatte: number().transform(tomStringTilNull).nullable(),
-      antallAdmAnsatte: number().transform(tomStringTilNull).nullable(),
-      antallUtsendte: number().transform(tomStringTilNull).nullable(),
-      andelRekruttertINorge: number()
-        .min(0, lagAndelMellomNullOgHundreMelding("ansatte rekruttert i Norge"))
-        .max(100, lagAndelMellomNullOgHundreMelding("ansatte rekruttert i Norge"))
-        .transform(tomStringTilNull)
-        .nullable(),
-      andelOmsetningINorge: number()
-        .min(0, lagAndelMellomNullOgHundreMelding("omsetning opptjent i Norge"))
-        .max(100, lagAndelMellomNullOgHundreMelding("omsetning opptjent i Norge"))
-        .transform(tomStringTilNull)
-        .nullable(),
-      andelKontrakterINorge: number()
-        .min(0, lagAndelMellomNullOgHundreMelding("oppdragskontrakter inngått i Norge"))
-        .max(100, lagAndelMellomNullOgHundreMelding("oppdragskontrakter inngått i Norge"))
-        .transform(tomStringTilNull)
-        .nullable(),
-      andelOppdragINorge: number()
-        .min(0, lagAndelMellomNullOgHundreMelding("oppdrag utført i Norge"))
-        .max(100, lagAndelMellomNullOgHundreMelding("oppdrag utført i Norge"))
-        .transform(tomStringTilNull)
-        .nullable(),
-    }),
-    utenlandsoppdraget: object().shape({
-      samletUtsendingsperiode: object().shape({
-        fom: string()
-          .nullable()
-          .test(erFoerTomTest)
+    })
+    .when("$behandlingsgrunnlagtype", {
+      is: erElektroniskSoknad,
+      then: object().shape({
+        soknadsperiodeFom: string()
           .erGyldigDato(
             lagMelding(
               KV.Menypunkter.Utenlandsoppdraget.tittel,
-              KV.Menypunkter.Utenlandsoppdraget.undertitler.tilleggsopplysninger,
+              KV.Menypunkter.Utenlandsoppdraget.undertitler.periode,
               SKRIV_INN_GYLDIG_DATO.melding
             )
+          )
+          .required(
+            lagMelding(
+              KV.Menypunkter.Utenlandsoppdraget.tittel,
+              KV.Menypunkter.Utenlandsoppdraget.undertitler.periode,
+              `Fra og med ${MAA_FYLLES_UT.melding}`
+            )
           ),
-        tom: string()
-          .nullable()
-          .test(erEtterFomTest)
+        soknadsperiodeTom: string()
           .erGyldigDato(
             lagMelding(
               KV.Menypunkter.Utenlandsoppdraget.tittel,
-              KV.Menypunkter.Utenlandsoppdraget.undertitler.tilleggsopplysninger,
+              KV.Menypunkter.Utenlandsoppdraget.undertitler.periode,
               SKRIV_INN_GYLDIG_DATO.melding
             )
+          )
+          .erEtterDatofelt(
+            "soknadsperiodeFom",
+            lagMelding(
+              KV.Menypunkter.Utenlandsoppdraget.tittel,
+              KV.Menypunkter.Utenlandsoppdraget.undertitler.periode,
+              `Til og med ${TIDLIGERE_ENN_FOM.melding}`
+            )
+          )
+          .when("$behandlingstema", {
+            is: MKVUtils.erUtsendt,
+            then: string().required(
+              lagMelding(
+                KV.Menypunkter.Utenlandsoppdraget.tittel,
+                KV.Menypunkter.Utenlandsoppdraget.undertitler.periode,
+                `Til og med ${MAA_FYLLES_UT.melding}`
+              )
+            ),
+          })
+          .nullable(),
+      }),
+      otherwise: object().shape({
+        soknadsperiodeFom: string()
+          .erGyldigDato(
+            lagMelding(
+              KV.Menypunkter.Periode.tittel,
+              KV.Menypunkter.Periode.undertitler.periode,
+              SKRIV_INN_GYLDIG_DATO.melding
+            )
+          )
+          .required(
+            lagMelding(
+              KV.Menypunkter.Periode.tittel,
+              KV.Menypunkter.Periode.undertitler.periode,
+              `Fra og med ${MAA_FYLLES_UT.melding}`
+            )
           ),
+        soknadsperiodeTom: string()
+          .erGyldigDato(
+            lagMelding(
+              KV.Menypunkter.Periode.tittel,
+              KV.Menypunkter.Periode.undertitler.periode,
+              SKRIV_INN_GYLDIG_DATO.melding
+            )
+          )
+          .erEtterDatofelt(
+            "soknadsperiodeFom",
+            lagMelding(
+              KV.Menypunkter.Periode.tittel,
+              KV.Menypunkter.Periode.undertitler.periode,
+              `Til og med ${TIDLIGERE_ENN_FOM.melding}`
+            )
+          )
+          .when("$behandlingstema", {
+            is: MKVUtils.erUtsendt,
+            then: string().required(
+              lagMelding(
+                KV.Menypunkter.Periode.tittel,
+                KV.Menypunkter.Periode.undertitler.periode,
+                `Til og med ${MAA_FYLLES_UT.melding}`
+              )
+            ),
+          })
+          .nullable(),
       }),
     }),
-  }),
 });
 
 export default soknad;

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/periode.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/periode.tsx
@@ -33,6 +33,7 @@ const Periode = ({
         <Soknadsperiode
           redigerbart={redigerbart}
           lagreSoknadOgOppfriskSaksopplysninger={lagreSoknadOgOppfriskSaksopplysninger}
+          tittel={KV.Menypunkter.Periode.undertitler.periode}
         />
       </Nav.Column>
       <Nav.Column xs="6">

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiode.js
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiode.js
@@ -73,14 +73,14 @@ export class Soknadsperiode extends Component {
   };
 
   render() {
-    const { redigerbart, soknadsperiodeFomErrors, soknadsperiodeTomErrors } = this.props;
+    const { redigerbart, soknadsperiodeFomErrors, soknadsperiodeTomErrors, tittel } = this.props;
     const { visEndrePeriode, skjulEndrePeriode, lagre, oppdaterFelt, avbryt } = this;
 
     const { erEndrePeriodeSynlig, soknadsperiodeFom, soknadsperiodeTom } = this.state;
 
     return (
       <div className="soknadsperiode">
-        <Nav.Typo.Normaltekst className="soknadsperiode__etikett">Periode</Nav.Typo.Normaltekst>
+        <Nav.Typo.Normaltekst className="soknadsperiode__etikett">{tittel}</Nav.Typo.Normaltekst>
         {!erEndrePeriodeSynlig && (
           <div className="periode__container">
             <Nav.Typo.Element className="periode">
@@ -114,6 +114,7 @@ Soknadsperiode.propTypes = {
   soknadsperiodeTom: PT.string.isRequired,
   soknadsperiodeFomErrors: PT.string,
   soknadsperiodeTomErrors: PT.string,
+  tittel: PT.string.isRequired,
 };
 
 Soknadsperiode.defaultProps = {

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/utenlandsoppdraget.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/utenlandsoppdraget.tsx
@@ -64,6 +64,7 @@ export const Utenlandsoppdraget = ({
           <Soknadsperiode
             redigerbart={redigerbart}
             lagreSoknadOgOppfriskSaksopplysninger={lagreSoknadOgOppfriskSaksopplysninger}
+            tittel={KV.Menypunkter.Utenlandsoppdraget.undertitler.periode}
           />
         </Nav.Column>
         {behandlingsgrunnlagtype !== SØKNAD_FOLKETRYGDEN && (

--- a/src/felleskomponenter/menypanelForm/soknad.tsx
+++ b/src/felleskomponenter/menypanelForm/soknad.tsx
@@ -22,6 +22,7 @@ import { formSelectors } from "../../ducks/form";
 const mapStateToProps = (state: RootState) => ({
   oppgittAdresseHarVerdier: formSelectors.SoknadOppgittAdresseHarVerdierSelector(state),
   behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
+  behandlingsgrunnlagtype: behandlingsgrunnlagSelectors.BehandlingsgrunnlagtypeSelector(state),
   initialValues: {
     utenlandskIdent: behandlingsgrunnlagSelectors.PersonOpplysningerSelector(state).utenlandskIdent,
     medfolgendeBarn: behandlingsgrunnlagSelectors.MedfolgendeBarnSelector(state),
@@ -201,6 +202,7 @@ const MenypanelForm = reduxForm<KV.Form.SoknadFormData, SoknadProps>({
       context: {
         skalOppgittAdresseValideres: props.oppgittAdresseHarVerdier,
         behandlingstema: props.behandlingstema,
+        behandlingsgrunnlagtype: props.behandlingsgrunnlagtype,
       },
     };
 

--- a/src/kodeverk/menypunkter.ts
+++ b/src/kodeverk/menypunkter.ts
@@ -37,7 +37,9 @@ export const Medlemskap = {
 
 export const Periode = {
   tittel: "Periode og land",
-  undertitler: {},
+  undertitler: {
+    periode: "Periode",
+  },
 };
 
 export const Person = {
@@ -56,6 +58,7 @@ export const Barnetrygd = {
 export const Utenlandsoppdraget = {
   tittel: "Utenlandsoppdraget",
   undertitler: {
+    periode: "Periode",
     tilleggsopplysninger: "Tilleggsopplysninger",
   },
 };


### PR DESCRIPTION
Oppsummeringsfeilmelding for `soknadsperiodeTom` (og noen flere felter) ble ikke vist, fordi `soknadsperiodeTom` sin feilmelding ikke hadde info om menypunkt.

Skiller på menypunkt "Periode og land" og "Utenlandsoppdraget", avhengig av `behandlingsgrunnlagtype`.