### PR TITLE
Endret fritekstvariabler til å ha samme struktur

### DIFF
--- a/src/services/modules/saksflyt/vedtak.ts
+++ b/src/services/modules/saksflyt/vedtak.ts
@@ -16,10 +16,10 @@ export interface FattVedtakEOSReqDto {
 export interface FattVedtakFTRLReqDto {
   behandlingsresultatTypeKode: string;
   vedtakstype: string | null;
-  fritekstInnledning: string | null;
-  fritekstBegrunnelse: string | null;
-  fritekstEktefelle: string | null;
-  fritekstBarn: string | null;
+  innledningFritekst: string | null;
+  begrunnelseFritekst: string | null;
+  ektefelleFritekst: string | null;
+  barnFritekst: string | null;
   kopiMottakere: KopiMottaker[];
 }
 export type FattVedtakTrygdeavtaleReqDto = FattVedtakFTRLReqDto;

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
@@ -46,8 +46,8 @@ const mapStateToProps = (state: RootState) => ({
   formValues: getFormValues(KV.Form.FTRL_VEDTAK)(state),
   formValuesRepresentant: getFormValues(KV.Form.REPRESENTANT)(state) as RepresentantformValues,
   initialValues: {
-    fritekstBegrunnelse: behandlingsresultatSelectors.BegrunnelseFritekstSelector(state),
-    fritekstInnledning: behandlingsresultatSelectors.InnledningFritekstSelector(state),
+    begrunnelseFritekst: behandlingsresultatSelectors.BegrunnelseFritekstSelector(state),
+    innledningFritekst: behandlingsresultatSelectors.InnledningFritekstSelector(state),
   },
 });
 
@@ -63,8 +63,8 @@ interface Props {
   redigerbart: boolean;
   alleLandkoder: KTObject[];
   formValues: {
-    fritekstInnledning?: string;
-    fritekstBegrunnelse?: string;
+    innledningFritekst?: string;
+    begrunnelseFritekst?: string;
   };
 }
 
@@ -151,8 +151,8 @@ const VurderingVedtak = ({
           produserbardokument: INNVILGELSE_FOLKETRYGDLOVEN_2_8,
           mottaker: muligMottaker.rolle,
           kopiMottakere: [],
-          innledningFritekst: formValues?.fritekstInnledning || null,
-          begrunnelseFritekst: formValues?.fritekstBegrunnelse || null,
+          innledningFritekst: formValues?.innledningFritekst || null,
+          begrunnelseFritekst: formValues?.begrunnelseFritekst || null,
           orgNr: muligMottaker?.orgnr || null,
           ektefelleFritekst: familieFormValues?.ektefelle_samboer?.fritekst || null,
           barnFritekst: familieFormValues?.barn?.fritekst || null,
@@ -225,10 +225,10 @@ const VurderingVedtak = ({
 
     await lagreOgFatteVedtak({
       behandlingsresultatTypeKode: MKV.Koder.behandlinger.behandlingsresultattyper.MEDLEM_I_FOLKETRYGDEN,
-      fritekstInnledning: formValues?.fritekstInnledning || null,
-      fritekstBegrunnelse: formValues?.fritekstBegrunnelse || null,
-      fritekstEktefelle: familieFormValues?.ektefelle_samboer?.fritekst || null,
-      fritekstBarn: familieFormValues?.barn?.fritekst || null,
+      innledningFritekst: formValues?.innledningFritekst || null,
+      begrunnelseFritekst: formValues?.begrunnelseFritekst || null,
+      ektefelleFritekst: familieFormValues?.ektefelle_samboer?.fritekst || null,
+      barnFritekst: familieFormValues?.barn?.fritekst || null,
       vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
       kopiMottakere: muligeMottakere.kopiMottakere.map(Api.DokumenterV2.konverterMuligMottakerTilKopiMottaker),
     });
@@ -240,9 +240,9 @@ const VurderingVedtak = ({
 
   const soknadslandErEtAvtaleland = avtaleland[soknadsland?.toString()] !== undefined;
 
-  const fritekstInnledningHjelpetekstTittel =
+  const innledningFritekstHjelpetekstTittel =
     "Teksten du skriver her vil vises etter informasjonen om vedtakets periode og resultat. Eksempel: Du er medlem i folketrygden fra 1. september 2022 til 31. desember 2024. Medlemskapet omfatter trygdedekning i folketrygdens helse- og pensjonsdel. Friteksten kommer her.";
-  const fritekstBegrunnelseHjelpetekstTittel =
+  const begrunnelseFritekstHjelpetekstTittel =
     "Teksten du skriver her vil vises etter standard begrunnelse for bestemmelsen.  Eksempel: Du har opplyst at du arbeider for Equinor ASA i Brasil. Vi har lagt til grunn at du er ansatt i en virksomhet med hovedsete i Norge. Friteksten kommer her.";
 
   return (
@@ -307,7 +307,7 @@ const VurderingVedtak = ({
       <Nav.Typo.Element className="fritekst_overskrift" tag="h3">
         Fritekst til innledning
         <Nav.Hjelpetekst
-          tittel={fritekstInnledningHjelpetekstTittel}
+          tittel={innledningFritekstHjelpetekstTittel}
           className="hjelpetekst"
           type={Nav.PopoverOrientering.Hoyre}
         >
@@ -318,7 +318,7 @@ const VurderingVedtak = ({
         </Nav.Hjelpetekst>
       </Nav.Typo.Element>
       <Skjema.HTMLEditor
-        feltNavn="fritekstInnledning"
+        feltNavn="innledningFritekst"
         className="fritekst_editor"
         placeholder="Skriv inn tilleggsinformasjon til innledning..."
         disabled={!redigerbart}
@@ -327,7 +327,7 @@ const VurderingVedtak = ({
       <Nav.Typo.Element className="fritekst_overskrift" tag="h3">
         Fritekst til begrunnelse{" "}
         <Nav.Hjelpetekst
-          tittel={fritekstBegrunnelseHjelpetekstTittel}
+          tittel={begrunnelseFritekstHjelpetekstTittel}
           className="hjelpetekst"
           type={Nav.PopoverOrientering.Hoyre}
         >
@@ -338,7 +338,7 @@ const VurderingVedtak = ({
         </Nav.Hjelpetekst>
       </Nav.Typo.Element>
       <Skjema.HTMLEditor
-        feltNavn="fritekstBegrunnelse"
+        feltNavn="begrunnelseFritekst"
         className="fritekst_editor"
         placeholder="Skriv inn tilleggsinformasjon til begrunnelse..."
         disabled={!redigerbart}

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -46,8 +46,8 @@ const mapStateToProps = (state: RootState, ownProps: Props) => ({
   familieFormValues: formSelectors.TrygdeavtaleFamileFormSelector(state).values,
   formValues: getFormValues(KV.Form.Trygdeavtale.VEDTAK)(state),
   initialValues: {
-    fritekstBegrunnelse: behandlingsresultatSelectors.BegrunnelseFritekstSelector(state),
-    fritekstInnledning: behandlingsresultatSelectors.InnledningFritekstSelector(state),
+    begrunnelseFritekst: behandlingsresultatSelectors.BegrunnelseFritekstSelector(state),
+    innledningFritekst: behandlingsresultatSelectors.InnledningFritekstSelector(state),
     lovvalgsperiodeFom:
       ownProps.resultat.lovvalgsperiodeFom && Utils.dato.formatterDatoTilNorsk(ownProps.resultat.lovvalgsperiodeFom),
     lovvalgsperiodeTom:
@@ -76,8 +76,8 @@ interface Props {
   formValues: {
     lovvalgsperiodeFom?: string;
     lovvalgsperiodeTom?: string;
-    fritekstInnledning?: string;
-    fritekstBegrunnelse?: string;
+    innledningFritekst?: string;
+    begrunnelseFritekst?: string;
     kopiTilArbeidsgiver?: boolean;
   };
 }
@@ -101,9 +101,9 @@ const VurderingVedtak = ({
 }: Props & PropsFromRedux) => {
   const periodeHjelpetekst =
     "Perioden som vises her er søknadsperiode. Hvis sluttdato for oppholdet ikke er oppgitt i søknaden, og/eller du vil endre sluttdato for vedtaket, trykk på Endre og skriv inn sluttdato.";
-  const fritekstInnledningHjelpetekstTittel =
+  const innledningFritekstHjelpetekstTittel =
     "Teksten du skriver her vil vises etter informasjonen om vedtakets periode og resultat. Eksempel: 'Du er omfattet av norsk trygdelovgivning og medlem i folketrygden fra 1. september 2022 til 31. desember 2024.' Friteksten kommer her";
-  const fritekstBegrunnelseHjelpetekstTittel =
+  const begrunnelseFritekstHjelpetekstTittel =
     "Teksten du skriver her vil vises etter standard begrunnelse for bestemmelsen. Eksempel: 'Vi har lagt til grunn at du er ansatt av og lønnet av en norsk arbeidsgiver, og sendt ut for å jobbe i Storbritannia i inntil tre år. Vi har gjort vurderingen fordi du har opplyst at du jobber for er ansatt av Equinor ASA.' Friteksten kommer her.";
   const [muligeMottakere, setMuligeMottakere] = useState(Api.DokumenterV2.tomHentMuligeMottakereResDto());
   const [visTomEndringFelt, setVisTomEndringFelt] = useState(false);
@@ -129,10 +129,10 @@ const VurderingVedtak = ({
 
   const lagFattVedtakTrygdeavtaleReqDto = (): Api.Saksflyt.Vedtak.FattVedtakTrygdeavtaleReqDto => ({
     behandlingsresultatTypeKode: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
-    fritekstInnledning: formValues?.fritekstInnledning || null,
-    fritekstBegrunnelse: formValues?.fritekstBegrunnelse || null,
-    fritekstEktefelle: familieFormValues?.ektefelle?.fritekst || null,
-    fritekstBarn: familieFormValues?.barn?.fritekst || null,
+    innledningFritekst: formValues?.innledningFritekst || null,
+    begrunnelseFritekst: formValues?.begrunnelseFritekst || null,
+    ektefelleFritekst: familieFormValues?.ektefelle?.fritekst || null,
+    barnFritekst: familieFormValues?.barn?.fritekst || null,
     vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
     kopiMottakere: getKopiMottakere(),
   });
@@ -195,8 +195,8 @@ const VurderingVedtak = ({
           produserbardokument: STORBRITANNIA,
           mottaker: muligMottaker.rolle,
           kopiMottakere: [],
-          innledningFritekst: formValues?.fritekstInnledning || null,
-          begrunnelseFritekst: formValues?.fritekstBegrunnelse || null,
+          innledningFritekst: formValues?.innledningFritekst || null,
+          begrunnelseFritekst: formValues?.begrunnelseFritekst || null,
           orgNr: muligMottaker?.orgnr || null,
           institusjonId: muligMottaker?.institusjonId || null,
           ektefelleFritekst: familieFormValues?.ektefelle?.fritekst || null,
@@ -319,7 +319,7 @@ const VurderingVedtak = ({
       <Nav.Typo.Element className={vurderingVedtakCls.element("fritekst_overskrift")} tag="h3">
         Fritekst til innledning
         <Nav.Hjelpetekst
-          tittel={fritekstInnledningHjelpetekstTittel}
+          tittel={innledningFritekstHjelpetekstTittel}
           className={vurderingVedtakCls.element("hjelpetekst")}
           type={Nav.PopoverOrientering.Hoyre}
         >
@@ -334,7 +334,7 @@ const VurderingVedtak = ({
         </Nav.Hjelpetekst>
       </Nav.Typo.Element>
       <Skjema.HTMLEditor
-        feltNavn="fritekstInnledning"
+        feltNavn="innledningFritekst"
         className={vurderingVedtakCls.element("fritekst_editor")}
         placeholder="Skriv inn tilleggsinformasjon til innledning..."
         disabled={!redigerbart}
@@ -343,7 +343,7 @@ const VurderingVedtak = ({
       <Nav.Typo.Element className={vurderingVedtakCls.element("fritekst_overskrift")} tag="h3">
         Fritekst til begrunnelse{" "}
         <Nav.Hjelpetekst
-          tittel={fritekstBegrunnelseHjelpetekstTittel}
+          tittel={begrunnelseFritekstHjelpetekstTittel}
           className={vurderingVedtakCls.element("hjelpetekst")}
           type={Nav.PopoverOrientering.Hoyre}
         >
@@ -359,7 +359,7 @@ const VurderingVedtak = ({
         </Nav.Hjelpetekst>
       </Nav.Typo.Element>
       <Skjema.HTMLEditor
-        feltNavn="fritekstBegrunnelse"
+        feltNavn="begrunnelseFritekst"
         className={vurderingVedtakCls.element("fritekst_editor")}
         placeholder="Skriv inn tilleggsinformasjon til begrunnelse..."
         disabled={!redigerbart}


### PR DESCRIPTION
Var feil variabelnavn i fritekst i storbritannia-brev. Endret alle disse til å ha samme format for å rette opp og unngå samme feil i fremtiden.