### PR TITLE
NOJIRA - graphql codegen forbedring

### DIFF
--- a/src/graphql/codegen.yml
+++ b/src/graphql/codegen.yml
@@ -2,7 +2,6 @@ schema:
   - http://localhost:8080/graphql:
       headers:
         Cookie: ""
-documents: "src/**/*.gql"
 config:
   scalars:
     # Mapper custom scalars i graphql-skjemaet til typescript-typer.
@@ -16,6 +15,9 @@ generates:
   # Genererer react-hooks for operations på samme sted som operations er definert.
   src/:
     preset: near-operation-file
+    documents:
+      - "src/**/*.gql"
+      - "!src/graphql/**/*.gql"
     presetConfig:
       extension: .generated.tsx
       baseTypesPath: graphql/generated/types.ts

--- a/src/graphql/codegen.yml
+++ b/src/graphql/codegen.yml
@@ -27,12 +27,14 @@ generates:
 
   # Genererer sdk til bruk utenfor react-komponenter.
   src/graphql/generated/getSdk.ts:
+    # Fjern utkommentert documents-key når man ønsker å legge til operations til SDKen(codegen-script ender med error hvis ingen documents finnes).
+    # documents: "src/graphql/**/*.gql"
     plugins:
+      # Fant ingen måte å peke typescript-generic-sdk til typer generert i src/graphql/generated/types.ts,
+      # derfor genereres typene også i src/graphql/generated/getSdk.ts.
       - typescript
       - typescript-operations
       - typescript-generic-sdk
     config:
-      # Fant ingen måte å peke typescript-generic-sdk til typer generert i src/graphql/generated/types.ts,
-      # derfor genereres typene også i src/graphql/generated/getSdk.ts.
       # Siden typene allerede er generert i src/graphql/generated/types.ts er det ikke nødvendig å eksportere de her.
       noExport: true

--- a/src/graphql/generated/getSdk.ts
+++ b/src/graphql/generated/getSdk.ts
@@ -19,11 +19,48 @@ type Scalars = {
   Long: number;
 };
 
+type Bostedsadresse = {
+  __typename?: 'Bostedsadresse';
+  coAdressenavn?: Maybe<Scalars['String']>;
+  adresse: StrukturertAdresseformat;
+  gyldigFraOgMed?: Maybe<Scalars['DateTime']>;
+  gyldigTilOgMed?: Maybe<Scalars['DateTime']>;
+  master: Scalars['String'];
+  kilde?: Maybe<Scalars['String']>;
+  erHistorisk: Scalars['Boolean'];
+};
 
 
+
+type Kontaktadresse = {
+  __typename?: 'Kontaktadresse';
+  coAdressenavn?: Maybe<Scalars['String']>;
+  semistrukturertAdresse?: Maybe<SemistrukturertAdresseformat>;
+  strukturertAdresse?: Maybe<StrukturertAdresseformat>;
+  gyldigFraOgMed?: Maybe<Scalars['DateTime']>;
+  gyldigTilOgMed?: Maybe<Scalars['DateTime']>;
+  master: Scalars['String'];
+  kilde?: Maybe<Scalars['String']>;
+  erHistorisk: Scalars['Boolean'];
+};
+
+
+type Oppholdsadresse = {
+  __typename?: 'Oppholdsadresse';
+  coAdressenavn?: Maybe<Scalars['String']>;
+  adresse: StrukturertAdresseformat;
+  gyldigFraOgMed?: Maybe<Scalars['DateTime']>;
+  gyldigTilOgMed?: Maybe<Scalars['DateTime']>;
+  master: Scalars['String'];
+  kilde?: Maybe<Scalars['String']>;
+  erHistorisk: Scalars['Boolean'];
+};
 
 type Personopplysninger = {
   __typename?: 'Personopplysninger';
+  bostedsadresser: Array<Bostedsadresse>;
+  kontaktadresser: Array<Kontaktadresse>;
+  oppholdsadresser: Array<Oppholdsadresse>;
   statsborgerskap: Array<Statsborgerskap>;
 };
 
@@ -43,6 +80,17 @@ type Saksopplysninger = {
   persondata: Personopplysninger;
 };
 
