### PR TITLE
InnledningFritekst kommer i behandlingsresultat

### DIFF
--- a/src/ducks/behandlingsresultat/selectors.js
+++ b/src/ducks/behandlingsresultat/selectors.js
@@ -39,6 +39,11 @@ export const BegrunnelseFritekstSelector = createSelector(
   (behandlingsresultat) => behandlingsresultat.begrunnelseFritekst
 );
 
+export const InnledningFritekstSelector = createSelector(
+  BehandlingsresultatSelector,
+  (behandlingsresultat) => behandlingsresultat.innledningFritekst
+);
+
 export const KontrollresultatBegrunnelseKoderSelector = createSelector(
   BehandlingsresultatSelector,
   (behandlingsresultat) => behandlingsresultat.kontrollresultatBegrunnelseKoder

--- a/src/proptypes/behandlingsresultat.js
+++ b/src/proptypes/behandlingsresultat.js
@@ -4,6 +4,7 @@ const BehandlingsresultatPropType = PT.shape({
   behandlingsresultatTypeKode: PT.string,
   begrunnelseKoder: PT.arrayOf(PT.string),
   begrunnelseFritekst: PT.string,
+  innledningFritekst: PT.string,
 });
 
 export { BehandlingsresultatPropType as Behandlingsresultat };

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
@@ -47,6 +47,7 @@ const mapStateToProps = (state: RootState) => ({
   formValuesRepresentant: getFormValues(KV.Form.REPRESENTANT)(state) as RepresentantformValues,
   initialValues: {
     fritekstBegrunnelse: behandlingsresultatSelectors.BegrunnelseFritekstSelector(state),
+    fritekstInnledning: behandlingsresultatSelectors.InnledningFritekstSelector(state),
   },
 });
 
@@ -303,28 +304,25 @@ const VurderingVedtak = ({
         </div>
       )}
 
-      {redigerbart && (
-        <>
-          <Nav.Typo.Element className="fritekst_overskrift" tag="h3">
-            Fritekst til innledning
-            <Nav.Hjelpetekst
-              tittel={fritekstInnledningHjelpetekstTittel}
-              className="hjelpetekst"
-              type={Nav.PopoverOrientering.Hoyre}
-            >
-              <p>Teksten du skriver her vil vises etter informasjonen om vedtakets periode og resultat. Eksempel:</p>
-              <p>&quot;Du er medlem i folketrygden fra 1. september 2022 til 31. desember 2024.</p>
-              <p>Medlemskapet omfatter trygdedekning i folketrygdens helse- og pensjonsdel.&quot;</p>
-              <p>Friteksten kommer her.</p>
-            </Nav.Hjelpetekst>
-          </Nav.Typo.Element>
-          <Skjema.HTMLEditor
-            feltNavn="fritekstInnledning"
-            className="fritekst_editor"
-            placeholder="Skriv inn tilleggsinformasjon til innledning..."
-          />
-        </>
-      )}
+      <Nav.Typo.Element className="fritekst_overskrift" tag="h3">
+        Fritekst til innledning
+        <Nav.Hjelpetekst
+          tittel={fritekstInnledningHjelpetekstTittel}
+          className="hjelpetekst"
+          type={Nav.PopoverOrientering.Hoyre}
+        >
+          <p>Teksten du skriver her vil vises etter informasjonen om vedtakets periode og resultat. Eksempel:</p>
+          <p>&quot;Du er medlem i folketrygden fra 1. september 2022 til 31. desember 2024.</p>
+          <p>Medlemskapet omfatter trygdedekning i folketrygdens helse- og pensjonsdel.&quot;</p>
+          <p>Friteksten kommer her.</p>
+        </Nav.Hjelpetekst>
+      </Nav.Typo.Element>
+      <Skjema.HTMLEditor
+        feltNavn="fritekstInnledning"
+        className="fritekst_editor"
+        placeholder="Skriv inn tilleggsinformasjon til innledning..."
+        disabled={!redigerbart}
+      />
 
       <Nav.Typo.Element className="fritekst_overskrift" tag="h3">
         Fritekst til begrunnelse{" "}

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -46,6 +46,7 @@ const mapStateToProps = (state: RootState, ownProps: Props) => ({
   formValues: getFormValues(KV.Form.Trygdeavtale.VEDTAK)(state),
   initialValues: {
     fritekstBegrunnelse: behandlingsresultatSelectors.BegrunnelseFritekstSelector(state),
+    fritekstInnledning: behandlingsresultatSelectors.InnledningFritekstSelector(state),
     lovvalgsperiodeFom:
       ownProps.resultat.lovvalgsperiodeFom && Utils.dato.formatterDatoTilNorsk(ownProps.resultat.lovvalgsperiodeFom),
     lovvalgsperiodeTom:
@@ -291,32 +292,29 @@ const VurderingVedtak = ({
         </Nav.Row>
       )}
 
-      {redigerbart && (
-        <>
-          <Nav.Typo.Element className={vurderingVedtakCls.element("fritekst_overskrift")} tag="h3">
-            Fritekst til innledning
-            <Nav.Hjelpetekst
-              tittel={fritekstInnledningHjelpetekstTittel}
-              className={vurderingVedtakCls.element("hjelpetekst")}
-              type={Nav.PopoverOrientering.Hoyre}
-            >
-              <p>Teksten du skriver her vil vises etter informasjonen om vedtakets periode og resultat.</p>
-              <p>
-                Eksempel:
-                <br />
-                &quot;Du er omfattet av norsk trygdelovgivning og medlem i folketrygden fra 1. september 2022 til 31.
-                desember 2024.&quot;
-              </p>
-              <p>Friteksten kommer her.</p>
-            </Nav.Hjelpetekst>
-          </Nav.Typo.Element>
-          <Skjema.HTMLEditor
-            feltNavn="fritekstInnledning"
-            className={vurderingVedtakCls.element("fritekst_editor")}
-            placeholder="Skriv inn tilleggsinformasjon til innledning..."
-          />
-        </>
-      )}
+      <Nav.Typo.Element className={vurderingVedtakCls.element("fritekst_overskrift")} tag="h3">
+        Fritekst til innledning
+        <Nav.Hjelpetekst
+          tittel={fritekstInnledningHjelpetekstTittel}
+          className={vurderingVedtakCls.element("hjelpetekst")}
+          type={Nav.PopoverOrientering.Hoyre}
+        >
+          <p>Teksten du skriver her vil vises etter informasjonen om vedtakets periode og resultat.</p>
+          <p>
+            Eksempel:
+            <br />
+            &quot;Du er omfattet av norsk trygdelovgivning og medlem i folketrygden fra 1. september 2022 til 31.
+            desember 2024.&quot;
+          </p>
+          <p>Friteksten kommer her.</p>
+        </Nav.Hjelpetekst>
+      </Nav.Typo.Element>
+      <Skjema.HTMLEditor
+        feltNavn="fritekstInnledning"
+        className={vurderingVedtakCls.element("fritekst_editor")}
+        placeholder="Skriv inn tilleggsinformasjon til innledning..."
+        disabled={!redigerbart}
+      />
 
       <Nav.Typo.Element className={vurderingVedtakCls.element("fritekst_overskrift")} tag="h3">
         Fritekst til begrunnelse{" "}


### PR DESCRIPTION
InnledningFritekst kommer i behandlingsresultat: 
initialiserer fritekst-felt i både FTRL og Trygdeavtale samt viser disse feltene i innsynsmodus