### PR TITLE
Menypunkt "Arbeidssted" stemmer ikke helt med skisser

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/representantIUtlandet/adresselinjer/adresselinjer.less
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/representantIUtlandet/adresselinjer/adresselinjer.less
@@ -1,5 +1,6 @@
 .adresselinjer {
   width: 100%;
+  margin-bottom: 1rem;
 
   &__adresselinje {
     display: flex;
@@ -14,6 +15,5 @@
 
   &__leggTil_symbol {
     margin-top: 0.5rem;
-    margin-bottom: 1rem;
   }
 }

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/representantIUtlandet/adresselinjer/adresselinjer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/representantIUtlandet/adresselinjer/adresselinjer.tsx
@@ -41,7 +41,7 @@ const InnerAdresselinjer = (props: InnerAdresselinjerProps) => {
             <Symboler.Slett onClick={() => remove(index)} className={adresselinjerCls.element("slett_symbol")} />
           </Nav.Row>
         ))}
-      {redigerbart && (
+      {redigerbart && felter.length < 4 && (
         <Nav.Row>
           <Nav.Column xs="9" className={adresselinjerCls.element("leggTil_symbol")}>
             <Mui.Knappelenke onClick={leggTilTomtFelt} ikon={Ikoner.Add}>

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/representantIUtlandet/representantIUtlandet.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/representantIUtlandet/representantIUtlandet.tsx
@@ -21,7 +21,8 @@ const mapStateToProps = (state: RootState) => ({
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, AnyAction>) => ({
-  initializeRepresentantNavn: () => dispatch(change(KV.Form.SOKNAD, "representantIUtlandet.representantNavn", "")),
+  initializeRepresentantIUtlandet: (value: KV.Form.RepresentantIUtlandet) =>
+    dispatch(change(KV.Form.SOKNAD, "representantIUtlandet", value)),
 });
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -35,7 +36,7 @@ const InnerRepresentantIUtlandet = (props: InnerRepresentantIUtlandetProps) => {
     redigerbart,
     soknadsland,
     behandlingsgrunnlagFeilmeldinger,
-    initializeRepresentantNavn,
+    initializeRepresentantIUtlandet,
     input: { value, onChange },
   } = props;
 
@@ -44,7 +45,7 @@ const InnerRepresentantIUtlandet = (props: InnerRepresentantIUtlandetProps) => {
   const slettRepresentantIUtlandet = () => onChange(null);
 
   const handleApneRedigering = async (apneRedigering: () => void) => {
-    await initializeRepresentantNavn();
+    await initializeRepresentantIUtlandet({ representantNavn: "", adresselinjer: ["", "", ""] });
     apneRedigering();
   };
 
@@ -64,7 +65,7 @@ const InnerRepresentantIUtlandet = (props: InnerRepresentantIUtlandetProps) => {
         <IngenDataRender
           redigerbart={redigerbart}
           onClick={() => handleApneRedigering(apneRedigering)}
-          lenketekst="Legg til representant i utlandet"
+          lenketekst="Legg til arbeidssted/representant"
         />
       )}
     />


### PR DESCRIPTION
Feil: 
- Det skal være 3 adresselinjer åpen når man lager ny representant. 
- Det kan maks være 4 adresselinjer.
- Feil tekst på legg-til knappen.

Venter på avklaring på de siste feilene: ble bestemt å holde overskriftene slik de er nå.

Jira: [MELOSYS-4893](https://jira.adeo.no/browse/MELOSYS-4893)