### PR TITLE
Landkoder skal være alle land for FTRL og Trygdeavtale

### DIFF
--- a/src/ducks/landkoder/index.ts
+++ b/src/ducks/landkoder/index.ts
@@ -1,0 +1,8 @@
+import * as landkoderOperations from "./operations";
+import * as landkoderSelectors from "./selectors";
+
+import landkoderReducers from "./reducers";
+
+export { landkoderOperations, landkoderSelectors };
+
+export default landkoderReducers;

--- a/src/ducks/landkoder/operations.ts
+++ b/src/ducks/landkoder/operations.ts
@@ -1,0 +1,11 @@
+import { doThenDispatch } from "../../services/utils";
+import * as Api from "../../services/api";
+import * as Types from "./types";
+
+export function hentLandkoder() {
+  return doThenDispatch(() => Api.Kodeverk.hentLandkoderIso2(), {
+    OK: Types.OK,
+    FEILET: Types.FEILET,
+    PENDING: Types.PENDING,
+  });
+}

--- a/src/ducks/landkoder/reducers.ts
+++ b/src/ducks/landkoder/reducers.ts
@@ -1,0 +1,21 @@
+import { STATUS } from "../../services";
+import { sorterLandOgGjørOmTilStoreForbokstaver } from "../../utils/land";
+import * as Types from "./types";
+
+export const initialState = {
+  status: STATUS.NOT_STARTED,
+  data: [],
+};
+
+export default function reducer(state = initialState, action: Types.Action) {
+  switch (action.type) {
+    case Types.PENDING:
+      return { ...state, status: STATUS.PENDING };
+    case Types.FEILET:
+      return { ...state, status: STATUS.ERROR, data: action.data };
+    case Types.OK:
+      return { ...state, status: STATUS.OK, data: sorterLandOgGjørOmTilStoreForbokstaver(action.data) };
+    default:
+      return state;
+  }
+}

--- a/src/ducks/landkoder/selectors.test.ts
+++ b/src/ducks/landkoder/selectors.test.ts
@@ -1,0 +1,42 @@
+import each from "jest-each";
+
+import MKV from "../../melosyskodeverk";
+import * as DucksTestUtils from "../test-utils";
+
+import { LandkoderSelector } from "./selectors";
+import { STATUS } from "../../services";
+
+describe("LandkoderSelector", () => {
+  const landkoderFraFellesKodeverk = [
+    { kode: "kode 1", term: "term 1" },
+    { kode: "kode 2", term: "term 2" },
+  ];
+  const lagState = (sakstypeKode: string) =>
+    DucksTestUtils.lagState({
+      landkoder: {
+        status: STATUS.OK,
+        data: landkoderFraFellesKodeverk,
+      },
+      fagsaker: {
+        status: STATUS.OK,
+        data: {
+          sakstype: {
+            kode: sakstypeKode,
+          },
+        },
+      },
+    });
+
+  describe("LandkoderSelector", () => {
+    each([
+      [MKV.Koder.sakstyper.FTRL, landkoderFraFellesKodeverk],
+      [MKV.Koder.sakstyper.EU_EOS, MKV.KTObjects.landkoder],
+      [MKV.Koder.sakstyper.TRYGDEAVTALE, landkoderFraFellesKodeverk],
+      [null, MKV.KTObjects.landkoder],
+    ]).it("returnerer rett landkodeliste for sakstype %s", (sakstypeKode, forventetKodeListe) => {
+      const state = lagState(sakstypeKode);
+
+      expect(LandkoderSelector(state)).toBe(forventetKodeListe);
+    });
+  });
+});

--- a/src/ducks/landkoder/selectors.ts
+++ b/src/ducks/landkoder/selectors.ts
@@ -1,0 +1,21 @@
+import { createSelector, Selector } from "reselect";
+import { RootState, StateSection } from "AppTypes";
+import MKV from "../../melosyskodeverk";
+import * as Types from "./types";
+import { SakstypeKodeSelector } from "../fagsaker/selectors";
+
+export const LandkoderDataSelector: Selector<RootState, StateSection<Types.Data>> = createSelector(
+  (state) => state.landkoder,
+  (landkoder) => landkoder.data || []
+);
+
+export const LandkoderSelector = createSelector(LandkoderDataSelector, SakstypeKodeSelector, (landkoder, sakstype) => {
+  switch (sakstype) {
+    case MKV.Koder.sakstyper.FTRL:
+    case MKV.Koder.sakstyper.TRYGDEAVTALE:
+      return landkoder;
+    case MKV.Koder.sakstyper.EU_EOS:
+    default:
+      return MKV.KTObjects.landkoder;
+  }
+});

