### PR TITLE
MELOSYS-4598 - alle eller ukjente soeknadsland

### DIFF
--- a/src/ducks/anmodningsperioder/operations.js
+++ b/src/ducks/anmodningsperioder/operations.js
@@ -56,7 +56,7 @@ export function lagre() {
 
 const byggAnmodningsperiodeArtikkel16 = (stegState, reduxState) => {
   const periode = behandlingsgrunnlagSelectors.PeriodeSelector(reduxState);
-  const soknadsland = behandlingsgrunnlagSelectors.SoknadslandSelector(reduxState);
+  const soknadsland = behandlingsgrunnlagSelectors.SoknadslandkoderSelector(reduxState);
   const medlemskapsperiodeID = lovvalgsperioderSelectors.MedlemskapsperiodeIDSelector(reduxState);
 
   const unntakFraLovvalgsland = soknadsland.join("");

--- a/src/ducks/avklartefakta/selectors.js
+++ b/src/ducks/avklartefakta/selectors.js
@@ -65,7 +65,7 @@ export const VurderingUnntakPeriode = createSelector(
  */
 export const Soknadsland = createSelector(
   (state) => SoknadslandFaktaerSelector(state),
-  (state) => behandlingsgrunnlagSelectors.SoknadslandSelector(state),
+  (state) => behandlingsgrunnlagSelectors.SoknadslandkoderSelector(state),
   (soknadslandFaktaer, alleLandISoknaden) =>
     alleLandISoknaden.map(
       (enkeltLand) =>

--- a/src/ducks/behandlingsgrunnlag/reducers.js
+++ b/src/ducks/behandlingsgrunnlag/reducers.js
@@ -239,7 +239,8 @@ export default function reducer(state = initialState, action) {
             typeFlyvninger: arbeidssted.typeFlyvninger || null,
           })),
           soeknadsland: {
-            landkoder: dokument.soknadsland,
+            landkoder: dokument.soknadsland.landkoder,
+            erUkjenteEllerAlleEosLand: dokument.soknadsland.erUkjenteEllerAlleEosLand,
           },
           periode: {
             fom: dokument.soknadsperiodeFom ? formatterDatoTilISO(dokument.soknadsperiodeFom) : null,

--- a/src/ducks/behandlingsgrunnlag/reducers.test.js
+++ b/src/ducks/behandlingsgrunnlag/reducers.test.js
@@ -252,7 +252,10 @@ describe("behandlingsgrunnlag reducer", () => {
             typeFlyvninger: MKV.Koder.flyvningstyper.NASJONAL,
           },
         ],
-        soknadsland: [],
+        soknadsland: {
+          landkoder: ["DK"],
+          erUkjenteEllerAlleEosLand: true,
+        },
         soknadsperiodeFom: "11.11.11",
         soknadsperiodeTom: "11.11.11",
         erSelvstendig: true,
@@ -448,7 +451,8 @@ describe("behandlingsgrunnlag reducer", () => {
             },
           ],
           soeknadsland: {
-            landkoder: [],
+            landkoder: ["DK"],
+            erUkjenteEllerAlleEosLand: true,
           },
           periode: {
             fom: "2011-11-11",

--- a/src/ducks/behandlingsgrunnlag/selectors.js
+++ b/src/ducks/behandlingsgrunnlag/selectors.js
@@ -167,8 +167,19 @@ export const HjemmebaserSelector = createSelector(LuftfartBaserSelector, (luftfa
   luftfartBaser.map((base) => base.hjemmebaseLand).filter((base) => base)
 );
 
-export const SoknadslandSelector = createSelector(BehandlingsgrunnlagDataSelector, (behandlingsgrunnlag) =>
-  behandlingsgrunnlag.soeknadsland ? behandlingsgrunnlag.soeknadsland.landkoder : []
+export const SoknadslandSelector = createSelector(
+  BehandlingsgrunnlagDataSelector,
+  (behandlingsgrunnlag) => behandlingsgrunnlag.soeknadsland || {}
+);
+
+export const SoknadslandkoderSelector = createSelector(
+  SoknadslandSelector,
+  (soknadsland) => soknadsland.landkoder || []
+);
+
+export const SoknadslandErUkjenteEllerAlleEosLandSelector = createSelector(
+  SoknadslandSelector,
+  (soknadsland) => soknadsland.erUkjenteEllerAlleEosLand
 );
 
 export const TrygdedekningSelector = createSelector(

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/arbeidssteder.less
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/arbeidssteder.less
@@ -1,5 +1,8 @@
 .arbeidssteder {
-  > * {
-    margin-bottom: 20px;
+  .innhold {
+    margin-top: 20px;
+    > * {
+      margin-bottom: 20px;
+    }
   }
 }

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/arbeidssteder.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/arbeidssteder.test.tsx
@@ -2,6 +2,7 @@ import React, { ComponentProps } from "react";
 import { mock, instance } from "ts-mockito";
 import { shallow } from "enzyme";
 
+import * as Nav from "../../../../utils/navFrontend";
 import * as Land from "./land";
 
 import MKV from "../../../../melosyskodeverk";
@@ -17,8 +18,25 @@ describe("Arbeidssteder", () => {
     props = instance(mockedProps);
   });
 
+  it("viser infomelding i stedet for arbeidssteder når erUkjenteEllerAlleEosLand er true", () => {
+    props.soknadsland = {
+      erUkjenteEllerAlleEosLand: true,
+    };
+    const arbeidssteder = shallow(<Arbeidssteder {...props} />);
+
+    const alertstripe = arbeidssteder.find(Nav.AlertStripe);
+
+    expect(alertstripe).toHaveLength(1);
+    expect(alertstripe.children().text()).toBe(
+      "Ikke mulig å legge til arbeidssted(er) når det ikke er oppgitt land. Du kan endre dette under sidemenypunkt “Periode og land”."
+    );
+  });
+
   describe("Arbeidssteder på land", () => {
     it("rendres vanligvis uten spørsmål fra altinn-søknad", () => {
+      props.soknadsland = {
+        erUkjenteEllerAlleEosLand: false,
+      };
       const arbeidssteder = shallow(<Arbeidssteder {...props} />);
       const arbeidsstederPaaLand = arbeidssteder.findWhere(
         (n) => n.type() === EditerbartElementListe && n.props().feltNavn === "arbeidPaaLand.fysiskeArbeidssteder"
@@ -30,6 +48,9 @@ describe("Arbeidssteder", () => {
     });
 
     it("rendres med spørsmål fra altinn-søknad dersom behandlingsgrunnlagtype tilsvarer altinn-søknad", () => {
+      props.soknadsland = {
+        erUkjenteEllerAlleEosLand: false,
+      };
       props.behandlingsgrunnlagtype = MKV.Koder.behandlingsgrunnlagtyper.SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS;
       const arbeidssteder = shallow(<Arbeidssteder {...props} />);
       const arbeidsstederPaaLand = arbeidssteder.findWhere(

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/arbeidssteder.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/arbeidssteder.tsx
@@ -58,6 +58,7 @@ const mapStateToProps = (state: RootState) => {
     erHjemmekontor: arbeidPaaLand.erHjemmekontor,
     erFastArbeidssted: arbeidPaaLand.erFastArbeidssted,
     behandlingsgrunnlagtype: behandlingsgrunnlagSelectors.BehandlingsgrunnlagtypeSelector(state),
+    soknadsland: soknadFormValueSelector(state, "soknadsland"),
   };
 };
 
@@ -85,19 +86,13 @@ export const Arbeidssteder = ({
   erFastArbeidssted,
   erHjemmekontor,
   behandlingsgrunnlagtype,
+  soknadsland: { erUkjenteEllerAlleEosLand },
 }: ArbeidsstederProps) => {
   const erSoknadFraAltinn =
     behandlingsgrunnlagtype === MKV.Koder.behandlingsgrunnlagtyper.SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS;
 
-  return (
-    <div className="arbeidssteder">
-      <div>
-        <Nav.Typo.Innholdstittel style={{ display: "inline", marginRight: "1em" }}>
-          {KV.Menypunkter.Arbeidssteder.tittel}
-        </Nav.Typo.Innholdstittel>
-        <span>{behandlingsgrunnlagEtikett}</span>
-        {visArbeidsforholdRolleEtiketter && <Etiketter.ArbeidsgiversDel style={{ marginLeft: "0.3em" }} />}
-      </div>
+  const arbeidsstederLister = (
+    <>
       <EditerbartElementListe
         redigerbart={redigerbart}
         feltNavn="arbeidPaaLand.fysiskeArbeidssteder"
@@ -162,6 +157,26 @@ export const Arbeidssteder = ({
         harData={(elementListe) => elementListe.length !== 0 && elementListe.every(flattArbeidsstedErIkkeTomt)}
         flereRedigeringsknapper={false}
       />
+    </>
+  );
+
+  const ukjenteEllerAlleEosLandValgtAlertstripe = (
+    <Nav.AlertStripe type="info">
+      Ikke mulig å legge til arbeidssted(er) når det ikke er oppgitt land. Du kan endre dette under sidemenypunkt
+      “Periode og land”.
+    </Nav.AlertStripe>
+  );
+
+  return (
+    <div className="arbeidssteder">
+      <Nav.Typo.Innholdstittel style={{ display: "inline", marginRight: "1em" }}>
+        {KV.Menypunkter.Arbeidssteder.tittel}
+      </Nav.Typo.Innholdstittel>
+      <span>{behandlingsgrunnlagEtikett}</span>
+      {visArbeidsforholdRolleEtiketter && <Etiketter.ArbeidsgiversDel style={{ marginLeft: "0.3em" }} />}
+      <div className="innhold">
+        {erUkjenteEllerAlleEosLand ? ukjenteEllerAlleEosLandValgtAlertstripe : arbeidsstederLister}
+      </div>
     </div>
   );
 };

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/redigerer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/redigerer.tsx
@@ -8,6 +8,7 @@ import * as Skjema from "../../../../skjema";
 import * as Nav from "../../../../../utils/navFrontend";
 import * as KV from "../../../../../kodeverk";
 
+import { useFeatureToggle } from "../../../../../featuretoggle";
 import MKV from "../../../../../melosyskodeverk";
 
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
@@ -22,25 +23,28 @@ const connector = connect(mapStateToProps);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 const Redigerer = ({ soknadsland: { erUkjenteEllerAlleEosLand, landkoder }, behandlingstema }: PropsFromRedux) => {
+  const erUkjenteEllerAlleEosLandToggle = useFeatureToggle("melosys.behandlingsmeny.toggle_ukjente_land");
+
   const minstEttLandValgt = landkoder.length > 0;
 
   return (
     <Nav.Fieldset legend="Land">
-      {behandlingstema === MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND && (
-        <Skjema.Checkbox
-          feltNavn="soknadsland.erUkjenteEllerAlleEosLand"
-          label={
-            <Nav.Typo.Normaltekst>
-              Flere EØS-land/Sveits. Ikke kjent hvilke.{" "}
-              <Nav.Hjelpetekst>
-                Når søker ikke vet hvilke land arbeidet/næringen skal utføres i, krysser du av her. Det er ikke mulig å
-                legge til andre land i tillegg.
-              </Nav.Hjelpetekst>
-            </Nav.Typo.Normaltekst>
-          }
-          disabled={minstEttLandValgt}
-        />
-      )}
+      {erUkjenteEllerAlleEosLandToggle === "enabled" &&
+        behandlingstema === MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND && (
+          <Skjema.Checkbox
+            feltNavn="soknadsland.erUkjenteEllerAlleEosLand"
+            label={
+              <Nav.Typo.Normaltekst>
+                Flere EØS-land/Sveits. Ikke kjent hvilke.{" "}
+                <Nav.Hjelpetekst>
+                  Når søker ikke vet hvilke land arbeidet/næringen skal utføres i, krysser du av her. Det er ikke mulig
+                  å legge til andre land i tillegg.
+                </Nav.Hjelpetekst>
+              </Nav.Typo.Normaltekst>
+            }
+            disabled={minstEttLandValgt}
+          />
+        )}
       <Skjema.MultiSelect
         label=""
         feltNavn="soknadsland.landkoder"

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/redigerer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/redigerer.tsx
@@ -1,21 +1,54 @@
 import React from "react";
-import { FormSection } from "redux-form";
 import { KTObject } from "@navikt/melosys-kodeverk";
+import { RootState } from "AppTypes";
+import { connect, ConnectedProps } from "react-redux";
+import { formValueSelector } from "redux-form";
 
 import * as Skjema from "../../../../skjema";
 import * as Nav from "../../../../../utils/navFrontend";
+import * as KV from "../../../../../kodeverk";
 
 import MKV from "../../../../../melosyskodeverk";
 
-const Redigerer = () => (
-  <FormSection name="soknadsland">
-    <Skjema.MultiSelect
-      label={<Nav.Typo.Normaltekst>Land</Nav.Typo.Normaltekst>}
-      feltNavn="landkoder"
-      redigerbart
-      options={MKV.KTObjects.landkoder.map(({ kode, term }: KTObject) => ({ value: kode, label: term }))}
-    />
-  </FormSection>
-);
+import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 
-export default Redigerer;
+const soknadFormValueSelector = formValueSelector<KV.Form.SoknadFormData>(KV.Form.SOKNAD);
+
+const mapStateToProps = (state: RootState) => ({
+  soknadsland: soknadFormValueSelector(state, "soknadsland"),
+  behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
+});
+const connector = connect(mapStateToProps);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+const Redigerer = ({ soknadsland: { erUkjenteEllerAlleEosLand, landkoder }, behandlingstema }: PropsFromRedux) => {
+  const minstEttLandValgt = landkoder.length > 0;
+
+  return (
+    <Nav.Fieldset legend="Land">
+      {behandlingstema === MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND && (
+        <Skjema.Checkbox
+          feltNavn="soknadsland.erUkjenteEllerAlleEosLand"
+          label={
+            <Nav.Typo.Normaltekst>
+              Flere EØS-land/Sveits. Ikke kjent hvilke.{" "}
+              <Nav.Hjelpetekst>
+                Når søker ikke vet hvilke land arbeidet/næringen skal utføres i, krysser du av her. Det er ikke mulig å
+                legge til andre land i tillegg.
+              </Nav.Hjelpetekst>
+            </Nav.Typo.Normaltekst>
+          }
+          disabled={minstEttLandValgt}
+        />
+      )}
+      <Skjema.MultiSelect
+        label=""
+        feltNavn="soknadsland.landkoder"
+        redigerbart={!erUkjenteEllerAlleEosLand}
+        options={MKV.KTObjects.landkoder.map(({ kode, term }: KTObject) => ({ value: kode, label: term }))}
+      />
+    </Nav.Fieldset>
+  );
+};
+
+export default connector(Redigerer);

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/redigerer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/redigerer.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { FormSection } from "redux-form";
 import { KTObject } from "@navikt/melosys-kodeverk";
 
 import * as Skjema from "../../../../skjema";
@@ -7,12 +8,14 @@ import * as Nav from "../../../../../utils/navFrontend";
 import MKV from "../../../../../melosyskodeverk";
 
 const Redigerer = () => (
-  <Skjema.MultiSelect
-    label={<Nav.Typo.Normaltekst>Land</Nav.Typo.Normaltekst>}
-    feltNavn="soknadsland"
-    redigerbart
-    options={MKV.KTObjects.landkoder.map(({ kode, term }: KTObject) => ({ value: kode, label: term }))}
-  />
+  <FormSection name="soknadsland">
+    <Skjema.MultiSelect
+      label={<Nav.Typo.Normaltekst>Land</Nav.Typo.Normaltekst>}
+      feltNavn="landkoder"
+      redigerbart
+      options={MKV.KTObjects.landkoder.map(({ kode, term }: KTObject) => ({ value: kode, label: term }))}
+    />
+  </FormSection>
 );
 
 export default Redigerer;

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/redigeringUtfort.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/redigeringUtfort.tsx
@@ -29,17 +29,20 @@ type RedigeringUtfortProps = PropsFromRedux & {
 const RedigeringUtfort = ({ soknadsland, soknadslandErUkjenteEllerAlleEosLand, className }: RedigeringUtfortProps) => {
   const cls = classNames(className, "soknadslandvelger-redigering-utfort");
 
+  const soknadslandTekst = soknadslandErUkjenteEllerAlleEosLand ? (
+    "Flere EØS-land/Sveits. Ikke kjent hvilke."
+  ) : (
+    <Nav.Typo.Element className="element">
+      {Utils.streng.arrayTilKonjunksjon(
+        soknadsland.map((land: string) => KV.kodeTilTerm(land, MKV.KTObjects.landkoder))
+      ) || "Ingen land valgt"}
+    </Nav.Typo.Element>
+  );
+
   return (
     <div className={cls}>
       <Nav.Typo.Normaltekst className="etikett-liten">Land</Nav.Typo.Normaltekst>
-      {soknadslandErUkjenteEllerAlleEosLand && "Flere EØS-land/Sveits. Ikke kjent hvilke."}
-      {!soknadslandErUkjenteEllerAlleEosLand && (
-        <Nav.Typo.Element className="element">
-          {Utils.streng.arrayTilKonjunksjon(
-            soknadsland.map((land: string) => KV.kodeTilTerm(land, MKV.KTObjects.landkoder))
-          ) || "Ingen land valgt"}
-        </Nav.Typo.Element>
-      )}
+      {soknadslandTekst}
     </div>
   );
 };

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/redigeringUtfort.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/redigeringUtfort.tsx
@@ -14,7 +14,10 @@ import { behandlingsgrunnlagSelectors } from "../../../../../ducks/behandlingsgr
 import "./redigeringUtfort.css";
 
 const mapStateToProps = (state: RootState) => ({
-  soknadsland: behandlingsgrunnlagSelectors.SoknadslandSelector(state),
+  soknadsland: behandlingsgrunnlagSelectors.SoknadslandkoderSelector(state),
+  soknadslandErUkjenteEllerAlleEosLand: behandlingsgrunnlagSelectors.SoknadslandErUkjenteEllerAlleEosLandSelector(
+    state
+  ),
 });
 const connector = connect(mapStateToProps);
 type PropsFromRedux = ConnectedProps<typeof connector>;
@@ -23,17 +26,20 @@ type RedigeringUtfortProps = PropsFromRedux & {
   className?: string;
 };
 
-const RedigeringUtfort = ({ soknadsland, className }: RedigeringUtfortProps) => {
+const RedigeringUtfort = ({ soknadsland, soknadslandErUkjenteEllerAlleEosLand, className }: RedigeringUtfortProps) => {
   const cls = classNames(className, "soknadslandvelger-redigering-utfort");
 
   return (
     <div className={cls}>
       <Nav.Typo.Normaltekst className="etikett-liten">Land</Nav.Typo.Normaltekst>
-      <Nav.Typo.Element className="element">
-        {Utils.streng.arrayTilKonjunksjon(
-          soknadsland.map((land: string) => KV.kodeTilTerm(land, MKV.KTObjects.landkoder))
-        ) || "Ingen land valgt"}
-      </Nav.Typo.Element>
+      {soknadslandErUkjenteEllerAlleEosLand && "Flere EØS-land/Sveits. Ikke kjent hvilke."}
+      {!soknadslandErUkjenteEllerAlleEosLand && (
+        <Nav.Typo.Element className="element">
+          {Utils.streng.arrayTilKonjunksjon(
+            soknadsland.map((land: string) => KV.kodeTilTerm(land, MKV.KTObjects.landkoder))
+          ) || "Ingen land valgt"}
+        </Nav.Typo.Element>
+      )}
     </div>
   );
 };

--- a/src/felleskomponenter/menypanelForm/soknad.tsx
+++ b/src/felleskomponenter/menypanelForm/soknad.tsx
@@ -144,7 +144,10 @@ const mapStateToProps = (state: RootState) => ({
     EOSBarnetrygdFraNAV: behandlingsgrunnlagSelectors.BostedSelector(state).EOSBarnetrygdFraNAV,
     soknadsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingsgrunnlagSelectors.PeriodeSelector(state).fom),
     soknadsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingsgrunnlagSelectors.PeriodeSelector(state).tom),
-    soknadsland: behandlingsgrunnlagSelectors.SoknadslandSelector(state),
+    soknadsland: {
+      landkoder: behandlingsgrunnlagSelectors.SoknadslandkoderSelector(state),
+      erUkjenteEllerAlleEosLand: behandlingsgrunnlagSelectors.SoknadslandErUkjenteEllerAlleEosLandSelector(state),
+    },
     arbeidsforholdUtland: behandlingsgrunnlagSelectors.ArbeidsforholdUtlandSelector(state),
     selvstendigNaeringsvirksomhetUtland: behandlingsgrunnlagSelectors.SelvstendigNaeringsvirksomhetUtlandSelector(
       state

--- a/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
+++ b/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
@@ -30,13 +30,28 @@ BehandlingOppgavesLinjeWrapper.propTypes = {
   children: PT.node.isRequired,
 };
 
+const lagLandStreng = (landkoder, erUkjenteEllerAlleEosLand) => {
+  if (erUkjenteEllerAlleEosLand) return "Flere EØS-land/Sveits. Ikke kjent hvilke.";
+
+  return landkoder ? landkoder.join(", ") : "(ukjent)";
+};
+
 /**
  * Dette er enkeltlinjen for én sak som inneholder sakstittel og metadata
  * for å gi saksbehandler en hent over sakens innhold før hun klikker
  * seg inn på den.
  */
 const BehandlingOppgave = ({ sak }) => {
-  const { sammensattNavn, sakstype, saksnummer, behandling, aktivTil, periode, land, fnr } = sak;
+  const {
+    sammensattNavn,
+    sakstype,
+    saksnummer,
+    behandling,
+    aktivTil,
+    periode,
+    land: { landkoder, erUkjenteEllerAlleEosLand },
+    fnr,
+  } = sak;
 
   const {
     behandlingID,
@@ -52,7 +67,7 @@ const BehandlingOppgave = ({ sak }) => {
   const { fom, tom } = periode;
   const tittel = `${KV.objektTilTerm(sakstype)} - ${sammensattNavn} - ${fnr}`;
   const link = Routing.lagUrl(saksnummer, behandlingID, behandlingstema.kode);
-  const landListeSomStreng = land ? land.join(", ") : "(ukjent)";
+  const landStreng = lagLandStreng(landkoder, erUkjenteEllerAlleEosLand);
   const oppdateringStatus = erUnderOppdatering && "(oppdateres nå)";
 
   const cl = classNames({
@@ -161,7 +176,7 @@ const BehandlingOppgave = ({ sak }) => {
                       <dt className="behandlingOppgave__meta__term">Land:</dt>
                     </Nav.Column>
                     <Nav.Column xs="12" md={kolonneBredder[1]}>
-                      <dd className="behandlingOppgave__meta__detalj">{landListeSomStreng}</dd>
+                      <dd className="behandlingOppgave__meta__detalj">{landStreng}</dd>
                     </Nav.Column>
                   </dl>
                 </Nav.Row>

--- a/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
+++ b/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
@@ -11,6 +11,8 @@ import * as Routing from "../../routing";
 
 import PanelHeader from "../panelHeader/panelHeader";
 import EnkeltDato from "../datoOmrade/enkeltDato";
+import Soknadsland from "../soknadsland";
+
 import { formatterDatoTilNorsk } from "../../utils/dato";
 
 import "./behandlingOppgave.css";
@@ -30,28 +32,13 @@ BehandlingOppgavesLinjeWrapper.propTypes = {
   children: PT.node.isRequired,
 };
 
-const lagLandStreng = (landkoder, erUkjenteEllerAlleEosLand) => {
-  if (erUkjenteEllerAlleEosLand) return "Flere EØS-land/Sveits. Ikke kjent hvilke.";
-
-  return landkoder ? landkoder.join(", ") : "(ukjent)";
-};
-
 /**
  * Dette er enkeltlinjen for én sak som inneholder sakstittel og metadata
  * for å gi saksbehandler en hent over sakens innhold før hun klikker
  * seg inn på den.
  */
 const BehandlingOppgave = ({ sak }) => {
-  const {
-    sammensattNavn,
-    sakstype,
-    saksnummer,
-    behandling,
-    aktivTil,
-    periode,
-    land: { landkoder, erUkjenteEllerAlleEosLand },
-    fnr,
-  } = sak;
+  const { sammensattNavn, sakstype, saksnummer, behandling, aktivTil, periode, land, fnr } = sak;
 
   const {
     behandlingID,
@@ -67,7 +54,6 @@ const BehandlingOppgave = ({ sak }) => {
   const { fom, tom } = periode;
   const tittel = `${KV.objektTilTerm(sakstype)} - ${sammensattNavn} - ${fnr}`;
   const link = Routing.lagUrl(saksnummer, behandlingID, behandlingstema.kode);
-  const landStreng = lagLandStreng(landkoder, erUkjenteEllerAlleEosLand);
   const oppdateringStatus = erUnderOppdatering && "(oppdateres nå)";
 
   const cl = classNames({
@@ -176,7 +162,9 @@ const BehandlingOppgave = ({ sak }) => {
                       <dt className="behandlingOppgave__meta__term">Land:</dt>
                     </Nav.Column>
                     <Nav.Column xs="12" md={kolonneBredder[1]}>
-                      <dd className="behandlingOppgave__meta__detalj">{landStreng}</dd>
+                      <dd className="behandlingOppgave__meta__detalj">
+                        <Soknadsland land={land} />
+                      </dd>
                     </Nav.Column>
                   </dl>
                 </Nav.Row>

--- a/src/felleskomponenter/oppgaveliste/fagsak.js
+++ b/src/felleskomponenter/oppgaveliste/fagsak.js
@@ -11,14 +11,9 @@ import PanelHeader from "../panelHeader/panelHeader";
 import EnkeltDato from "../datoOmrade/enkeltDato";
 import { DatoOmradeDescription } from "../datoOmrade/datoOmrade";
 import sorterElementerEtterDato from "../sorterbarListe/sorterElementerEtterDato";
+import Soknadsland from "../soknadsland";
 
 import "./fagsak.css";
-
-const lagLandStreng = (landkoder, erUkjenteEllerAlleEosLand) => {
-  if (erUkjenteEllerAlleEosLand) return "Flere EØS-land/Sveits. Ikke kjent hvilke.";
-
-  return landkoder ? landkoder.join(", ") : "(ukjent)";
-};
 
 /**
  * Dette er enkeltlinjen for én sak som inneholder sakstittel og metadata
@@ -28,12 +23,8 @@ const lagLandStreng = (landkoder, erUkjenteEllerAlleEosLand) => {
 const Fagsak = ({ sak }) => {
   const { opprettetDato, sakstype, saksstatus, saksnummer, behandlingOversikter } = sak;
   const VIS_FORSTE_BEHANDLING_OVERSIKT_PERIODE_LAND = 0;
-  const {
-    periode,
-    land: { landkoder, erUkjenteEllerAlleEosLand },
-  } = behandlingOversikter[VIS_FORSTE_BEHANDLING_OVERSIKT_PERIODE_LAND]; // UX ønsker å ha periode og land vist kun en gang. på topp
+  const { periode, land } = behandlingOversikter[VIS_FORSTE_BEHANDLING_OVERSIKT_PERIODE_LAND]; // UX ønsker å ha periode og land vist kun en gang. på topp
   const tittel = `${KV.objektTilTerm(sakstype)}`;
-  const landStreng = lagLandStreng(landkoder, erUkjenteEllerAlleEosLand);
   const customMargin = { marginLeft: "1em" };
 
   const sorterteBehandlinger = behandlingOversikter
@@ -57,7 +48,9 @@ const Fagsak = ({ sak }) => {
               <dt>Opprettet:</dt>
               <dd>{<EnkeltDato dato={opprettetDato} /> || "(ukjent)"}</dd>
               <dt>Land:</dt>
-              <dd>{landStreng}</dd>
+              <dd>
+                <Soknadsland land={land} />
+              </dd>
             </dl>
           </Nav.Column>
           <Nav.Column xs="12" md="3">

--- a/src/felleskomponenter/oppgaveliste/fagsak.js
+++ b/src/felleskomponenter/oppgaveliste/fagsak.js
@@ -14,6 +14,12 @@ import sorterElementerEtterDato from "../sorterbarListe/sorterElementerEtterDato
 
 import "./fagsak.css";
 
+const lagLandStreng = (landkoder, erUkjenteEllerAlleEosLand) => {
+  if (erUkjenteEllerAlleEosLand) return "Flere EØS-land/Sveits. Ikke kjent hvilke.";
+
+  return landkoder ? landkoder.join(", ") : "(ukjent)";
+};
+
 /**
  * Dette er enkeltlinjen for én sak som inneholder sakstittel og metadata
  * for å gi saksbehandler oversikt over sakens innhold før hun klikker
@@ -22,9 +28,12 @@ import "./fagsak.css";
 const Fagsak = ({ sak }) => {
   const { opprettetDato, sakstype, saksstatus, saksnummer, behandlingOversikter } = sak;
   const VIS_FORSTE_BEHANDLING_OVERSIKT_PERIODE_LAND = 0;
-  const { periode, land } = behandlingOversikter[VIS_FORSTE_BEHANDLING_OVERSIKT_PERIODE_LAND]; // UX ønsker å ha periode og land vist kun en gang. på topp
+  const {
+    periode,
+    land: { landkoder, erUkjenteEllerAlleEosLand },
+  } = behandlingOversikter[VIS_FORSTE_BEHANDLING_OVERSIKT_PERIODE_LAND]; // UX ønsker å ha periode og land vist kun en gang. på topp
   const tittel = `${KV.objektTilTerm(sakstype)}`;
-  const landListeSomStreng = land ? land.join(", ") : "(ukjent)";
+  const landStreng = lagLandStreng(landkoder, erUkjenteEllerAlleEosLand);
   const customMargin = { marginLeft: "1em" };
 
   const sorterteBehandlinger = behandlingOversikter
@@ -48,7 +57,7 @@ const Fagsak = ({ sak }) => {
               <dt>Opprettet:</dt>
               <dd>{<EnkeltDato dato={opprettetDato} /> || "(ukjent)"}</dd>
               <dt>Land:</dt>
-              <dd>{landListeSomStreng}</dd>
+              <dd>{landStreng}</dd>
             </dl>
           </Nav.Column>
           <Nav.Column xs="12" md="3">

--- a/src/felleskomponenter/oppsummering/modaler/endreBehandlingstema/dialogboksEndreBehandlingstema.tsx
+++ b/src/felleskomponenter/oppsummering/modaler/endreBehandlingstema/dialogboksEndreBehandlingstema.tsx
@@ -5,6 +5,7 @@ import { RootState } from "AppTypes";
 import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
 import { behandlingerOperations, behandlingerSelectors } from "../../../../ducks/behandlinger";
+import { behandlingsgrunnlagOperations } from "../../../../ducks/behandlingsgrunnlag";
 import { behandlingstemaSelectors } from "../../../../ducks/behandlingstema";
 import { fagsakSelectors } from "../../../../ducks/fagsaker";
 import { navigeringOperations } from "../../../../ducks/navigering";
@@ -26,6 +27,7 @@ const mapStateToProps = (state: RootState) => ({
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
   hentBehandling: (behandlingID: number) => dispatch(behandlingerOperations.hentBehandling(behandlingID)),
+  hentBehandlingsgrunnlag: (behandlingID: number) => dispatch(behandlingsgrunnlagOperations.hent(behandlingID)),
   tilAnnenSide: (link: string) => dispatch(navigeringOperations.tilAnnenSide(link)),
 });
 
@@ -41,6 +43,7 @@ function DialogboksEndreBehandlingstema({
   avbryt,
   behandlingID,
   hentBehandling,
+  hentBehandlingsgrunnlag,
   muligeBehandlingstema,
   saksnummer,
   tilAnnenSide,
@@ -61,6 +64,7 @@ function DialogboksEndreBehandlingstema({
       .then(() => {
         setBehandlingstemaEndret(true);
         hentBehandling(behandlingID);
+        hentBehandlingsgrunnlag(behandlingID);
         const nyLink = Routing.lagUrl(saksnummer, behandlingID, behandlingstema);
         if (nyLink && nyLink !== link) tilAnnenSide(nyLink);
       })
@@ -139,6 +143,7 @@ DialogboksEndreBehandlingstema.propTypes = {
   behandlingID: PT.number.isRequired,
   behandlingstema: PT.string.isRequired,
   hentBehandling: PT.func.isRequired,
+  hentBehandlingsgrunnlag: PT.func.isRequired,
   muligeBehandlingstema: PT.array.isRequired,
   saksnummer: PT.string.isRequired,
   tilAnnenSide: PT.func.isRequired,

--- a/src/felleskomponenter/skjema/input/checkbox.js
+++ b/src/felleskomponenter/skjema/input/checkbox.js
@@ -29,7 +29,7 @@ function InnerCheckboxComponent({ input, meta, label, submitOnChange, onClick, d
 }
 
 InnerCheckboxComponent.propTypes = {
-  label: PT.string.isRequired,
+  label: PT.node.isRequired,
   errorMessage: PT.arrayOf(PT.string),
   submitOnChange: PT.bool,
   input: PT.object, // eslint-disable-line react/forbid-prop-types

--- a/src/felleskomponenter/soknadsland.tsx
+++ b/src/felleskomponenter/soknadsland.tsx
@@ -1,0 +1,17 @@
+interface SoknadslandProps {
+  land: {
+    landkoder: string[];
+    erUkjenteEllerAlleEosLand: boolean;
+  };
+}
+
+const Soknadsland = ({ land }: SoknadslandProps) => {
+  if (!land) return "(ukjent)";
+
+  const { landkoder, erUkjenteEllerAlleEosLand } = land;
+  if (erUkjenteEllerAlleEosLand) return "Flere EØS-land/Sveits. Ikke kjent hvilke.";
+
+  return landkoder?.length > 0 ? landkoder.join(", ") : "(ukjent)";
+};
+
+export default Soknadsland;

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingStart.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingStart.tsx
@@ -24,7 +24,7 @@ import { FeatureToggle } from "../../../../featuretoggle";
 
 const mapStateToProps = (state: RootState) => {
   const initialSoknadsperiode = behandlingsgrunnlagSelectors.PeriodeSelector(state);
-  const initialSoeknadsland = behandlingsgrunnlagSelectors.SoknadslandSelector(state);
+  const initialSoeknadsland = behandlingsgrunnlagSelectors.SoknadslandkoderSelector(state);
   const initialTrygdedekning = behandlingsgrunnlagSelectors.TrygdedekningSelector(state);
   return {
     trygdedekninger: folketrygdenkodeverkSelectors.TrygdedekningerSelector(state),

--- a/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVedtak.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/ftrl/vurderingVedtak.tsx
@@ -25,7 +25,7 @@ const mapStateToProps = (state: RootState) => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
   medlemskapsperioder: medlemskapsperioderSelectors.AlleMedlemskapsperioderSelector(state),
   innvilgelsesResultater: folketrygdenkodeverkSelectors.InnvilgelsesResultatSelector(state),
-  soknadsland: behandlingsgrunnlagSelectors.SoknadslandSelector(state),
+  soknadsland: behandlingsgrunnlagSelectors.SoknadslandkoderSelector(state),
   trygdeavgiftFormValues: formSelectors.VurderTrygdeavgiftFormSelector(state).values,
   formValues: getFormValues(KV.Form.FTRL_VEDTAK)(state),
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { reset } from "redux-form";
+import { reset, formValueSelector } from "redux-form";
 import { connect } from "react-redux";
 import PT from "prop-types";
 
@@ -27,12 +27,19 @@ import { BOOLSK_STRING } from "../../../constants";
 
 import "./vurderingArbeidsmonster.css";
 
+export const UkjenteEllerFlereEosLandLinje = () => (
+  <div className="land__enkeltlinje">
+    <span>Flere EØS-land/Sveits. Ikke oppgitt hvilke.</span>
+    <Mui.Checkbox disabled checked label="ja" className="marginaltArbeidCheckbox" />
+  </div>
+);
+
 /**
  * Enkeltsjekkboks for marginalt arbeid i et land.
  *
  * @param props Objekt Diverse props (se propTypes)
  */
-export const LandLinje = (props) => {
+export const CheckableLandLinje = (props) => {
   const { landKode, avklartMarginaltArbeidILand, oppdaterData, redigerbart, resetForm } = props;
 
   useEffect(() => {
@@ -70,7 +77,7 @@ export const LandLinje = (props) => {
   );
 };
 
-LandLinje.propTypes = {
+CheckableLandLinje.propTypes = {
   oppdaterData: PT.func.isRequired,
   landKode: MPT.Kodeverk.isRequired,
   avklartMarginaltArbeidILand: PT.object,
@@ -78,7 +85,7 @@ LandLinje.propTypes = {
   resetForm: PT.func.isRequired,
 };
 
-LandLinje.defaultProps = {
+CheckableLandLinje.defaultProps = {
   avklartMarginaltArbeidILand: undefined,
 };
 
@@ -86,52 +93,73 @@ const landLinjeMapDispatchToProps = (dispatch) => ({
   resetForm: (form) => dispatch(reset(form)),
 });
 
-const ConnectedLandLinje = connect(null, landLinjeMapDispatchToProps)(LandLinje);
+export const ConnectedCheckableLandLinje = connect(null, landLinjeMapDispatchToProps)(CheckableLandLinje);
 
-const MarginaltArbeid = ({ arbeidsland, redigerbart, marginaltArbeid, oppdaterData }) => (
-  <Nav.Fieldset legend="Er det marginalt arbeid i noen av landene?">
-    <div className="marginaltArbeid">
-      <div className="landliste_innhold">
-        <div className="land__enkeltlinje">
-          <Nav.Typo.UndertekstBold>Land</Nav.Typo.UndertekstBold>
-          <Nav.Typo.UndertekstBold className="marginaltArbeidCheckbox">
-            Marginalt arbeid? {"(<5%)"}
-          </Nav.Typo.UndertekstBold>
+export const MarginaltArbeid = ({
+  arbeidsland,
+  redigerbart,
+  marginaltArbeid,
+  oppdaterData,
+  soknadsland: { erUkjenteEllerAlleEosLand },
+}) => {
+  const landlinjer = erUkjenteEllerAlleEosLand ? (
+    <UkjenteEllerFlereEosLandLinje />
+  ) : (
+    arbeidsland.map(({ land }) => {
+      const avklartMarginaltArbeidILand = marginaltArbeid.find(
+        (enkeltAvklaring) => enkeltAvklaring.subjektID === land.kode
+      );
+
+      const key = `marginaltArbeidslandListe${land.kode}`;
+      return (
+        <ConnectedCheckableLandLinje
+          landKode={land}
+          avklartMarginaltArbeidILand={avklartMarginaltArbeidILand}
+          key={key}
+          oppdaterData={oppdaterData}
+          redigerbart={redigerbart}
+        />
+      );
+    })
+  );
+
+  return (
+    <Nav.Fieldset legend="Er det marginalt arbeid i noen av landene?">
+      <div className="marginaltArbeid">
+        <div className="landliste_innhold">
+          <div className="land__enkeltlinje">
+            <Nav.Typo.UndertekstBold>Land</Nav.Typo.UndertekstBold>
+            <Nav.Typo.UndertekstBold className="marginaltArbeidCheckbox">
+              Marginalt arbeid? {"(<5%)"}
+            </Nav.Typo.UndertekstBold>
+          </div>
+          {landlinjer}
         </div>
-        {arbeidsland.map(({ land }) => {
-          const avklartMarginaltArbeidILand = marginaltArbeid.find(
-            (enkeltAvklaring) => enkeltAvklaring.subjektID === land.kode
-          );
-
-          const key = `marginaltArbeidslandListe${land.kode}`;
-          return (
-            <ConnectedLandLinje
-              landKode={land}
-              avklartMarginaltArbeidILand={avklartMarginaltArbeidILand}
-              key={key}
-              oppdaterData={oppdaterData}
-              redigerbart={redigerbart}
-            />
-          );
-        })}
       </div>
-    </div>
-  </Nav.Fieldset>
-);
+    </Nav.Fieldset>
+  );
+};
 
 MarginaltArbeid.propTypes = {
   arbeidsland: PT.arrayOf(MPT.ArbeidslandMedYrkesaktivitet),
   marginaltArbeid: PT.array,
-  landMedVesentligArbeid: PT.array.isRequired,
-  erNorgeValgt: PT.bool.isRequired,
   redigerbart: PT.bool.isRequired,
   oppdaterData: PT.func.isRequired,
+  soknadsland: PT.object.isRequired,
 };
 
 MarginaltArbeid.defaultProps = {
   arbeidsland: [],
   marginaltArbeid: [],
 };
+
+const soknadFormValueSelector = formValueSelector(KV.Form.SOKNAD);
+
+const marginaltArbeidMapStateToProps = (state) => ({
+  soknadsland: soknadFormValueSelector(state, "soknadsland"),
+});
+
+const ConnectedMarginaltArbeid = connect(marginaltArbeidMapStateToProps)(MarginaltArbeid);
 
 /**
  * Dette er hovedkomponenten for fanen "Arbeidsmønster". Denne trekker inn MarginaltArbeid som er utlistingen av sjekkbokser og håndtereren
@@ -314,7 +342,7 @@ export const VurderingArbeidsmonster = ({
     <div className="vurderingArbeidsmonster">
       <Nav.Typo.Undertittel>Vurder aktiviteten i de ulike landene</Nav.Typo.Undertittel>
       <div className="arbeidsmonster">
-        <MarginaltArbeid
+        <ConnectedMarginaltArbeid
           redigerbart={redigerbart}
           marginaltArbeid={marginaltArbeid}
           arbeidsland={arbeidsland}

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster.test.js
@@ -7,7 +7,13 @@ import { BOOLSK_STRING } from "../../../constants";
 import MKV from "../../../melosyskodeverk";
 import { lagAvklartfakta } from "../../../regler/avklartefakta";
 
-import { VurderingArbeidsmonster, LandLinje } from "./vurderingArbeidsmonster";
+import {
+  VurderingArbeidsmonster,
+  MarginaltArbeid,
+  CheckableLandLinje,
+  ConnectedCheckableLandLinje,
+  UkjenteEllerFlereEosLandLinje,
+} from "./vurderingArbeidsmonster";
 
 describe("VurderingVurderarbeidsland", () => {
   let props = null;
@@ -42,7 +48,47 @@ describe("VurderingVurderarbeidsland", () => {
   });
 });
 
-describe("LandLinje", () => {
+describe("MarginaltArbeid", () => {
+  let props = null;
+
+  beforeEach(() => {
+    props = {
+      arbeidsland: [
+        {
+          land: { kode: "DK", term: "Danmark" },
+          erLonnetArbeid: true,
+          erSelvstendigNaeringsvirksomhet: true,
+        },
+      ],
+      marginaltArbeid: [],
+      redigerbart: true,
+      oppdaterData: jest.fn(),
+      soknadsland: {
+        landkoder: ["DK"],
+        erUkjenteEllerAlleEosLand: false,
+      },
+    };
+  });
+
+  it("viser ConnectedCheckableLandLinje`r når erUkjenteEllerAlleEosLand er false", () => {
+    const marginaltArbeid = shallow(<MarginaltArbeid {...props} />);
+
+    const landLinjer = marginaltArbeid.find(ConnectedCheckableLandLinje);
+
+    expect(landLinjer).toHaveLength(1);
+  });
+
+  it("viser 1 UkjenteEllerFlereEosLandLinje når erUkjenteEllerAlleEosLand er true", () => {
+    props.soknadsland.erUkjenteEllerAlleEosLand = true;
+    const marginaltArbeid = shallow(<MarginaltArbeid {...props} />);
+
+    const landLinjer = marginaltArbeid.find(UkjenteEllerFlereEosLandLinje);
+
+    expect(landLinjer).toHaveLength(1);
+  });
+});
+
+describe("CheckableLandLinje", () => {
   describe("ved klikk på checkbox", () => {
     let props = null;
 
@@ -55,7 +101,7 @@ describe("LandLinje", () => {
         resetForm: jest.fn(),
       };
 
-      const landLinje = shallow(<LandLinje {...props} />);
+      const landLinje = shallow(<CheckableLandLinje {...props} />);
       const checkbox = landLinje.find(Mui.Checkbox);
       const checkboxOnCheck = checkbox.props().onCheck;
 
@@ -74,5 +120,15 @@ describe("LandLinje", () => {
       expect(props.resetForm).toHaveBeenCalledWith(KV.Form.ARTIKKEL_13_X_VEDTAK);
       expect(props.resetForm).toHaveBeenCalledWith(KV.Form.ARTIKKEL_13_UTPEKLAND);
     });
+  });
+});
+
+describe("UkjenteEllerFlereEosLandLinje", () => {
+  it("viser en disabled checkbox", () => {
+    const landLinje = shallow(<UkjenteEllerFlereEosLandLinje />);
+    const checkbox = landLinje.find(Mui.Checkbox);
+
+    expect(checkbox).toHaveLength(1);
+    expect(checkbox.props().disabled).toBe(true);
   });
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/index.ts
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/index.ts
@@ -1,0 +1,3 @@
+import VurderingArbeidsmonster from "./vurderingArbeidsmonster";
+
+export default VurderingArbeidsmonster;

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/landlinje/index.ts
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/landlinje/index.ts
@@ -1,0 +1,3 @@
+import LandLinje from "./landlinje";
+
+export default LandLinje;

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/landlinje/landlinje.less
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/landlinje/landlinje.less
@@ -1,0 +1,19 @@
+.vurderingArbeidsmonster__landlinje {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 0.5rem 10% 0.5rem 0;
+  border-bottom: 1px solid black;
+
+  :first-child {
+    width: 40%;
+  }
+
+  &__marginaltArbeidCheckbox {
+    width: 20%;
+  }
+
+  * {
+    margin-bottom: 0; // Fjerner margin på Nav.Checkbox for å passe inn i rad
+  }
+}

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/landlinje/landlinje.test.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/landlinje/landlinje.test.tsx
@@ -1,0 +1,39 @@
+import React, { ComponentProps } from "react";
+import { shallow } from "enzyme";
+import { mock, instance } from "ts-mockito";
+
+import * as Mui from "../../../../ui";
+
+import LandLinje from "./landlinje";
+
+describe("LandLinje", () => {
+  const mockedProps = mock<ComponentProps<typeof LandLinje>>();
+  const props = instance(mockedProps);
+
+  props.land = "DK";
+  props.checkbox = {
+    checked: true,
+    onCheck: jest.fn(),
+    redigerbart: true,
+    value: "Testvalue",
+  };
+
+  const landLinje = shallow(<LandLinje {...props} />);
+
+  it("viser land", () => {
+    expect(landLinje.contains("DK")).toBe(true);
+  });
+
+  it("viser checkbox", () => {
+    const checkbox = landLinje.find(Mui.Checkbox);
+
+    expect(checkbox).toHaveLength(1);
+
+    const checkboxProps = checkbox.props();
+
+    expect(checkboxProps.checked).toBe(props.checkbox.checked);
+    expect(checkboxProps.onCheck).toBe(props.checkbox.onCheck);
+    expect(checkboxProps.disabled).toBe(!props.checkbox.redigerbart);
+    expect(checkboxProps.value).toBe(props.checkbox.value);
+  });
+});

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/landlinje/landlinje.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/landlinje/landlinje.tsx
@@ -1,0 +1,31 @@
+import React, { ComponentProps, InputHTMLAttributes } from "react";
+
+import * as Mui from "../../../../ui";
+
+import "./landlinje.css";
+
+type LandLinjeProps = {
+  land: string;
+  checkbox: {
+    redigerbart: boolean;
+    checked: boolean;
+    value?: InputHTMLAttributes<HTMLInputElement>["value"];
+    onCheck?: ComponentProps<typeof Mui.Checkbox>["onCheck"];
+  };
+};
+
+const LandLinje = ({ land, checkbox: { redigerbart, checked, value, onCheck } }: LandLinjeProps) => (
+  <div className="vurderingArbeidsmonster__landlinje">
+    <span>{land}</span>
+    <Mui.Checkbox
+      disabled={!redigerbart}
+      checked={checked}
+      value={value}
+      onCheck={onCheck}
+      label="ja"
+      className="vurderingArbeidsmonster__landlinje__marginaltArbeidCheckbox"
+    />
+  </div>
+);
+
+export default LandLinje;

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/vurderingArbeidsmonster.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/vurderingArbeidsmonster.js
@@ -3,35 +3,32 @@ import { reset, formValueSelector } from "redux-form";
 import { connect } from "react-redux";
 import PT from "prop-types";
 
-import MKV from "../../../melosyskodeverk";
+import MKV from "../../../../melosyskodeverk";
 
-import * as Nav from "../../../utils/navFrontend";
-import * as MPT from "../../../proptypes";
-import * as KV from "../../../kodeverk";
-import * as Mui from "../../../felleskomponenter/ui";
+import * as Nav from "../../../../utils/navFrontend";
+import * as MPT from "../../../../proptypes";
+import * as KV from "../../../../kodeverk";
 
-import EnkeltAvklartfakta from "./felles/enkeltAvklartfakta";
-import { VurderingVesentligAktivitetINorgeTyper } from "../../../kodeverk/koder";
-import { hentFaktaVerdi, konverterTilStegData, lagAvklartfakta } from "../../../regler/avklartefakta";
+import LandLinje from "./landlinje";
+import EnkeltAvklartfakta from "../felles/enkeltAvklartfakta";
+import { VurderingVesentligAktivitetINorgeTyper } from "../../../../kodeverk/koder";
+import { hentFaktaVerdi, konverterTilStegData, lagAvklartfakta } from "../../../../regler/avklartefakta";
 import {
   lagLovvalgsbestemmelse,
   slettLovvalgsbestemmelse,
   konverterLovvalgsbestemmelseTilStegData,
-} from "../../../regler/lovvalgsbestemmelser";
+} from "../../../../regler/lovvalgsbestemmelser";
 import {
   lagTilleggBestemmelse,
   slettTilleggBestemmelse,
   konverterTilleggBestemmelseTilStegData,
-} from "../../../regler/tilleggbestemmelser";
-import { BOOLSK_STRING } from "../../../constants";
+} from "../../../../regler/tilleggbestemmelser";
+import { BOOLSK_STRING } from "../../../../constants";
 
 import "./vurderingArbeidsmonster.css";
 
 export const UkjenteEllerFlereEosLandLinje = () => (
-  <div className="land__enkeltlinje">
-    <span>Flere EØS-land/Sveits. Ikke oppgitt hvilke.</span>
-    <Mui.Checkbox disabled checked label="ja" className="marginaltArbeidCheckbox" />
-  </div>
+  <LandLinje land="Flere EØS-land/Sveits. Ikke oppgitt hvilke" checkbox={{ redigerbart: false, checked: true }} />
 );
 
 /**
@@ -63,17 +60,15 @@ export const CheckableLandLinje = (props) => {
   };
 
   return (
-    <div className="land__enkeltlinje">
-      <span>{`${landKode.term} (${landKode.kode})`}</span>
-      <Mui.Checkbox
-        disabled={!redigerbart}
-        checked={erMarginaltArbeidIArbeidsland === true}
-        value={BOOLSK_STRING.SANN}
-        onCheck={klikkHandler}
-        label="ja"
-        className="marginaltArbeidCheckbox"
-      />
-    </div>
+    <LandLinje
+      land={`${landKode.term} (${landKode.kode})`}
+      checkbox={{
+        redigerbart,
+        checked: erMarginaltArbeidIArbeidsland === true,
+        value: BOOLSK_STRING.SANN,
+        onCheck: klikkHandler,
+      }}
+    />
   );
 };
 

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/vurderingArbeidsmonster.less
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/vurderingArbeidsmonster.less
@@ -1,4 +1,4 @@
-@import "../../../constants";
+@import "../../../../constants";
 
 .vurderingArbeidsmonster {
   .arbeidsmonster {
@@ -28,18 +28,6 @@
 
         :first-child {
           width: 40%;
-        }
-
-        .marginaltArbeidCheckbox {
-          width: 20%;
-        }
-
-        .yrkesaktivitet {
-          width: 20%;
-        }
-
-        * {
-          margin-bottom: 0; // Fjerner margin på Nav.Checkbox for å passe inn i rad
         }
       }
     }

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/vurderingArbeidsmonster.test.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingArbeidsmonster/vurderingArbeidsmonster.test.js
@@ -1,11 +1,10 @@
 import React from "react";
 
-import * as KV from "../../../kodeverk";
-import * as Mui from "../../../felleskomponenter/ui";
+import * as KV from "../../../../kodeverk";
 
-import { BOOLSK_STRING } from "../../../constants";
-import MKV from "../../../melosyskodeverk";
-import { lagAvklartfakta } from "../../../regler/avklartefakta";
+import { BOOLSK_STRING } from "../../../../constants";
+import MKV from "../../../../melosyskodeverk";
+import { lagAvklartfakta } from "../../../../regler/avklartefakta";
 
 import {
   VurderingArbeidsmonster,
@@ -14,6 +13,7 @@ import {
   ConnectedCheckableLandLinje,
   UkjenteEllerFlereEosLandLinje,
 } from "./vurderingArbeidsmonster";
+import LandLinje from "./landlinje";
 
 describe("VurderingVurderarbeidsland", () => {
   let props = null;
@@ -101,9 +101,10 @@ describe("CheckableLandLinje", () => {
         resetForm: jest.fn(),
       };
 
-      const landLinje = shallow(<CheckableLandLinje {...props} />);
-      const checkbox = landLinje.find(Mui.Checkbox);
-      const checkboxOnCheck = checkbox.props().onCheck;
+      const checkableLandLinje = shallow(<CheckableLandLinje {...props} />);
+      const landLinje = checkableLandLinje.find(LandLinje);
+
+      const checkboxOnCheck = landLinje.props().checkbox.onCheck;
 
       checkboxOnCheck();
     });
@@ -124,11 +125,11 @@ describe("CheckableLandLinje", () => {
 });
 
 describe("UkjenteEllerFlereEosLandLinje", () => {
-  it("viser en disabled checkbox", () => {
-    const landLinje = shallow(<UkjenteEllerFlereEosLandLinje />);
-    const checkbox = landLinje.find(Mui.Checkbox);
+  it("viser en LandLinje med ikke-redigerbar checkbox", () => {
+    const ukjenteEllerFlereEosLandLinje = shallow(<UkjenteEllerFlereEosLandLinje />);
+    const landLinje = ukjenteEllerFlereEosLandLinje.find(LandLinje);
 
-    expect(checkbox).toHaveLength(1);
-    expect(checkbox.props().disabled).toBe(true);
+    expect(landLinje).toHaveLength(1);
+    expect(landLinje.props().checkbox.redigerbart).toBe(false);
   });
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVurderarbeidsland.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVurderarbeidsland.js
@@ -273,7 +273,7 @@ const soknadFormValuesSelector = formValueSelector(KV.Form.SOKNAD);
 const mapStateToProps = (state) => ({
   maritimtArbeid: formSelectors.MaritimtArbeidSelector(state),
   hjemmebaser: behandlingsgrunnlagSelectors.HjemmebaserSelector(state),
-  soknadsland: soknadFormValuesSelector(state, "soknadsland"),
+  soknadsland: soknadFormValuesSelector(state, "soknadsland.landkoder"),
   arbeidsland: avklartefaktaSelectors.ArbeidslandSelector(state),
   fjernedeArbeidsland: avklartefaktaSelectors.IkkeArbeidslandSoknadslandSelector(state),
 });

--- a/src/felleskomponenter/ui/checkbox/checkbox.tsx
+++ b/src/felleskomponenter/ui/checkbox/checkbox.tsx
@@ -11,7 +11,7 @@ interface onCheckProperties {
 }
 
 interface CheckboxProps extends FilteredNavCheckboxProps {
-  onCheck: (properties: onCheckProperties) => void;
+  onCheck?: (properties: onCheckProperties) => void;
 }
 
 class Checkbox extends Component<CheckboxProps> {
@@ -22,7 +22,7 @@ class Checkbox extends Component<CheckboxProps> {
 
     const handleKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter" && this.navCheckbox) {
-        onCheck({
+        onCheck?.({
           checked: !this.navCheckbox.checked,
           value: rest.value,
         });
@@ -30,7 +30,7 @@ class Checkbox extends Component<CheckboxProps> {
     };
 
     const changeHandler = (e: ChangeEvent<HTMLInputElement>) => {
-      onCheck({
+      onCheck?.({
         checked: e.target.checked,
         value: rest.value,
       });

--- a/src/services/modules/behandlingsgrunnlag.js
+++ b/src/services/modules/behandlingsgrunnlag.js
@@ -1,7 +1,0 @@
-import { API_BASE_URL, BEHANDLINGSGRUNNLAG } from "../api-constants";
-
-import { getAsJson, postAsJson } from "../utils";
-
-export const hent = (behandlingID) => getAsJson(`${API_BASE_URL}${BEHANDLINGSGRUNNLAG}/${behandlingID}`);
-export const send = (behandlingID, behandlingsgrunnlag) =>
-  postAsJson(`${API_BASE_URL}${BEHANDLINGSGRUNNLAG}/${behandlingID}`, behandlingsgrunnlag);

--- a/src/services/modules/behandlingsgrunnlag/behandlingsgrunnlag.ts
+++ b/src/services/modules/behandlingsgrunnlag/behandlingsgrunnlag.ts
@@ -2,9 +2,12 @@ import { API_BASE_URL, BEHANDLINGSGRUNNLAG } from "../../api-constants";
 
 import { getAsJson, postAsJson } from "../../utils";
 
-import { TheRootSchema as Behandlingsgrunnlag } from "./types";
+import { BehandlingsgrunnlagResDto, BehandlingsgrunnlagReqDto } from "./types";
 
-export const hent = (behandlingID: number): Promise<Behandlingsgrunnlag> =>
+export const hent = (behandlingID: number): Promise<BehandlingsgrunnlagResDto> =>
   getAsJson(`${API_BASE_URL}${BEHANDLINGSGRUNNLAG}/${behandlingID}`);
-export const send = (behandlingID: number, behandlingsgrunnlag: Behandlingsgrunnlag): Promise<Behandlingsgrunnlag> =>
+export const send = (
+  behandlingID: number,
+  behandlingsgrunnlag: BehandlingsgrunnlagReqDto
+): Promise<BehandlingsgrunnlagResDto> =>
   postAsJson(`${API_BASE_URL}${BEHANDLINGSGRUNNLAG}/${behandlingID}`, behandlingsgrunnlag);

--- a/src/services/modules/behandlingsgrunnlag/behandlingsgrunnlag.ts
+++ b/src/services/modules/behandlingsgrunnlag/behandlingsgrunnlag.ts
@@ -1,0 +1,10 @@
+import { API_BASE_URL, BEHANDLINGSGRUNNLAG } from "../../api-constants";
+
+import { getAsJson, postAsJson } from "../../utils";
+
+import { TheRootSchema as Behandlingsgrunnlag } from "./types";
+
+export const hent = (behandlingID: number): Promise<Behandlingsgrunnlag> =>
+  getAsJson(`${API_BASE_URL}${BEHANDLINGSGRUNNLAG}/${behandlingID}`);
+export const send = (behandlingID: number, behandlingsgrunnlag: Behandlingsgrunnlag): Promise<Behandlingsgrunnlag> =>
+  postAsJson(`${API_BASE_URL}${BEHANDLINGSGRUNNLAG}/${behandlingID}`, behandlingsgrunnlag);

--- a/src/services/modules/behandlingsgrunnlag/index.ts
+++ b/src/services/modules/behandlingsgrunnlag/index.ts
@@ -1,0 +1,1 @@
+export * from "./behandlingsgrunnlag";

--- a/src/services/modules/behandlingsgrunnlag/types.ts
+++ b/src/services/modules/behandlingsgrunnlag/types.ts
@@ -1,229 +1,47 @@
-export type TheArbeidsgiverbekrefterutsendelseSchema = boolean | null;
-export type TheArbeidstakeransattunderutsendelsenSchema = boolean | null;
-export type TheErstatterarbeidstakerenutsendteSchema = boolean | null;
-export type TheArbeidstakertidligereutsendt24MndSchema = boolean | null;
-export type TheArbeidsgiverbetalerarbeidsgiveravgiftSchema = boolean | null;
-export type TheTrygdeavgifttrukketgjennomskattSchema = boolean | null;
-export type TheLoennOgGodtgjoerelseSchema = {
-  norskArbgUtbetalerLoenn: TheNorskArbgUtbetalerLoennSchema;
-  erArbeidstakerAnsattHelePerioden: TheErArbeidstakerAnsattHelePeriodenSchema;
-  utlArbgUtbetalerLoenn: TheUtlArbgUtbetalerLoennSchema;
-  bruttoLoennPerMnd: TheBruttoLoennPerMndSchema;
-  bruttoLoennUtlandPerMnd: TheBruttoLoennUtlandPerMndSchema;
-  mottarNaturalytelser: TheMottarNaturalytelserSchema;
-  samletVerdiNaturalytelser: TheSamletVerdiNaturalytelserSchema;
-  erArbeidsgiveravgiftHelePerioden: TheErArbeidsgiveravgiftHelePeriodenSchema;
-  erTrukketTrygdeavgift: TheErTrukketTrygdeavgiftSchema;
-  utlArbTilhoererSammeKonsern: TheUtlArbTilhoererSammeKonsernSchema;
+type Arbeidsgiverbekrefterutsendelse = boolean | null;
+type Arbeidstakeransattunderutsendelsen = boolean | null;
+type Erstatterarbeidstakerenutsendte = boolean | null;
+type Arbeidstakertidligereutsendt24Mnd = boolean | null;
+type Arbeidsgiverbetalerarbeidsgiveravgift = boolean | null;
+type Trygdeavgifttrukketgjennomskatt = boolean | null;
+type LoennOgGodtgjoerelse = {
+  norskArbgUtbetalerLoenn: NorskArbgUtbetalerLoenn;
+  erArbeidstakerAnsattHelePerioden: ErArbeidstakerAnsattHelePerioden;
+  utlArbgUtbetalerLoenn: UtlArbgUtbetalerLoenn;
+  bruttoLoennPerMnd: BruttoLoennPerMnd;
+  bruttoLoennUtlandPerMnd: BruttoLoennUtlandPerMnd;
+  mottarNaturalytelser: MottarNaturalytelser;
+  samletVerdiNaturalytelser: SamletVerdiNaturalytelser;
+  erArbeidsgiveravgiftHelePerioden: ErArbeidsgiveravgiftHelePerioden;
+  erTrukketTrygdeavgift: ErTrukketTrygdeavgift;
+  utlArbTilhoererSammeKonsern: UtlArbTilhoererSammeKonsern;
 } | null;
-export type TheNorskArbgUtbetalerLoennSchema = boolean | null;
-export type TheErArbeidstakerAnsattHelePeriodenSchema = boolean | null;
-export type TheUtlArbgUtbetalerLoennSchema = boolean | null;
-export type TheBruttoLoennPerMndSchema = number | null;
-export type TheBruttoLoennUtlandPerMndSchema = number | null;
-export type TheMottarNaturalytelserSchema = boolean | null;
-export type TheSamletVerdiNaturalytelserSchema = number | null;
-export type TheErArbeidsgiveravgiftHelePeriodenSchema = boolean | null;
-export type TheErTrukketTrygdeavgiftSchema = boolean | null;
-export type TheUtlArbTilhoererSammeKonsernSchema = boolean | null;
-export type TheIdSchema = string | null;
-export type TheLandkodeSchema = string;
-export type TheUtenlandskIdentSchema = TheItemsSchema[];
-export type TheMedfolgendeBarnSchema = {
+type NorskArbgUtbetalerLoenn = boolean | null;
+type ErArbeidstakerAnsattHelePerioden = boolean | null;
+type UtlArbgUtbetalerLoenn = boolean | null;
+type BruttoLoennPerMnd = number | null;
+type BruttoLoennUtlandPerMnd = number | null;
+type MottarNaturalytelser = boolean | null;
+type SamletVerdiNaturalytelser = number | null;
+type ErArbeidsgiveravgiftHelePerioden = boolean | null;
+type ErTrukketTrygdeavgift = boolean | null;
+type UtlArbTilhoererSammeKonsern = boolean | null;
+type Id = string | null;
+type Landkode = string;
+type UtenlandskIdent = {
+  ident: Id;
+  landkode: Landkode;
+};
+type MedfolgendeBarn = {
   uuid: string;
   fnr: string | null;
   navn: string | null;
   relasjonsrolle: "BARN" | "EKTEFELLE_SAMBOER";
 }[];
-export type TheNavnSchema = string | null;
-export type TheForetakutlandSchema = TheItemsSchema1[];
-export type TheItemsSchema2 = string | null;
-export type TheOppholdslandkoderSchema = TheItemsSchema2[];
-export type TheEktefelleellerbarninorgeSchema = boolean | null;
-export type TheStudentfinansieringkodeSchema = string | null;
-export type TheStudentsemesterSchema = string | null;
-export type TheIntensjonomreturSchema = boolean | null;
-export type TheAntallmaanederinorgeSchema = number | null;
-export type TheErselvstendigSchema = boolean | null;
-export type TheOrgnrSchema = string | null;
-export type TheFortsetteretterarbeidiutlandetSchema = boolean | null;
-export type TheSelvstendigforetakSchema = TheItemsSchema3[];
-export type TheEnhetNavnSchema = string | null;
-export type TheFartsomradekodeSchema = string | null;
-export type TheFlagglandkodeSchema = string | null;
-export type TheTerritorialfarvannSchema = string | null;
-export type TheInnretningstypeSchema = string | null;
-export type TheMaritimtArbeidSchema = TheMaritimtarbeidSchema[];
-export type TheHjemmebaseNavnSchema = string | null;
-export type TheHjemmebaseLandSchema = string | null;
-export type TheTypeFlyvningerSchema = "NASJONAL" | "INTERNASJONAL" | "BEGGE" | null;
-export type TheLuftfartBaserSchema = TheLuftfartBaserItemSchema[];
-export type TheAntalladmansatteSchema = number | null;
-export type TheAntallAnsatteSchema = number | null;
-export type TheAntallUtsendteSchema = number | null;
-export type TheAndelomsetninginorgeSchema = number | null;
-export type TheAndelOppdragINorgeSchema = number | null;
-export type TheAndelkontrakterinorgeSchema = number | null;
-export type TheAndelRekruttertINorgeSchema = number | null;
-export type TheItemsSchema4 = string;
-export type TheEkstraArbeidsgivereSchema = TheItemsSchema4[];
-export type TheKodeSchema = string;
-export type TheTermSchema = string | null;
-
-export interface TheRootSchema {
-  mottaksdato: string | null;
-  data:
-    | {
-        arbeidsgiversBekreftelse: {
-          arbeidsgiverBekrefterUtsendelse: TheArbeidsgiverbekrefterutsendelseSchema;
-          arbeidstakerAnsattUnderUtsendelsen: TheArbeidstakeransattunderutsendelsenSchema;
-          erstatterArbeidstakerenUtsendte: TheErstatterarbeidstakerenutsendteSchema;
-          arbeidstakerTidligereUtsendt24Mnd: TheArbeidstakertidligereutsendt24MndSchema;
-          arbeidsgiverBetalerArbeidsgiveravgift: TheArbeidsgiverbetalerarbeidsgiveravgiftSchema;
-          trygdeavgiftTrukketGjennomSkatt: TheTrygdeavgifttrukketgjennomskattSchema;
-          trygdeavgiftTrukketGjennomSkattDato: string | null;
-        };
-        loennOgGodtgjoerelse: TheLoennOgGodtgjoerelseSchema;
-        personOpplysninger: ThePersonopplysningerSchema;
-        arbeidPaaLand: {
-          fysiskeArbeidssteder: {
-            adresse: {
-              tilleggsnavn: string | null;
-              gatenavn: string | null;
-              husnummerEtasjeLeilighet: string | null;
-              postboks: string | null;
-              region: string | null;
-              postnummer: string | null;
-              poststed: string | null;
-              landkode: string | null;
-            };
-            virksomhetNavn: string | null;
-          }[];
-          erHjemmekontor: boolean | null;
-          erFastArbeidssted: boolean | null;
-        };
-        foretakUtland: TheForetakutlandSchema;
-        oppholdUtland: TheOppholdutlandSchema;
-        bosted: TheBostedSchema;
-        selvstendigArbeid: TheSelvstendigarbeidSchema;
-        maritimtArbeid: TheMaritimtArbeidSchema;
-        luftfartBaser: TheLuftfartBaserSchema;
-        soeknadsland: TheSoeknadslandSchema;
-        periode: PeriodeMedFomTom;
-        juridiskArbeidsgiverNorge: TheJuridiskarbeidsgivernorgeSchema;
-        arbeidssituasjonOgOevrig: {
-          harLoennetArbeidMinstEnMndFoerUtsending: boolean | null;
-          beskrivelseArbeidSisteMnd: string | null;
-          harAndreArbeidsgivereIUtsendingsperioden: boolean | null;
-          beskrivelseAnnetArbeid: string | null;
-          erSkattepliktig: boolean | null;
-          mottarYtelserNorge: boolean | null;
-          mottarYtelserUtlandet: boolean | null;
-        };
-        utenlandsoppdraget: {
-          erUtsendelseForOppdragIUtlandet: boolean | null;
-          erAnsattForOppdragIUtlandet: boolean | null;
-          erFortsattAnsattEtterOppdraget: boolean | null;
-          erDrattPaaEgetInitiativ: boolean | null;
-          erErstatningTidligereUtsendte: boolean | null;
-          samletUtsendingsperiode: PeriodeMedFomTom1;
-        } | null;
-      }
-    | {
-        juridiskArbeidsgiverNorge: TheJuridiskarbeidsgivernorgeSchema;
-        personOpplysninger: ThePersonopplysningerSchema;
-        arbeidPaaLand: {
-          fysiskeArbeidssteder: {
-            adresse: {
-              tilleggsnavn: string | null;
-              gatenavn: string | null;
-              husnummerEtasjeLeilighet: string | null;
-              postboks: string | null;
-              region: string | null;
-              postnummer: string | null;
-              poststed: string | null;
-              landkode: string | null;
-            };
-            virksomhetNavn: string | null;
-          }[];
-          erHjemmekontor: boolean | null;
-          erFastArbeidssted: boolean | null;
-        };
-        foretakUtland: TheForetakutlandSchema;
-        oppholdUtland: TheOppholdutlandSchema;
-        bosted: TheBostedSchema;
-        selvstendigArbeid: TheSelvstendigarbeidSchema;
-        maritimtArbeid: TheMaritimtArbeidSchema;
-        luftfartBaser: TheLuftfartBaserSchema;
-        soeknadsland: TheSoeknadslandSchema;
-        periode: PeriodeMedFomTom;
-        overgangsregelbestemmelser: (TheKodeverkSchema | string)[];
-        ytterligereInformasjon: string | null;
-      }
-    | {
-        arbeidsgiversBekreftelse: {
-          arbeidsgiverBekrefterUtsendelse: TheArbeidsgiverbekrefterutsendelseSchema;
-          arbeidstakerAnsattUnderUtsendelsen: TheArbeidstakeransattunderutsendelsenSchema;
-          erstatterArbeidstakerenUtsendte: TheErstatterarbeidstakerenutsendteSchema;
-          arbeidstakerTidligereUtsendt24Mnd: TheArbeidstakertidligereutsendt24MndSchema;
-          arbeidsgiverBetalerArbeidsgiveravgift: TheArbeidsgiverbetalerarbeidsgiveravgiftSchema;
-          trygdeavgiftTrukketGjennomSkatt: TheTrygdeavgifttrukketgjennomskattSchema;
-          trygdeavgiftTrukketGjennomSkattDato: string | null;
-        };
-        loennOgGodtgjoerelse: TheLoennOgGodtgjoerelseSchema;
-        personOpplysninger: ThePersonopplysningerSchema;
-        arbeidPaaLand: {
-          fysiskeArbeidssteder: {
-            adresse: {
-              tilleggsnavn: string | null;
-              gatenavn: string | null;
-              husnummerEtasjeLeilighet: string | null;
-              postboks: string | null;
-              region: string | null;
-              postnummer: string | null;
-              poststed: string | null;
-              landkode: string | null;
-            };
-            virksomhetNavn: string | null;
-          }[];
-          erHjemmekontor: boolean | null;
-          erFastArbeidssted: boolean | null;
-        };
-        foretakUtland: TheForetakutlandSchema;
-        oppholdUtland: TheOppholdutlandSchema;
-        bosted: TheBostedSchema;
-        selvstendigArbeid: TheSelvstendigarbeidSchema;
-        maritimtArbeid: TheMaritimtArbeidSchema;
-        luftfartBaser: TheLuftfartBaserSchema;
-        soeknadsland: TheSoeknadslandSchema;
-        periode: PeriodeMedFomTom;
-        juridiskArbeidsgiverNorge: TheJuridiskarbeidsgivernorgeSchema;
-        trygdedekning:
-          | (
-              | "UTEN_DEKNING"
-              | "FULL_DEKNING_EOSFO"
-              | "HELSEDEL"
-              | "HELSEDEL_MED_SYKE_OG_FORELDREPENGER"
-              | "PENSJONSDEL"
-              | "HELSE_OG_PENSJONSDEL"
-              | "HELSE_OG_PENSJONSDEL_MED_SYKE_OG_FORELDREPENGER"
-              | "FULL_DEKNING_FTRL"
-            )
-          | null;
-      };
-  type: string;
-}
-export interface ThePersonopplysningerSchema {
-  utenlandskIdent: TheUtenlandskIdentSchema;
-  medfolgendeFamilie: TheMedfolgendeBarnSchema;
-}
-export interface TheItemsSchema {
-  ident: TheIdSchema;
-  landkode: TheLandkodeSchema;
-}
-export interface TheItemsSchema1 {
+type Navn = string | null;
+type Foretakutland = {
   uuid: string;
-  navn: TheNavnSchema;
+  navn: Navn;
   orgnr: string | null;
   selvstendigNaeringsvirksomhet: boolean;
   adresse: {
@@ -236,21 +54,207 @@ export interface TheItemsSchema1 {
     poststed: string | null;
     landkode: string | null;
   };
+};
+
+type Oppholdslandkode = string | null;
+type Ektefelleellerbarninorge = boolean | null;
+type Studentfinansieringkode = string | null;
+type Studentsemester = string | null;
+type Intensjonomretur = boolean | null;
+type Antallmaanederinorge = number | null;
+type Erselvstendig = boolean | null;
+type Orgnr = string | null;
+type Fortsetteretterarbeidiutlandet = boolean | null;
+type Selvstendigforetak = {
+  orgnr: Orgnr;
+  fortsetterEtterArbeidIUtlandet: Fortsetteretterarbeidiutlandet;
+};
+type EnhetNavn = string | null;
+type Fartsomradekode = string | null;
+type Flagglandkode = string | null;
+type Territorialfarvann = string | null;
+type Innretningstype = string | null;
+type MaritimtArbeid = Maritimtarbeid[];
+type HjemmebaseNavn = string | null;
+type HjemmebaseLand = string | null;
+type TypeFlyvninger = "NASJONAL" | "INTERNASJONAL" | "BEGGE" | null;
+type Antalladmansatte = number | null;
+type AntallAnsatte = number | null;
+type AntallUtsendte = number | null;
+type Andelomsetninginorge = number | null;
+type AndelOppdragINorge = number | null;
+type Andelkontrakterinorge = number | null;
+type AndelRekruttertINorge = number | null;
+type EkstraArbeidsgiver = string;
+type Kode = string;
+type Term = string | null;
+
+type BehandlingsgrunnlagData =
+  | {
+      arbeidsgiversBekreftelse: {
+        arbeidsgiverBekrefterUtsendelse: Arbeidsgiverbekrefterutsendelse;
+        arbeidstakerAnsattUnderUtsendelsen: Arbeidstakeransattunderutsendelsen;
+        erstatterArbeidstakerenUtsendte: Erstatterarbeidstakerenutsendte;
+        arbeidstakerTidligereUtsendt24Mnd: Arbeidstakertidligereutsendt24Mnd;
+        arbeidsgiverBetalerArbeidsgiveravgift: Arbeidsgiverbetalerarbeidsgiveravgift;
+        trygdeavgiftTrukketGjennomSkatt: Trygdeavgifttrukketgjennomskatt;
+        trygdeavgiftTrukketGjennomSkattDato: string | null;
+      };
+      loennOgGodtgjoerelse: LoennOgGodtgjoerelse;
+      personOpplysninger: Personopplysninger;
+      arbeidPaaLand: {
+        fysiskeArbeidssteder: {
+          adresse: {
+            tilleggsnavn: string | null;
+            gatenavn: string | null;
+            husnummerEtasjeLeilighet: string | null;
+            postboks: string | null;
+            region: string | null;
+            postnummer: string | null;
+            poststed: string | null;
+            landkode: string | null;
+          };
+          virksomhetNavn: string | null;
+        }[];
+        erHjemmekontor: boolean | null;
+        erFastArbeidssted: boolean | null;
+      };
+      foretakUtland: Foretakutland[];
+      oppholdUtland: Oppholdutland;
+      bosted: Bosted;
+      selvstendigArbeid: Selvstendigarbeid;
+      maritimtArbeid: MaritimtArbeid;
+      luftfartBaser: LuftfartBase[];
+      soeknadsland: Soeknadsland;
+      periode: Periode;
+      juridiskArbeidsgiverNorge: Juridiskarbeidsgivernorge;
+      arbeidssituasjonOgOevrig: {
+        harLoennetArbeidMinstEnMndFoerUtsending: boolean | null;
+        beskrivelseArbeidSisteMnd: string | null;
+        harAndreArbeidsgivereIUtsendingsperioden: boolean | null;
+        beskrivelseAnnetArbeid: string | null;
+        erSkattepliktig: boolean | null;
+        mottarYtelserNorge: boolean | null;
+        mottarYtelserUtlandet: boolean | null;
+      };
+      utenlandsoppdraget: {
+        erUtsendelseForOppdragIUtlandet: boolean | null;
+        erAnsattForOppdragIUtlandet: boolean | null;
+        erFortsattAnsattEtterOppdraget: boolean | null;
+        erDrattPaaEgetInitiativ: boolean | null;
+        erErstatningTidligereUtsendte: boolean | null;
+        samletUtsendingsperiode: NullablePeriode;
+      } | null;
+    }
+  | {
+      juridiskArbeidsgiverNorge: Juridiskarbeidsgivernorge;
+      personOpplysninger: Personopplysninger;
+      arbeidPaaLand: {
+        fysiskeArbeidssteder: {
+          adresse: {
+            tilleggsnavn: string | null;
+            gatenavn: string | null;
+            husnummerEtasjeLeilighet: string | null;
+            postboks: string | null;
+            region: string | null;
+            postnummer: string | null;
+            poststed: string | null;
+            landkode: string | null;
+          };
+          virksomhetNavn: string | null;
+        }[];
+        erHjemmekontor: boolean | null;
+        erFastArbeidssted: boolean | null;
+      };
+      foretakUtland: Foretakutland[];
+      oppholdUtland: Oppholdutland;
+      bosted: Bosted;
+      selvstendigArbeid: Selvstendigarbeid;
+      maritimtArbeid: MaritimtArbeid;
+      luftfartBaser: LuftfartBase[];
+      soeknadsland: Soeknadsland;
+      periode: Periode;
+      overgangsregelbestemmelser: (Kodeverk | string)[];
+      ytterligereInformasjon: string | null;
+    }
+  | {
+      arbeidsgiversBekreftelse: {
+        arbeidsgiverBekrefterUtsendelse: Arbeidsgiverbekrefterutsendelse;
+        arbeidstakerAnsattUnderUtsendelsen: Arbeidstakeransattunderutsendelsen;
+        erstatterArbeidstakerenUtsendte: Erstatterarbeidstakerenutsendte;
+        arbeidstakerTidligereUtsendt24Mnd: Arbeidstakertidligereutsendt24Mnd;
+        arbeidsgiverBetalerArbeidsgiveravgift: Arbeidsgiverbetalerarbeidsgiveravgift;
+        trygdeavgiftTrukketGjennomSkatt: Trygdeavgifttrukketgjennomskatt;
+        trygdeavgiftTrukketGjennomSkattDato: string | null;
+      };
+      loennOgGodtgjoerelse: LoennOgGodtgjoerelse;
+      personOpplysninger: Personopplysninger;
+      arbeidPaaLand: {
+        fysiskeArbeidssteder: {
+          adresse: {
+            tilleggsnavn: string | null;
+            gatenavn: string | null;
+            husnummerEtasjeLeilighet: string | null;
+            postboks: string | null;
+            region: string | null;
+            postnummer: string | null;
+            poststed: string | null;
+            landkode: string | null;
+          };
+          virksomhetNavn: string | null;
+        }[];
+        erHjemmekontor: boolean | null;
+        erFastArbeidssted: boolean | null;
+      };
+      foretakUtland: Foretakutland[];
+      oppholdUtland: Oppholdutland;
+      bosted: Bosted;
+      selvstendigArbeid: Selvstendigarbeid;
+      maritimtArbeid: MaritimtArbeid;
+      luftfartBaser: LuftfartBase[];
+      soeknadsland: Soeknadsland;
+      periode: Periode;
+      juridiskArbeidsgiverNorge: Juridiskarbeidsgivernorge;
+      trygdedekning:
+        | (
+            | "UTEN_DEKNING"
+            | "FULL_DEKNING_EOSFO"
+            | "HELSEDEL"
+            | "HELSEDEL_MED_SYKE_OG_FORELDREPENGER"
+            | "PENSJONSDEL"
+            | "HELSE_OG_PENSJONSDEL"
+            | "HELSE_OG_PENSJONSDEL_MED_SYKE_OG_FORELDREPENGER"
+            | "FULL_DEKNING_FTRL"
+          )
+        | null;
+    };
+
+export type BehandlingsgrunnlagReqDto = BehandlingsgrunnlagData;
+
+export interface BehandlingsgrunnlagResDto {
+  mottaksdato: string | null;
+  data: BehandlingsgrunnlagData;
+  type: string;
 }
-export interface TheOppholdutlandSchema {
-  oppholdslandkoder: TheOppholdslandkoderSchema;
-  oppholdsPeriode: TheOppholdsperiodeSchema;
-  ektefelleEllerBarnINorge: TheEktefelleellerbarninorgeSchema;
-  studentFinansieringKode: TheStudentfinansieringkodeSchema;
-  studentSemester: TheStudentsemesterSchema;
+interface Personopplysninger {
+  utenlandskIdent: UtenlandskIdent[];
+  medfolgendeFamilie: MedfolgendeBarn;
 }
-export interface TheOppholdsperiodeSchema {
+
+interface Oppholdutland {
+  oppholdslandkoder: Oppholdslandkode[];
+  oppholdsPeriode: Oppholdsperiode;
+  ektefelleEllerBarnINorge: Ektefelleellerbarninorge;
+  studentFinansieringKode: Studentfinansieringkode;
+  studentSemester: Studentsemester;
+}
+interface Oppholdsperiode {
   fom: string;
   tom: string | null;
 }
-export interface TheBostedSchema {
-  intensjonOmRetur: TheIntensjonomreturSchema;
-  antallMaanederINorge: TheAntallmaanederinorgeSchema;
+interface Bosted {
+  intensjonOmRetur: Intensjonomretur;
+  antallMaanederINorge: Antallmaanederinorge;
   oppgittAdresse: {
     tilleggsnavn: string | null;
     gatenavn: string | null;
@@ -262,51 +266,48 @@ export interface TheBostedSchema {
     landkode: string | null;
   };
 }
-export interface TheSelvstendigarbeidSchema {
-  erSelvstendig: TheErselvstendigSchema;
-  selvstendigForetak: TheSelvstendigforetakSchema;
+interface Selvstendigarbeid {
+  erSelvstendig: Erselvstendig;
+  selvstendigForetak: Selvstendigforetak[];
 }
-export interface TheItemsSchema3 {
-  orgnr: TheOrgnrSchema;
-  fortsetterEtterArbeidIUtlandet: TheFortsetteretterarbeidiutlandetSchema;
-}
-export interface TheMaritimtarbeidSchema {
-  enhetNavn: TheEnhetNavnSchema;
-  fartsomradeKode: TheFartsomradekodeSchema;
-  flaggLandkode: TheFlagglandkodeSchema;
+
+interface Maritimtarbeid {
+  enhetNavn: EnhetNavn;
+  fartsomradeKode: Fartsomradekode;
+  flaggLandkode: Flagglandkode;
   innretningLandkode: string | null;
-  territorialfarvann: TheTerritorialfarvannSchema;
-  innretningstype: TheInnretningstypeSchema;
+  territorialfarvann: Territorialfarvann;
+  innretningstype: Innretningstype;
 }
-export interface TheLuftfartBaserItemSchema {
-  hjemmebaseNavn: TheHjemmebaseNavnSchema;
-  hjemmebaseLand: TheHjemmebaseLandSchema;
-  typeFlyvninger: TheTypeFlyvningerSchema;
+interface LuftfartBase {
+  hjemmebaseNavn: HjemmebaseNavn;
+  hjemmebaseLand: HjemmebaseLand;
+  typeFlyvninger: TypeFlyvninger;
 }
-export interface TheSoeknadslandSchema {
+interface Soeknadsland {
   landkoder: string[];
   erUkjenteEllerAlleEosLand: boolean;
 }
-export interface PeriodeMedFomTom {
+interface Periode {
   fom: string;
   tom: string | null;
 }
-export interface TheJuridiskarbeidsgivernorgeSchema {
-  antallAdmAnsatte: TheAntalladmansatteSchema;
-  antallAnsatte: TheAntallAnsatteSchema;
-  antallUtsendte: TheAntallUtsendteSchema;
-  andelOmsetningINorge: TheAndelomsetninginorgeSchema;
-  andelOppdragINorge: TheAndelOppdragINorgeSchema;
-  andelKontrakterINorge: TheAndelkontrakterinorgeSchema;
-  andelRekruttertINorge: TheAndelRekruttertINorgeSchema;
-  ekstraArbeidsgivere: TheEkstraArbeidsgivereSchema;
+interface Juridiskarbeidsgivernorge {
+  antallAdmAnsatte: Antalladmansatte;
+  antallAnsatte: AntallAnsatte;
+  antallUtsendte: AntallUtsendte;
+  andelOmsetningINorge: Andelomsetninginorge;
+  andelOppdragINorge: AndelOppdragINorge;
+  andelKontrakterINorge: Andelkontrakterinorge;
+  andelRekruttertINorge: AndelRekruttertINorge;
+  ekstraArbeidsgivere: EkstraArbeidsgiver[];
   erOffentligVirksomhet: boolean | null;
 }
-export interface PeriodeMedFomTom1 {
+interface NullablePeriode {
   fom: string | null;
   tom: string | null;
 }
-export interface TheKodeverkSchema {
-  kode: TheKodeSchema;
-  term: TheTermSchema;
+interface Kodeverk {
+  kode: Kode;
+  term: Term;
 }

--- a/src/services/modules/behandlingsgrunnlag/types.ts
+++ b/src/services/modules/behandlingsgrunnlag/types.ts
@@ -1,0 +1,312 @@
+export type TheArbeidsgiverbekrefterutsendelseSchema = boolean | null;
+export type TheArbeidstakeransattunderutsendelsenSchema = boolean | null;
+export type TheErstatterarbeidstakerenutsendteSchema = boolean | null;
+export type TheArbeidstakertidligereutsendt24MndSchema = boolean | null;
+export type TheArbeidsgiverbetalerarbeidsgiveravgiftSchema = boolean | null;
+export type TheTrygdeavgifttrukketgjennomskattSchema = boolean | null;
+export type TheLoennOgGodtgjoerelseSchema = {
+  norskArbgUtbetalerLoenn: TheNorskArbgUtbetalerLoennSchema;
+  erArbeidstakerAnsattHelePerioden: TheErArbeidstakerAnsattHelePeriodenSchema;
+  utlArbgUtbetalerLoenn: TheUtlArbgUtbetalerLoennSchema;
+  bruttoLoennPerMnd: TheBruttoLoennPerMndSchema;
+  bruttoLoennUtlandPerMnd: TheBruttoLoennUtlandPerMndSchema;
+  mottarNaturalytelser: TheMottarNaturalytelserSchema;
+  samletVerdiNaturalytelser: TheSamletVerdiNaturalytelserSchema;
+  erArbeidsgiveravgiftHelePerioden: TheErArbeidsgiveravgiftHelePeriodenSchema;
+  erTrukketTrygdeavgift: TheErTrukketTrygdeavgiftSchema;
+  utlArbTilhoererSammeKonsern: TheUtlArbTilhoererSammeKonsernSchema;
+} | null;
+export type TheNorskArbgUtbetalerLoennSchema = boolean | null;
+export type TheErArbeidstakerAnsattHelePeriodenSchema = boolean | null;
+export type TheUtlArbgUtbetalerLoennSchema = boolean | null;
+export type TheBruttoLoennPerMndSchema = number | null;
+export type TheBruttoLoennUtlandPerMndSchema = number | null;
+export type TheMottarNaturalytelserSchema = boolean | null;
+export type TheSamletVerdiNaturalytelserSchema = number | null;
+export type TheErArbeidsgiveravgiftHelePeriodenSchema = boolean | null;
+export type TheErTrukketTrygdeavgiftSchema = boolean | null;
+export type TheUtlArbTilhoererSammeKonsernSchema = boolean | null;
+export type TheIdSchema = string | null;
+export type TheLandkodeSchema = string;
+export type TheUtenlandskIdentSchema = TheItemsSchema[];
+export type TheMedfolgendeBarnSchema = {
+  uuid: string;
+  fnr: string | null;
+  navn: string | null;
+  relasjonsrolle: "BARN" | "EKTEFELLE_SAMBOER";
+}[];
+export type TheNavnSchema = string | null;
+export type TheForetakutlandSchema = TheItemsSchema1[];
+export type TheItemsSchema2 = string | null;
+export type TheOppholdslandkoderSchema = TheItemsSchema2[];
+export type TheEktefelleellerbarninorgeSchema = boolean | null;
+export type TheStudentfinansieringkodeSchema = string | null;
+export type TheStudentsemesterSchema = string | null;
+export type TheIntensjonomreturSchema = boolean | null;
+export type TheAntallmaanederinorgeSchema = number | null;
+export type TheErselvstendigSchema = boolean | null;
+export type TheOrgnrSchema = string | null;
+export type TheFortsetteretterarbeidiutlandetSchema = boolean | null;
+export type TheSelvstendigforetakSchema = TheItemsSchema3[];
+export type TheEnhetNavnSchema = string | null;
+export type TheFartsomradekodeSchema = string | null;
+export type TheFlagglandkodeSchema = string | null;
+export type TheTerritorialfarvannSchema = string | null;
+export type TheInnretningstypeSchema = string | null;
+export type TheMaritimtArbeidSchema = TheMaritimtarbeidSchema[];
+export type TheHjemmebaseNavnSchema = string | null;
+export type TheHjemmebaseLandSchema = string | null;
+export type TheTypeFlyvningerSchema = "NASJONAL" | "INTERNASJONAL" | "BEGGE" | null;
+export type TheLuftfartBaserSchema = TheLuftfartBaserItemSchema[];
+export type TheAntalladmansatteSchema = number | null;
+export type TheAntallAnsatteSchema = number | null;
+export type TheAntallUtsendteSchema = number | null;
+export type TheAndelomsetninginorgeSchema = number | null;
+export type TheAndelOppdragINorgeSchema = number | null;
+export type TheAndelkontrakterinorgeSchema = number | null;
+export type TheAndelRekruttertINorgeSchema = number | null;
+export type TheItemsSchema4 = string;
+export type TheEkstraArbeidsgivereSchema = TheItemsSchema4[];
+export type TheKodeSchema = string;
+export type TheTermSchema = string | null;
+
+export interface TheRootSchema {
+  mottaksdato: string | null;
+  data:
+    | {
+        arbeidsgiversBekreftelse: {
+          arbeidsgiverBekrefterUtsendelse: TheArbeidsgiverbekrefterutsendelseSchema;
+          arbeidstakerAnsattUnderUtsendelsen: TheArbeidstakeransattunderutsendelsenSchema;
+          erstatterArbeidstakerenUtsendte: TheErstatterarbeidstakerenutsendteSchema;
+          arbeidstakerTidligereUtsendt24Mnd: TheArbeidstakertidligereutsendt24MndSchema;
+          arbeidsgiverBetalerArbeidsgiveravgift: TheArbeidsgiverbetalerarbeidsgiveravgiftSchema;
+          trygdeavgiftTrukketGjennomSkatt: TheTrygdeavgifttrukketgjennomskattSchema;
+          trygdeavgiftTrukketGjennomSkattDato: string | null;
+        };
+        loennOgGodtgjoerelse: TheLoennOgGodtgjoerelseSchema;
+        personOpplysninger: ThePersonopplysningerSchema;
+        arbeidPaaLand: {
+          fysiskeArbeidssteder: {
+            adresse: {
+              tilleggsnavn: string | null;
+              gatenavn: string | null;
+              husnummerEtasjeLeilighet: string | null;
+              postboks: string | null;
+              region: string | null;
+              postnummer: string | null;
+              poststed: string | null;
+              landkode: string | null;
+            };
+            virksomhetNavn: string | null;
+          }[];
+          erHjemmekontor: boolean | null;
+          erFastArbeidssted: boolean | null;
+        };
+        foretakUtland: TheForetakutlandSchema;
+        oppholdUtland: TheOppholdutlandSchema;
+        bosted: TheBostedSchema;
+        selvstendigArbeid: TheSelvstendigarbeidSchema;
+        maritimtArbeid: TheMaritimtArbeidSchema;
+        luftfartBaser: TheLuftfartBaserSchema;
+        soeknadsland: TheSoeknadslandSchema;
+        periode: PeriodeMedFomTom;
+        juridiskArbeidsgiverNorge: TheJuridiskarbeidsgivernorgeSchema;
+        arbeidssituasjonOgOevrig: {
+          harLoennetArbeidMinstEnMndFoerUtsending: boolean | null;
+          beskrivelseArbeidSisteMnd: string | null;
+          harAndreArbeidsgivereIUtsendingsperioden: boolean | null;
+          beskrivelseAnnetArbeid: string | null;
+          erSkattepliktig: boolean | null;
+          mottarYtelserNorge: boolean | null;
+          mottarYtelserUtlandet: boolean | null;
+        };
+        utenlandsoppdraget: {
+          erUtsendelseForOppdragIUtlandet: boolean | null;
+          erAnsattForOppdragIUtlandet: boolean | null;
+          erFortsattAnsattEtterOppdraget: boolean | null;
+          erDrattPaaEgetInitiativ: boolean | null;
+          erErstatningTidligereUtsendte: boolean | null;
+          samletUtsendingsperiode: PeriodeMedFomTom1;
+        } | null;
+      }
+    | {
+        juridiskArbeidsgiverNorge: TheJuridiskarbeidsgivernorgeSchema;
+        personOpplysninger: ThePersonopplysningerSchema;
+        arbeidPaaLand: {
+          fysiskeArbeidssteder: {
+            adresse: {
+              tilleggsnavn: string | null;
+              gatenavn: string | null;
+              husnummerEtasjeLeilighet: string | null;
+              postboks: string | null;
+              region: string | null;
+              postnummer: string | null;
+              poststed: string | null;
+              landkode: string | null;
+            };
+            virksomhetNavn: string | null;
+          }[];
+          erHjemmekontor: boolean | null;
+          erFastArbeidssted: boolean | null;
+        };
+        foretakUtland: TheForetakutlandSchema;
+        oppholdUtland: TheOppholdutlandSchema;
+        bosted: TheBostedSchema;
+        selvstendigArbeid: TheSelvstendigarbeidSchema;
+        maritimtArbeid: TheMaritimtArbeidSchema;
+        luftfartBaser: TheLuftfartBaserSchema;
+        soeknadsland: TheSoeknadslandSchema;
+        periode: PeriodeMedFomTom;
+        overgangsregelbestemmelser: (TheKodeverkSchema | string)[];
+        ytterligereInformasjon: string | null;
+      }
+    | {
+        arbeidsgiversBekreftelse: {
+          arbeidsgiverBekrefterUtsendelse: TheArbeidsgiverbekrefterutsendelseSchema;
+          arbeidstakerAnsattUnderUtsendelsen: TheArbeidstakeransattunderutsendelsenSchema;
+          erstatterArbeidstakerenUtsendte: TheErstatterarbeidstakerenutsendteSchema;
+          arbeidstakerTidligereUtsendt24Mnd: TheArbeidstakertidligereutsendt24MndSchema;
+          arbeidsgiverBetalerArbeidsgiveravgift: TheArbeidsgiverbetalerarbeidsgiveravgiftSchema;
+          trygdeavgiftTrukketGjennomSkatt: TheTrygdeavgifttrukketgjennomskattSchema;
+          trygdeavgiftTrukketGjennomSkattDato: string | null;
+        };
+        loennOgGodtgjoerelse: TheLoennOgGodtgjoerelseSchema;
+        personOpplysninger: ThePersonopplysningerSchema;
+        arbeidPaaLand: {
+          fysiskeArbeidssteder: {
+            adresse: {
+              tilleggsnavn: string | null;
+              gatenavn: string | null;
+              husnummerEtasjeLeilighet: string | null;
+              postboks: string | null;
+              region: string | null;
+              postnummer: string | null;
+              poststed: string | null;
+              landkode: string | null;
+            };
+            virksomhetNavn: string | null;
+          }[];
+          erHjemmekontor: boolean | null;
+          erFastArbeidssted: boolean | null;
+        };
+        foretakUtland: TheForetakutlandSchema;
+        oppholdUtland: TheOppholdutlandSchema;
+        bosted: TheBostedSchema;
+        selvstendigArbeid: TheSelvstendigarbeidSchema;
+        maritimtArbeid: TheMaritimtArbeidSchema;
+        luftfartBaser: TheLuftfartBaserSchema;
+        soeknadsland: TheSoeknadslandSchema;
+        periode: PeriodeMedFomTom;
+        juridiskArbeidsgiverNorge: TheJuridiskarbeidsgivernorgeSchema;
+        trygdedekning:
+          | (
+              | "UTEN_DEKNING"
+              | "FULL_DEKNING_EOSFO"
+              | "HELSEDEL"
+              | "HELSEDEL_MED_SYKE_OG_FORELDREPENGER"
+              | "PENSJONSDEL"
+              | "HELSE_OG_PENSJONSDEL"
+              | "HELSE_OG_PENSJONSDEL_MED_SYKE_OG_FORELDREPENGER"
+              | "FULL_DEKNING_FTRL"
+            )
+          | null;
+      };
+  type: string;
+}
+export interface ThePersonopplysningerSchema {
+  utenlandskIdent: TheUtenlandskIdentSchema;
+  medfolgendeFamilie: TheMedfolgendeBarnSchema;
+}
+export interface TheItemsSchema {
+  ident: TheIdSchema;
+  landkode: TheLandkodeSchema;
+}
+export interface TheItemsSchema1 {
+  uuid: string;
+  navn: TheNavnSchema;
+  orgnr: string | null;
+  selvstendigNaeringsvirksomhet: boolean;
+  adresse: {
+    tilleggsnavn: string | null;
+    gatenavn: string | null;
+    husnummerEtasjeLeilighet: string | null;
+    postboks: string | null;
+    region: string | null;
+    postnummer: string | null;
+    poststed: string | null;
+    landkode: string | null;
+  };
+}
+export interface TheOppholdutlandSchema {
+  oppholdslandkoder: TheOppholdslandkoderSchema;
+  oppholdsPeriode: TheOppholdsperiodeSchema;
+  ektefelleEllerBarnINorge: TheEktefelleellerbarninorgeSchema;
+  studentFinansieringKode: TheStudentfinansieringkodeSchema;
+  studentSemester: TheStudentsemesterSchema;
+}
+export interface TheOppholdsperiodeSchema {
+  fom: string;
+  tom: string | null;
+}
+export interface TheBostedSchema {
+  intensjonOmRetur: TheIntensjonomreturSchema;
+  antallMaanederINorge: TheAntallmaanederinorgeSchema;
+  oppgittAdresse: {
+    tilleggsnavn: string | null;
+    gatenavn: string | null;
+    husnummerEtasjeLeilighet: string | null;
+    postboks: string | null;
+    region: string | null;
+    postnummer: string | null;
+    poststed: string | null;
+    landkode: string | null;
+  };
+}
+export interface TheSelvstendigarbeidSchema {
+  erSelvstendig: TheErselvstendigSchema;
+  selvstendigForetak: TheSelvstendigforetakSchema;
+}
+export interface TheItemsSchema3 {
+  orgnr: TheOrgnrSchema;
+  fortsetterEtterArbeidIUtlandet: TheFortsetteretterarbeidiutlandetSchema;
+}
+export interface TheMaritimtarbeidSchema {
+  enhetNavn: TheEnhetNavnSchema;
+  fartsomradeKode: TheFartsomradekodeSchema;
+  flaggLandkode: TheFlagglandkodeSchema;
+  innretningLandkode: string | null;
+  territorialfarvann: TheTerritorialfarvannSchema;
+  innretningstype: TheInnretningstypeSchema;
+}
+export interface TheLuftfartBaserItemSchema {
+  hjemmebaseNavn: TheHjemmebaseNavnSchema;
+  hjemmebaseLand: TheHjemmebaseLandSchema;
+  typeFlyvninger: TheTypeFlyvningerSchema;
+}
+export interface TheSoeknadslandSchema {
+  landkoder: string[];
+  erUkjenteEllerAlleEosLand: boolean;
+}
+export interface PeriodeMedFomTom {
+  fom: string;
+  tom: string | null;
+}
+export interface TheJuridiskarbeidsgivernorgeSchema {
+  antallAdmAnsatte: TheAntalladmansatteSchema;
+  antallAnsatte: TheAntallAnsatteSchema;
+  antallUtsendte: TheAntallUtsendteSchema;
+  andelOmsetningINorge: TheAndelomsetninginorgeSchema;
+  andelOppdragINorge: TheAndelOppdragINorgeSchema;
+  andelKontrakterINorge: TheAndelkontrakterinorgeSchema;
+  andelRekruttertINorge: TheAndelRekruttertINorgeSchema;
+  ekstraArbeidsgivere: TheEkstraArbeidsgivereSchema;
+  erOffentligVirksomhet: boolean | null;
+}
+export interface PeriodeMedFomTom1 {
+  fom: string | null;
+  tom: string | null;
+}
+export interface TheKodeverkSchema {
+  kode: TheKodeSchema;
+  term: TheTermSchema;
+}

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -393,7 +393,7 @@ Saksbehandling.defaultProps = {
 
 const mapStateToProps = (state) => ({
   anmodningsperioderErSendtUtlandet: anmodningsperioderSelectors.AnmodningsperioderErSendtUtlandetSelector(state),
-  arbeidsland: behandlingsgrunnlagSelectors.SoknadslandSelector(state),
+  arbeidsland: behandlingsgrunnlagSelectors.SoknadslandkoderSelector(state),
   behandlingsgrunnlag: behandlingsgrunnlagSelectors.BehandlingsgrunnlagDataSelector(state),
   behandlingsgrunnlagPeriodeFom: Utils.dato.formatterDatoTilNorsk(
     behandlingsgrunnlagSelectors.PeriodeSelector(state).fom

--- a/src/sider/journalforing/komponenter/enkeltSak.js
+++ b/src/sider/journalforing/komponenter/enkeltSak.js
@@ -5,12 +5,23 @@ import * as MPT from "../../../proptypes/";
 import * as Skjema from "../../../felleskomponenter/skjema";
 import EnkeltDato from "../../../felleskomponenter/datoOmrade/enkeltDato";
 
+const lagLandStreng = (landkoder, erUkjenteEllerAlleEosLand) => {
+  if (erUkjenteEllerAlleEosLand) return "Flere EØS-land/Sveits. Ikke kjent hvilke.";
+
+  return landkoder ? landkoder.join(", ") : "(ukjent)";
+};
+
 /** Den enkelte sak-elementet som brukes i iterasjon i listen
  */
 const EnkeltSak = (props) => {
   const { opprettetDato, behandlingOversikter, sakstype, saksstatus, saksnummer } = props.sak;
 
-  const { land, behandlingstype, periode, behandlingsstatus } = behandlingOversikter[0];
+  const {
+    land: { landkoder, erUkjenteEllerAlleEosLand },
+    behandlingstype,
+    periode,
+    behandlingsstatus,
+  } = behandlingOversikter[0];
   return (
     <Skjema.CustomRadioPanelElement
       tittel={KV.objektTilTerm(sakstype)}
@@ -26,7 +37,7 @@ const EnkeltSak = (props) => {
         },
         { term: "Saksstatus:", description: KV.objektTilTerm(saksstatus) },
         { term: "Saksnummer:", description: saksnummer },
-        { term: "Land:", description: land ? land.join(", ") : "(ukjent)" },
+        { term: "Land:", description: lagLandStreng(landkoder, erUkjenteEllerAlleEosLand) },
         { term: "Behandlingsstatus:", description: KV.objektTilTerm(behandlingsstatus) },
         { term: "Opprettet:", description: <EnkeltDato dato={opprettetDato} /> },
       ]}

--- a/src/sider/journalforing/komponenter/enkeltSak.js
+++ b/src/sider/journalforing/komponenter/enkeltSak.js
@@ -3,25 +3,16 @@ import React, { Fragment } from "react";
 import * as KV from "../../../kodeverk";
 import * as MPT from "../../../proptypes/";
 import * as Skjema from "../../../felleskomponenter/skjema";
+
 import EnkeltDato from "../../../felleskomponenter/datoOmrade/enkeltDato";
-
-const lagLandStreng = (landkoder, erUkjenteEllerAlleEosLand) => {
-  if (erUkjenteEllerAlleEosLand) return "Flere EØS-land/Sveits. Ikke kjent hvilke.";
-
-  return landkoder ? landkoder.join(", ") : "(ukjent)";
-};
+import Soknadsland from "../../../felleskomponenter/soknadsland";
 
 /** Den enkelte sak-elementet som brukes i iterasjon i listen
  */
 const EnkeltSak = (props) => {
   const { opprettetDato, behandlingOversikter, sakstype, saksstatus, saksnummer } = props.sak;
 
-  const {
-    land: { landkoder, erUkjenteEllerAlleEosLand },
-    behandlingstype,
-    periode,
-    behandlingsstatus,
-  } = behandlingOversikter[0];
+  const { land, behandlingstype, periode, behandlingsstatus } = behandlingOversikter[0];
   return (
     <Skjema.CustomRadioPanelElement
       tittel={KV.objektTilTerm(sakstype)}
@@ -37,7 +28,7 @@ const EnkeltSak = (props) => {
         },
         { term: "Saksstatus:", description: KV.objektTilTerm(saksstatus) },
         { term: "Saksnummer:", description: saksnummer },
-        { term: "Land:", description: lagLandStreng(landkoder, erUkjenteEllerAlleEosLand) },
+        { term: "Land:", description: <Soknadsland land={land} /> },
         { term: "Behandlingsstatus:", description: KV.objektTilTerm(behandlingsstatus) },
         { term: "Opprettet:", description: <EnkeltDato dato={opprettetDato} /> },
       ]}


### PR DESCRIPTION
- Legger til checkbox for å kunne velge "flere EØS-land/Sveits". Bruker featuretoggle `melosys.behandlingsmeny.toggle_ukjente_land`.
- Se [story](https://jira.adeo.no/browse/MELOSYS-4598) og [confluence](https://confluence.adeo.no/pages/viewpage.action?pageId=414015398).
- Lagt til felt `behandlingsgrunnlag.soeknadsland.erUkjenteEllerAlleEosLand`. 
- Oppdatert diverse skjermbilder for å kunne vise at "flere EØS-land/Sveits" er haket av, f.eks. oppgavebenk og søk-skjermbilde.

melosys-api: https://github.com/navikt/melosys-api/pull/710
schema: https://github.com/navikt/melosys-schema/pull/251