### PR TITLE
Legger til resetFlyt ved ending av periode i steg 1

### DIFF
--- a/src/services/modules/trygdeavtale/flyt.ts
+++ b/src/services/modules/trygdeavtale/flyt.ts
@@ -68,4 +68,4 @@ export const hentFlyt = (behandlingID: number): Promise<FlytResDto> =>
 export const sendFlyt = (behandlingID: number, data: FlytReqDto): Promise<FlytResDto> =>
   putAsJson(`${TRYGDEAVTALE_FLYT_BASE_URL}${behandlingID}`, data);
 
-export const slettFlyt = (behandlingID: number) => deleteAsJson(`${TRYGDEAVTALE_FLYT_BASE_URL}${behandlingID}`);
+export const resetFlyt = (behandlingID: number) => deleteAsJson(`${TRYGDEAVTALE_FLYT_BASE_URL}${behandlingID}`);

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
@@ -112,7 +112,7 @@ const VurderingAvklarVirksomhet = ({
 const VurderingAvklarVirksomhetForm = reduxForm<{}, PropsFromRedux & Props>({
   form: KV.Form.Trygdeavtale.AVKLAR_VIRKSOMHET,
   destroyOnUnmount: true,
-  keepDirtyOnReinitialize: true,
+  enableReinitialize: true,
   updateUnregisteredFields: true,
   validate: lagYupToReduxformErrorMapper(vurdering_avklar_virksomhet),
 })(VurderingAvklarVirksomhet);

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang.tsx
@@ -67,12 +67,10 @@ interface Props {
   hentFlytOgOppdaterAktuelleSteg: () => void;
   lagreBehandlingsgrunnlagOgOppdaterStegData: () => void;
   redigerbart: boolean;
-  resultat: Api.Trygdeavtale.Resultat;
   steg: Api.Trygdeavtale.Steg;
   tilForsiden: () => void;
-  oppdaterFlyt: (data: Api.Trygdeavtale.FlytReqDto) => void;
   oppfriskOgLastInnSaksopplysninger: () => void;
-  // slettFlyt: () => void;
+  resetFlyt: () => void;
 }
 
 const VurderingInngang = ({
@@ -85,14 +83,12 @@ const VurderingInngang = ({
   hentFlytOgOppdaterAktuelleSteg,
   lagreBehandlingsgrunnlag,
   redigerbart,
-  resultat,
   steg,
   tilForsiden,
-  oppdaterFlyt,
   oppdaterPeriode,
   oppdaterSoeknadsland,
   oppfriskOgLastInnSaksopplysninger,
-  // slettFlyt,
+  resetFlyt,
   visMenypanel,
 }: PropsFromRedux & Props) => {
   const [initialFomTom, setInitialFomTom] = useState<{ fom?: string; tom?: string }>({});
@@ -114,7 +110,6 @@ const VurderingInngang = ({
   const lagreBehandlingsgrunnlagOgHentStegStatus = async () => {
     await lagreBehandlingsgrunnlag();
     hentFlytOgOppdaterAktuelleSteg();
-    oppdaterFlyt({ resultat });
   };
   const debouncedLagrebehandlingsgrunnlagOgHentStegStatus = useCallback(
     Utils._debounce(lagreBehandlingsgrunnlagOgHentStegStatus, 300),
@@ -192,7 +187,7 @@ const VurderingInngang = ({
         <DialogboksOppfriskSak
           oppfrisk={async () => {
             await oppfriskOgLastInnSaksopplysninger();
-            hentFlytOgOppdaterAktuelleSteg();
+            resetFlyt();
           }}
           avbryt={() => setVisOppfrisk(false)}
           lukk={() => {

--- a/src/sider/trygdeavtale/stegvelger.tsx
+++ b/src/sider/trygdeavtale/stegvelger.tsx
@@ -114,7 +114,7 @@ class Stegvelger extends Component<Props, State> {
   };
 
   resetFlyt = () => {
-    Api.Trygdeavtale.resetFlyt(this.props.behandlingID).then((response) =>
+    return Api.Trygdeavtale.resetFlyt(this.props.behandlingID).then((response) =>
       this.setState({ aktuelleSteg: this.mapFlytResDtoOmTilAktuelleSteg(response) })
     );
   };

--- a/src/sider/trygdeavtale/stegvelger.tsx
+++ b/src/sider/trygdeavtale/stegvelger.tsx
@@ -113,8 +113,10 @@ class Stegvelger extends Component<Props, State> {
     return propsValue && prevPropsValue && !Utils._isEqual(propsValue, prevPropsValue);
   };
 
-  slettFlyt = () => {
-    Api.Trygdeavtale.slettFlyt(this.props.behandlingID);
+  resetFlyt = () => {
+    Api.Trygdeavtale.resetFlyt(this.props.behandlingID).then((response) =>
+      this.setState({ aktuelleSteg: this.mapFlytResDtoOmTilAktuelleSteg(response) })
+    );
   };
 
   oppdaterFlyt = (request: Api.Trygdeavtale.FlytReqDto) => {
@@ -136,7 +138,7 @@ class Stegvelger extends Component<Props, State> {
       fortsett: this.fortsett,
       tilbake: this.tilbake,
       oppdaterFlyt: this.debouncedOppdaterFlyt,
-      slettFlyt: this.slettFlyt,
+      resetFlyt: this.resetFlyt,
       tilForsiden: this.props.tilForsiden,
       oppfriskOgLastInnSaksopplysninger: this.props.oppfriskOgLastInnSaksopplysninger,
       hentFlytOgOppdaterAktuelleSteg: this.hentFlytOgOppdaterAktuelleSteg,


### PR DESCRIPTION
Når periode endres og saksopplysninger oppfriskes skal også flyten resettes - dvs alle tidligere tatt valg på senere steg på taes igjen.

Setter `enableReinitialize: true` i vurderingAvklarVirksomhet for at virksomhet-steget skal refreshes når `resultat.virksomheter = []`, istedenfor å huske det gamle valget.