### PR TITLE
NOJIRA - GHA jobb for å slette gamle workflow runs

### DIFF
--- a/.github/workflows/delete-workflows.yml
+++ b/.github/workflows/delete-workflows.yml
@@ -1,0 +1,21 @@
+name: Delete old workflow runs
+on:
+  schedule:
+    - cron: '0 0 * * 0' # hver søndag
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Retention days'
+        required: true
+        default: 30
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old workflow runs
+        uses: Mattraks/delete-workflow-runs@v1.2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          retain_days: ${{ github.event.inputs.days || 30 }}


### PR DESCRIPTION
Ser det ligger en del gamle(2 år+) workflow runs i repoet. Ønsker å slette de så det blir litt tydeligere hvilke workflows som er i bruk
+ 
Er nødt til å slette alle workflow runs for en workflow for at selve workflowen skal forsvinne fra /actions-siden, og har ikke så lyst til å gjøre det manuelt 😄 

