### PR TITLE
NOJIRA - Skip-link

### DIFF
--- a/src/sider/rammeverk/komponenter/topplinje.js
+++ b/src/sider/rammeverk/komponenter/topplinje.js
@@ -6,6 +6,7 @@ import PT from "prop-types";
 import { ReactComponent as NavLogo } from "../../../resources/images/nav.svg";
 import * as MPT from "../../../proptypes/";
 import * as Utils from "../../../utils/utils";
+import * as Nav from "../../../navFrontend";
 
 import { saksbehandlerSelectors } from "../../../ducks/saksbehandler/";
 import { oppgaverOperations } from "../../../ducks/oppgaver/";
@@ -36,6 +37,9 @@ const Topplinje = (props) => {
 
   return (
     <header className="topplinje">
+      <a className="skip-link" href="#main-container">
+        <Nav.Typo.Systemtittel>Hopp til hovedinnhold</Nav.Typo.Systemtittel>
+      </a>
       <div className="topplinje__brand">
         <button onClick={tilForsidenHandler} className="topplinje__brandKnapp">
           <NavLogo className="brand__logo" alt="To personer på NAV kontor" />

--- a/src/sider/rammeverk/komponenter/topplinje.less
+++ b/src/sider/rammeverk/komponenter/topplinje.less
@@ -1,8 +1,10 @@
+@topplinjeHoyde: 48px;
+
 .topplinje {
   background-color: #393939;
   display: flex;
   flex-direction: row;
-  height: 48px;
+  height: @topplinjeHoyde;
 
   .skip-link {
     color: #393939;
@@ -10,12 +12,15 @@
     display: flex;
     align-items: center;
     padding: 0 1em;
+
     position: absolute;
     left: -2000px;
-
+    height: @topplinjeHoyde;
+    transition: all 4s;
     &:focus {
       position: relative;
       left: 0;
+      transition: none;
     }
   }
 }

--- a/src/sider/rammeverk/komponenter/topplinje.less
+++ b/src/sider/rammeverk/komponenter/topplinje.less
@@ -3,6 +3,14 @@
   display: flex;
   flex-direction: row;
   height: 48px;
+
+  .skip-link {
+    color: #393939;
+    background-color: white;
+    display: flex;
+    align-items: center;
+    padding: 0 1em;
+  }
 }
 
 .topplinje__brand {

--- a/src/sider/rammeverk/komponenter/topplinje.less
+++ b/src/sider/rammeverk/komponenter/topplinje.less
@@ -10,6 +10,13 @@
     display: flex;
     align-items: center;
     padding: 0 1em;
+    position: absolute;
+    left: -2000px;
+
+    &:focus {
+      position: relative;
+      left: 0;
+    }
   }
 }
 

--- a/src/sider/rammeverk/rammeverk.js
+++ b/src/sider/rammeverk/rammeverk.js
@@ -13,7 +13,9 @@ function Hovedside({ children }) {
       <FeatureToggle togglename="melosys.design.PERSONLINJE">
         {(status) => status === "enabled" && <Personlinje />}
       </FeatureToggle>
-      <div className="main-container">{children}</div>
+      <div id="main-container" className="main-container">
+        {children}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Legger til en [skip-link](https://webaim.org/techniques/skipnav/), for å kunne hoppe over personlinje og behandlingsmeny ved navigering med tab eller screenreader.

Bruker css-transition pga:
> One potential issue with this approach is that if the user navigates very quickly using the Tab key, the link may be visible on the page for only a fraction of a second and may be overlooked. This can be partially addressed by ensuring that the skip link is very visually distinctive at the top of the page when visible. Additionally, one could use scripting or CSS transitions to cause the link to animate so it remains visible on screen for more time.