### PR TITLE
Nojira vilkaar post feil

### DIFF
--- a/src/felleskomponenter/skjema/htmleditor/htmleditor.tsx
+++ b/src/felleskomponenter/skjema/htmleditor/htmleditor.tsx
@@ -41,6 +41,7 @@ function InnerHTMLEditorComponent({ input, ...rest }: InnerHtmlEditorComponentPr
         editorClassName="editor"
         onEditorStateChange={onEditorStateChange}
         placeholder={rest.placeholder || ""}
+        readOnly={rest?.disabled}
       />
     </div>
   );

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingBestemmelse.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingBestemmelse.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, Fragment, useEffect, useState } from "react";
+import React, { ChangeEventHandler, Fragment, useCallback, useEffect, useState } from "react";
 import { RootState } from "AppTypes";
 import { connect, ConnectedProps } from "react-redux";
 import { ThunkDispatch } from "redux-thunk";
@@ -6,6 +6,7 @@ import { Action } from "redux";
 
 import MKV from "../../../../melosyskodeverk";
 import * as Nav from "../../../../utils/navFrontend";
+import * as Utils from "../../../../utils";
 
 import { vilkarSelectors } from "../../../../ducks/vilkar";
 import { lagBegrunnelse, lagVilkaar } from "../../../../regler/vilkar";
