### PR TITLE
MELOSYS-4606 - Forhåndsvisning feiler

### DIFF
--- a/src/ducks/behandlingsgrunnlag/reducers.js
+++ b/src/ducks/behandlingsgrunnlag/reducers.js
@@ -299,18 +299,22 @@ export default function reducer(state = initialState, action) {
           personOpplysninger: {
             utenlandskIdent: dokument.utenlandskIdent,
             medfolgendeFamilie: [
-              ...dokument.medfolgendeBarn.map((enkeltBarn) => ({
-                uuid: enkeltBarn.uuid,
-                navn: enkeltBarn.navn,
-                fnr: enkeltBarn.fnr,
-                relasjonsrolle: KV.Koder.Relasjonsrolle.BARN,
-              })),
-              ...dokument.medfolgendeEktefelleSamboer.map((enkeltEktefelleSamboer) => ({
-                uuid: enkeltEktefelleSamboer.uuid,
-                navn: enkeltEktefelleSamboer.navn,
-                fnr: enkeltEktefelleSamboer.fnr,
-                relasjonsrolle: KV.Koder.Relasjonsrolle.EKTEFELLE_SAMBOER,
-              })),
+              ...dokument.medfolgendeBarn
+                .filter((enkeltBarn) => enkeltBarn.fnr && enkeltBarn.navn)
+                .map((enkeltBarn) => ({
+                  uuid: enkeltBarn.uuid,
+                  navn: enkeltBarn.navn,
+                  fnr: enkeltBarn.fnr,
+                  relasjonsrolle: KV.Koder.Relasjonsrolle.BARN,
+                })),
+              ...dokument.medfolgendeEktefelleSamboer
+                .filter((enkeltEktefelleSamboer) => enkeltEktefelleSamboer.fnr && enkeltEktefelleSamboer.navn)
+                .map((enkeltEktefelleSamboer) => ({
+                  uuid: enkeltEktefelleSamboer.uuid,
+                  navn: enkeltEktefelleSamboer.navn,
+                  fnr: enkeltEktefelleSamboer.fnr,
+                  relasjonsrolle: KV.Koder.Relasjonsrolle.EKTEFELLE_SAMBOER,
+                })),
             ],
           },
           overgangsregelbestemmelser:

--- a/src/felleskomponenter/menypanel/menypunkter/editerbartElement/editerbartElement.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/editerbartElement/editerbartElement.tsx
@@ -89,12 +89,16 @@ const EditerbartElement = ({
     (visLagreKnappBareHvisHarData ? harData : true) &&
     (visLagreKnapp !== undefined ? visLagreKnapp : true);
 
-  const lagreClickHandler: MouseEventHandler<HTMLButtonElement> = async (e) => {
-    e.persist();
+  const lagreClickHandler: MouseEventHandler<HTMLButtonElement> = async (event) => {
+    event.persist();
 
     if (onLagreClick) {
-      const validert = await onLagreClick(e);
-      if (!validert) return;
+      try {
+        const validert = await onLagreClick(event);
+        if (!validert) return;
+      } catch (error) {
+        return;
+      }
     }
 
     setStatus(hentNesteStatus());

--- a/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/editerbartElementListe.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/editerbartElementListe.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType } from "react";
+import React, { ElementType, MouseEvent } from "react";
 import PT from "prop-types";
 import { connect, ConnectedProps } from "react-redux";
 import { FieldArray, change, WrappedFieldArrayProps } from "redux-form";
@@ -30,6 +30,7 @@ interface BaseProps {
   flereRedigeringsknapper?: boolean;
   onBinClick?: (index: number) => void;
   symbolsynlighet?: SymbolsynlighetConfig;
+  onLagreClick?: (e: MouseEvent) => boolean | Promise<boolean>;
 }
 
 type InnerEditerbartElementListeProps = WrappedFieldArrayProps & BaseProps;
@@ -65,6 +66,7 @@ export const InnerEditerbartElementListe = ({
   settFeltVerdi,
   onBinClick,
   symbolsynlighet,
+  onLagreClick,
 }: InnerEditerbartElementListeProps & PropsFromRedux) => {
   const editerbartElementListeCls = classNames(className);
 
@@ -90,6 +92,7 @@ export const InnerEditerbartElementListe = ({
           leggTilTekst={innerLeggTilTekst}
           leggTil={leggTil}
           onBinClick={onBinClick}
+          onLagreClick={onLagreClick}
         />
       ) : (
         <EnRedigeringsknappListe
@@ -110,6 +113,7 @@ export const InnerEditerbartElementListe = ({
           leggTil={leggTil}
           onBinClick={onBinClick}
           symbolsynlighet={symbolsynlighet}
+          onLagreClick={onLagreClick}
         />
       )}
     </div>

--- a/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/editerbartElementListe.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/editerbartElementListe.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType, MouseEvent } from "react";
+import React, { ElementType } from "react";
 import PT from "prop-types";
 import { connect, ConnectedProps } from "react-redux";
 import { FieldArray, change, WrappedFieldArrayProps } from "redux-form";
@@ -23,14 +23,14 @@ interface BaseProps {
   className?: string;
   hentNavn?: (element: any) => string;
   tittelTekst: string;
-  harData: (elementListe: any[], element: any) => boolean;
+  harData: (elementer: any[], element: any) => boolean;
   tittelIkon?: ElementType;
   tittelUnderstrek?: boolean;
   elementUnderstrek?: boolean;
   flereRedigeringsknapper?: boolean;
   onBinClick?: (index: number) => void;
   symbolsynlighet?: SymbolsynlighetConfig;
-  onLagreClick?: (e: MouseEvent) => boolean | Promise<boolean>;
+  onLagreClick?: (elementer: any[]) => boolean | Promise<boolean>;
 }
 
 type InnerEditerbartElementListeProps = WrappedFieldArrayProps & BaseProps;
@@ -72,7 +72,16 @@ export const InnerEditerbartElementListe = ({
 
   const leggTil = () => fields.push(hentDefaultElement());
 
-  const innerLeggTilTekst = typeof leggTilTekst === "function" ? leggTilTekst(fields.getAll()) : leggTilTekst;
+  const elementer = fields.getAll();
+
+  const innerLeggTilTekst = typeof leggTilTekst === "function" ? leggTilTekst(elementer) : leggTilTekst;
+
+  const lagreClickHandler = () => {
+    if (onLagreClick) {
+      return onLagreClick(elementer);
+    }
+    return true;
+  };
 
   return (
     <div className={editerbartElementListeCls}>
@@ -92,7 +101,7 @@ export const InnerEditerbartElementListe = ({
           leggTilTekst={innerLeggTilTekst}
           leggTil={leggTil}
           onBinClick={onBinClick}
-          onLagreClick={onLagreClick}
+          onLagreClick={lagreClickHandler}
         />
       ) : (
         <EnRedigeringsknappListe
@@ -113,7 +122,7 @@ export const InnerEditerbartElementListe = ({
           leggTil={leggTil}
           onBinClick={onBinClick}
           symbolsynlighet={symbolsynlighet}
-          onLagreClick={onLagreClick}
+          onLagreClick={lagreClickHandler}
         />
       )}
     </div>

--- a/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/enRedigeringsknappListe.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/enRedigeringsknappListe.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType } from "react";
+import React, { ElementType, MouseEvent } from "react";
 import { FieldArrayFieldsProps } from "redux-form";
 import classNames from "classnames";
 
@@ -53,6 +53,7 @@ interface EnRedigeringsKnappListeProps<T> {
   leggTilTekst: string;
   onBinClick?: (index: number) => void;
   symbolsynlighet?: SymbolsynlighetConfig;
+  onLagreClick?: (e: MouseEvent) => boolean | Promise<boolean>;
 }
 
 function EnRedigeringsKnappListe<T>({
@@ -73,6 +74,7 @@ function EnRedigeringsKnappListe<T>({
   leggTilTekst,
   onBinClick,
   symbolsynlighet,
+  onLagreClick,
 }: EnRedigeringsKnappListeProps<T>) {
   const RedigererKomponent = redigererKomponent;
   const RedigeringUtfortKomponent = redigeringUtfortKomponent;
@@ -119,6 +121,7 @@ function EnRedigeringsKnappListe<T>({
       harData={harData()}
       symbolsynlighet={symbolsynlighet}
       visLagreKnappBareHvisHarData
+      onLagreClick={onLagreClick}
       redigererRender={() => (
         <div>
           {RedigererPreElementerKomponent && (

--- a/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/flereRedigeringsknapperListe.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/flereRedigeringsknapperListe.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType } from "react";
+import React, { ElementType, MouseEvent } from "react";
 import { FieldArrayFieldsProps } from "redux-form";
 import classNames from "classnames";
 
@@ -24,6 +24,7 @@ interface FlereRedigeringsKnapperListeProps<T> {
   leggTil: () => void;
   leggTilTekst: string;
   onBinClick?: (index: number) => void;
+  onLagreClick?: (e: MouseEvent) => boolean | Promise<boolean>;
 }
 
 function FlereRedigeringsKnapperListe<T>({
@@ -41,6 +42,7 @@ function FlereRedigeringsKnapperListe<T>({
   leggTil,
   leggTilTekst,
   onBinClick,
+  onLagreClick,
 }: FlereRedigeringsKnapperListeProps<T>) {
   const RedigererKomponent = redigererKomponent;
   const RedigeringUtfortKomponent = redigeringUtfortKomponent;
@@ -72,6 +74,7 @@ function FlereRedigeringsKnapperListe<T>({
               tittelUnderstrek
               onBinClick={slett}
               symbolsynlighet={visAlltidBinSymbolsynlighet}
+              onLagreClick={onLagreClick}
               redigererRender={() => (
                 <RedigererKomponent
                   redigerbart={redigerbart}

--- a/src/felleskomponenter/menypanel/menypunkter/familieforhold/familieforholdContainer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/familieforhold/familieforholdContainer.tsx
@@ -29,93 +29,101 @@ const FamilieforholdContainer = ({
   visBehandlingsgrunnlagData,
   setMenypanelFeilmelding,
   visEktefelleSamboerMedPaReisen,
-}: FamilieforholdContainerProps) => (
-  <Nav.Container fluid className="familieforhold-container">
-    <Nav.Row>
-      <Nav.Column xs="12">
-        <Nav.Typo.Innholdstittel style={{ display: "inline", marginRight: "1em" }}>
-          {KV.Menypunkter.Familieforhold.tittel}
-        </Nav.Typo.Innholdstittel>
-      </Nav.Column>
-    </Nav.Row>
-    <Nav.Row className="familiemedlemmer-row">
-      <Nav.Column xs="12">
-        <Familiemedlemmer setMenypanelFeilmelding={setMenypanelFeilmelding} />
-      </Nav.Column>
-    </Nav.Row>
-    {visBehandlingsgrunnlagData && (
-      <>
-        <Nav.Row>
-          <Nav.Column xs="12" className="etikett-container">
-            <span>{behandlingsgrunnlagEtikett}</span>
-            {visArbeidsforholdRolleEtiketter && <Etiketter.ArbeidstakersDel style={{ marginLeft: "0.3em" }} />}
-          </Nav.Column>
-        </Nav.Row>
-        {visEktefelleSamboerMedPaReisen ? (
-          <div>
-            <Mui.Undertittel
-              tekst={KV.Menypunkter.Familieforhold.undertitler.familieMedPaReisen}
-              ikon={Ikoner.Familie}
-              understrek
-            />
+}: FamilieforholdContainerProps) => {
+  const sjekkAtMedfolgendeFamiliemedlemmerHarFnrOgNavn = (familiemedlemmer: KV.Form.MedfolgendeFamilie[]) =>
+    familiemedlemmer.every((familiemedlem) => familiemedlem.fnr && familiemedlem.navn);
+
+  return (
+    <Nav.Container fluid className="familieforhold-container">
+      <Nav.Row>
+        <Nav.Column xs="12">
+          <Nav.Typo.Innholdstittel style={{ display: "inline", marginRight: "1em" }}>
+            {KV.Menypunkter.Familieforhold.tittel}
+          </Nav.Typo.Innholdstittel>
+        </Nav.Column>
+      </Nav.Row>
+      <Nav.Row className="familiemedlemmer-row">
+        <Nav.Column xs="12">
+          <Familiemedlemmer setMenypanelFeilmelding={setMenypanelFeilmelding} />
+        </Nav.Column>
+      </Nav.Row>
+      {visBehandlingsgrunnlagData && (
+        <>
+          <Nav.Row>
+            <Nav.Column xs="12" className="etikett-container">
+              <span>{behandlingsgrunnlagEtikett}</span>
+              {visArbeidsforholdRolleEtiketter && <Etiketter.ArbeidstakersDel style={{ marginLeft: "0.3em" }} />}
+            </Nav.Column>
+          </Nav.Row>
+          {visEktefelleSamboerMedPaReisen ? (
+            <div>
+              <Mui.Undertittel
+                tekst={KV.Menypunkter.Familieforhold.undertitler.familieMedPaReisen}
+                ikon={Ikoner.Familie}
+                understrek
+              />
+              <Nav.Row>
+                <Nav.Column xs="12" className="familiemedpareisen">
+                  <EditerbartElementListe
+                    redigerbart={redigerbart}
+                    feltNavn="medfolgendeBarn"
+                    redigererKomponent={MedfolgendeFamilie.Redigerer}
+                    redigeringUtfortKomponent={MedfolgendeFamilie.RedigeringUtfort}
+                    ingenDataKomponent={() => <div className="ingen-data" />}
+                    leggTilTekst={(elementer) => (elementer.length > 0 ? "Legg til nytt barn" : "Legg til barn")}
+                    hentDefaultElement={() => ({ uuid: Utils._uuid() })}
+                    tittelTekst="Barn"
+                    tittelUnderstrek={false}
+                    harData={(elementListe) => elementListe.length !== 0 && elementListe.every((v) => v)}
+                    flereRedigeringsknapper={false}
+                    onLagreClick={sjekkAtMedfolgendeFamiliemedlemmerHarFnrOgNavn}
+                  />
+                </Nav.Column>
+              </Nav.Row>
+              <Nav.Row>
+                <Nav.Column xs="12" className="familiemedpareisen">
+                  <EditerbartElementListe
+                    redigerbart={redigerbart}
+                    feltNavn="medfolgendeEktefelleSamboer"
+                    redigererKomponent={MedfolgendeFamilie.Redigerer}
+                    redigeringUtfortKomponent={MedfolgendeFamilie.RedigeringUtfort}
+                    ingenDataKomponent={() => <div className="ingen-data" />}
+                    leggTilTekst="Legg til ektefelle/partner/samboer"
+                    hentDefaultElement={() => ({ uuid: Utils._uuid() })}
+                    tittelTekst="Ektefelle/partner/samboer"
+                    tittelUnderstrek={false}
+                    harData={(elementListe) => elementListe.length !== 0 && elementListe.every((v) => v)}
+                    flereRedigeringsknapper={false}
+                    onLagreClick={sjekkAtMedfolgendeFamiliemedlemmerHarFnrOgNavn}
+                  />
+                </Nav.Column>
+              </Nav.Row>
+            </div>
+          ) : (
             <Nav.Row>
-              <Nav.Column xs="12" className="familiemedpareisen">
+              <Nav.Column xs="12">
                 <EditerbartElementListe
                   redigerbart={redigerbart}
                   feltNavn="medfolgendeBarn"
                   redigererKomponent={MedfolgendeFamilie.Redigerer}
                   redigeringUtfortKomponent={MedfolgendeFamilie.RedigeringUtfort}
-                  ingenDataKomponent={() => <div className="ingen-data" />}
+                  ingenDataKomponent={MedfolgendeFamilie.IngenData}
                   leggTilTekst={(elementer) => (elementer.length > 0 ? "Legg til nytt barn" : "Legg til barn")}
                   hentDefaultElement={() => ({ uuid: Utils._uuid() })}
-                  tittelTekst="Barn"
-                  tittelUnderstrek={false}
+                  tittelTekst={KV.Menypunkter.Familieforhold.undertitler.barnMedPaReisen}
+                  tittelIkon={Ikoner.ParentAndKid}
+                  tittelUnderstrek
                   harData={(elementListe) => elementListe.length !== 0 && elementListe.every((v) => v)}
                   flereRedigeringsknapper={false}
+                  onLagreClick={sjekkAtMedfolgendeFamiliemedlemmerHarFnrOgNavn}
                 />
               </Nav.Column>
             </Nav.Row>
-            <Nav.Row>
-              <Nav.Column xs="12" className="familiemedpareisen">
-                <EditerbartElementListe
-                  redigerbart={redigerbart}
-                  feltNavn="medfolgendeEktefelleSamboer"
-                  redigererKomponent={MedfolgendeFamilie.Redigerer}
-                  redigeringUtfortKomponent={MedfolgendeFamilie.RedigeringUtfort}
-                  ingenDataKomponent={() => <div className="ingen-data" />}
-                  leggTilTekst="Legg til ektefelle/partner/samboer"
-                  hentDefaultElement={() => ({ uuid: Utils._uuid() })}
-                  tittelTekst="Ektefelle/partner/samboer"
-                  tittelUnderstrek={false}
-                  harData={(elementListe) => elementListe.length !== 0 && elementListe.every((v) => v)}
-                  flereRedigeringsknapper={false}
-                />
-              </Nav.Column>
-            </Nav.Row>
-          </div>
-        ) : (
-          <Nav.Row>
-            <Nav.Column xs="12">
-              <EditerbartElementListe
-                redigerbart={redigerbart}
-                feltNavn="medfolgendeBarn"
-                redigererKomponent={MedfolgendeFamilie.Redigerer}
-                redigeringUtfortKomponent={MedfolgendeFamilie.RedigeringUtfort}
-                ingenDataKomponent={MedfolgendeFamilie.IngenData}
-                leggTilTekst={(elementer) => (elementer.length > 0 ? "Legg til nytt barn" : "Legg til barn")}
-                hentDefaultElement={() => ({ uuid: Utils._uuid() })}
-                tittelTekst={KV.Menypunkter.Familieforhold.undertitler.barnMedPaReisen}
-                tittelIkon={Ikoner.ParentAndKid}
-                tittelUnderstrek
-                harData={(elementListe) => elementListe.length !== 0 && elementListe.every((v) => v)}
-                flereRedigeringsknapper={false}
-              />
-            </Nav.Column>
-          </Nav.Row>
-        )}
-      </>
-    )}
-  </Nav.Container>
-);
+          )}
+        </>
+      )}
+    </Nav.Container>
+  );
+};
 
 export default FamilieforholdContainer;


### PR DESCRIPTION
Forhåndsvisning av brev feiler hvis man i Familieforhold-menypunktet har lagt til et "Barn med på reisen" uten fnr og navn. Sørger derfor for at fnr og navn er utfylt før `behandlingsgrunnlag` lagres. (gjort det samme for samboer/ektefelle)