### PR TITLE
Kun mulig med én virksomhet

### DIFF
--- a/src/services/modules/trygdeavtale/flyt.ts
+++ b/src/services/modules/trygdeavtale/flyt.ts
@@ -16,7 +16,7 @@ export type Familiemedlem = {
 };
 
 export interface Resultat {
-  virksomheter?: string[];
+  virksomhet?: string;
   vedtak?: string;
   innvilgelse?: string;
   bestemmelse?: string;

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { RootState } from "AppTypes";
-import { ThunkDispatch } from "redux-thunk";
-import { Action } from "redux";
-import { reduxForm, change, getFormValues } from "redux-form";
+import { reduxForm, getFormValues } from "redux-form";
 
 import * as Api from "../../../services/api";
 import * as KV from "../../../kodeverk";
-import * as Mui from "../../../felleskomponenter/ui";
+import * as Skjema from "../../../felleskomponenter/skjema";
 import * as Nav from "../../../navFrontend";
 
 import { formSelectors } from "../../../ducks/form";
@@ -24,22 +22,17 @@ const mapStateToProps = (state: RootState, ownProps: Props) => ({
     })) || [],
   formValues: getFormValues(KV.Form.Trygdeavtale.AVKLAR_VIRKSOMHET)(state),
   initialValues: {
-    virksomheter: ownProps.resultat?.virksomheter,
+    virksomhet: ownProps.resultat?.virksomheter && ownProps.resultat.virksomheter[0],
   },
   formIsValid: formSelectors.TrygdeavtaleAvklarVirksomhetFormValidSelector(state),
 });
 
-const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
-  changeValgteVirksomheter: (data: string[]) =>
-    dispatch(change(KV.Form.Trygdeavtale.AVKLAR_VIRKSOMHET, "virksomheter", data)),
-});
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
+const connector = connect(mapStateToProps, {});
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 interface FormValuesProps {
-  virksomheter?: string[];
+  virksomhet?: string;
 }
 interface Props {
   data: Api.Trygdeavtale.StegData;
@@ -53,7 +46,6 @@ interface Props {
 }
 
 const VurderingAvklarVirksomhet = ({
-  changeValgteVirksomheter,
   formValues,
   formIsValid,
   fortsett,
@@ -71,7 +63,7 @@ const VurderingAvklarVirksomhet = ({
   useEffect(() => {
     if (redigerbart && formValues) {
       oppdaterFlyt({
-        resultat: { ...resultat, virksomheter: formValues.virksomheter || [] },
+        resultat: { ...resultat, virksomheter: formValues.virksomhet ? [formValues.virksomhet] : [] },
       });
     }
   }, [formValues]);
@@ -85,12 +77,11 @@ const VurderingAvklarVirksomhet = ({
         </Nav.Hjelpetekst>
       </Nav.Typo.Undertittel>
 
-      <Mui.Checkboxgruppe
-        muligeValg={virksomheterListe}
-        onChange={(checkedVirksomheter) => changeValgteVirksomheter(checkedVirksomheter)}
-        disabled={!redigerbart}
-        defaultValg={formValues?.virksomheter || []}
-      />
+      <Skjema.RadioGruppe feltNavn="virksomhet" label="">
+        {virksomheterListe?.map((virksomhet) => (
+          <Skjema.Radio feltNavn="virksomhet" label={virksomhet.term} id={virksomhet.kode} value={virksomhet.kode} />
+        ))}
+      </Skjema.RadioGruppe>
 
       <div className="fane__knapplinje">
         <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
@@ -22,7 +22,7 @@ const mapStateToProps = (state: RootState, ownProps: Props) => ({
     })) || [],
   formValues: getFormValues(KV.Form.Trygdeavtale.AVKLAR_VIRKSOMHET)(state),
   initialValues: {
-    virksomhet: ownProps.resultat?.virksomheter && ownProps.resultat.virksomheter[0],
+    virksomhet: ownProps.resultat?.virksomhet,
   },
   formIsValid: formSelectors.TrygdeavtaleAvklarVirksomhetFormValidSelector(state),
 });
@@ -63,7 +63,7 @@ const VurderingAvklarVirksomhet = ({
   useEffect(() => {
     if (redigerbart && formValues) {
       oppdaterFlyt({
-        resultat: { ...resultat, virksomheter: formValues.virksomhet ? [formValues.virksomhet] : [] },
+        resultat: { ...resultat, virksomhet: formValues.virksomhet },
       });
     }
   }, [formValues]);

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
@@ -27,7 +27,7 @@ const mapStateToProps = (state: RootState, ownProps: Props) => ({
   formIsValid: formSelectors.TrygdeavtaleAvklarVirksomhetFormValidSelector(state),
 });
 
-const connector = connect(mapStateToProps, {});
+const connector = connect(mapStateToProps);
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
 

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhetSchema.js
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhetSchema.js
@@ -1,9 +1,9 @@
-import { object, array } from "yup";
+import { object, string } from "yup";
 
-const VIRKSOMHET_KREVES = { melding: "Du må velge minst én virksomhet" };
+const VIRKSOMHET_KREVES = { melding: "Du må velge én virksomhet" };
 
 const vurdering_avklar_virksomhet = object().shape({
-  virksomheter: array().min(1).required(VIRKSOMHET_KREVES),
+  virksomhet: string().required(VIRKSOMHET_KREVES),
 });
 
 export default vurdering_avklar_virksomhet;

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingFamilie.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingFamilie.tsx
@@ -51,7 +51,7 @@ const mapStateToProps = (state: RootState, ownProps: Props) => ({
   initialValues: initializeFamilieFormValues(ownProps.data, ownProps.resultat),
 });
 
-const connector = connect(mapStateToProps, {});
+const connector = connect(mapStateToProps);
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
 


### PR DESCRIPTION
Det kom opp på et møte at det kun skal være mulig å ha én virksomhet i dette steget. 
[Slack-avklaring](https://nav-it.slack.com/archives/C02H9ME4AUW/p1637658977018600)

Melosys-trygdeavtale sender/mottar også nå bare én virksomhet: https://github.com/navikt/melosys-trygdeavtale/pull/21