### PR TITLE
MELOSYS-4838: Landvelger - oppdateres redux når land er valgt

### DIFF
--- a/src/felleskomponenter/skjema/landvelger/enkeltLand.js
+++ b/src/felleskomponenter/skjema/landvelger/enkeltLand.js
@@ -91,6 +91,11 @@ export class EnkeltLand extends Component {
     return landListe.length === 1 ? landListe[0] : false;
   };
 
+  landErValgt = (landkodeObjekt) => {
+    this.reduxOppdaterLand(landkodeObjekt.kode);
+    this.setState({ inputVerdi: Utils.land.landTekstFormat(landkodeObjekt), error: null });
+  };
+
   fokusUtHandler = () => {
     const { inputVerdi } = this.state;
 
@@ -103,8 +108,7 @@ export class EnkeltLand extends Component {
     const landkodeObjekt = this.finnEttLand(inputVerdi);
 
     if (landkodeObjekt) {
-      this.reduxOppdaterLand(landkodeObjekt.kode);
-      this.setState({ inputVerdi: Utils.land.landTekstFormat(landkodeObjekt), error: null });
+      this.landErValgt(landkodeObjekt);
     } else {
       this.setState({ error: "Finner ikke landet du har skrevet inn." });
     }
@@ -113,6 +117,12 @@ export class EnkeltLand extends Component {
   inputEndringHandler = (e) => {
     const inputVerdi = e.target.value;
     this.setState({ inputVerdi });
+
+    const landkodeObjekt = this.finnEttLand(inputVerdi);
+
+    if (inputVerdi === Utils.land.landTekstFormat(landkodeObjekt)) {
+      this.landErValgt(landkodeObjekt);
+    }
   };
 
   tomFeilmelding = () => {

--- a/src/felleskomponenter/skjema/landvelger/enkeltLand.js
+++ b/src/felleskomponenter/skjema/landvelger/enkeltLand.js
@@ -91,7 +91,7 @@ export class EnkeltLand extends Component {
     return landListe.length === 1 ? landListe[0] : false;
   };
 
-  landErValgt = (landkodeObjekt) => {
+  oppdaterLandReduxOgKomponentState = (landkodeObjekt) => {
     this.reduxOppdaterLand(landkodeObjekt.kode);
     this.setState({ inputVerdi: Utils.land.landTekstFormat(landkodeObjekt), error: null });
   };
@@ -108,7 +108,7 @@ export class EnkeltLand extends Component {
     const landkodeObjekt = this.finnEttLand(inputVerdi);
 
     if (landkodeObjekt) {
-      this.landErValgt(landkodeObjekt);
+      this.oppdaterLandReduxOgKomponentState(landkodeObjekt);
     } else {
       this.setState({ error: "Finner ikke landet du har skrevet inn." });
     }
@@ -121,7 +121,7 @@ export class EnkeltLand extends Component {
     const landkodeObjekt = this.finnEttLand(inputVerdi);
 
     if (inputVerdi === Utils.land.landTekstFormat(landkodeObjekt)) {
-      this.landErValgt(landkodeObjekt);
+      this.oppdaterLandReduxOgKomponentState(landkodeObjekt);
     }
   };
 

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet.tsx
@@ -81,7 +81,7 @@ const VurderingAvklarVirksomhet = ({
 
       <Skjema.RadioGruppe feltNavn="virksomhet" label="">
         {virksomheterListe?.map((virksomhet) => (
-          <Skjema.Radio feltNavn="virksomhet" label={virksomhet.term} id={virksomhet.kode} value={virksomhet.kode} />
+          <Skjema.Radio feltNavn="virksomhet" label={virksomhet.term} key={virksomhet.kode} value={virksomhet.kode} />
         ))}
       </Skjema.RadioGruppe>
 


### PR DESCRIPTION
Fra test: 
>  jeg skulle teste Steg 1 så oppdaget jeg at jeg må trykke en ekstra gang etter at jeg har valgt land for at knappen blir aktivert (blir blå)

Dette er fordi `LandVelger -> enkeltLand` tidligere oppdaterte land(i redux) kun på `onBlur`. I denne PR-en legger jeg til en sjekk på at land er valgt fra listen og dersom dette stemmer oppdateres redux med en gang endringen skjer. 
[Slack-spørsmål](https://nav-it.slack.com/archives/C01BSCJM127/p1638194165081000)
[MELOSYS-4838](https://jira.adeo.no/browse/MELOSYS-4838)