### PR TITLE
Bugs funnet: Arbeidssted feilmeldinger

### DIFF
--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -243,7 +243,7 @@ const soknad = object().when("$behandlingstema", {
         )
     ),
     representantIUtlandet: object()
-      .when("$behandlingstema", {
+      .when("$sakstype", {
         is: erTrygdeavtaleSak,
         then: object()
           .shape({

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -154,7 +154,7 @@ const VurderingVedtak = ({
     if (behandlingsgrunnlagStatus === "OK") {
       debouncedKontrollerVedtak(oppdaterFørKontroll);
     }
-  }, [resultat.lovvalgsperiodeTom, behandlingsgrunnlagStatus]);
+  }, [resultat.lovvalgsperiodeTom, behandlingsgrunnlagStatus, resultat.bestemmelse]);
 
   useEffect(() => {
     if (steg.status === StegStatus.FERDIG) {


### PR DESCRIPTION
Jira: [MELOSYS-4895](https://jira.adeo.no/browse/MELOSYS-4895)

> Får opp et varsel når jeg forsøker å forhåndsvise vedtak og attest

Denne gjøres i backend. https://github.com/navikt/melosys-api/pull/940 

>Får opp feilmelding også når jeg velger art. 8.2 på steg 3, bestemmelse

Dette viste seg var fordi man ikke kontrollerte vedtaket på nytt etter bestemmelse-endring. La til resultat.bestemmelse i useEffecten som håndterer vedtakkontrollen.

> Dvs. at det ikke skal være mulig å lagre arbeidssted uten at navn er lagret

Dette var implementert, men ved endringer i desember så ble en slurvefeil lagt inn. Fikset nå. behandlingstema -> sakstype. 