### PR TITLE
MELOSYS-4723 - stavekontroll fritekstfelt

### DIFF
--- a/src/felleskomponenter/skjema/htmleditor/htmleditor.tsx
+++ b/src/felleskomponenter/skjema/htmleditor/htmleditor.tsx
@@ -17,7 +17,11 @@ type InnerHtmlEditorComponentProps = {
   [x: string]: any;
 };
 
-function InnerHTMLEditorComponent({ input, ...rest }: InnerHtmlEditorComponentProps & WrappedFieldProps) {
+function InnerHTMLEditorComponent({
+  input,
+  spellcheck = true,
+  ...rest
+}: InnerHtmlEditorComponentProps & WrappedFieldProps) {
   const [currentEditorState, setCurrentEditorState] = useState(
     EditorState.createWithContent(ContentState.createFromBlockArray(convertFromHTML(input.value).contentBlocks))
   );
@@ -43,6 +47,7 @@ function InnerHTMLEditorComponent({ input, ...rest }: InnerHtmlEditorComponentPr
         placeholder={rest.placeholder || ""}
         readOnly={rest?.disabled}
         stripPastedStyles
+        spellCheck={spellcheck}
       />
     </div>
   );

--- a/src/navFrontend/index.js
+++ b/src/navFrontend/index.js
@@ -4,17 +4,6 @@ import AlertStripe, { AlertStripeAdvarsel, AlertStripeInfo } from "nav-frontend-
 import EtikettBase from "nav-frontend-etiketter";
 import { Container, Row, Column } from "nav-frontend-grid";
 import Hjelpetekst from "nav-frontend-hjelpetekst";
-import {
-  Checkbox,
-  Radio,
-  RadioPanelGruppe,
-  SkjemaGruppe,
-  Fieldset,
-  Select,
-  SelectProps,
-  Input,
-  Textarea,
-} from "nav-frontend-skjema";
 import * as Typo from "nav-frontend-typografi";
 import { Knapp, Hovedknapp, Flatknapp } from "nav-frontend-knapper";
 import Lesmerpanel from "nav-frontend-lesmerpanel";
@@ -28,6 +17,17 @@ import Chevron from "nav-frontend-chevron";
 import { LenkepanelBase } from "nav-frontend-lenkepanel";
 import { PopoverOrientering } from "nav-frontend-popover";
 import { Xknapp } from "nav-frontend-ikonknapper";
+import {
+  Checkbox,
+  Radio,
+  RadioPanelGruppe,
+  SkjemaGruppe,
+  Fieldset,
+  Select,
+  SelectProps,
+  Input,
+  Textarea,
+} from "./skjema";
 
 export {
   AlertStripeAdvarsel,

--- a/src/navFrontend/skjema.js
+++ b/src/navFrontend/skjema.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+import { Textarea as NavFrontendTextarea } from "nav-frontend-skjema";
+
+// eslint-disable-next-line react/prop-types
+const Textarea = (props) => <NavFrontendTextarea {...props} spellCheck={props.spellCheck || true} />;
+
+export { Textarea };
+export {
+  Checkbox,
+  Radio,
+  RadioPanelGruppe,
+  SkjemaGruppe,
+  Fieldset,
+  Select,
+  SelectProps,
+  Input,
+} from "nav-frontend-skjema";

--- a/src/navFrontend/skjema.js
+++ b/src/navFrontend/skjema.js
@@ -3,7 +3,7 @@ import React from "react";
 import { Textarea as NavFrontendTextarea } from "nav-frontend-skjema";
 
 // eslint-disable-next-line react/prop-types
-const Textarea = (props) => <NavFrontendTextarea {...props} spellCheck={props.spellCheck || true} />;
+const Textarea = ({ spellCheck = true, ...rest }) => <NavFrontendTextarea {...rest} spellCheck={spellCheck} />;
 
 export { Textarea };
 export {


### PR DESCRIPTION
Legg til stavekontroll for fritekstfelter(i praksis alle steder hvor `Textarea` og wysiwyg-editor er brukt).