### PR TITLE
Periode og land blir lagret i behandlingsgrunnlaget

### DIFF
--- a/src/services/modules/trygdeavtale/flyt.ts
+++ b/src/services/modules/trygdeavtale/flyt.ts
@@ -16,9 +16,6 @@ export type Familiemedlem = {
 };
 
 export interface Resultat {
-  fom?: string;
-  tom?: string | null;
-  land?: string[];
   virksomheter?: string[];
   vedtak?: string;
   innvilgelse?: string;
@@ -40,6 +37,10 @@ export interface FamilieValg {
 }
 
 export interface StegData {
+  periodeFom?: string;
+  periodeTom?: string | null;
+  soeknadsland?: string[];
+  landValg: KTObject[];
   virksomheter?: Virksomhet[];
   vedtakValg?: KTObject[];
   innvilgelseValg?: KTObject[];

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang.tsx
@@ -1,11 +1,10 @@
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useCallback, useEffect, useState } from "react";
 import { RootState } from "AppTypes";
 import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
 import { connect, ConnectedProps } from "react-redux";
 import { getFormValues, reduxForm } from "redux-form";
 
-import MKV from "../../../melosyskodeverk";
 import * as Api from "../../../services/api";
 import * as KV from "../../../kodeverk";
 import * as Nav from "../../../utils/navFrontend";
@@ -13,7 +12,7 @@ import * as Skjema from "../../../felleskomponenter/skjema";
 import * as Utils from "../../../utils";
 
 import DialogboksOppfriskSak from "../../../felleskomponenter/dialogboks/oppfrisk/dialogboksOppfrisk";
-import { behandlingerSelectors } from "../../../ducks/behandlinger";
+import { behandlingsgrunnlagOperations, behandlingsgrunnlagSelectors } from "../../../ducks/behandlingsgrunnlag";
 import { menypanelOperations } from "../../../ducks/menypanel";
 import { formSelectors } from "../../../ducks/form";
 
@@ -22,21 +21,32 @@ import vurdering_inngang from "./vurderingInngangSchema";
 
 import "./vurderingInngang.css";
 
-const initializeValues = (resultat: Api.Trygdeavtale.Resultat | undefined) => ({
-  fom: resultat?.fom ? Utils.dato.formatterDatoTilNorsk(resultat.fom) : undefined,
-  tom: resultat?.tom ? Utils.dato.formatterDatoTilNorsk(resultat.tom) : undefined,
-  land: resultat?.land?.[0],
+interface Periode {
+  fom?: string | null;
+  tom?: string | null;
+}
+
+const initializeValues = (periode: Periode, landkoder: String[]) => ({
+  fom: periode.fom ? Utils.dato.formatterDatoTilNorsk(periode.fom) : undefined,
+  tom: periode.tom ? Utils.dato.formatterDatoTilNorsk(periode.tom) : undefined,
+  land: landkoder[0],
 });
 
-const mapStateToProps = (state: RootState, ownProps: Props) => ({
+const mapStateToProps = (state: RootState) => ({
   formValues: getFormValues(KV.Form.Trygdeavtale.INNGANG)(state),
-  initialValues: initializeValues(ownProps.resultat),
+  initialValues: initializeValues(
+    behandlingsgrunnlagSelectors.PeriodeSelector(state),
+    behandlingsgrunnlagSelectors.SoknadslandkoderSelector(state)
+  ),
   formIsValid: formSelectors.TrygdeavtaleInngangFormValidSelector(state),
-  behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
   visMenypanel: () => dispatch(menypanelOperations.visMenypanel()),
+  oppdaterPeriode: (periode: Periode) => dispatch(behandlingsgrunnlagOperations.oppdaterPeriode(periode)),
+  oppdaterSoeknadsland: (landkoder: String[]) =>
+    dispatch(behandlingsgrunnlagOperations.oppdaterSoeknadsland(landkoder, false)),
+  lagreBehandlingsgrunnlag: () => dispatch(behandlingsgrunnlagOperations.lagre()),
 });
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -51,9 +61,11 @@ interface FormValuesProps {
 
 interface Props {
   annenBehandlingOppfriskes: boolean;
+  data: Api.Trygdeavtale.StegData;
   fortsett: () => void;
   formValues: FormValuesProps;
   hentFlytOgOppdaterAktuelleSteg: () => void;
+  lagreBehandlingsgrunnlagOgOppdaterStegData: () => void;
   redigerbart: boolean;
   resultat: Api.Trygdeavtale.Resultat;
   steg: Api.Trygdeavtale.Steg;
@@ -65,17 +77,20 @@ interface Props {
 
 const VurderingInngang = ({
   annenBehandlingOppfriskes,
-  behandlingstema,
+  data: { landValg },
   formValues,
   formIsValid,
   fortsett,
-  hentFlytOgOppdaterAktuelleSteg,
   initialValues,
+  hentFlytOgOppdaterAktuelleSteg,
+  lagreBehandlingsgrunnlag,
   redigerbart,
   resultat,
   steg,
   tilForsiden,
   oppdaterFlyt,
+  oppdaterPeriode,
+  oppdaterSoeknadsland,
   oppfriskOgLastInnSaksopplysninger,
   // slettFlyt,
   visMenypanel,
@@ -96,18 +111,34 @@ const VurderingInngang = ({
     }
   }, []);
 
+  const lagreBehandlingsgrunnlagOgHentStegStatus = async () => {
+    await lagreBehandlingsgrunnlag();
+    hentFlytOgOppdaterAktuelleSteg();
+    oppdaterFlyt({ resultat });
+  };
+  const debouncedLagrebehandlingsgrunnlagOgHentStegStatus = useCallback(
+    Utils._debounce(lagreBehandlingsgrunnlagOgHentStegStatus, 300),
+    []
+  );
+
   useEffect(() => {
     if (redigerbart && formValues) {
-      oppdaterFlyt({
-        resultat: {
-          ...resultat,
-          fom: formValues.fom ? Utils.dato.formatterDatoTilISO(formValues.fom) : undefined,
-          tom: formValues.tom ? Utils.dato.formatterDatoTilISO(formValues.tom) : undefined,
-          land: formValues.land ? [formValues.land] : [],
-        },
+      const isoFom = Utils.dato.formatterDatoTilISO(formValues.fom);
+      const isoTom = Utils.dato.formatterDatoTilISO(formValues.tom);
+      oppdaterPeriode({
+        fom: isoFom === "Invalid date" ? null : isoFom,
+        tom: isoTom === "Invalid date" ? null : isoTom,
       });
+      debouncedLagrebehandlingsgrunnlagOgHentStegStatus();
     }
-  }, [formValues]);
+  }, [formValues?.fom, formValues?.tom]);
+
+  useEffect(() => {
+    if (redigerbart && formValues) {
+      oppdaterSoeknadsland(formValues?.land ? [formValues.land] : []);
+      debouncedLagrebehandlingsgrunnlagOgHentStegStatus();
+    }
+  }, [formValues?.land]);
 
   const fortsettHandle = () => {
     if (formValues.fom !== initialFomTom?.fom || formValues.tom !== initialFomTom?.tom) {
@@ -137,9 +168,10 @@ const VurderingInngang = ({
                   <Hjelpetekst />
                 </Fragment>
               }
+              landkoder={landValg}
               feltNavn="land"
               placeholder="Velg..."
-              disabled={!redigerbart || behandlingstema === MKV.Koder.behandlinger.behandlingstema.TRYGDEAVTALE_UK}
+              disabled={!redigerbart}
             />
           </Nav.Column>
         </Nav.Row>

--- a/src/sider/trygdeavtale/stegvelger.tsx
+++ b/src/sider/trygdeavtale/stegvelger.tsx
@@ -140,6 +140,7 @@ class Stegvelger extends Component<Props, State> {
       tilForsiden: this.props.tilForsiden,
       oppfriskOgLastInnSaksopplysninger: this.props.oppfriskOgLastInnSaksopplysninger,
       hentFlytOgOppdaterAktuelleSteg: this.hentFlytOgOppdaterAktuelleSteg,
+      lagreBehandlingsgrunnlagOgOppdaterStegData: this.lagreBehandlingsgrunnlagOgOppdaterStegData,
     };
 
     return response.steg?.map((enkeltSteg: Api.Trygdeavtale.Steg) => {


### PR DESCRIPTION
Periode og land blir lagret direkte i behandlingsgrunnlaget, men mel-trygdeavtale bestemmer fortsatt om steget er fullført eller ikke.

Periode og land-feltene henter nå data fra behandlingsgrunnlaget. Endinger her lagres i behandlingsgrunnlaget og trigger ny sjekk mot mel-trygdeavtale om steget er gyldig.
Land skal ikke lengre være disabled, men heller ha begrenset valg av land (landValg i StegData).

Finnes PR-er for både [mel-trygdeavtale](https://github.com/navikt/melosys-trygdeavtale/pull/15) og [mel-api ](https://github.com/navikt/melosys-api/pull/826)som kan være lurt å pulle ned om det skal testes med docker-compose