### PR TITLE
Fix deploy

### DIFF
--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: teammelosys
   labels:
     team: teammelosys
+  annotations:
+    nais.io/security-does-not-matter: "true"
 spec:
   image: {{image}}
   port: 3000

--- a/nais/redis.yaml
+++ b/nais/redis.yaml
@@ -3,6 +3,8 @@ kind: "Application"
 metadata:
   labels:
     team: teammelosys
+  annotations:
+    nais.io/read-only-file-system: "false"
   name: {{APP_NAME}}
   namespace: teammelosys
 spec:

--- a/nais/redis.yaml
+++ b/nais/redis.yaml
@@ -5,6 +5,7 @@ metadata:
     team: teammelosys
   annotations:
     nais.io/read-only-file-system: "false"
+    nais.io/restricted: "false"
   name: {{APP_NAME}}
   namespace: teammelosys
 spec:

--- a/nais/redis.yaml
+++ b/nais/redis.yaml
@@ -4,8 +4,7 @@ metadata:
   labels:
     team: teammelosys
   annotations:
-    nais.io/read-only-file-system: "false"
-    nais.io/restricted: "false"
+    nais.io/security-does-not-matter: "true"
   name: {{APP_NAME}}
   namespace: teammelosys
 spec:


### PR DESCRIPTION
Fiks etter https://nav-it.slack.com/archives/C01DE3M9YBV/p1629806987033000 ble skrudd på i dev-clustere. Melosys-web sitt docker-image sliter med det jeg antar er unix-permissions, men jeg kjenner ikke godt nok til hvordan det er bygd opp til å løse det ordentlig uten å sette meg dypere ned i det. Annotasjonen på nais.yaml setter det tilbake som det var før nevnte endring.

Må også gi redis lov til å skrive til filsystemet.