### PR TITLE
Melosys 4818 ny vurdering steg 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5381,9 +5381,9 @@
       }
     },
     "@navikt/melosys-kodeverk": {
-      "version": "5.15.104",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.104/064c151ecf8ab80b242d34a60d99e8f1f4f24aa73a0d420045df556915943318",
-      "integrity": "sha512-q5MxykoMvPby1KtX9rSy0Hk99utC38f39ZVJn+PgYIwxcF715BPGQug9mjEUkoj6aMTkvGVkRXi5okIKukwdhw=="
+      "version": "5.15.107",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.107/97fe6257f571c7ab651a450d9d609d352a4ab25fb3b9803163dc43d2772a3e68",
+      "integrity": "sha512-RrDO972DsEJi+FsDHlpWy+gE9FqHi82gEpRqyW71enMnx13zLybIzQr3buOPZDfUShla6fW6sx80cQuFSA1CeQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.20",
     "@loadable/component": "^5.10.3",
-    "@navikt/melosys-kodeverk": "5.15.104",
+    "@navikt/melosys-kodeverk": "5.15.107",
     "classnames": "^2.2.6",
     "connected-react-router": "^6.6.1",
     "date-fns": "^2.20.0",

--- a/src/ducks/vedtak/operations.js
+++ b/src/ducks/vedtak/operations.js
@@ -67,7 +67,7 @@ export function avslaaSoknad(behandlingID, data) {
     fritekstSed: null,
     mottakerinstitusjoner: [],
     vedtakstype: MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-    revurderBegrunnelse: null,
+    nyVurderingBakgrunn: null,
   };
 
   return doThenDispatch(

--- a/src/services/modules/saksflyt/vedtak.ts
+++ b/src/services/modules/saksflyt/vedtak.ts
@@ -10,7 +10,7 @@ export interface FattVedtakEOSReqDto {
   fritekst?: string | null;
   fritekstSed?: string | null;
   mottakerinstitusjoner: string[];
-  revurderBegrunnelse: string | null;
+  nyVurderingBakgrunn: string | null;
 }
 
 export interface FattVedtakFTRLReqDto {
@@ -21,7 +21,7 @@ export interface FattVedtakFTRLReqDto {
   ektefelleFritekst: string | null;
   barnFritekst: string | null;
   kopiMottakere: KopiMottaker[];
-  revurderBegrunnelse: string | null | undefined;
+  nyVurderingBakgrunn: string | null | undefined;
 }
 
 export type FattVedtakTrygdeavtaleReqDto = FattVedtakFTRLReqDto;

--- a/src/services/modules/saksflyt/vedtak.ts
+++ b/src/services/modules/saksflyt/vedtak.ts
@@ -22,7 +22,10 @@ export interface FattVedtakFTRLReqDto {
   barnFritekst: string | null;
   kopiMottakere: KopiMottaker[];
 }
-export type FattVedtakTrygdeavtaleReqDto = FattVedtakFTRLReqDto;
+
+export type FattVedtakTrygdeavtaleReqDto = FattVedtakFTRLReqDto & {
+  nyVurderingBakgrunn: string | null;
+};
 
 interface EndreVedtakReqDto {
   begrunnelseKode: string;

--- a/src/services/modules/saksflyt/vedtak.ts
+++ b/src/services/modules/saksflyt/vedtak.ts
@@ -21,11 +21,10 @@ export interface FattVedtakFTRLReqDto {
   ektefelleFritekst: string | null;
   barnFritekst: string | null;
   kopiMottakere: KopiMottaker[];
+  revurderBegrunnelse: string | null | undefined;
 }
 
-export type FattVedtakTrygdeavtaleReqDto = FattVedtakFTRLReqDto & {
-  nyVurderingBakgrunn: string | null;
-};
+export type FattVedtakTrygdeavtaleReqDto = FattVedtakFTRLReqDto;
 
 interface EndreVedtakReqDto {
   begrunnelseKode: string;

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.js
@@ -239,7 +239,7 @@ export const VurderingArbeidEttLandOvrigVedtak = ({
       fritekstSed: values.fritekstSed,
       mottakerinstitusjoner,
       vedtakstype: values.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-      revurderBegrunnelse: values.vedtakstypebegrunnelse,
+      nyVurderingBakgrunn: values.vedtakstypebegrunnelse,
     });
 
     // Vedtak-operation navigerer til forside, og komponenten kan derfor være unmountet.

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.test.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidEttLandOvrigVedtak.test.js
@@ -68,7 +68,7 @@ describe("VurderingArbeidEttLandOvrigVedtak", () => {
       fritekstSed: "fritekst til SED",
       mottakerinstitusjoner: null,
       vedtakstype: MKV.Koder.vedtakstyper.KORRIGERT_VEDTAK,
-      revurderBegrunnelse: "begrunnelse for revurdering",
+      nyVurderingBakgrunn: "begrunnelse for revurdering",
     });
   });
 

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.js
@@ -111,7 +111,7 @@ export const VurderingArtikkel13_x_vedtak = ({
         .filter((inst) => inst.kreverMottakerinstitusjon)
         .map((inst) => inst.id),
       vedtakstype: values.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-      revurderBegrunnelse: values.vedtakstypebegrunnelse,
+      nyVurderingBakgrunn: values.vedtakstypebegrunnelse,
     });
 
     // Vedtak-operation navigerer til forside, og komponenten kan derfor være unmountet.

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak.js
@@ -407,7 +407,7 @@ export const VurderingArtikkel16Vedtak = ({
       fritekstSed: null,
       mottakerinstitusjoner: null,
       vedtakstype: formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-      revurderBegrunnelse: formValues.vedtakstypebegrunnelse,
+      nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
     });
 
     // Vedtak-operation navigerer til forside, og komponenten kan derfor være unmountet.

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak.test.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak.test.js
@@ -25,7 +25,7 @@ describe("VurderingArtikkel16Vedtak", () => {
       behandlingstype: MKV.Koder.behandlinger.behandlingstyper.SOEKNAD,
       touch: jest.fn(),
       formValues: {
-        vedtakstypebegrunnelse: MKV.Koder.begrunnelser.nyvurderingbakgrunner.SAKSBEHANDLER_OPPDAGET_FEIL,
+        vedtakstypebegrunnelse: MKV.Koder.begrunnelser.nyvurderingbakgrunner.FEIL_I_BEHANDLING,
         vedtakstype: MKV.Koder.vedtakstyper.KORRIGERINGSVEDTAK,
         vedtaksbrevFritekst: "Test",
       },

--- a/src/sider/eu_eøs/stegKomponenter/vurderingAvslag12_x_og_16.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingAvslag12_x_og_16.js
@@ -85,7 +85,7 @@ const VurderingAvslag12_x_og_16 = ({
       fritekstSed: null,
       mottakerinstitusjoner: null,
       vedtakstype: formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-      revurderBegrunnelse: formValues.vedtakstypebegrunnelse,
+      nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
     });
 
     // Vedtak-operation navigerer til forside, og komponenten kan derfor være unmountet.

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak.js
@@ -111,7 +111,7 @@ const VurderingVedtak = ({
       fritekstSed: formValues.fritekstSed,
       mottakerinstitusjoner: erSoknadEllerNyVurdering ? [formValues.mottakerinstitusjon] : [],
       vedtakstype: formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-      revurderBegrunnelse: formValues.vedtakstypebegrunnelse,
+      nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
     });
 
     // Vedtak-operation navigerer til forside, og komponenten kan derfor være unmountet.

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
@@ -231,7 +231,7 @@ const VurderingVedtak = ({
       barnFritekst: familieFormValues?.barn?.fritekst || null,
       vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
       kopiMottakere: muligeMottakere.kopiMottakere.map(Api.DokumenterV2.konverterMuligMottakerTilKopiMottaker),
-      revurderBegrunnelse: null,
+      nyVurderingBakgrunn: null,
     });
 
     if (isMounted.current) {

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
@@ -231,6 +231,7 @@ const VurderingVedtak = ({
       barnFritekst: familieFormValues?.barn?.fritekst || null,
       vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
       kopiMottakere: muligeMottakere.kopiMottakere.map(Api.DokumenterV2.konverterMuligMottakerTilKopiMottaker),
+      revurderBegrunnelse: null,
     });
 
     if (isMounted.current) {

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.less
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.less
@@ -72,4 +72,11 @@
     margin: 0;
     display: inline-block;
   }
+  &__nyvurdering {
+    margin-left: 0.5rem;
+    margin-bottom: -1rem;
+    .skjema__legend {
+      margin-bottom: 8px;
+    }
+  }
 }

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -4,6 +4,7 @@ import { Action } from "redux";
 import { RootState } from "AppTypes";
 import { connect, ConnectedProps } from "react-redux";
 import { getFormValues, reduxForm } from "redux-form";
+import { KTObject } from "@navikt/melosys-kodeverk";
 
 import MKV from "../../../melosyskodeverk";
 import * as Api from "../../../services/api";
@@ -54,6 +55,8 @@ const mapStateToProps = (state: RootState, ownProps: Props) => ({
       ownProps.resultat.lovvalgsperiodeTom && Utils.dato.formatterDatoTilNorsk(ownProps.resultat.lovvalgsperiodeTom),
   },
   formIsValid: formSelectors.TrygdeavtaleVedtakFormValidSelector(state),
+  erNyVurdering:
+    behandlingerSelectors.BehandlingstypeKodeSelector(state) === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING,
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
@@ -79,6 +82,7 @@ interface Props {
     innledningFritekst?: string;
     begrunnelseFritekst?: string;
     kopiTilArbeidsgiver?: boolean;
+    nyVurderingBakgrunn?: string;
   };
 }
 
@@ -86,6 +90,7 @@ const VurderingVedtak = ({
   behandlingID,
   behandlingsgrunnlagStatus,
   data: { bestemmelseValg },
+  erNyVurdering,
   tilbake,
   redigerbart,
   resultat,
@@ -135,6 +140,7 @@ const VurderingVedtak = ({
     barnFritekst: familieFormValues?.barn?.fritekst || null,
     vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
     kopiMottakere: getKopiMottakere(),
+    nyVurderingBakgrunn: formValues?.nyVurderingBakgrunn || null,
   });
 
   const kontrollerVedtak = (oppdaterRegisteropplysninger: boolean = false) => {
@@ -315,6 +321,28 @@ const VurderingVedtak = ({
           </Nav.Typo.Normaltekst>
         </Nav.Column>
       </Nav.Row>
+
+      {erNyVurdering && (
+        <Nav.Fieldset legend="Oppgi grunn for nytt vedtak" className={vurderingVedtakCls.element("nyvurdering")}>
+          <Nav.Row>
+            <Nav.Column xs="6">
+              <Skjema.Select
+                label=""
+                feltNavn="nyVurderingBakgrunn"
+                disabled={!redigerbart}
+                emptyFieldText="Velg"
+                emptyFieldDisabled={!!formValues?.nyVurderingBakgrunn}
+              >
+                {MKV.KTObjects.begrunnelser.nyVurderingBakgrunner.map((bakgrunn: KTObject) => (
+                  <option key={bakgrunn.kode} value={bakgrunn.kode}>
+                    {bakgrunn.term}
+                  </option>
+                ))}
+              </Skjema.Select>
+            </Nav.Column>
+          </Nav.Row>
+        </Nav.Fieldset>
+      )}
 
       <Nav.Typo.Element className={vurderingVedtakCls.element("fritekst_overskrift")} tag="h3">
         Fritekst til innledning

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -141,7 +141,7 @@ const VurderingVedtak = ({
     barnFritekst: familieFormValues?.barn?.fritekst || null,
     vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
     kopiMottakere: getKopiMottakere(),
-    nyVurderingBakgrunn: formValues?.nyVurderingBakgrunn || null,
+    revurderBegrunnelse: formValues?.nyVurderingBakgrunn || null,
   });
 
   const kontrollerVedtak = (oppdaterRegisteropplysninger: boolean = false) => {

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -334,7 +334,7 @@ const VurderingVedtak = ({
                 emptyFieldText="Velg"
                 emptyFieldDisabled={!!formValues?.nyVurderingBakgrunn}
               >
-                {MKV.KTObjects.begrunnelser.nyVurderingBakgrunner.map((bakgrunn: KTObject) => (
+                {MKV.KTObjects.begrunnelser.nyvurderingbakgrunner?.map((bakgrunn: KTObject) => (
                   <option key={bakgrunn.kode} value={bakgrunn.kode}>
                     {bakgrunn.term}
                   </option>

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -84,6 +84,7 @@ interface Props {
     begrunnelseFritekst?: string;
     kopiTilArbeidsgiver?: boolean;
     nyVurderingBakgrunn?: string;
+    nyVurderingBakgrunnFritekst?: string;
   };
 }
 
@@ -116,6 +117,7 @@ const VurderingVedtak = ({
   const [vedtakPending, setVedtakPending] = useState(false);
   const [oppdaterFørKontroll, setOppdaterFørKontroll] = useState(true);
   const isMounted = Hooks.useIsMounted();
+  const FRITEKST = "Fritekst";
 
   const filterKopiMottakere = (muligMottaker: Api.DokumenterV2.MuligMottaker) => {
     if ([KV.Koder.MottakerRolle.ARBEIDSGIVER, KV.Koder.MottakerRolle.REPRESENTANT].includes(muligMottaker?.rolle)) {
@@ -141,7 +143,10 @@ const VurderingVedtak = ({
     barnFritekst: familieFormValues?.barn?.fritekst || null,
     vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
     kopiMottakere: getKopiMottakere(),
-    nyVurderingBakgrunn: formValues?.nyVurderingBakgrunn || null,
+    nyVurderingBakgrunn:
+      formValues?.nyVurderingBakgrunn === FRITEKST
+        ? formValues?.nyVurderingBakgrunnFritekst
+        : formValues?.nyVurderingBakgrunn,
   });
 
   const kontrollerVedtak = (oppdaterRegisteropplysninger: boolean = false) => {
@@ -324,25 +329,33 @@ const VurderingVedtak = ({
       </Nav.Row>
 
       {erNyVurdering && (
-        <Nav.Fieldset legend="Oppgi grunn for nytt vedtak" className={vurderingVedtakCls.element("nyvurdering")}>
-          <Nav.Row>
-            <Nav.Column xs="6">
-              <Skjema.Select
-                label=""
-                feltNavn="nyVurderingBakgrunn"
-                disabled={!redigerbart}
-                emptyFieldText="Velg"
-                emptyFieldDisabled={!!formValues?.nyVurderingBakgrunn}
-              >
-                {MKV.KTObjects.begrunnelser.nyvurderingbakgrunner?.map((bakgrunn: KTObject) => (
-                  <option key={bakgrunn.kode} value={bakgrunn.kode}>
-                    {bakgrunn.term}
-                  </option>
-                ))}
-              </Skjema.Select>
-            </Nav.Column>
-          </Nav.Row>
-        </Nav.Fieldset>
+        <>
+          <Nav.Fieldset legend="Oppgi grunn for nytt vedtak" className={vurderingVedtakCls.element("nyvurdering")}>
+            <Nav.Row>
+              <Nav.Column xs="6">
+                <Skjema.Select
+                  label=""
+                  feltNavn="nyVurderingBakgrunn"
+                  disabled={!redigerbart}
+                  emptyFieldText="Velg"
+                  emptyFieldDisabled={!!formValues?.nyVurderingBakgrunn}
+                >
+                  {MKV.KTObjects.begrunnelser.nyvurderingbakgrunner?.map((bakgrunn: KTObject) => (
+                    <option key={bakgrunn.kode} value={bakgrunn.kode} label={bakgrunn.term || ""} />
+                  ))}
+                  <option key={FRITEKST} value={FRITEKST} label={FRITEKST} />
+                </Skjema.Select>
+              </Nav.Column>
+            </Nav.Row>
+          </Nav.Fieldset>
+          {formValues?.nyVurderingBakgrunn === FRITEKST && (
+            <Skjema.Input
+              feltNavn="nyVurderingBakgrunnFritekst"
+              label=""
+              className={vurderingVedtakCls.element("nyvurdering")}
+            />
+          )}
+        </>
       )}
 
       <Nav.Typo.Element className={vurderingVedtakCls.element("fritekst_overskrift")} tag="h3">

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -141,7 +141,7 @@ const VurderingVedtak = ({
     barnFritekst: familieFormValues?.barn?.fritekst || null,
     vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
     kopiMottakere: getKopiMottakere(),
-    revurderBegrunnelse: formValues?.nyVurderingBakgrunn || null,
+    nyVurderingBakgrunn: formValues?.nyVurderingBakgrunn || null,
   });
 
   const kontrollerVedtak = (oppdaterRegisteropplysninger: boolean = false) => {


### PR DESCRIPTION
- Legger til Select-komponent som viser alle mulig koder i nyvurderingbakgrunner-kodeverket. Dette blir oppdatert her: https://github.com/navikt/melosys-kodeverk/pull/202)
- Legger til nyVurderingBakgrunn som ett felt i objektet som blir sendt til backend.

⚠️ **OBS! Denne må pushes samtidig som melosys-api for å unngå krøll med kodeverk-versjoner.**