### PR TITLE
MELOSYS-4598 - småfiks søknadsland

### DIFF
--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -1,4 +1,4 @@
-import { object, array, string, lazy, mixed, number } from "yup";
+import { object, array, string, lazy, mixed, number, boolean } from "yup";
 
 import * as Utils from "../../utils";
 import * as KV from "../../kodeverk";
@@ -309,6 +309,20 @@ const soknad = object().when("$behandlingstema", {
             )
           ),
       }),
+    }),
+    soknadsland: object().shape({
+      landkoder: array().when("erUkjenteEllerAlleEosLand", {
+        is: (erUkjenteEllerAlleEosLand) => !erUkjenteEllerAlleEosLand,
+        then: array().min(
+          1,
+          lagMelding(
+            KV.Menypunkter.Utenlandsoppdraget.tittel,
+            KV.Menypunkter.Utenlandsoppdraget.undertitler.land,
+            "Oppgi minst ett søknadsland"
+          )
+        ),
+      }),
+      erUkjenteEllerAlleEosLand: boolean(),
     }),
   }),
 });

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
@@ -51,7 +51,7 @@ const finnSedMottakerLand = (arbeidsland, bostedsland, lovvalgsperiode) => {
     return bostedslandKode;
   }
 
-  return arbeidsland[0].kode;
+  return arbeidsland[0]?.kode;
 };
 
 const VurderingVedtak = ({
@@ -163,7 +163,7 @@ const VurderingVedtak = ({
             </Nav.Column>
           </Nav.Row>
         )}
-        {erSoknadEllerNyVurdering && (
+        {erSoknadEllerNyVurdering && sedMottakerLand && (
           <Nav.Row className="mottakerinstitusjoner">
             <Nav.Column xs="7">
               <Mottakerinstitusjonvelger

--- a/src/kodeverk/menypunkter.ts
+++ b/src/kodeverk/menypunkter.ts
@@ -59,6 +59,7 @@ export const Utenlandsoppdraget = {
   tittel: "Utenlandsoppdraget",
   undertitler: {
     periode: "Periode",
+    land: "Land",
     tilleggsopplysninger: "Tilleggsopplysninger",
   },
 };


### PR DESCRIPTION
- Fikser at app krasjer når man står i vedtakssteg for art.12. og fjerner alle søknadsland via meny.
- Viser feilmelding dersom sb prøver å gå videre i stegvelger uten søknadsland, men mindre de har krysset av for ukjente/alle eøs-land.