### PR TITLE
Bugfix trygdevtale bestemmelse-steg

### DIFF
--- a/src/felleskomponenter/skjema/input/radio.js
+++ b/src/felleskomponenter/skjema/input/radio.js
@@ -10,6 +10,7 @@ function InnerInputComponent({
   input,
   forhandsvalgt,
   meta, // eslint-disable-line no-unused-vars
+  customOnChange,
   ...rest
 }) {
   const inputProps = {
@@ -32,6 +33,10 @@ function InnerInputComponent({
       }}
       feil={feil}
       onFocus={() => {}}
+      onChange={(event) => {
+        inputProps.onChange(event);
+        customOnChange();
+      }}
     />
   );
 }
@@ -40,12 +45,14 @@ InnerInputComponent.defaultProps = {
   input: undefined,
   meta: undefined,
   forhandsvalgt: false,
+  customOnChange: () => {},
 };
 
 InnerInputComponent.propTypes = {
   input: PT.object, // eslint-disable-line react/forbid-prop-types
   meta: PT.object, // eslint-disable-line react/forbid-prop-types
   forhandsvalgt: PT.bool,
+  customOnChange: PT.func,
 };
 
 /** Redux støtter i utgangspunktet ikke boolske valg i

--- a/src/felleskomponenter/skjema/input/radio.js
+++ b/src/felleskomponenter/skjema/input/radio.js
@@ -10,12 +10,17 @@ function InnerInputComponent({
   input,
   forhandsvalgt,
   meta, // eslint-disable-line no-unused-vars
-  customOnChange,
+  onChange,
   ...rest
 }) {
+  const innerChange = (e) => {
+    if (onChange) onChange(e);
+    input.onChange(e);
+  };
   const inputProps = {
     ...input,
     ...rest,
+    onChange: innerChange,
   };
   const gjeldendeFeltVerdi = input.value;
   const radioButtonVerdi = rest.value;
@@ -33,10 +38,6 @@ function InnerInputComponent({
       }}
       feil={feil}
       onFocus={() => {}}
-      onChange={(event) => {
-        inputProps.onChange(event);
-        customOnChange();
-      }}
     />
   );
 }
@@ -45,14 +46,14 @@ InnerInputComponent.defaultProps = {
   input: undefined,
   meta: undefined,
   forhandsvalgt: false,
-  customOnChange: () => {},
+  onChange: undefined,
 };
 
 InnerInputComponent.propTypes = {
   input: PT.object, // eslint-disable-line react/forbid-prop-types
   meta: PT.object, // eslint-disable-line react/forbid-prop-types
   forhandsvalgt: PT.bool,
-  customOnChange: PT.func,
+  onChange: PT.func,
 };
 
 /** Redux støtter i utgangspunktet ikke boolske valg i

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
@@ -62,6 +62,7 @@ const VurderingBestemmelse = ({
   data: { vedtakValg, innvilgelseValg, bestemmelseValg, bestemmelseTekst },
   formIsValid,
   formValues,
+  initialValues,
   fortsett,
   tilbake,
   redigerbart,
@@ -84,12 +85,16 @@ const VurderingBestemmelse = ({
   }, [formValues]);
 
   useEffect(() => {
-    resetField("innvilgelse");
-    resetField("bestemmelse");
+    if (formValues?.vedtak && !Utils._isEqual(formValues.vedtak, initialValues.vedtak)) {
+      resetField("innvilgelse");
+      resetField("bestemmelse");
+    }
   }, [formValues?.vedtak]);
 
   useEffect(() => {
-    resetField("bestemmelse");
+    if (formValues?.innvilgelse && !Utils._isEqual(formValues.innvilgelse, initialValues.innvilgelse)) {
+      resetField("bestemmelse");
+    }
   }, [formValues?.innvilgelse]);
 
   if (!formValues) return null;

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
@@ -96,7 +96,7 @@ const VurderingBestemmelse = ({
             label={valg.term}
             value={valg.kode}
             disabled={!redigerbart}
-            customOnChange={() => {
+            onChange={() => {
               resetField("innvilgelse");
               resetField("bestemmelse");
             }}
@@ -113,7 +113,7 @@ const VurderingBestemmelse = ({
               label={valg.term}
               value={valg.kode}
               disabled={!redigerbart}
-              customOnChange={() => resetField("bestemmelse")}
+              onChange={() => resetField("bestemmelse")}
             />
           ))}
         </Nav.Fieldset>

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
@@ -62,7 +62,6 @@ const VurderingBestemmelse = ({
   data: { vedtakValg, innvilgelseValg, bestemmelseValg, bestemmelseTekst },
   formIsValid,
   formValues,
-  initialValues,
   fortsett,
   tilbake,
   redigerbart,
@@ -84,19 +83,6 @@ const VurderingBestemmelse = ({
     }
   }, [formValues]);
 
-  useEffect(() => {
-    if (formValues?.vedtak && !Utils._isEqual(formValues.vedtak, initialValues.vedtak)) {
-      resetField("innvilgelse");
-      resetField("bestemmelse");
-    }
-  }, [formValues?.vedtak]);
-
-  useEffect(() => {
-    if (formValues?.innvilgelse && !Utils._isEqual(formValues.innvilgelse, initialValues.innvilgelse)) {
-      resetField("bestemmelse");
-    }
-  }, [formValues?.innvilgelse]);
-
   if (!formValues) return null;
   return (
     <div className="vurderingBestemmelse">
@@ -104,7 +90,17 @@ const VurderingBestemmelse = ({
 
       <Nav.Fieldset legend="Kan du fatte vedtak?">
         {vedtakValg?.map((valg) => (
-          <Skjema.Radio key={valg.kode} feltNavn="vedtak" label={valg.term} value={valg.kode} disabled={!redigerbart} />
+          <Skjema.Radio
+            key={valg.kode}
+            feltNavn="vedtak"
+            label={valg.term}
+            value={valg.kode}
+            disabled={!redigerbart}
+            customOnChange={() => {
+              resetField("innvilgelse");
+              resetField("bestemmelse");
+            }}
+          />
         ))}
       </Nav.Fieldset>
 
@@ -117,6 +113,7 @@ const VurderingBestemmelse = ({
               label={valg.term}
               value={valg.kode}
               disabled={!redigerbart}
+              customOnChange={() => resetField("bestemmelse")}
             />
           ))}
         </Nav.Fieldset>


### PR DESCRIPTION
Feltene innvilgelse og bestemmelse ble resatt on mount. Disse skal egentlig kun endres etter start når radio-knappene endrer seg siden det er avhengigheter i vedtak -> innvilgelse -> bestemmelse.

La til funksjonalitet for å kunne legge ved `customOnChange`-handler til Skjema.Radio. Denne kjøres **i tillegg til** default CHANGE event til redux-form (som oppdaterer redux)