+type SemistrukturertAdresseformat = {
+  __typename?: 'SemistrukturertAdresseformat';
+  adresselinje1?: Maybe<Scalars['String']>;
+  adresselinje2?: Maybe<Scalars['String']>;
+  adresselinje3?: Maybe<Scalars['String']>;
+  adresselinje4?: Maybe<Scalars['String']>;
+  postnummer?: Maybe<Scalars['String']>;
+  poststed?: Maybe<Scalars['String']>;
+  land: Scalars['String'];
+};
+
 type Statsborgerskap = {
   __typename?: 'Statsborgerskap';
   land: Scalars['String'];
@@ -54,49 +102,23 @@ type Statsborgerskap = {
   erHistorisk: Scalars['Boolean'];
 };
 
-type HentStatsborgerskapQueryVariables = Exact<{
-  behandlingID: Scalars['Long'];
-}>;
+type StrukturertAdresseformat = {
+  __typename?: 'StrukturertAdresseformat';
+  tilleggsnavn?: Maybe<Scalars['String']>;
+  gatenavn?: Maybe<Scalars['String']>;
+  husnummerEtasjeLeilighet?: Maybe<Scalars['String']>;
+  postboks?: Maybe<Scalars['String']>;
+  postnummer?: Maybe<Scalars['String']>;
+  poststed?: Maybe<Scalars['String']>;
+  region?: Maybe<Scalars['String']>;
+  land: Scalars['String'];
+};
 
 
-type HentStatsborgerskapQuery = (
-  { __typename?: 'Query' }
-  & { hentSaksopplysninger: (
-    { __typename?: 'Saksopplysninger' }
-    & { persondata: (
-      { __typename?: 'Personopplysninger' }
-      & { statsborgerskap: Array<(
-        { __typename?: 'Statsborgerskap' }
-        & Pick<Statsborgerskap, 'land' | 'bekreftelsesdato' | 'gyldigFraOgMed' | 'gyldigTilOgMed' | 'master' | 'kilde' | 'erHistorisk'>
-      )> }
-    ) }
-  ) }
-);
-
-
- const HentStatsborgerskapDocument = gql`
-    query hentStatsborgerskap($behandlingID: Long!) {
-  hentSaksopplysninger(behandlingID: $behandlingID) {
-    persondata {
-      statsborgerskap {
-        land
-        bekreftelsesdato
-        gyldigFraOgMed
-        gyldigTilOgMed
-        master
-        kilde
-        erHistorisk
-      }
-    }
-  }
-}
-    `;
 export type Requester<C= {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>
 export function getSdk<C>(requester: Requester<C>) {
   return {
-    hentStatsborgerskap(variables: HentStatsborgerskapQueryVariables, options?: C): Promise<HentStatsborgerskapQuery> {
-      return requester<HentStatsborgerskapQuery, HentStatsborgerskapQueryVariables>(HentStatsborgerskapDocument, variables, options);
-    }
+
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/src/graphql/generated/types.ts
+++ b/src/graphql/generated/types.ts
@@ -17,11 +17,48 @@ export type Scalars = {
   Long: number;
 };
 
+export type Bostedsadresse = {
+  __typename?: 'Bostedsadresse';
+  coAdressenavn?: Maybe<Scalars['String']>;
+  adresse: StrukturertAdresseformat;
+  gyldigFraOgMed?: Maybe<Scalars['DateTime']>;
+  gyldigTilOgMed?: Maybe<Scalars['DateTime']>;
+  master: Scalars['String'];
+  kilde?: Maybe<Scalars['String']>;
+  erHistorisk: Scalars['Boolean'];
+};
 
 
+
+export type Kontaktadresse = {
+  __typename?: 'Kontaktadresse';
+  coAdressenavn?: Maybe<Scalars['String']>;
+  semistrukturertAdresse?: Maybe<SemistrukturertAdresseformat>;
+  strukturertAdresse?: Maybe<StrukturertAdresseformat>;
+  gyldigFraOgMed?: Maybe<Scalars['DateTime']>;
+  gyldigTilOgMed?: Maybe<Scalars['DateTime']>;
+  master: Scalars['String'];
+  kilde?: Maybe<Scalars['String']>;
+  erHistorisk: Scalars['Boolean'];
+};
+
+
+export type Oppholdsadresse = {
+  __typename?: 'Oppholdsadresse';
+  coAdressenavn?: Maybe<Scalars['String']>;
+  adresse: StrukturertAdresseformat;
+  gyldigFraOgMed?: Maybe<Scalars['DateTime']>;
+  gyldigTilOgMed?: Maybe<Scalars['DateTime']>;
+  master: Scalars['String'];
+  kilde?: Maybe<Scalars['String']>;
+  erHistorisk: Scalars['Boolean'];
+};
 
 export type Personopplysninger = {
   __typename?: 'Personopplysninger';
+  bostedsadresser: Array<Bostedsadresse>;
+  kontaktadresser: Array<Kontaktadresse>;
+  oppholdsadresser: Array<Oppholdsadresse>;
   statsborgerskap: Array<Statsborgerskap>;
 };
 
@@ -41,6 +78,17 @@ export type Saksopplysninger = {
   persondata: Personopplysninger;
 };
 
+export type SemistrukturertAdresseformat = {
+  __typename?: 'SemistrukturertAdresseformat';
+  adresselinje1?: Maybe<Scalars['String']>;
+  adresselinje2?: Maybe<Scalars['String']>;
+  adresselinje3?: Maybe<Scalars['String']>;
+  adresselinje4?: Maybe<Scalars['String']>;
+  postnummer?: Maybe<Scalars['String']>;
+  poststed?: Maybe<Scalars['String']>;
+  land: Scalars['String'];
+};
+
 export type Statsborgerskap = {
   __typename?: 'Statsborgerskap';
   land: Scalars['String'];
@@ -50,4 +98,16 @@ export type Statsborgerskap = {
   master: Scalars['String'];
   kilde?: Maybe<Scalars['String']>;
   erHistorisk: Scalars['Boolean'];
+};
+
+export type StrukturertAdresseformat = {
+  __typename?: 'StrukturertAdresseformat';
+  tilleggsnavn?: Maybe<Scalars['String']>;
+  gatenavn?: Maybe<Scalars['String']>;
+  husnummerEtasjeLeilighet?: Maybe<Scalars['String']>;
+  postboks?: Maybe<Scalars['String']>;
+  postnummer?: Maybe<Scalars['String']>;
+  poststed?: Maybe<Scalars['String']>;
+  region?: Maybe<Scalars['String']>;
+  land: Scalars['String'];
 };


### PR DESCRIPTION
Da jeg så på https://github.com/navikt/melosys-web/pull/1245 så jeg at det er ønskelig å kunne opprette en ny query for å hente statsborgerskap, men med litt andre felter. Dessverre gikk det ikke an å kalle denne nye queryen for hentStatsborgerskap, siden det allerede eksisterer en query med det navnet. Denne PRen gjør slik at det er mulig å ha to queries med samme navn.

Fulgte [denne](https://github.com/dotansimha/graphql-code-generator/issues/2890#issuecomment-558660241) for å fikse.