--- a/src/ducks/landkoder/types.ts
+++ b/src/ducks/landkoder/types.ts
@@ -1,0 +1,23 @@
+import { KTObject } from "@navikt/melosys-kodeverk";
+
+export const OK = "landkoder/OK";
+export const FEILET = "landkoder/FEILET";
+export const PENDING = "landkoder/PENDING";
+
+export type Data = KTObject[];
+
+interface FeiletAction {
+  type: typeof FEILET;
+  data: any;
+}
+
+interface PendingAction {
+  type: typeof PENDING;
+}
+
+interface OkAction {
+  type: typeof OK;
+  data: Data;
+}
+
+export type Action = FeiletAction | PendingAction | OkAction;

--- a/src/ducks/test-utils/lagstate.ts
+++ b/src/ducks/test-utils/lagstate.ts
@@ -1,6 +1,6 @@
 import { RootState } from "AppTypes";
 
-import { STATUS } from "../../services/utils";
+import { STATUS } from "../../services";
 
 /**
  * Genererer default state for redux til testing, samt tillater å sette individuelle states.
@@ -35,6 +35,7 @@ function lagState({
   feiletrespons = { status: STATUS.OK, data: {} },
   folketrygdenkodeverk = { status: STATUS.OK, data: {} },
   journalforing = { status: STATUS.OK, data: {} },
+  landkoder = { status: STATUS.OK, data: [] },
   lovvalgsperioder = { status: STATUS.OK, data: [] },
   medlemskapsperioder = { status: STATUS.OK, data: {} },
   modaler = { status: STATUS.OK, data: {} },
@@ -70,6 +71,7 @@ function lagState({
     feiletrespons,
     folketrygdenkodeverk,
     journalforing,
+    landkoder,
     lovvalgsperioder,
     medlemskapsperioder,
     modaler,

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/enkeltArbeidsforholdUtlandRedigerer/enkeltArbeidsforholdUtland.js
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/enkeltArbeidsforholdUtlandRedigerer/enkeltArbeidsforholdUtland.js
@@ -16,15 +16,7 @@ export const EnkeltArbeidsforholdUtland = ({ redigerbart, overordnetFeltNavn, cl
   useEffect(() => {
     if (sakstype === MKV.Koder.sakstyper.FTRL) {
       API.Kodeverk.hentLandkoderIso2().then((response) => {
-        setAlternativLandsliste(
-          response
-            .sort((a, b) => {
-              if (a.term > b.term) return 1;
-              if (b.term > a.term) return -1;
-              return 0;
-            })
-            .map((item) => ({ ...item, term: Utils.streng.storeForbokstaverForLand(item.term) }))
-        );
+        setAlternativLandsliste(Utils.land.sorterLandOgGjørOmTilStoreForbokstaver(response));
       });
     }
   }, [sakstype]);

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/enkeltArbeidsforholdUtlandRedigerer/enkeltArbeidsforholdUtland.js
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/enkeltArbeidsforholdUtlandRedigerer/enkeltArbeidsforholdUtland.js
@@ -1,109 +1,85 @@
-import React, { useEffect, useState } from "react";
-import { connect } from "react-redux";
+import React from "react";
 import PT from "prop-types";
 
-import MKV from "../../../../../melosyskodeverk";
 import * as Nav from "../../../../../navFrontend";
 import * as Skjema from "../../../../skjema";
-import * as API from "../../../../../services/api";
-import * as Utils from "../../../../../utils";
 
-import { fagsakSelectors } from "../../../../../ducks/fagsaker";
-
-export const EnkeltArbeidsforholdUtland = ({ redigerbart, overordnetFeltNavn, className, sakstype }) => {
-  const [alternativLandsliste, setAlternativLandsliste] = useState();
-
-  useEffect(() => {
-    if (sakstype === MKV.Koder.sakstyper.FTRL) {
-      API.Kodeverk.hentLandkoderIso2().then((response) => {
-        setAlternativLandsliste(Utils.land.sorterLandOgGjørOmTilStoreForbokstaver(response));
-      });
-    }
-  }, [sakstype]);
-
-  return (
-    <div className={className}>
-      <Nav.Row>
-        <Nav.Column xs="6">
-          <Skjema.Input label="Navn på virksomheten" feltNavn={`${overordnetFeltNavn}.navn`} disabled={!redigerbart} />
-        </Nav.Column>
-        <Nav.Column xs="6">
-          <Skjema.Input label="Registreringsnummer" feltNavn={`${overordnetFeltNavn}.orgnr`} disabled={!redigerbart} />
-        </Nav.Column>
-      </Nav.Row>
-      <Nav.Row>
-        <Nav.Column xs="12">
-          <Skjema.Input
-            label="Adressetilleggsnavn"
-            feltNavn={`${overordnetFeltNavn}.adresse.tilleggsnavn`}
-            disabled={!redigerbart}
-          />
-        </Nav.Column>
-      </Nav.Row>
-      <Nav.Row>
-        <Nav.Column xs="6">
-          <Skjema.Input
-            label="Adresse til arbeidsgiver"
-            feltNavn={`${overordnetFeltNavn}.adresse.gatenavn`}
-            disabled={!redigerbart}
-          />
-        </Nav.Column>
-        <Nav.Column xs="6">
-          <Skjema.Input
-            label="Husnummer"
-            feltNavn={`${overordnetFeltNavn}.adresse.husnummerEtasjeLeilighet`}
-            disabled={!redigerbart}
-          />
-        </Nav.Column>
-      </Nav.Row>
-      <Nav.Row>
-        <Nav.Column xs="6">
-          <Skjema.Input label="Poststed" feltNavn={`${overordnetFeltNavn}.adresse.poststed`} disabled={!redigerbart} />
-        </Nav.Column>
-        <Nav.Column xs="6">
-          <Skjema.Input
-            label="Postnummer"
-            feltNavn={`${overordnetFeltNavn}.adresse.postnummer`}
-            disabled={!redigerbart}
-          />
-        </Nav.Column>
-      </Nav.Row>
-      <Nav.Row>
-        <Nav.Column xs="12">
-          <Skjema.Input label="Postboks" feltNavn={`${overordnetFeltNavn}.adresse.postboks`} disabled={!redigerbart} />
-        </Nav.Column>
-      </Nav.Row>
-      <Nav.Row>
-        <Nav.Column xs="6">
-          <Skjema.Input label="Region" feltNavn={`${overordnetFeltNavn}.adresse.region`} disabled={!redigerbart} />
-        </Nav.Column>
-        <Nav.Column xs="6">
-          <Skjema.LandVelger
-            label="Land"
-            feltNavn={`${overordnetFeltNavn}.adresse.landkode`}
-            disabled={!redigerbart}
-            bredde="fullbredde"
-            landkoder={alternativLandsliste}
-          />
-        </Nav.Column>
-      </Nav.Row>
-    </div>
-  );
-};
+export const EnkeltArbeidsforholdUtland = ({ redigerbart, overordnetFeltNavn, className }) => (
+  <div className={className}>
+    <Nav.Row>
+      <Nav.Column xs="6">
+        <Skjema.Input label="Navn på virksomheten" feltNavn={`${overordnetFeltNavn}.navn`} disabled={!redigerbart} />
+      </Nav.Column>
+      <Nav.Column xs="6">
+        <Skjema.Input label="Registreringsnummer" feltNavn={`${overordnetFeltNavn}.orgnr`} disabled={!redigerbart} />
+      </Nav.Column>
+    </Nav.Row>
+    <Nav.Row>
+      <Nav.Column xs="12">
+        <Skjema.Input
+          label="Adressetilleggsnavn"
+          feltNavn={`${overordnetFeltNavn}.adresse.tilleggsnavn`}
+          disabled={!redigerbart}
+        />
+      </Nav.Column>
+    </Nav.Row>
+    <Nav.Row>
+      <Nav.Column xs="6">
+        <Skjema.Input
+          label="Adresse til arbeidsgiver"
+          feltNavn={`${overordnetFeltNavn}.adresse.gatenavn`}
+          disabled={!redigerbart}
+        />
+      </Nav.Column>
+      <Nav.Column xs="6">
+        <Skjema.Input
+          label="Husnummer"
+          feltNavn={`${overordnetFeltNavn}.adresse.husnummerEtasjeLeilighet`}
+          disabled={!redigerbart}
+        />
+      </Nav.Column>
+    </Nav.Row>
+    <Nav.Row>
+      <Nav.Column xs="6">
+        <Skjema.Input label="Poststed" feltNavn={`${overordnetFeltNavn}.adresse.poststed`} disabled={!redigerbart} />
+      </Nav.Column>
+      <Nav.Column xs="6">
+        <Skjema.Input
+          label="Postnummer"
+          feltNavn={`${overordnetFeltNavn}.adresse.postnummer`}
+          disabled={!redigerbart}
+        />
+      </Nav.Column>
+    </Nav.Row>
+    <Nav.Row>
+      <Nav.Column xs="12">
+        <Skjema.Input label="Postboks" feltNavn={`${overordnetFeltNavn}.adresse.postboks`} disabled={!redigerbart} />
+      </Nav.Column>
+    </Nav.Row>
+    <Nav.Row>
+      <Nav.Column xs="6">
+        <Skjema.Input label="Region" feltNavn={`${overordnetFeltNavn}.adresse.region`} disabled={!redigerbart} />
+      </Nav.Column>
+      <Nav.Column xs="6">
+        <Skjema.LandVelger
+          label="Land"
+          feltNavn={`${overordnetFeltNavn}.adresse.landkode`}
+          disabled={!redigerbart}
+          bredde="fullbredde"
+        />
+      </Nav.Column>
+    </Nav.Row>
+  </div>
+);
 
 EnkeltArbeidsforholdUtland.propTypes = {
   redigerbart: PT.bool.isRequired,
   overordnetFeltNavn: PT.string.isRequired,
   className: PT.string,
-  sakstype: PT.string.isRequired,
 };
 
 EnkeltArbeidsforholdUtland.defaultProps = {
   className: undefined,
 };
 
-const mapStateToProps = (state) => ({
-  sakstype: fagsakSelectors.SakstypeKodeSelector(state),
-});
-
-export default connect(mapStateToProps)(EnkeltArbeidsforholdUtland);
+export default EnkeltArbeidsforholdUtland;

--- a/src/felleskomponenter/skjema/landvelger/LandVelger.js
+++ b/src/felleskomponenter/skjema/landvelger/LandVelger.js
@@ -22,7 +22,7 @@ const connector = connect(mapStateToProps);
  * prop-type multiLand som er subkomponenter i landvelgeren.
  * @param props
  */
