### PR TITLE
Melosys 4819 ny vurdering steg1 trygdeavtale

### DIFF
--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -153,12 +153,12 @@ const VurderingVedtak = ({
   const debouncedHentMuligeMottakere = useCallback(Utils._debounce(hentMuligeMottakere, 300), []);
 
   useEffect(() => {
-    debouncedKontrollerVedtak(oppdaterFørKontroll);
+    if (redigerbart) debouncedKontrollerVedtak(oppdaterFørKontroll);
     return () => debouncedKontrollerVedtak.cancel();
   }, []);
 
   useEffect(() => {
-    if (behandlingsgrunnlagStatus === "OK") {
+    if (behandlingsgrunnlagStatus === "OK" && redigerbart) {
       debouncedKontrollerVedtak(oppdaterFørKontroll);
     }
   }, [resultat.lovvalgsperiodeTom, behandlingsgrunnlagStatus]);

--- a/src/sider/trygdeavtale/stegvelger.less
+++ b/src/sider/trygdeavtale/stegvelger.less
@@ -3,11 +3,14 @@
 .stegvelger {
   border-radius: 4px;
 
-  .valideringsfeil {
+  .varselstripe {
     margin-top: -1.5rem;
     margin-bottom: 0.5rem;
     &__liste {
       margin: 0 0 0 -1rem;
+    }
+    &__overskrift {
+      font-weight: bold;
     }
     .alertstripe__tekst {
       max-width: none !important;

--- a/src/sider/trygdeavtale/stegvelger.tsx
+++ b/src/sider/trygdeavtale/stegvelger.tsx
@@ -60,6 +60,7 @@ const stegMap = {
 
 const mapStateToProps = (state: RootState) => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
+  behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
   behandlingsgrunnlag: behandlingsgrunnlagSelectors.BehandlingsgrunnlagDataSelector(state),
   behandlingsgrunnlagFeilmeldinger: formSelectors.SoknadErrorsSelector(state),
   soknadForm: formSelectors.SoknadenFormSelector(state),
@@ -256,11 +257,14 @@ class Stegvelger extends Component<Props, State> {
   render() {
     const {
       state: { aktuelleSteg, visBehandlingsgrunnlagFeilmeldinger, valideringFeil },
+      props: { behandlingstype },
       oppdaterAktivtSteg,
       mapFeilmeldinger,
     } = this;
 
     const vedtakStegErAktivt = aktuelleSteg?.find((steg: AktueltSteg) => steg.vedtakSteg && steg.aktivtSteg);
+    const inngangStegErAktivt = aktuelleSteg?.find((steg: AktueltSteg) => steg.id === "INNGANG" && steg.aktivtSteg);
+    const erNyVurdering = behandlingstype === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING;
 
     return (
       <TrackVisibility partialVisibility>
@@ -270,9 +274,18 @@ class Stegvelger extends Component<Props, State> {
               <div>
                 <StegLinje steg={aktuelleSteg} stegKlikk={oppdaterAktivtSteg} />
                 {!Utils._isEmpty(valideringFeil) && vedtakStegErAktivt && (
-                  <Nav.AlertStripeFeil className="valideringsfeil">
-                    {mapFeilmeldinger(valideringFeil)}
-                  </Nav.AlertStripeFeil>
+                  <Nav.AlertStripeFeil className="varselstripe">{mapFeilmeldinger(valideringFeil)}</Nav.AlertStripeFeil>
+                )}
+                {erNyVurdering && inngangStegErAktivt && (
+                  <Nav.AlertStripeAdvarsel className="varselstripe">
+                    <Nav.Typo.Normaltekst className="varselstripe__overskrift">
+                      Ny behandling av sak
+                    </Nav.Typo.Normaltekst>
+                    <Nav.Typo.Normaltekst>
+                      Du har startet en ny behandling av en sak der tidligere behandling er avsluttet. Sjekk sakens
+                      opplysninger og vurder videre behandling.
+                    </Nav.Typo.Normaltekst>
+                  </Nav.AlertStripeAdvarsel>
                 )}
                 {aktuelleSteg.map((item: AktueltSteg) => (
                   <StegFane key={item.id} faneData={item} />

--- a/src/sider/trygdeavtale/stegvelger.tsx
+++ b/src/sider/trygdeavtale/stegvelger.tsx
@@ -261,7 +261,7 @@ class Stegvelger extends Component<Props, State> {
   render() {
     const {
       state: { aktuelleSteg, visBehandlingsgrunnlagFeilmeldinger, valideringFeil },
-      props: { behandlingstype },
+      props: { behandlingstype, redigerbart },
       oppdaterAktivtSteg,
       mapFeilmeldinger,
     } = this;
@@ -280,7 +280,7 @@ class Stegvelger extends Component<Props, State> {
                 {!Utils._isEmpty(valideringFeil) && vedtakStegErAktivt && (
                   <Nav.AlertStripeFeil className="varselstripe">{mapFeilmeldinger(valideringFeil)}</Nav.AlertStripeFeil>
                 )}
-                {erNyVurdering && inngangStegErAktivt && (
+                {erNyVurdering && redigerbart && inngangStegErAktivt && (
                   <Nav.AlertStripeAdvarsel className="varselstripe">
                     <Nav.Typo.Normaltekst className="varselstripe__overskrift">
                       Ny behandling av sak

--- a/src/sider/trygdeavtale/stegvelger.tsx
+++ b/src/sider/trygdeavtale/stegvelger.tsx
@@ -114,6 +114,10 @@ class Stegvelger extends Component<Props, State> {
     ) {
       this.debouncedOppdaterSteg();
     }
+
+    if (prevProps.behandlingID && prevProps.behandlingID !== this.props.behandlingID) {
+      this.hentFlytOgOppdaterAktuelleSteg();
+    }
   }
 
   hentFlytOgOppdaterAktuelleSteg = () =>


### PR DESCRIPTION
- Det skal være en advarsel-stripe over steg 1 dersom det er ny vurdering. Denne skal ikke vises i innsynsmodus (redigerbart = false).
- Resultat (data) fra trygdeavtale hentes på nytt dersom behandlingID endrer seg etter mount. Antar dette kun skjer i ny-vurdering-tilfelle. Worst case så er det bare en GET som ikke endrer noe. 
- Merket også at ikke alt på vedtaksteget var gjemt bak en redigerbart-sjekk.

Jira: [MELOSYS-4819](https://jira.adeo.no/browse/MELOSYS-4819#)