### PR TITLE
NOJIRA - ikke vis null-string for Semistrukturertadresse

### DIFF
--- a/src/felleskomponenter/adresser/semistrukturertAdresse.test.tsx
+++ b/src/felleskomponenter/adresser/semistrukturertAdresse.test.tsx
@@ -1,10 +1,11 @@
 import React, { ComponentProps } from "react";
 import { shallow } from "enzyme";
 import { mock, instance } from "ts-mockito";
+import each from "jest-each";
 
 import MKV from "../../melosyskodeverk";
 
-import SemistrukturertAdresse from "./semistrukturertAdresse";
+import SemistrukturertAdresse, { PostnrStedLandLinje } from "./semistrukturertAdresse";
 
 describe("SemistrukturertAdresse", () => {
   const mockedProps = mock<ComponentProps<typeof SemistrukturertAdresse>>();
@@ -14,15 +15,12 @@ describe("SemistrukturertAdresse", () => {
     props = instance(mockedProps);
   });
 
-  it("viser alle felter for semistrukturert adresse", () => {
+  it("viser noen felter for semistrukturert adresse", () => {
     props.adresse = {
       adresselinje1: "Oslogata 1",
       adresselinje2: "Trondheimsgata 1",
       adresselinje3: "Bergensgata 1",
       adresselinje4: "Tromsøgata 1",
-      land: MKV.Koder.landkoder.NO,
-      postnummer: "0000",
-      poststed: "Oslo",
     };
 
     const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
@@ -31,7 +29,6 @@ describe("SemistrukturertAdresse", () => {
     expect(semistrukturertAdresse.text()).toContain("Trondheimsgata 1");
     expect(semistrukturertAdresse.text()).toContain("Bergensgata 1");
     expect(semistrukturertAdresse.text()).toContain("Tromsøgata 1");
-    expect(semistrukturertAdresse.text()).toContain(`0000 Oslo, ${MKV.Koder.landkoder.NO}`);
   });
 
   it("viser et adresse-element", () => {
@@ -40,7 +37,23 @@ describe("SemistrukturertAdresse", () => {
     expect(semistrukturertAdresse.find("address")).toHaveLength(1);
   });
 
-  it("viser ikke null- eller undefined-stringer dersom felter er null eller undefined", () => {
+  it("viser en PostnrStedLandLinje", () => {
+    props.adresse = {
+      land: MKV.Koder.landkoder.NO,
+      postnummer: "0000",
+      poststed: "Oslo",
+    };
+
+    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
+
+    const postnrStedLandLinje = semistrukturertAdresse.find(PostnrStedLandLinje);
+    expect(postnrStedLandLinje).toHaveLength(1);
+    expect(postnrStedLandLinje.props().land).toBe(MKV.Koder.landkoder.NO);
+    expect(postnrStedLandLinje.props().postnummer).toBe("0000");
+    expect(postnrStedLandLinje.props().poststed).toBe("Oslo");
+  });
+
+  it("viser ikke null- eller undefined-stringer dersom felter mangler", () => {
     props.adresse = {
       adresselinje1: null,
       adresselinje2: null,
@@ -56,34 +69,61 @@ describe("SemistrukturertAdresse", () => {
     expect(semistrukturertAdresse.text()).not.toContain("null");
     expect(semistrukturertAdresse.text()).not.toContain("undefined");
   });
+});
 
-  it("viser ikke komma dersom land mangler", () => {
-    props.adresse.postnummer = "1234";
-    props.adresse.poststed = "Trondheim";
-    props.adresse.land = undefined;
+describe("PostnrStedLandLinje", () => {
+  each([
+    [
+      {
+        postnummer: "1234",
+        poststed: "Trondheim",
+        land: undefined,
+      },
+      "1234 Trondheim",
+    ],
+    [
+      {
+        postnummer: null,
+        poststed: null,
+        land: MKV.Koder.landkoder.NO,
+      },
+      "NO",
+    ],
+    [
+      {
+        postnummer: "1234",
+        poststed: null,
+        land: MKV.Koder.landkoder.NO,
+      },
+      "1234, NO",
+    ],
+    [
+      {
+        postnummer: null,
+        poststed: "Trondheim",
+        land: MKV.Koder.landkoder.NO,
+      },
+      "Trondheim, NO",
+    ],
+    [
+      {
+        postnummer: null,
+        poststed: null,
+        land: undefined,
+      },
+      "",
+    ],
+    [
+      {
+        postnummer: "1234",
+        poststed: "Trondheim",
+        land: MKV.Koder.landkoder.NO,
+      },
+      "1234 Trondheim, NO",
+    ],
+  ]).test("for props %s, viser %s", (props, rendretTekst) => {
+    const postnrStedLandLinje = shallow(<PostnrStedLandLinje {...props} />);
 
-    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
-
-    expect(semistrukturertAdresse.text()).not.toContain(",");
-  });
-
-  it("viser ikke komma dersom postnummer og poststed mangler", () => {
-    props.adresse.postnummer = null;
-    props.adresse.poststed = null;
-    props.adresse.land = MKV.Koder.landkoder.NO;
-
-    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
-
-    expect(semistrukturertAdresse.text()).not.toContain(",");
-  });
-
-  it("viser komma dersom bare poststed mangler", () => {
-    props.adresse.postnummer = "1234";
-    props.adresse.poststed = null;
-    props.adresse.land = MKV.Koder.landkoder.NO;
-
-    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
-
-    expect(semistrukturertAdresse.text()).toContain(",");
+    expect(postnrStedLandLinje.text()).toBe(rendretTekst);
   });
 });

--- a/src/felleskomponenter/adresser/semistrukturertAdresse.test.tsx
+++ b/src/felleskomponenter/adresser/semistrukturertAdresse.test.tsx
@@ -53,15 +53,25 @@ describe("SemistrukturertAdresse", () => {
     expect(postnrStedLandLinje.props().poststed).toBe("Oslo");
   });
 
+  it("ikke vis PostnrStedLandLinje hvis postnummer, poststed og land mangler", () => {
+    props.adresse = {
+      land: undefined,
+      postnummer: null,
+      poststed: null,
+    };
+
+    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
+
+    const postnrStedLandLinje = semistrukturertAdresse.find(PostnrStedLandLinje);
+    expect(postnrStedLandLinje).toHaveLength(0);
+  });
+
   it("viser ikke null- eller undefined-stringer dersom felter mangler", () => {
     props.adresse = {
       adresselinje1: null,
       adresselinje2: null,
       adresselinje3: null,
       adresselinje4: null,
-      land: undefined,
-      postnummer: null,
-      poststed: null,
     };
 
     const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
@@ -104,14 +114,6 @@ describe("PostnrStedLandLinje", () => {
         land: MKV.Koder.landkoder.NO,
       },
       "Trondheim, NO",
-    ],
-    [
-      {
-        postnummer: null,
-        poststed: null,
-        land: undefined,
-      },
-      "",
     ],
     [
       {

--- a/src/felleskomponenter/adresser/semistrukturertAdresse.test.tsx
+++ b/src/felleskomponenter/adresser/semistrukturertAdresse.test.tsx
@@ -27,11 +27,11 @@ describe("SemistrukturertAdresse", () => {
 
     const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
 
-    expect(semistrukturertAdresse.contains("Oslogata 1")).toBe(true);
-    expect(semistrukturertAdresse.contains("Trondheimsgata 1")).toBe(true);
-    expect(semistrukturertAdresse.contains("Bergensgata 1")).toBe(true);
-    expect(semistrukturertAdresse.contains("Tromsøgata 1")).toBe(true);
-    expect(semistrukturertAdresse.contains(`0000 Oslo, ${MKV.Koder.landkoder.NO}`)).toBe(true);
+    expect(semistrukturertAdresse.text()).toContain("Oslogata 1");
+    expect(semistrukturertAdresse.text()).toContain("Trondheimsgata 1");
+    expect(semistrukturertAdresse.text()).toContain("Bergensgata 1");
+    expect(semistrukturertAdresse.text()).toContain("Tromsøgata 1");
+    expect(semistrukturertAdresse.text()).toContain(`0000 Oslo, ${MKV.Koder.landkoder.NO}`);
   });
 
   it("viser et adresse-element", () => {

--- a/src/felleskomponenter/adresser/semistrukturertAdresse.test.tsx
+++ b/src/felleskomponenter/adresser/semistrukturertAdresse.test.tsx
@@ -8,21 +8,25 @@ import SemistrukturertAdresse from "./semistrukturertAdresse";
 
 describe("SemistrukturertAdresse", () => {
   const mockedProps = mock<ComponentProps<typeof SemistrukturertAdresse>>();
-  const props = instance(mockedProps);
+  let props = instance(mockedProps);
 
-  props.adresse = {
-    adresselinje1: "Oslogata 1",
-    adresselinje2: "Trondheimsgata 1",
-    adresselinje3: "Bergensgata 1",
-    adresselinje4: "Tromsøgata 1",
-    land: MKV.Koder.landkoder.NO,
-    postnummer: "0000",
-    poststed: "Oslo",
-  };
-
-  const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
+  beforeEach(() => {
+    props = instance(mockedProps);
+  });
 
   it("viser alle felter for semistrukturert adresse", () => {
+    props.adresse = {
+      adresselinje1: "Oslogata 1",
+      adresselinje2: "Trondheimsgata 1",
+      adresselinje3: "Bergensgata 1",
+      adresselinje4: "Tromsøgata 1",
+      land: MKV.Koder.landkoder.NO,
+      postnummer: "0000",
+      poststed: "Oslo",
+    };
+
+    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
+
     expect(semistrukturertAdresse.contains("Oslogata 1")).toBe(true);
     expect(semistrukturertAdresse.contains("Trondheimsgata 1")).toBe(true);
     expect(semistrukturertAdresse.contains("Bergensgata 1")).toBe(true);
@@ -31,6 +35,35 @@ describe("SemistrukturertAdresse", () => {
   });
 
   it("viser et adresse-element", () => {
+    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
+
     expect(semistrukturertAdresse.find("address")).toHaveLength(1);
+  });
+
+  it("viser ikke null- eller undefined-stringer dersom felter er null eller undefined", () => {
+    props.adresse = {
+      adresselinje1: null,
+      adresselinje2: null,
+      adresselinje3: null,
+      adresselinje4: null,
+      land: undefined,
+      postnummer: null,
+      poststed: null,
+    };
+
+    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
+
+    expect(semistrukturertAdresse.text()).not.toContain("null");
+    expect(semistrukturertAdresse.text()).not.toContain("undefined");
+  });
+
+  it("viser ikke komma ved land-tekst dersom land er undefined", () => {
+    props.adresse.postnummer = "1234";
+    props.adresse.poststed = "Trondheim";
+    props.adresse.land = undefined;
+
+    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
+
+    expect(semistrukturertAdresse.text()).not.toContain(",");
   });
 });

--- a/src/felleskomponenter/adresser/semistrukturertAdresse.test.tsx
+++ b/src/felleskomponenter/adresser/semistrukturertAdresse.test.tsx
@@ -57,7 +57,7 @@ describe("SemistrukturertAdresse", () => {
     expect(semistrukturertAdresse.text()).not.toContain("undefined");
   });
 
-  it("viser ikke komma ved land-tekst dersom land er undefined", () => {
+  it("viser ikke komma dersom land mangler", () => {
     props.adresse.postnummer = "1234";
     props.adresse.poststed = "Trondheim";
     props.adresse.land = undefined;
@@ -65,5 +65,25 @@ describe("SemistrukturertAdresse", () => {
     const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
 
     expect(semistrukturertAdresse.text()).not.toContain(",");
+  });
+
+  it("viser ikke komma dersom postnummer og poststed mangler", () => {
+    props.adresse.postnummer = null;
+    props.adresse.poststed = null;
+    props.adresse.land = MKV.Koder.landkoder.NO;
+
+    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
+
+    expect(semistrukturertAdresse.text()).not.toContain(",");
+  });
+
+  it("viser komma dersom bare poststed mangler", () => {
+    props.adresse.postnummer = "1234";
+    props.adresse.poststed = null;
+    props.adresse.land = MKV.Koder.landkoder.NO;
+
+    const semistrukturertAdresse = shallow(<SemistrukturertAdresse {...props} />);
+
+    expect(semistrukturertAdresse.text()).toContain(",");
   });
 });

--- a/src/felleskomponenter/adresser/semistrukturertAdresse.tsx
+++ b/src/felleskomponenter/adresser/semistrukturertAdresse.tsx
@@ -9,14 +9,15 @@ interface SemistrukturertAdresseProps {
 const SemistrukturertAdresse = ({
   adresse: { adresselinje1, adresselinje2, adresselinje3, adresselinje4, postnummer, poststed, land },
 }: SemistrukturertAdresseProps) => {
-  const postNrStedLandLinje = `${postnummer} ${poststed}, ${land}`;
+  const kommaLand = `, ${land}`;
+  const postNrStedLandLinje = `${postnummer ?? ""} ${poststed ?? ""}${land ? kommaLand : ""}`;
 
   return (
     <address>
-      <div>{adresselinje1}</div>
-      <div>{adresselinje2}</div>
-      <div>{adresselinje3}</div>
-      <div>{adresselinje4}</div>
+      {adresselinje1 && <div>{adresselinje1}</div>}
+      {adresselinje2 && <div>{adresselinje2}</div>}
+      {adresselinje3 && <div>{adresselinje3}</div>}
+      {adresselinje4 && <div>{adresselinje4}</div>}
       <div>{postNrStedLandLinje}</div>
     </address>
   );

--- a/src/felleskomponenter/adresser/semistrukturertAdresse.tsx
+++ b/src/felleskomponenter/adresser/semistrukturertAdresse.tsx
@@ -11,7 +11,7 @@ export const PostnrStedLandLinje = ({ land, postnummer, poststed }: PostnrStedLa
     skalViseKomma ? ", " : ""
   }${land ?? ""}`;
 
-  return <div>{postNrStedLandLinje}</div>;
+  return <>{postNrStedLandLinje}</>;
 };
 
 interface SemistrukturertAdresseProps {
@@ -20,14 +20,22 @@ interface SemistrukturertAdresseProps {
 
 const SemistrukturertAdresse = ({
   adresse: { adresselinje1, adresselinje2, adresselinje3, adresselinje4, postnummer, poststed, land },
-}: SemistrukturertAdresseProps) => (
-  <address>
-    {adresselinje1 && <div>{adresselinje1}</div>}
-    {adresselinje2 && <div>{adresselinje2}</div>}
-    {adresselinje3 && <div>{adresselinje3}</div>}
-    {adresselinje4 && <div>{adresselinje4}</div>}
-    <PostnrStedLandLinje postnummer={postnummer} poststed={poststed} land={land} />
-  </address>
-);
+}: SemistrukturertAdresseProps) => {
+  const visPostnrStedLandLinje = [postnummer, poststed, land].some((element) => element);
+
+  return (
+    <address>
+      {adresselinje1 && <div>{adresselinje1}</div>}
+      {adresselinje2 && <div>{adresselinje2}</div>}
+      {adresselinje3 && <div>{adresselinje3}</div>}
+      {adresselinje4 && <div>{adresselinje4}</div>}
+      {visPostnrStedLandLinje && (
+        <div>
+          <PostnrStedLandLinje postnummer={postnummer} poststed={poststed} land={land} />
+        </div>
+      )}
+    </address>
+  );
+};
 
 export default SemistrukturertAdresse;

--- a/src/felleskomponenter/adresser/semistrukturertAdresse.tsx
+++ b/src/felleskomponenter/adresser/semistrukturertAdresse.tsx
@@ -9,8 +9,8 @@ interface SemistrukturertAdresseProps {
 const SemistrukturertAdresse = ({
   adresse: { adresselinje1, adresselinje2, adresselinje3, adresselinje4, postnummer, poststed, land },
 }: SemistrukturertAdresseProps) => {
-  const kommaLand = `, ${land}`;
-  const postNrStedLandLinje = `${postnummer ?? ""} ${poststed ?? ""}${land ? kommaLand : ""}`;
+  const skalViseKomma = (postnummer || poststed) && land;
+  const postNrStedLandLinje = `${postnummer ?? ""} ${poststed ?? ""}${skalViseKomma ? ", " : ""}${land ?? ""}`;
 
   return (
     <address>

--- a/src/felleskomponenter/adresser/semistrukturertAdresse.tsx
+++ b/src/felleskomponenter/adresser/semistrukturertAdresse.tsx
@@ -2,25 +2,32 @@ import React from "react";
 
 import { SemistrukturertAdresseformat } from "../../graphql";
 
+type PostnrStedLandLinjeProps = Pick<SemistrukturertAdresseProps["adresse"], "land" | "postnummer" | "poststed">;
+
+export const PostnrStedLandLinje = ({ land, postnummer, poststed }: PostnrStedLandLinjeProps) => {
+  const skalViseKomma = (postnummer || poststed) && land;
+  const skalViseMellomrom = postnummer && poststed;
+  const postNrStedLandLinje = `${postnummer ?? ""}${skalViseMellomrom ? " " : ""}${poststed ?? ""}${
+    skalViseKomma ? ", " : ""
+  }${land ?? ""}`;
+
+  return <div>{postNrStedLandLinje}</div>;
+};
+
 interface SemistrukturertAdresseProps {
   adresse: Partial<SemistrukturertAdresseformat>;
 }
 
 const SemistrukturertAdresse = ({
   adresse: { adresselinje1, adresselinje2, adresselinje3, adresselinje4, postnummer, poststed, land },
-}: SemistrukturertAdresseProps) => {
-  const skalViseKomma = (postnummer || poststed) && land;
-  const postNrStedLandLinje = `${postnummer ?? ""} ${poststed ?? ""}${skalViseKomma ? ", " : ""}${land ?? ""}`;
-
-  return (
-    <address>
-      {adresselinje1 && <div>{adresselinje1}</div>}
-      {adresselinje2 && <div>{adresselinje2}</div>}
-      {adresselinje3 && <div>{adresselinje3}</div>}
-      {adresselinje4 && <div>{adresselinje4}</div>}
-      <div>{postNrStedLandLinje}</div>
-    </address>
-  );
-};
+}: SemistrukturertAdresseProps) => (
+  <address>
+    {adresselinje1 && <div>{adresselinje1}</div>}
+    {adresselinje2 && <div>{adresselinje2}</div>}
+    {adresselinje3 && <div>{adresselinje3}</div>}
+    {adresselinje4 && <div>{adresselinje4}</div>}
+    <PostnrStedLandLinje postnummer={postnummer} poststed={poststed} land={land} />
+  </address>
+);
 
 export default SemistrukturertAdresse;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46343153/140297665-1446db05-ff27-474b-b16a-cac4baaa405b.png)

Forhindrer visning av "null" for poststed og postnummer for kontaktadresse.