### PR TITLE
La til beslutning_lovvalg_* til å kunne ha flere land

### DIFF
--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.tsx
@@ -16,6 +16,7 @@ import { behandlingerSelectors } from "../../../ducks/behandlinger";
 import { vilkarOperations } from "../../../ducks/vilkar";
 
 import "./vurderingInngang.css";
+import { kanHaFlereLand } from "../../../melosyskodeverk/utils";
 
 const { OVERSTYRT_AV_SAKSBEHANDLER } = MKV.Koder.begrunnelser.inngangsvilkaar;
 
@@ -59,8 +60,7 @@ export const Varsler = ({ oppfyllerInngangsvilkar, inngangsvilkaar, landkoder, b
     );
   }
 
-  const flereLandEnnTillatt =
-    landkoder.length > 1 && behandlingstema !== MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND;
+  const flereLandEnnTillatt = landkoder.length > 1 && !kanHaFlereLand(behandlingstema);
 
   return (
     <div className="vurderinginngang">

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.tsx
@@ -59,7 +59,7 @@ export const Varsler = ({ oppfyllerInngangsvilkar, inngangsvilkaar, landkoder, b
     );
   }
 
-  const flereSoknadslandEnnLovlig = landkoder.length > 1 && !MKVUtils.kanHaFlereSoknadsland(behandlingstema);
+  const flereSoknadslandEnnTillatt = landkoder.length > 1 && !MKVUtils.kanHaFlereSoknadsland(behandlingstema);
 
   return (
     <div className="vurderinginngang">
@@ -72,7 +72,7 @@ export const Varsler = ({ oppfyllerInngangsvilkar, inngangsvilkaar, landkoder, b
             </li>
           ))}
       </ul>
-      {flereSoknadslandEnnLovlig && (
+      {flereSoknadslandEnnTillatt && (
         <Nav.AlertStripeAdvarsel>
           Du har valgt et behandlingstema som kun tillater ett arbeidsland. Du må fjerne arbeidsland, eller endre
           behandlingstema for å kunne fatte vedtak.

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.tsx
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingInngang.tsx
@@ -10,13 +10,12 @@ import * as KV from "../../../kodeverk";
 import * as Utils from "../../../utils";
 import * as Api from "../../../services/api";
 
-import MKV from "../../../melosyskodeverk";
+import MKV, { Utils as MKVUtils } from "../../../melosyskodeverk";
 
 import { behandlingerSelectors } from "../../../ducks/behandlinger";
 import { vilkarOperations } from "../../../ducks/vilkar";
 
 import "./vurderingInngang.css";
-import { kanHaFlereLand } from "../../../melosyskodeverk/utils";
 
 const { OVERSTYRT_AV_SAKSBEHANDLER } = MKV.Koder.begrunnelser.inngangsvilkaar;
 
@@ -60,7 +59,7 @@ export const Varsler = ({ oppfyllerInngangsvilkar, inngangsvilkaar, landkoder, b
     );
   }
 
-  const flereLandEnnTillatt = landkoder.length > 1 && !kanHaFlereLand(behandlingstema);
+  const flereSoknadslandEnnLovlig = landkoder.length > 1 && !MKVUtils.kanHaFlereSoknadsland(behandlingstema);
 
   return (
     <div className="vurderinginngang">
@@ -73,7 +72,7 @@ export const Varsler = ({ oppfyllerInngangsvilkar, inngangsvilkaar, landkoder, b
             </li>
           ))}
       </ul>
-      {flereLandEnnTillatt && (
+      {flereSoknadslandEnnLovlig && (
         <Nav.AlertStripeAdvarsel>
           Du har valgt et behandlingstema som kun tillater ett arbeidsland. Du må fjerne arbeidsland, eller endre
           behandlingstema for å kunne fatte vedtak.

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
@@ -27,6 +27,7 @@ import { lagYupToReduxformErrorMapper } from "../../../yup";
 import VurderingArtikkel12VedtakSchema from "./vurderingArtikkel12VedtakSchema";
 
 import "./vurderingVedtak.css";
+import { kanHaFlereLand } from "../../../melosyskodeverk/utils";
 
 const finnLovvalgSomTerm = (lovvalgsbestemmelse = {}, tilleggsbestemmelse = {}) => {
   if (
@@ -119,8 +120,7 @@ const VurderingVedtak = ({
   };
 
   const sedMottakerLand = finnSedMottakerLand(arbeidsland, bostedsland || {}, lovvalget);
-  const flereLandEnnLovlig =
-    arbeidsland.length > 1 && behandlingstema !== MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND;
+  const flereLandEnnLovlig = arbeidsland.length > 1 && !kanHaFlereLand(behandlingstema);
 
   return (
     <div className="vedtak">

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
@@ -27,7 +27,6 @@ import { lagYupToReduxformErrorMapper } from "../../../yup";
 import VurderingArtikkel12VedtakSchema from "./vurderingArtikkel12VedtakSchema";
 
 import "./vurderingVedtak.css";
-import { kanHaFlereLand } from "../../../melosyskodeverk/utils";
 
 const finnLovvalgSomTerm = (lovvalgsbestemmelse = {}, tilleggsbestemmelse = {}) => {
   if (
@@ -120,7 +119,7 @@ const VurderingVedtak = ({
   };
 
   const sedMottakerLand = finnSedMottakerLand(arbeidsland, bostedsland || {}, lovvalget);
-  const flereLandEnnLovlig = arbeidsland.length > 1 && !kanHaFlereLand(behandlingstema);
+  const flereSoknadslandEnnLovlig = arbeidsland.length > 1 && !MKVUtils.kanHaFlereSoknadsland(behandlingstema);
 
   return (
     <div className="vedtak">
@@ -180,7 +179,7 @@ const VurderingVedtak = ({
             {redigerbart && <PdfLenkeListe behandlingID={behandlingID} dokumenter={pdfDokumenter} />}
           </Nav.Column>
         </Nav.Row>
-        {flereLandEnnLovlig && (
+        {flereSoknadslandEnnLovlig && (
           <Nav.AlertStripe type="feil">Det er kun tillat med ett arbeidsland i vedtaket.</Nav.AlertStripe>
         )}
         <Nav.Row>
@@ -188,7 +187,7 @@ const VurderingVedtak = ({
             <Nav.Hovedknapp
               spinner={vedtakPending}
               autoDisableVedSpinner
-              disabled={!redigerbart || flereLandEnnLovlig}
+              disabled={!redigerbart || flereSoknadslandEnnLovlig}
               onClick={fattVedtak}
             >
               Fatt vedtak

--- a/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
+++ b/src/felleskomponenter/stegvelger/stegKomponenter/vurderingVedtak.js
@@ -119,7 +119,7 @@ const VurderingVedtak = ({
   };
 
   const sedMottakerLand = finnSedMottakerLand(arbeidsland, bostedsland || {}, lovvalget);
-  const flereSoknadslandEnnLovlig = arbeidsland.length > 1 && !MKVUtils.kanHaFlereSoknadsland(behandlingstema);
+  const flereSoknadslandEnnTillatt = arbeidsland.length > 1 && !MKVUtils.kanHaFlereSoknadsland(behandlingstema);
 
   return (
     <div className="vedtak">
@@ -179,7 +179,7 @@ const VurderingVedtak = ({
             {redigerbart && <PdfLenkeListe behandlingID={behandlingID} dokumenter={pdfDokumenter} />}
           </Nav.Column>
         </Nav.Row>
-        {flereSoknadslandEnnLovlig && (
+        {flereSoknadslandEnnTillatt && (
           <Nav.AlertStripe type="feil">Det er kun tillat med ett arbeidsland i vedtaket.</Nav.AlertStripe>
         )}
         <Nav.Row>
@@ -187,7 +187,7 @@ const VurderingVedtak = ({
             <Nav.Hovedknapp
               spinner={vedtakPending}
               autoDisableVedSpinner
-              disabled={!redigerbart || flereSoknadslandEnnLovlig}
+              disabled={!redigerbart || flereSoknadslandEnnTillatt}
               onClick={fattVedtak}
             >
               Fatt vedtak

--- a/src/melosyskodeverk/utils.js
+++ b/src/melosyskodeverk/utils.js
@@ -22,3 +22,10 @@ export const erUtsendt = (behandlingstema) =>
     MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER,
     MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG,
   ].includes(behandlingstema);
+
+export const kanHaFlereLand = (behandlingstema) =>
+  [
+    MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND,
+    MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE,
+    MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND,
+  ].includes(behandlingstema);

--- a/src/melosyskodeverk/utils.js
+++ b/src/melosyskodeverk/utils.js
@@ -23,7 +23,7 @@ export const erUtsendt = (behandlingstema) =>
     MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG,
   ].includes(behandlingstema);
 
-export const kanHaFlereLand = (behandlingstema) =>
+export const kanHaFlereSoknadsland = (behandlingstema) =>
   [
     MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND,
     MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE,


### PR DESCRIPTION
Tillater flere arbeidsland for behandlingstemaene `BESLUTNING_LOVVALG_NORGE`  og `BESLUTNING_LOVVALG_ANNET_LAND` i likhet med  løsningen som allerede er implementert for `ARBEID_FLERE_LAND`