### PR TITLE
MELOSYS-4649 - Vis begrunnelse i innsyn ved mottatt A009

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5381,9 +5381,9 @@
       }
     },
     "@navikt/melosys-kodeverk": {
-      "version": "5.15.76",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.76/61dc74dd433ae3cdab89e96802da8e23489e1dffc9c179efc55032cf9e49e30c",
-      "integrity": "sha512-hB8YeU58HN8hTGfopVMrEFC0ufn7bbU/wffNcysb8p/vlXS1BhUHlS8qAVE+aas671EYMoC8qoYzJXYbOUqbLg=="
+      "version": "5.15.78",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.78/235828954964f09a79f3bed9cf3a57b7205236437568f272dfbb2e98bbb724eb",
+      "integrity": "sha512-fjUGhYezaXxxHr13zGeJR1w6M4szJOIW18tmhk6y3GpDnHlReYzZ7pM2LYg/lHAplEl8YMYHSNNnKzFiuGl5BQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.20",
     "@loadable/component": "^5.10.3",
-    "@navikt/melosys-kodeverk": "5.15.76",
+    "@navikt/melosys-kodeverk": "5.15.78",
     "classnames": "^2.2.6",
     "connected-react-router": "^6.6.1",
     "date-fns": "^2.20.0",

--- a/src/ducks/behandlingsresultat/selectors.js
+++ b/src/ducks/behandlingsresultat/selectors.js
@@ -7,10 +7,26 @@
 
 import { createSelector } from "reselect";
 
-/* eslint import/prefer-default-export:"off" */
-export const BehandlingsresultatSelector = createSelector(
-  (state) => (state.behandlingsresultat ? state.behandlingsresultat.data : []),
+import * as Utils from "../../services/utils";
+
+const BehandlingsResultatStateSelector = createSelector(
+  (state) => state.behandlingsresultat || {},
   (behandlingsresultat) => behandlingsresultat
+);
+
+export const BehandlingsresultatSelector = createSelector(
+  BehandlingsResultatStateSelector,
+  (behandlingsresultatState) => behandlingsresultatState.data || {}
+);
+
+const BehandlingsresultatStatusSelector = createSelector(
+  BehandlingsResultatStateSelector,
+  (behandlingsresultatState) => behandlingsresultatState.status || {}
+);
+
+export const BehandlingsresultatStatusErOkSelector = createSelector(
+  BehandlingsresultatStatusSelector,
+  (behandlingsresultatStatus) => behandlingsresultatStatus === Utils.STATUS.OK
 );
 
 export const VedtakstypeSelector = createSelector(

--- a/src/ducks/behandlingsresultat/selectors.js
+++ b/src/ducks/behandlingsresultat/selectors.js
@@ -9,19 +9,14 @@ import { createSelector } from "reselect";
 
 import * as Utils from "../../services/utils";
 
-const BehandlingsResultatStateSelector = createSelector(
-  (state) => state.behandlingsresultat || {},
+export const BehandlingsresultatSelector = createSelector(
+  (state) => state.behandlingsresultat.data || {},
   (behandlingsresultat) => behandlingsresultat
 );
 
-export const BehandlingsresultatSelector = createSelector(
-  BehandlingsResultatStateSelector,
-  (behandlingsresultatState) => behandlingsresultatState.data || {}
-);
-
 const BehandlingsresultatStatusSelector = createSelector(
-  BehandlingsResultatStateSelector,
-  (behandlingsresultatState) => behandlingsresultatState.status || {}
+  (state) => state.behandlingsresultat.status,
+  (behandlingsresultatStatus) => behandlingsresultatStatus
 );
 
 export const BehandlingsresultatStatusErOkSelector = createSelector(

--- a/src/sider/eu_eøs/registrering/unntaksperioder/saksopplysninger.js
+++ b/src/sider/eu_eøs/registrering/unntaksperioder/saksopplysninger.js
@@ -113,7 +113,7 @@ const Saksopplysninger = ({
     ) {
       godkjentUnntaksperiode();
     } else if (behandlingsresultat.utfallRegistreringUnntak === MKV.Koder.utfallregistreringunntak.IKKE_GODKJENT) {
-      ikkeGodkjentUnntaksperiode(behandlingsresultat);
+      ikkeGodkjentUnntaksperiode();
     }
   };
 

--- a/src/sider/eu_eøs/registrering/unntaksperioder/saksopplysninger.js
+++ b/src/sider/eu_eøs/registrering/unntaksperioder/saksopplysninger.js
@@ -42,6 +42,7 @@ const Saksopplysninger = ({
   lastInnSaksopplysninger,
   tilForsiden,
   startOgVisOppfriskModal,
+  behandlingsresultatErHentet,
 }) => {
   const [unntaksperiodeVurdering, setUnntaksperiodeVurdering] = React.useState(KV.Koder.Unntaksperiode.AVSLAG);
   const [begrunnelseFritekst, setBegrunnelseFritekst] = React.useState("");
@@ -366,7 +367,7 @@ const Saksopplysninger = ({
                   </Nav.Fieldset>
                 </Nav.Column>
               </Nav.Row>
-              {unntaksperiodeVurdering === KV.Koder.Unntaksperiode.AVSLAG && (
+              {unntaksperiodeVurdering === KV.Koder.Unntaksperiode.AVSLAG && behandlingsresultatErHentet && (
                 <Fragment>
                   <Nav.Row>
                     <Nav.Column xs="6">
@@ -378,7 +379,7 @@ const Saksopplysninger = ({
                           tillatFritekst={false}
                           onChange={listevalgEndringHandler}
                           feil={ikkeGodkjentFeilmeldinger.begrunnelseKoder}
-                          defaultElementer={ikkeGodkjentBegrunnelseKoder}
+                          defaultElementer={behandlingsresultat.begrunnelseKoder}
                         />
                       </Nav.Fieldset>
                     </Nav.Column>
@@ -439,6 +440,7 @@ Saksopplysninger.propTypes = {
   behandlingsresultat: PT.object,
   tilForsiden: PT.func.isRequired,
   startOgVisOppfriskModal: PT.func.isRequired,
+  behandlingsresultatErHentet: PT.bool.isRequired,
 };
 
 Saksopplysninger.defaultProps = {
@@ -453,6 +455,7 @@ const mapStateToProps = (state) => ({
   lovvalgsperiode: lovvalgsperioderSelectors.LovvalgsperiodeSelector(state),
   sedLovvalgsperiode: behandlingerSelectors.SEDSelector(state).lovvalgsperiode,
   behandlingsresultat: behandlingsresultatSelectors.BehandlingsresultatSelector(state),
+  behandlingsresultatErHentet: behandlingsresultatSelectors.BehandlingsresultatStatusErOkSelector(state),
 });
 const mapDispatchToProps = (dispatch) => ({
   oppdaterAvklartefakta: (behandlingID, avklartefaktaListe) =>


### PR DESCRIPTION
- Fikser bug hvor begrunnelse for "ikke godkjenning" av unntaksperiode ikke ble vist i innsynsmodus. Skjedde fordi `defaultElementer` på `<Mui.ListevelgerFlervalg />` ble satt før behandlingsresultat var hentet fra backend.

Kan testes ved å:
- kjøre mot melosys-web-mock og åpne http://localhost:3000/melosys/EU_EOS/registrering/3/unntaksperioder/?behandlingID=3
- sette behandlingsresultat.begrunnelseKode til en kode fra https://github.com/navikt/melosys-kodeverk/blob/master/src/begrunnelser/ikke_godkjent_begrunnelser.js
- Sette behandlingsresultat.utfallRegistreringUnntak til `"IKKE_GODKJENT"`
- sette` redigerbart: false` for behandlingId 3