### PR TITLE
Inkluderer kopimottakere i payload da den brukes i api

### DIFF
--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -194,7 +194,7 @@ const VurderingVedtak = ({
         data: {
           produserbardokument: STORBRITANNIA,
           mottaker: muligMottaker.rolle,
-          kopiMottakere: [],
+          kopiMottakere: getKopiMottakere(),
           innledningFritekst: formValues?.innledningFritekst || null,
           begrunnelseFritekst: formValues?.begrunnelseFritekst || null,
           orgNr: muligMottaker?.orgnr || null,


### PR DESCRIPTION
Inkluderer kopimottakere i payload da den brukes i api for VirksomhetArbeidsgiverSkalHaKopi