### PR TITLE
Midlertidig grået ut valg som ikke er med i første prodsetting

### DIFF
--- a/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
@@ -95,7 +95,7 @@ const VurderingBestemmelse = ({
             feltNavn="vedtak"
             label={valg.term}
             value={valg.kode}
-            disabled={!redigerbart}
+            disabled={!redigerbart || valg.kode.startsWith("NEI")}
             onChange={() => {
               resetField("innvilgelse");
               resetField("bestemmelse");
@@ -112,7 +112,7 @@ const VurderingBestemmelse = ({
               feltNavn="innvilgelse"
               label={valg.term}
               value={valg.kode}
-              disabled={!redigerbart}
+              disabled={!redigerbart || valg.kode.startsWith("NEI")}
               onChange={() => resetField("bestemmelse")}
             />
           ))}


### PR DESCRIPTION
Nevnt på [confluence](https://confluence.adeo.no/display/TEESSI/Storbritannia#Storbritannia-Generiskflytforbilateraleavtaler): 

> Valg som ikke er tilgjengelige er "grået ut"