### PR TITLE
No jira uk pilot kontaktopplysninger forhandsvisning

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/arbeidsforholdNorgeListe/arbeidsforholdNorgeListe.js
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/arbeidsforholdNorgeListe/arbeidsforholdNorgeListe.js
@@ -124,6 +124,7 @@ export const EnkeltArbeidsforholdNorge = ({
   ] = useKontaktOpplysninger(saksnummer, organisasjon.orgnr || "");
 
   const slett = () => {
+    slettKontaktOpplysninger();
     fields.remove(indeks);
   };
 

--- a/src/kodeverk/koder.ts
+++ b/src/kodeverk/koder.ts
@@ -153,6 +153,7 @@ export const PersonStatus = {
 export const MottakerRolle = {
   BRUKER: "BRUKER",
   ARBEIDSGIVER: "ARBEIDSGIVER",
+  MYNDIGHET: "MYNDIGHET",
 };
 
 export enum StegNavn {

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -113,12 +113,7 @@ const VurderingVedtak = ({
 
   const filterKopiMottakere = (muligMottaker: Api.DokumenterV2.MuligMottaker) => {
     if (muligMottaker?.rolle === KV.Koder.MottakerRolle.ARBEIDSGIVER) {
-      // Kopi til arbeidsgiver skal bare være med om krysset av
       return formValues?.kopiTilArbeidsgiver;
-    }
-    if (muligMottaker?.rolle === KV.Koder.MottakerRolle.MYNDIGHET && muligMottaker?.institusjonId !== null) {
-      // Kopi til utenlandske myndigheter skal ikke være med om bestemmelse 8.2
-      return resultat.bestemmelse !== "UK_ART8_2";
     }
     return true;
   };

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -113,7 +113,12 @@ const VurderingVedtak = ({
 
   const filterKopiMottakere = (muligMottaker: Api.DokumenterV2.MuligMottaker) => {
     if (muligMottaker?.rolle === KV.Koder.MottakerRolle.ARBEIDSGIVER) {
+      // Kopi til arbeidsgiver skal bare være med om krysset av
       return formValues?.kopiTilArbeidsgiver;
+    }
+    if (muligMottaker?.rolle === KV.Koder.MottakerRolle.MYNDIGHET && muligMottaker?.institusjonId !== null) {
+      // Kopi til utenlandske myndigheter skal ikke være med om bestemmelse 8.2
+      return resultat.bestemmelse !== "UK_ART8_2";
     }
     return true;
   };


### PR DESCRIPTION
1. Mette fant bug hvor hun skrev inn kontaktopplysninger under arbeidgiver/virksomhet i sidemeny. Fjernet arbeidsgiver i Norge som hun nettop la inn data, men ble ikke fjernet fra backend og kom med i brev. Fjerner nå kontaktopplysningene ved slett også
2. "Kopi til utenlandske myndigheter" kom på listen over dokumenter selv om art 8.2 (tomt dokument som ikke ble sendt ut)