@@ -95,6 +96,8 @@ const VurderingBestemmelse = ({
     oppdater();
   };
 
+  const debouncedLagreVilkar = useCallback(Utils._debounce(lagreVilkar, 1000), []);
+
   useEffect(() => {
     handleEndreBestemmelse(bestemmelse);
     vilkarListe.forEach((vilkar: any) => {
@@ -105,6 +108,7 @@ const VurderingBestemmelse = ({
     });
     setValgteVilkar(new Map(valgteVilkar));
     setValgteBegrunnelser(new Map(valgteBegrunnelser));
+    return () => debouncedLagreVilkar.cancel();
   }, []);
 
   useEffect(() => {
@@ -119,7 +123,7 @@ const VurderingBestemmelse = ({
 
     setErAlleValgGjort(!!alleVilkarHarSvarJaOgvalgtBegrunnelse);
     if (alleVilkarHarSvarJaOgvalgtBegrunnelse) {
-      lagreVilkar();
+      debouncedLagreVilkar();
     }
   }, [valgteBegrunnelser, valgtBestemmelse, valgteVilkar]);
 

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingBestemmelse.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingBestemmelse.tsx
@@ -226,6 +226,7 @@ const VurderingBestemmelse = ({
                   onChange={handleEndreBegrunnelse}
                   name={vilkaar}
                   value={valgteBegrunnelser.get(`${vilkaar}`)}
+                  disabled={!redigerbart}
                 >
                   <option key="" value="" disabled={!!valgteBegrunnelser.get(`${vilkaar}`)}>
                     Velg
@@ -285,10 +286,15 @@ const VurderingBestemmelse = ({
         )}
 
       <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={false} className="fane__navigasjonsknapp" onClick={tilbake}>
+        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
           Tilbake
         </Nav.Knapp>
-        <Nav.Hovedknapp mini disabled={!erAlleValgGjort} className="fane__navigasjonsknapp" onClick={handleBefreft}>
+        <Nav.Hovedknapp
+          mini
+          disabled={!erAlleValgGjort || !redigerbart}
+          className="fane__navigasjonsknapp"
+          onClick={handleBefreft}
+        >
           Fortsett
         </Nav.Hovedknapp>
       </div>

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingBestemmelse.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingBestemmelse.tsx
@@ -122,7 +122,7 @@ const VurderingBestemmelse = ({
       ).length === valgteBestemmelseVilkar.vilkårOgBegrunnelser.length;
 
     setErAlleValgGjort(!!alleVilkarHarSvarJaOgvalgtBegrunnelse);
-    if (alleVilkarHarSvarJaOgvalgtBegrunnelse) {
+    if (alleVilkarHarSvarJaOgvalgtBegrunnelse && redigerbart) {
       debouncedLagreVilkar();
     }
   }, [valgteBegrunnelser, valgtBestemmelse, valgteVilkar]);

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingFamilie.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingFamilie.tsx
@@ -146,7 +146,7 @@ const VurderingFamilie = ({
   const debouncedLagring = useCallback(Utils._debounce(lagreMedfolgendeFamilie, 1000), []);
 
   useEffect(() => {
-    debouncedLagring({ formValues, formIsValid });
+    if (redigerbart) debouncedLagring({ formValues, formIsValid });
   }, [formIsValid, formValues]);
 
   useEffect(() => {

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingFamilie.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingFamilie.tsx
@@ -235,6 +235,7 @@ const VurderingFamilie = ({
                       emptyFieldText="Velg..."
                       emptyFieldDisabled={!redigerbart || !!formValues.barn[barn.uuid].begrunnelse}
                       name={barn.uuid}
+                      disabled={!redigerbart}
                     >
                       {medfolgende_barn_begrunnelser.map((begrunnelse: KTObject) => (
                         <option key={begrunnelse.kode} value={begrunnelse.kode}>
@@ -252,7 +253,7 @@ const VurderingFamilie = ({
             ) && (
               <div style={{ marginBottom: "2rem" }}>
                 <Nav.Typo.Element>Fritekst til avsnitt om barn i vedtaksbrev</Nav.Typo.Element>
-                <Skjema.HTMLEditor feltNavn="barn.fritekst" className="fritekst" />
+                <Skjema.HTMLEditor feltNavn="barn.fritekst" className="fritekst" disabled={!redigerbart} />
               </div>
             )}
           </Nav.Fieldset>
@@ -293,6 +294,7 @@ const VurderingFamilie = ({
                           !redigerbart || !!formValues.ektefelle_samboer[ektefelleSamboer.uuid].begrunnelse
                         }
                         name={ektefelleSamboer.uuid}
+                        disabled={!redigerbart}
                       >
                         {medfolgende_ektefelle_samboer_begrunnelser.map((begrunnelse: KTObject) => (
                           <option key={begrunnelse.kode} value={begrunnelse.kode}>
@@ -311,7 +313,7 @@ const VurderingFamilie = ({
             ) && (
               <div>
                 <Nav.Typo.Element>Fritekst til avsnitt om ektefelle/samboer i vedtaksbrev</Nav.Typo.Element>
-                <Skjema.HTMLEditor feltNavn="ektefelle_samboer.fritekst" className="fritekst" />
+                <Skjema.HTMLEditor feltNavn="ektefelle_samboer.fritekst" className="fritekst" disabled={!redigerbart} />
               </div>
             )}
           </Nav.Fieldset>
@@ -326,7 +328,7 @@ const VurderingFamilie = ({
       )}
 
       <div className="fane__knapplinje">
-        <Nav.Knapp mini className="fane__navigasjonsknapp" onClick={tilbake}>
+        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
           Tilbake
         </Nav.Knapp>
         <Nav.Hovedknapp

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingPerioder.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingPerioder.tsx
@@ -307,7 +307,8 @@ const VurderingPerioder = ({
       }
     });
     oppdater();
-    debouncedLagreMedlemskapsperioder({ medlemskapsperioder: formValues?.medlemskapsperioder, valid: formIsValid });
+    if (redigerbart)
+      debouncedLagreMedlemskapsperioder({ medlemskapsperioder: formValues?.medlemskapsperioder, valid: formIsValid });
   }, [formValues?.medlemskapsperioder, formIsValid]);
 
   const handleSlett = (index: number) => {

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingRepresentant.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingRepresentant.tsx
@@ -186,7 +186,7 @@ const VurderingRepresentant = ({
                 </option>
               ))}
             </datalist>
-            <Skjema.Checkbox feltNavn="selvbetalende" label="Søker er selvbetalende" />
+            <Skjema.Checkbox feltNavn="selvbetalende" label="Søker er selvbetalende" disabled={!redigerbart} />
           </Nav.Column>
           {representantData && (
             <Nav.Column xs="6">

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingRepresentant.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingRepresentant.tsx
@@ -149,7 +149,7 @@ const VurderingRepresentant = ({
 
   useEffect(() => {
     oppdater();
-    debouncedLagring({ formValues, formIsValid });
+    if (redigerbart) debouncedLagring({ formValues, formIsValid });
   }, [formIsValid, formValues]);
 
   return (

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingStart.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingStart.tsx
@@ -127,7 +127,7 @@ const VurderingStart = ({
   const debouncedOppdatering = useCallback(Utils._debounce(oppdaterLokalBehandlingsgrunnlag, 500), []);
 
   useEffect(() => {
-    debouncedOppdatering({ formValues, formIsValid });
+    if (redigerbart) debouncedOppdatering({ formValues, formIsValid });
   }, [formIsValid, formValues]);
 
   const fortsettHandle = () => {

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingStart.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingStart.tsx
@@ -190,6 +190,7 @@ const VurderingStart = ({
               feltNavn="land"
               placeholder="Velg..."
               landkoder={alleLandkoder}
+              disabled={!redigerbart}
             />
           </Nav.Column>
         </Nav.Row>
@@ -202,6 +203,7 @@ const VurderingStart = ({
               feltNavn="trygdedekning"
               emptyFieldText="Velg"
               emptyFieldDisabled={!!formValues.trygdedekning}
+              disabled={!redigerbart}
             >
               {trygdedekninger.map((item: KTObject) => (
                 <option key={item.kode} value={item.kode}>
@@ -214,7 +216,12 @@ const VurderingStart = ({
       </Nav.Fieldset>
 
       <div className="fane__knapplinje">
-        <Nav.Hovedknapp mini disabled={!formIsValid} className="fane__navigasjonsknapp" onClick={fortsettHandle}>
+        <Nav.Hovedknapp
+          mini
+          disabled={!formIsValid || !redigerbart}
+          className="fane__navigasjonsknapp"
+          onClick={fortsettHandle}
+        >
           Fortsett
         </Nav.Hovedknapp>
       </div>

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingTrygdeavgift.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingTrygdeavgift.tsx
@@ -491,7 +491,7 @@ const VurderingTrygdeavgift = ({
   }
 
   useEffect(() => {
-    if (formValues?.avgiftsgrunnlag && erAvgiftsgrunnlagGyldig(formValues.avgiftsgrunnlag)) {
+    if (redigerbart && formValues?.avgiftsgrunnlag && erAvgiftsgrunnlagGyldig(formValues.avgiftsgrunnlag)) {
       Api.Trygdeavgift.sendGrunnlag(behandlingID, {
         lønnsforhold: formValues.avgiftsgrunnlag.lønnsforhold,
         trygdeavgiftsgrunnlagNorge: formValues.avgiftsgrunnlag.trygdeavgiftsgrunnlagNorge || null,

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVirksomhet.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVirksomhet.tsx
@@ -119,10 +119,15 @@ const VurderingVirksomhet = ({
       />
 
       <div className="fane__knapplinje">
-        <Nav.Knapp mini className="fane__navigasjonsknapp" onClick={tilbake}>
+        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
           Tilbake
         </Nav.Knapp>
-        <Nav.Hovedknapp mini disabled={!formIsValid} className="fane__navigasjonsknapp" onClick={handleFortsett}>
+        <Nav.Hovedknapp
+          mini
+          disabled={!formIsValid || !redigerbart}
+          className="fane__navigasjonsknapp"
+          onClick={handleFortsett}
+        >
           Fortsett
         </Nav.Hovedknapp>
       </div>


### PR DESCRIPTION
vilkaar ble postet flere ganger etter hverandre når man åpnet/refreshet en sak der bestemmelse-steget allerede var fylt inn. Dette skapte problemer mot databasen da flush blir brukt i lagringen i api.

Mekket debounce på lagring, og gjorde ellers endringer slik at POST/PUT til api kun skjer når saken er `redigerbart`.