### PR TITLE
Designendring på steg-knappene til FTRL og Trygdeavtale

### DIFF
--- a/src/felleskomponenter/ui/index.js
+++ b/src/felleskomponenter/ui/index.js
@@ -9,6 +9,7 @@ import Elementskrift from "./elementskrift";
 import RedigerbarListe from "./redigerbarliste";
 import LesMerPanel from "./lesmerpanel";
 import Checkbox from "./checkbox";
+import StegKnapper from "./stegKnapp";
 
 export {
   Knapp,
@@ -22,4 +23,5 @@ export {
   Elementskrift,
   RedigerbarListe,
   LesMerPanel,
+  StegKnapper,
 };

--- a/src/felleskomponenter/ui/stegKnapp/index.ts
+++ b/src/felleskomponenter/ui/stegKnapp/index.ts
@@ -1,0 +1,3 @@
+import StegKnapper from "./stegKnapper";
+
+export default StegKnapper;

--- a/src/felleskomponenter/ui/stegKnapp/stegKnapper.less
+++ b/src/felleskomponenter/ui/stegKnapp/stegKnapper.less
@@ -1,0 +1,14 @@
+.stegKnapper {
+  margin: 2em 0 0.25rem 0;
+
+  &__bekreft {
+    display: flex;
+  }
+
+  &__tilbake {
+    margin: 0.25em 0 0 0;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    margin-bottom: -0.75rem;
+  }
+}

--- a/src/felleskomponenter/ui/stegKnapp/stegKnapper.test.tsx
+++ b/src/felleskomponenter/ui/stegKnapp/stegKnapper.test.tsx
@@ -1,0 +1,38 @@
+import React, { ComponentProps } from "react";
+import { instance, mock } from "ts-mockito";
+import { shallow } from "enzyme";
+
+import * as Nav from "../../../navFrontend";
+import StegKnapper from "./stegKnapper";
+
+describe("stegKnapper", () => {
+  const mockedProps = mock<ComponentProps<typeof StegKnapper>>();
+  let props = instance(mockedProps);
+
+  beforeEach(() => {
+    props = instance(mockedProps);
+  });
+
+  it("viser ikke tilbake-knapp når visTilbakeKnapp = false", () => {
+    props.visTilbakeKnapp = false;
+    const stegKnapper = shallow(<StegKnapper {...props} />);
+
+    const bekreftKnapp = stegKnapper.find(Nav.Hovedknapp);
+    const tilbakeKnapp = stegKnapper.find(Nav.Flatknapp);
+
+    expect(bekreftKnapp).toHaveLength(1);
+    expect(tilbakeKnapp).toHaveLength(0);
+  });
+
+  it("viser tilbake-knapp når visTilbakeKnapp = true", () => {
+    props.visTilbakeKnapp = true;
+    props.tilbake = {};
+    const stegKnapper = shallow(<StegKnapper {...props} />);
+
+    const bekreftKnapp = stegKnapper.find(Nav.Hovedknapp);
+    const tilbakeKnapp = stegKnapper.find(Nav.Flatknapp);
+
+    expect(bekreftKnapp).toHaveLength(1);
+    expect(tilbakeKnapp).toHaveLength(1);
+  });
+});

--- a/src/felleskomponenter/ui/stegKnapp/stegKnapper.test.tsx
+++ b/src/felleskomponenter/ui/stegKnapp/stegKnapper.test.tsx
@@ -26,7 +26,7 @@ describe("stegKnapper", () => {
 
   it("viser tilbake-knapp når visTilbakeKnapp = true", () => {
     props.visTilbakeKnapp = true;
-    props.tilbake = {};
+    props.tilbakeKnappProps = {};
     const stegKnapper = shallow(<StegKnapper {...props} />);
 
     const bekreftKnapp = stegKnapper.find(Nav.Hovedknapp);

--- a/src/felleskomponenter/ui/stegKnapp/stegKnapper.tsx
+++ b/src/felleskomponenter/ui/stegKnapp/stegKnapper.tsx
@@ -1,0 +1,40 @@
+import React, { ComponentProps } from "react";
+import classNames from "classnames";
+
+import * as Nav from "../../../navFrontend";
+import * as Ikoner from "../../../resources/images";
+
+import "./stegKnapper.css";
+
+interface StegKnapperProps {
+  bekreft: ComponentProps<typeof Nav.Hovedknapp>;
+  bekreftTekst?: string;
+  visTilbakeKnapp?: boolean;
+  tilbake?: ComponentProps<typeof Nav.Flatknapp>;
+  className?: string;
+}
+
+const StegKnapper = ({
+  bekreft,
+  bekreftTekst = "Bekreft og fortsett",
+  visTilbakeKnapp = true,
+  tilbake,
+  className,
+}: StegKnapperProps) => {
+  const cls = classNames("stegKnapper", className);
+  return (
+    <div className={cls}>
+      <Nav.Hovedknapp mini className="stegKnapper__bekreft" {...bekreft}>
+        {bekreftTekst}
+      </Nav.Hovedknapp>
+      {visTilbakeKnapp && tilbake && (
+        <Nav.Flatknapp mini className="stegKnapper__tilbake" {...tilbake}>
+          <Ikoner.ArrowLeft />
+          <span>Tilbake</span>
+        </Nav.Flatknapp>
+      )}
+    </div>
+  );
+};
+
+export default StegKnapper;

--- a/src/felleskomponenter/ui/stegKnapp/stegKnapper.tsx
+++ b/src/felleskomponenter/ui/stegKnapp/stegKnapper.tsx
@@ -7,28 +7,28 @@ import * as Ikoner from "../../../resources/images";
 import "./stegKnapper.css";
 
 interface StegKnapperProps {
-  bekreft: ComponentProps<typeof Nav.Hovedknapp>;
+  bekreftKnappProps: ComponentProps<typeof Nav.Hovedknapp>;
   bekreftTekst?: string;
   visTilbakeKnapp?: boolean;
-  tilbake?: ComponentProps<typeof Nav.Flatknapp>;
+  tilbakeKnappProps?: ComponentProps<typeof Nav.Flatknapp>;
   className?: string;
 }
 
 const StegKnapper = ({
-  bekreft,
+  bekreftKnappProps,
   bekreftTekst = "Bekreft og fortsett",
   visTilbakeKnapp = true,
-  tilbake,
+  tilbakeKnappProps,
   className,
 }: StegKnapperProps) => {
   const cls = classNames("stegKnapper", className);
   return (
     <div className={cls}>
-      <Nav.Hovedknapp mini className="stegKnapper__bekreft" {...bekreft}>
+      <Nav.Hovedknapp mini className="stegKnapper__bekreft" {...bekreftKnappProps}>
         {bekreftTekst}
       </Nav.Hovedknapp>
-      {visTilbakeKnapp && tilbake && (
-        <Nav.Flatknapp mini className="stegKnapper__tilbake" {...tilbake}>
+      {visTilbakeKnapp && tilbakeKnappProps && (
+        <Nav.Flatknapp mini className="stegKnapper__tilbake" {...tilbakeKnappProps}>
           <Ikoner.ArrowLeft />
           <span>Tilbake</span>
         </Nav.Flatknapp>

--- a/src/resources/images/arrow-left.svg
+++ b/src/resources/images/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="14" viewBox="0 0 16 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16 7.66732L2.47 7.66732L7.33333 12.6976L6.41697 13.6673L0 7.00065L6.41697 0.333984L7.33333 1.30368L2.47 6.33398L16 6.33398V7.66732Z" fill="#0067C5"/>
+</svg>

--- a/src/resources/images/index.js
+++ b/src/resources/images/index.js
@@ -1,5 +1,6 @@
 import { ReactComponent as AccountCircle } from "./line-version-account-circle.svg";
 import { ReactComponent as Add } from "./add.svg";
+import { ReactComponent as ArrowLeft } from "./arrow-left.svg";
 import { ReactComponent as AddOne } from "./line-version-add-1.svg";
 import { ReactComponent as Arbeidsgiver } from "./ikon-arbeidsgiver.svg";
 import { ReactComponent as Arbeidsforhold } from "./ikon-arbeidsforhold.svg";
@@ -61,6 +62,7 @@ import { Kjoenn } from "./helpercomponents";
 export {
   AccountCircle,
   Add,
+  ArrowLeft,
   AddOne,
   Arbeidsgiver,
   Arbeidsforhold,

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse.tsx
@@ -6,6 +6,7 @@ import { Action } from "redux";
 
 import MKV from "../../../../melosyskodeverk";
 import * as Nav from "../../../../navFrontend";
+import * as Mui from "../../../../felleskomponenter/ui";
 import * as Utils from "../../../../utils";
 
 import { vilkarSelectors } from "../../../../ducks/vilkar";
@@ -127,7 +128,7 @@ const VurderingBestemmelse = ({
     }
   }, [valgteBegrunnelser, valgtBestemmelse, valgteVilkar]);
 
-  const handleBefreft = () => {
+  const handleBekreft = () => {
     opprettMedlemskapsperiodeFraBestemmelse();
     bekreft();
   };
@@ -285,19 +286,10 @@ const VurderingBestemmelse = ({
           ))
         )}
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={!erAlleValgGjort || !redigerbart}
-          className="fane__navigasjonsknapp"
-          onClick={handleBefreft}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: handleBekreft, disabled: !erAlleValgGjort || !redigerbart }}
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse.tsx
@@ -287,8 +287,8 @@ const VurderingBestemmelse = ({
         )}
 
       <Mui.StegKnapper
-        bekreft={{ onClick: handleBekreft, disabled: !erAlleValgGjort || !redigerbart }}
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        bekreftKnappProps={{ onClick: handleBekreft, disabled: !erAlleValgGjort || !redigerbart }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingFamilie.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingFamilie.tsx
@@ -329,8 +329,8 @@ const VurderingFamilie = ({
       )}
 
       <Mui.StegKnapper
-        bekreft={{ onClick: bekreft, disabled: !redigerbart || !formIsValid }}
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        bekreftKnappProps={{ onClick: bekreft, disabled: !redigerbart || !formIsValid }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingFamilie.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingFamilie.tsx
@@ -7,6 +7,7 @@ import { change, getFormValues, reduxForm } from "redux-form";
 import { KTObject } from "@navikt/melosys-kodeverk";
 
 import * as Nav from "../../../../navFrontend";
+import * as Mui from "../../../../felleskomponenter/ui";
 import * as Utils from "../../../../utils";
 import * as Skjema from "../../../../felleskomponenter/skjema";
 import * as KV from "../../../../kodeverk";
@@ -327,19 +328,10 @@ const VurderingFamilie = ({
         </div>
       )}
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={!redigerbart || !formIsValid}
-          className="fane__navigasjonsknapp"
-          onClick={bekreft}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: bekreft, disabled: !redigerbart || !formIsValid }}
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPerioder.tsx
@@ -399,19 +399,10 @@ const VurderingPerioder = ({
         <Nav.AlertStripe type="advarsel">Du må legge inn minst én periode før du kan fortsette.</Nav.AlertStripe>
       )}
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={!redigerbart || !formIsValid}
-          className="fane__navigasjonsknapp"
-          onClick={handleBekreft}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: handleBekreft, disabled: !redigerbart || !formIsValid }}
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPerioder.tsx
@@ -400,8 +400,8 @@ const VurderingPerioder = ({
       )}
 
       <Mui.StegKnapper
-        bekreft={{ onClick: handleBekreft, disabled: !redigerbart || !formIsValid }}
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        bekreftKnappProps={{ onClick: handleBekreft, disabled: !redigerbart || !formIsValid }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingRepresentant.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingRepresentant.tsx
@@ -237,8 +237,8 @@ const VurderingRepresentant = ({
       )}
 
       <Mui.StegKnapper
-        bekreft={{ onClick: bekreft, disabled: !redigerbart || !formIsValid }}
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        bekreftKnappProps={{ onClick: bekreft, disabled: !redigerbart || !formIsValid }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingRepresentant.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingRepresentant.tsx
@@ -6,6 +6,7 @@ import { RootState } from "AppTypes";
 import { Action } from "redux";
 
 import * as Nav from "../../../../navFrontend";
+import * as Mui from "../../../../felleskomponenter/ui";
 import * as Skjema from "../../../../felleskomponenter/skjema";
 import * as KV from "../../../../kodeverk";
 import * as Api from "../../../../services/api";
@@ -235,19 +236,10 @@ const VurderingRepresentant = ({
         </Nav.Row>
       )}
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={!redigerbart || !formIsValid}
-          className="fane__navigasjonsknapp"
-          onClick={bekreft}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: bekreft, disabled: !redigerbart || !formIsValid }}
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingStart.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingStart.tsx
@@ -206,7 +206,7 @@ export const VurderingStart = ({
       </Nav.Fieldset>
 
       <Mui.StegKnapper
-        bekreft={{ onClick: fortsettHandle, disabled: !formIsValid || !redigerbart }}
+        bekreftKnappProps={{ onClick: fortsettHandle, disabled: !formIsValid || !redigerbart }}
         visTilbakeKnapp={false}
       />
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingStart.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingStart.tsx
@@ -7,6 +7,7 @@ import { RootState } from "AppTypes";
 import { KTObject } from "@navikt/melosys-kodeverk";
 
 import * as Nav from "../../../../navFrontend";
+import * as Mui from "../../../../felleskomponenter/ui";
 import * as Skjema from "../../../../felleskomponenter/skjema";
 import * as Utils from "../../../../utils";
 import * as KV from "../../../../kodeverk";
@@ -204,16 +205,10 @@ export const VurderingStart = ({
         </Nav.Row>
       </Nav.Fieldset>
 
-      <div className="fane__knapplinje">
-        <Nav.Hovedknapp
-          mini
-          disabled={!formIsValid || !redigerbart}
-          className="fane__navigasjonsknapp"
-          onClick={fortsettHandle}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: fortsettHandle, disabled: !formIsValid || !redigerbart }}
+        visTilbakeKnapp={false}
+      />
 
       {visOppfrisk && (
         <DialogboksOppfriskSak

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -6,6 +6,7 @@ import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
 
 import MKV from "../../../../../melosyskodeverk";
+import * as Mui from "../../../../../felleskomponenter/ui";
 import * as Nav from "../../../../../navFrontend";
 import * as Api from "../../../../../services/api";
 import * as Utils from "../../../../../utils";
@@ -294,19 +295,10 @@ const VurderingTrygdeavgift = ({
         <Trygdeavgiftsgrunnlag {...trygdeavgiftsgrunnlagComponentProps} erVirksomhetNorsk={false} />
       )}
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={!redigerbart || !erStegGyldig}
-          className="fane__navigasjonsknapp"
-          onClick={bekreft}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: bekreft, disabled: !redigerbart || !erStegGyldig }}
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -296,8 +296,8 @@ const VurderingTrygdeavgift = ({
       )}
 
       <Mui.StegKnapper
-        bekreft={{ onClick: bekreft, disabled: !redigerbart || !erStegGyldig }}
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        bekreftKnappProps={{ onClick: bekreft, disabled: !redigerbart || !erStegGyldig }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
@@ -359,9 +359,14 @@ const VurderingVedtak = ({
       )}
 
       <Mui.StegKnapper
-        bekreft={{ onClick: fattVedtak, disabled: !redigerbart, autoDisableVedSpinner: true, spinner: vedtakPending }}
+        bekreftKnappProps={{
+          onClick: fattVedtak,
+          disabled: !redigerbart,
+          autoDisableVedSpinner: true,
+          spinner: vedtakPending,
+        }}
         bekreftTekst="Fatt vedtak"
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
@@ -7,6 +7,7 @@ import { KTObject } from "@navikt/melosys-kodeverk";
 
 import MKV from "../../../../melosyskodeverk";
 import * as Api from "../../../../services/api";
+import * as Mui from "../../../../felleskomponenter/ui";
 import * as Nav from "../../../../navFrontend";
 import * as Utils from "../../../../utils";
 import * as KV from "../../../../kodeverk";
@@ -357,21 +358,11 @@ const VurderingVedtak = ({
         />
       )}
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={!redigerbart}
-          className="fane__navigasjonsknapp"
-          onClick={fattVedtak}
-          spinner={vedtakPending}
-          autoDisableVedSpinner
-        >
-          Fatt vedtak
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: fattVedtak, disabled: !redigerbart, autoDisableVedSpinner: true, spinner: vedtakPending }}
+        bekreftTekst="Fatt vedtak"
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVirksomhet.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVirksomhet.tsx
@@ -119,8 +119,8 @@ const VurderingVirksomhet = ({
       />
 
       <Mui.StegKnapper
-        bekreft={{ onClick: handleFortsett, disabled: !formIsValid || !redigerbart }}
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        bekreftKnappProps={{ onClick: handleFortsett, disabled: !formIsValid || !redigerbart }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVirksomhet.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVirksomhet.tsx
@@ -118,19 +118,10 @@ const VurderingVirksomhet = ({
         defaultValg={lagredeValgtevirksomheter}
       />
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={!formIsValid || !redigerbart}
-          className="fane__navigasjonsknapp"
-          onClick={handleFortsett}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: handleFortsett, disabled: !formIsValid || !redigerbart }}
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
@@ -94,8 +94,11 @@ const VurderingAvklarVirksomhet = ({
       />
 
       <Mui.StegKnapper
-        bekreft={{ onClick: fortsett, disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart }}
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        bekreftKnappProps={{
+          onClick: fortsett,
+          disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart,
+        }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
@@ -93,19 +93,10 @@ const VurderingAvklarVirksomhet = ({
         defaultValg={formValues?.virksomheter || []}
       />
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart}
-          className="fane__navigasjonsknapp"
-          onClick={fortsett}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: fortsett, disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart }}
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
@@ -9,6 +9,7 @@ import parse from "html-react-parser";
 
 import * as Api from "../../../services/api";
 import * as KV from "../../../kodeverk";
+import * as Mui from "../../../felleskomponenter/ui";
 import * as Nav from "../../../navFrontend";
 import * as Skjema from "../../../felleskomponenter/skjema";
 import * as Utils from "../../../utils";
@@ -150,19 +151,10 @@ const VurderingBestemmelse = ({
         </Nav.Row>
       )}
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart}
-          className="fane__navigasjonsknapp"
-          onClick={fortsett}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: fortsett, disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart }}
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse.tsx
@@ -152,8 +152,11 @@ const VurderingBestemmelse = ({
       )}
 
       <Mui.StegKnapper
-        bekreft={{ onClick: fortsett, disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart }}
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        bekreftKnappProps={{
+          onClick: fortsett,
+          disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart,
+        }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingFamilie.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingFamilie.tsx
@@ -6,6 +6,7 @@ import { KTObject } from "@navikt/melosys-kodeverk";
 
 import * as Api from "../../../services/api";
 import * as KV from "../../../kodeverk";
+import * as Mui from "../../../felleskomponenter/ui";
 import * as Nav from "../../../navFrontend";
 import * as Skjema from "../../../felleskomponenter/skjema";
 import * as Utils from "../../../utils";
@@ -267,19 +268,10 @@ const VurderingFamilie = ({
         </div>
       )}
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart}
-          className="fane__navigasjonsknapp"
-          onClick={fortsett}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{ onClick: fortsett, disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart }}
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingFamilie.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingFamilie.tsx
@@ -269,8 +269,11 @@ const VurderingFamilie = ({
       )}
 
       <Mui.StegKnapper
-        bekreft={{ onClick: fortsett, disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart }}
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        bekreftKnappProps={{
+          onClick: fortsett,
+          disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart,
+        }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang.tsx
@@ -7,6 +7,7 @@ import { getFormValues, reduxForm } from "redux-form";
 
 import * as Api from "../../../services/api";
 import * as KV from "../../../kodeverk";
+import * as Mui from "../../../felleskomponenter/ui";
 import * as Nav from "../../../navFrontend";
 import * as Skjema from "../../../felleskomponenter/skjema";
 import * as Utils from "../../../utils";
@@ -168,16 +169,13 @@ const VurderingInngang = ({
         </Nav.Row>
       </Nav.Fieldset>
 
-      <div className="fane__knapplinje">
-        <Nav.Hovedknapp
-          mini
-          disabled={steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart}
-          className="fane__navigasjonsknapp"
-          onClick={fortsettHandle}
-        >
-          Fortsett
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{
+          onClick: fortsettHandle,
+          disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart,
+        }}
+        visTilbakeKnapp={false}
+      />
 
       {visOppfrisk && (
         <DialogboksOppfriskSak

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang.tsx
@@ -170,7 +170,7 @@ const VurderingInngang = ({
       </Nav.Fieldset>
 
       <Mui.StegKnapper
-        bekreft={{
+        bekreftKnappProps={{
           onClick: fortsettHandle,
           disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart,
         }}

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -361,14 +361,14 @@ const VurderingVedtak = ({
       )}
 
       <Mui.StegKnapper
-        bekreft={{
+        bekreftKnappProps={{
           onClick: fattVedtak,
           disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart || visTomEndringFelt,
           autoDisableVedSpinner: true,
           spinner: vedtakPending,
         }}
         bekreftTekst="Fatt vedtak"
-        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>
   );

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -8,6 +8,7 @@ import { getFormValues, reduxForm } from "redux-form";
 import MKV from "../../../melosyskodeverk";
 import * as Api from "../../../services/api";
 import * as Hooks from "../../../hooks";
+import * as Mui from "../../../felleskomponenter/ui";
 import * as Nav from "../../../navFrontend";
 import * as Utils from "../../../utils";
 import * as KV from "../../../kodeverk";
@@ -359,21 +360,16 @@ const VurderingVedtak = ({
         />
       )}
 
-      <div className="fane__knapplinje">
-        <Nav.Knapp mini disabled={!redigerbart} className="fane__navigasjonsknapp" onClick={tilbake}>
-          Tilbake
-        </Nav.Knapp>
-        <Nav.Hovedknapp
-          mini
-          disabled={steg.status !== StegStatus.FERDIG || !redigerbart || !formIsValid || visTomEndringFelt}
-          className="fane__navigasjonsknapp"
-          onClick={fattVedtak}
-          autoDisableVedSpinner
-          spinner={vedtakPending}
-        >
-          Fatt vedtak
-        </Nav.Hovedknapp>
-      </div>
+      <Mui.StegKnapper
+        bekreft={{
+          onClick: fattVedtak,
+          disabled: steg.status !== StegStatus.FERDIG || !formIsValid || !redigerbart || visTomEndringFelt,
+          autoDisableVedSpinner: true,
+          spinner: vedtakPending,
+        }}
+        bekreftTekst="Fatt vedtak"
+        tilbake={{ onClick: tilbake, disabled: !redigerbart }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Legger til felleskomponenten stegKnapper som skal ta over for Bekreft- og Tilbake-knappene i stegene for FTRL og Trygdeavtale.

[Melosys-4793](https://jira.adeo.no/browse/MELOSYS-4793)