-const LandVelger = (props) => {
+export const LandVelger = (props) => {
   const { multiLand, landkoder, landkoderFraSakstype } = props;
   const dataListID = lagDatalistID();
   const landkodeliste = landkoder || landkoderFraSakstype;

--- a/src/felleskomponenter/skjema/landvelger/LandVelger.js
+++ b/src/felleskomponenter/skjema/landvelger/LandVelger.js
@@ -1,9 +1,10 @@
 import React from "react";
+import { connect } from "react-redux";
 import PT from "prop-types";
 
-import MKV from "../../../melosyskodeverk";
 import * as MPT from "../../../proptypes";
 import * as Utils from "../../../utils";
+import { landkoderSelectors } from "../../../ducks/landkoder";
 import EnkeltLand from "./enkeltLand";
 import MultiLand from "./multiLand";
 
@@ -11,24 +12,31 @@ import { lagDatalistID } from "./utils";
 
 import "./landvelger.css";
 
+const mapStateToProps = (state) => ({
+  landkoderFraSakstype: landkoderSelectors.LandkoderSelector(state),
+});
+
+const connector = connect(mapStateToProps);
+
 /** Dette er inngangskomponent for MultiLand eller EnkeltLand. Disse avgjøres via
  * prop-type multiLand som er subkomponenter i landvelgeren.
  * @param props
  */
 const LandVelger = (props) => {
-  const { multiLand } = props;
+  const { multiLand, landkoder, landkoderFraSakstype } = props;
   const dataListID = lagDatalistID();
+  const landkodeliste = landkoder || landkoderFraSakstype;
 
   return (
     <div>
       {multiLand ? (
-        <MultiLand {...props} landkoder={props.landkoder} dataListID={dataListID} />
+        <MultiLand {...props} landkoder={landkodeliste} dataListID={dataListID} />
       ) : (
-        <EnkeltLand {...props} landkoder={props.landkoder} dataListID={dataListID} />
+        <EnkeltLand {...props} landkoder={landkodeliste} dataListID={dataListID} />
       )}
       <div className="landliste__dataliste">
         <datalist id={dataListID}>
-          {props.landkoder.map((item) => (
+          {landkodeliste.map((item) => (
             <option key={item.kode} value={Utils.land.landTekstFormat(item)} />
           ))}
         </datalist>
@@ -45,6 +53,7 @@ LandVelger.propTypes = {
   bredde: PT.string,
   placeholder: PT.string,
   landkoder: PT.arrayOf(MPT.Kodeverk),
+  landkoderFraSakstype: PT.arrayOf(MPT.Kodeverk).isRequired,
 };
 
 LandVelger.defaultProps = {
@@ -53,7 +62,7 @@ LandVelger.defaultProps = {
   label: undefined,
   bredde: "XL",
   placeholder: undefined,
-  landkoder: MKV.KTObjects.landkoder,
+  landkoder: undefined,
 };
 
-export default LandVelger;
+export default connector(LandVelger);

--- a/src/felleskomponenter/skjema/landvelger/LandVelger.test.js
+++ b/src/felleskomponenter/skjema/landvelger/LandVelger.test.js
@@ -10,7 +10,12 @@ describe("Landvelger", () => {
       feltNavn: "test",
       multiLand: false,
       label: "test",
-      landkoderFraSakstype: [{ kode: "kode1", term: "term1" }],
+      landkoder: undefined,
+      landkoderFraSakstype: [
+        { kode: "kode1", term: "term1" },
+        { kode: "kode2", term: "term2" },
+        { kode: "kode3", term: "term3" },
+      ],
     };
   });
 
@@ -38,6 +43,13 @@ describe("Landvelger", () => {
   });
 
   describe("Dersom landkoder prop", () => {
+    it("er satt til en egendefinert liste", () => {
+      props.landkoder = [{ kode: "egenKode", term: "egenTerm" }];
+      const landVelger = shallow(<LandVelger {...props} />);
+
+      expect(landVelger.find("datalist").children()).toHaveLength(props.landkoder.length);
+    });
+
     it("er satt til tom liste", () => {
       props.landkoder = [];
       const landVelger = shallow(<LandVelger {...props} />);
@@ -46,9 +58,10 @@ describe("Landvelger", () => {
     });
 
     it("ikke er satt", () => {
+      props.landkoder = undefined;
       const landVelger = shallow(<LandVelger {...props} />);
 
-      expect(landVelger.find("datalist").children()).not.toHaveLength(0);
+      expect(landVelger.find("datalist").children()).toHaveLength(props.landkoderFraSakstype.length);
     });
   });
 });

--- a/src/felleskomponenter/skjema/landvelger/LandVelger.test.js
+++ b/src/felleskomponenter/skjema/landvelger/LandVelger.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Landvelger from "./LandVelger";
+import { LandVelger } from "./LandVelger";
 
 describe("Landvelger", () => {
   let props = null;
@@ -10,13 +10,14 @@ describe("Landvelger", () => {
       feltNavn: "test",
       multiLand: false,
       label: "test",
+      landkoderFraSakstype: [{ kode: "kode1", term: "term1" }],
     };
   });
 
   describe("Dersom multiland prop er false", () => {
     it("viser enkeltland og ikke multiland", () => {
       props.multiLand = false;
-      const landVelger = shallow(<Landvelger {...props} />);
+      const landVelger = shallow(<LandVelger {...props} />);
       expect(landVelger.find("EnkeltLandWrapper")).toHaveLength(1);
       expect(landVelger.find("MultiLandWrapper")).toHaveLength(0);
     });
@@ -25,27 +26,27 @@ describe("Landvelger", () => {
   describe("Dersom multiland prop er true", () => {
     it("viser multiland og ikke enkeltland", () => {
       props.multiLand = true;
-      const landVelger = shallow(<Landvelger {...props} />);
+      const landVelger = shallow(<LandVelger {...props} />);
       expect(landVelger.find("EnkeltLandWrapper")).toHaveLength(0);
       expect(landVelger.find("MultiLandWrapper")).toHaveLength(1);
     });
   });
 
   it("viser en datalist", () => {
-    const landVelger = shallow(<Landvelger {...props} />);
+    const landVelger = shallow(<LandVelger {...props} />);
     expect(landVelger.find("datalist")).toHaveLength(1);
   });
 
   describe("Dersom landkoder prop", () => {
     it("er satt til tom liste", () => {
       props.landkoder = [];
-      const landVelger = shallow(<Landvelger {...props} />);
+      const landVelger = shallow(<LandVelger {...props} />);
 
       expect(landVelger.find("datalist").children()).toHaveLength(0);
     });
 
     it("ikke er satt", () => {
-      const landVelger = shallow(<Landvelger {...props} />);
+      const landVelger = shallow(<LandVelger {...props} />);
 
       expect(landVelger.find("datalist").children()).not.toHaveLength(0);
     });

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -18,7 +18,7 @@ import fagsakerReducer from "./ducks/fagsaker";
 import feiletResponseReducer from "./ducks/feiletrespons";
 import folketrygdenkodeverkReducer from "./ducks/folketrygdenkodeverk";
 import journalforingReducer from "./ducks/journalforing";
-import landkoder from "./ducks/landkoder";
+import landkoderReducer from "./ducks/landkoder";
 import lovvalgsperioderReducer from "./ducks/lovvalgsperioder";
 import medlemskapsperioderReducer from "./ducks/medlemskapsperioder";
 import modalerReducer from "./ducks/modaler";
@@ -57,7 +57,7 @@ const createRootReducer = (history: History) =>
     feiletrespons: feiletResponseReducer,
     folketrygdenkodeverk: folketrygdenkodeverkReducer,
     journalforing: journalforingReducer,
-    landkoder,
+    landkoder: landkoderReducer,
     lovvalgsperioder: lovvalgsperioderReducer,
     medlemskapsperioder: medlemskapsperioderReducer,
     modaler: modalerReducer,

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -18,6 +18,7 @@ import fagsakerReducer from "./ducks/fagsaker";
 import feiletResponseReducer from "./ducks/feiletrespons";
 import folketrygdenkodeverkReducer from "./ducks/folketrygdenkodeverk";
 import journalforingReducer from "./ducks/journalforing";
+import landkoder from "./ducks/landkoder";
 import lovvalgsperioderReducer from "./ducks/lovvalgsperioder";
 import medlemskapsperioderReducer from "./ducks/medlemskapsperioder";
 import modalerReducer from "./ducks/modaler";
@@ -56,6 +57,7 @@ const createRootReducer = (history: History) =>
     feiletrespons: feiletResponseReducer,
     folketrygdenkodeverk: folketrygdenkodeverkReducer,
     journalforing: journalforingReducer,
+    landkoder: landkoder,
     lovvalgsperioder: lovvalgsperioderReducer,
     medlemskapsperioder: medlemskapsperioderReducer,
     modaler: modalerReducer,

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -57,7 +57,7 @@ const createRootReducer = (history: History) =>
     feiletrespons: feiletResponseReducer,
     folketrygdenkodeverk: folketrygdenkodeverkReducer,
     journalforing: journalforingReducer,
-    landkoder: landkoder,
+    landkoder,
     lovvalgsperioder: lovvalgsperioderReducer,
     medlemskapsperioder: medlemskapsperioderReducer,
     modaler: modalerReducer,

--- a/src/services/modules/kodeverk.tsx
+++ b/src/services/modules/kodeverk.tsx
@@ -6,7 +6,7 @@ const MELOSYS_INTERNT = "melosys-internt";
 
 export const hentFolketrygdenKodeverk = () => getAsJson(`${API_BASE_URL}${KODEVERK}/${MELOSYS_INTERNT}/folketrygden`);
 export const hentNavFellesKodeverk = (kodeverknavn: string) =>
-  cachedGetAsJson(`${API_BASE_URL}${KODEVERK}/${NAV_FELLES}/${kodeverknavn}`);
+  cachedGetAsJson(`${API_BASE_URL}${KODEVERK}/${NAV_FELLES}/${kodeverknavn}`, 3600);
 export function hentLandkoderIso2() {
   return hentNavFellesKodeverk("LANDKODER_ISO2");
 }

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -32,6 +32,7 @@ import { menypanelOperations } from "../../../ducks/menypanel";
 import { folketrygdenkodeverkOperations } from "../../../ducks/folketrygdenkodeverk";
 import { oppsummertfaktaOperations } from "../../../ducks/oppsummertfakta";
 import { vilkarOperations } from "../../../ducks/vilkar";
+import { landkoderOperations, landkoderSelectors } from "../../../ducks/landkoder";
 import { medlemskapsperioderOperations } from "../../../ducks/medlemskapsperioder";
 
 import { AvslaattSoknad, HenlagtSak } from "../../eu_eøs/saksbehandling/komponenter/stegErstatter";
@@ -112,6 +113,7 @@ const Saksbehandling = ({
   hentDokumentOversikt,
   hentFagsaker,
   hentFolketrygdenKodeverk,
+  hentLandkoder,
   hentMedlemskapsperioder,
   hentOppsummertFakta,
   lagreAllData,
@@ -119,6 +121,7 @@ const Saksbehandling = ({
   lagreBehandlingsgrunnlagOgOppfriskSaksopplysninger,
   lagreOgLukk,
   lagreVilkar,
+  landkoder,
   location,
   match,
   oppdaterBehandlingsgrunnlag,
@@ -143,7 +146,6 @@ const Saksbehandling = ({
   visRevurderFagsakDialogHandle,
 }) => {
   const [behandlingID, setBehandlingID] = useState(-1);
-  const [landkoder, setLandkoder] = useState([]);
   const [bestemmelser, setBestemmelser] = useState([]);
   const [saksopplysningerLastet, setSaksopplysningerLastet] = useState(false);
   const folketrygdenToggle = useFeatureToggle("melosys.folketrygden.mvp");
@@ -194,9 +196,7 @@ const Saksbehandling = ({
 
   useEffect(() => {
     lastInnSaksopplysninger();
-    API.Kodeverk.hentLandkoderIso2().then((response) => {
-      setLandkoder(Utils.land.sorterLandOgGjørOmTilStoreForbokstaver(response));
-    });
+    hentLandkoder();
 
     return () => {
       resetFagsakState();
@@ -349,6 +349,7 @@ Saksbehandling.propTypes = {
   hentBehandlingsresultat: PT.func.isRequired,
   hentDokumentOversikt: PT.func.isRequired,
   hentFagsaker: PT.func.isRequired,
+  hentLandkoder: PT.func.isRequired,
   hentMedlemskapsperioder: PT.func.isRequired,
   hentOppsummertFakta: PT.func.isRequired,
   hentFolketrygdenKodeverk: PT.func.isRequired,
@@ -401,6 +402,7 @@ const mapStateToProps = (state) => ({
   dokumentOversikt: dokumenterSelectors.DokumentOversiktSelector(state),
   fagsak: fagsakSelectors.FagsakSelector(state),
   fagsakStatusKode: fagsakSelectors.FagsakStatusSelector(state),
+  landkoder: landkoderSelectors.LandkoderSelector(state),
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   person: behandlingerSelectors.PersonSelector(state),
   redigerbart: redigerbartSelectors.RedigerbartSelector(state),
@@ -415,6 +417,7 @@ const mapDispatchToProps = (dispatch) => ({
   hentDokumentOversikt: (saksnummer) => dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer)),
   hentFagsaker: (saksnummer) => dispatch(fagsakOperations.hent(saksnummer)),
   hentFolketrygdenKodeverk: () => dispatch(folketrygdenkodeverkOperations.hentKodeverkForFolketrygden()),
+  hentLandkoder: () => dispatch(landkoderOperations.hentLandkoder()),
   hentMedlemskapsperioder: (bid) => dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(bid)),
   hentOppsummertFakta: (bid) => dispatch(oppsummertfaktaOperations.hentOppsummertFakta(bid)),
   lagreAllData: () => dispatch(datalastingOperations.lagreAllData()),

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -336,6 +336,7 @@ Saksbehandling.propTypes = {
   fagsak: MPT.Fagsak,
   fagsakStatusKode: PT.string.isRequired,
   history: PT.object.isRequired,
+  landkoder: PT.arrayOf(MPT.Kodeverk).isRequired,
   location: PT.object.isRequired,
   match: PT.object.isRequired,
   oppsummering: MPT.Behandlinger.Oppsummering,

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -195,18 +195,7 @@ const Saksbehandling = ({
   useEffect(() => {
     lastInnSaksopplysninger();
     API.Kodeverk.hentLandkoderIso2().then((response) => {
-      setLandkoder(
-        response
-          .sort((a, b) => {
-            if (a.term > b.term) return 1;
-            if (b.term > a.term) return -1;
-            return 0;
-          })
-          .map((item) => ({
-            ...item,
-            term: Utils.streng.storeForbokstaverForLand(item.term),
-          }))
-      );
+      setLandkoder(Utils.land.sorterLandOgGjørOmTilStoreForbokstaver(response));
     });
 
     return () => {

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingStart.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingStart.tsx
@@ -76,7 +76,6 @@ interface Props {
   oppdater: () => void;
   redigerbart: boolean;
   oppdaterData: (avklartefakta: any) => void;
-  alleLandkoder: KTObject[];
   formValues: FormValuesProp;
   tilForsiden: () => void;
   lagreBehandlingsgrunnlagOgOppfriskSaksopplysninger: () => void;
@@ -87,7 +86,6 @@ export const VurderingStart = ({
   bekreft,
   redigerbart,
   formValues = {},
-  alleLandkoder,
   oppdaterPeriode,
   oppdaterSoeknadslandkoder,
   oppdaterTrygdedekning,
@@ -169,7 +167,6 @@ export const VurderingStart = ({
               }
               feltNavn="land"
               placeholder="Velg..."
-              landkoder={alleLandkoder}
               disabled={!redigerbart}
             />
           </Nav.Column>

--- a/src/sider/ftrl/saksbehandling/stegMap/start.js
+++ b/src/sider/ftrl/saksbehandling/stegMap/start.js
@@ -16,7 +16,6 @@ class Start extends Steg {
     this.tittel = "Start";
     this.komponent = VurderingStart;
     this.samleRelevanteData = (_propsLight) => ({
-      alleLandkoder: _propsLight.landkoder,
       redigerbart: _propsLight.generiskStegRedigerbart,
       annenBehandlingOppfriskes: _propsLight.annenBehandlingOppfriskes,
     });

--- a/src/sider/trygdeavtale/saksbehandling.js
+++ b/src/sider/trygdeavtale/saksbehandling.js
@@ -24,6 +24,7 @@ import { fagsakOperations, fagsakSelectors } from "../../ducks/fagsaker";
 import { lovvalgsperioderOperations } from "../../ducks/lovvalgsperioder";
 import { redigerbartSelectors } from "../../ducks/redigerbart";
 import { menypanelOperations } from "../../ducks/menypanel";
+import { landkoderOperations } from "../../ducks/landkoder";
 import { formSelectors } from "../../ducks/form";
 
 import Stegvelger from "./stegvelger";
@@ -101,6 +102,7 @@ const Saksbehandling = ({
   hentBehandlingsgrunnlag,
   hentBehandlingsresultat,
   hentDokumentOversikt,
+  hentLandkoder,
   hentLovvalgsperiode,
   hentFagsaker,
   lagreOgLukk,
@@ -171,6 +173,8 @@ const Saksbehandling = ({
 
   useEffect(() => {
     lastInnSaksopplysninger();
+    hentLandkoder();
+
     return () => {
       resetBehandlingerState();
       resetBehandlingsgrunnlagState();
@@ -295,6 +299,7 @@ Saksbehandling.propTypes = {
   hentBehandlingsgrunnlag: PT.func.isRequired,
   hentBehandlingsresultat: PT.func.isRequired,
   hentDokumentOversikt: PT.func.isRequired,
+  hentLandkoder: PT.func.isRequired,
   hentLovvalgsperiode: PT.func.isRequired,
   hentFagsaker: PT.func.isRequired,
   lagreOgLukk: PT.func.isRequired,
@@ -350,6 +355,7 @@ const mapDispatchToProps = (dispatch) => ({
   hentBehandlingsgrunnlag: (bid) => dispatch(behandlingsgrunnlagOperations.hent(bid)),
   hentBehandlingsresultat: (bid) => dispatch(behandlingsresultatOperations.hent(bid)),
   hentDokumentOversikt: (saksnummer) => dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer)),
+  hentLandkoder: () => dispatch(landkoderOperations.hentLandkoder()),
   hentLovvalgsperiode: (bid) => dispatch(lovvalgsperioderOperations.hent(bid)),
   hentFagsaker: (saksnummer) => dispatch(fagsakOperations.hent(saksnummer)),
   resetFagsakState: () => dispatch(fagsakOperations.resetFagsakState()),

--- a/src/utils/land.js
+++ b/src/utils/land.js
@@ -1,1 +1,16 @@
+import { storeForbokstaverForLand } from "./streng";
+
 export const landTekstFormat = (landObjekt) => `${landObjekt.term} (${landObjekt.kode})`;
+
+export const sorterLandOgGjørOmTilStoreForbokstaver = (landObjekter) => {
+  return landObjekter
+    .sort((a, b) => {
+      if (a.term > b.term) return 1;
+      if (b.term > a.term) return -1;
+      return 0;
+    })
+    .map((item) => ({
+      ...item,
+      term: storeForbokstaverForLand(item.term),
+    }));
+};


### PR DESCRIPTION
- Landkoder lagres i redux og er satt opp en selector som velger rett landkodeliste for sakstypen til behandlingen. Flytter sortering av landkodelisten til reduceren slik at det kun skal måtte skje én gang per henting.
-  Landkoder hentes av Saksbehandler.js for FTRL og Trygdeavtale - dette fordi de er top-komponenter, og jeg ikke ser bedre løsning for det uten at det blir hacky. Skulle gjerne hentet én gang per session, men som nevnt - virker hacky.
- LandVelger bruker nevnt selector med mindre det er gitt egendefinert landliste i props
- Fjerner egen alternativ landliste der det kan hentes av LandVelger istedenfor