### PR TITLE
Legger til støtte i knyttTilSak.js for Trygdeavtale

### DIFF
--- a/src/sider/journalforing/komponenter/fagsakVelger.js
+++ b/src/sider/journalforing/komponenter/fagsakVelger.js
@@ -11,9 +11,20 @@ import { JOURNALFORING_HENSIKT } from "../../../constants";
 
 import "./fagsakVelger.css";
 
-const behandlingstyper = MKV.KTObjects.behandlinger.behandlingstyper.filter(
-  ({ kode }) => kode === MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE
-);
+const behandlingstyper = (sakstype) => {
+  switch (sakstype) {
+    case MKV.Koder.sakstyper.EU_EOS:
+      return MKV.KTObjects.behandlinger.behandlingstyper.filter(
+        ({ kode }) => kode === MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE
+      );
+    case MKV.Koder.sakstyper.TRYGDEAVTALE:
+      return MKV.KTObjects.behandlinger.behandlingstyper.filter(
+        ({ kode }) => kode === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING
+      );
+    default:
+      return [];
+  }
+};
 
 const FagsakVelger = (props) => {
   const { fagsakListe, settJournalforingHensikt } = props;
@@ -27,7 +38,7 @@ const FagsakVelger = (props) => {
       {
         value: sak.saksnummer,
         innhold: <EnkeltSak sak={sak} />,
-        footer: <KnyttTilSak sak={sak} behandlingstyper={behandlingstyper} />,
+        footer: <KnyttTilSak sak={sak} behandlingstyper={behandlingstyper(sak.sakstype.kode)} />,
       },
     ],
     []

--- a/src/sider/journalforing/komponenter/knyttTilSak.js
+++ b/src/sider/journalforing/komponenter/knyttTilSak.js
@@ -21,6 +21,9 @@ export const KnyttTilSak = (props) => {
   );
   const clsElementskrift = { "border-bottom": "none" };
 
+  const visOpprettNyBehandling = !sakInneholderSEDBehandling;
+  const visUtenOppretteBehandling = sak.sakstype.kode === MKV.Koder.sakstyper.EU_EOS;
+
   if (sisteBehandling.behandlingsstatus.kode === MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET) {
     return (
       <div className="panelramme">
@@ -31,10 +34,12 @@ export const KnyttTilSak = (props) => {
           style={clsElementskrift}
         />
         <Skjema.RadioGruppe feltNavn="opprettBehandling" label="Knytt til sak">
-          {!sakInneholderSEDBehandling && (
+          {visOpprettNyBehandling && (
             <Skjema.Radio feltNavn="opprettBehandling" value={BOOLSK.SANN} label="Opprett ny behandling" />
           )}
-          <Skjema.Radio feltNavn="opprettBehandling" value={BOOLSK.USANN} label="Uten å opprette behandling" />
+          {visUtenOppretteBehandling && (
+            <Skjema.Radio feltNavn="opprettBehandling" value={BOOLSK.USANN} label="Uten å opprette behandling" />
+          )}
         </Skjema.RadioGruppe>
         {opprettBehandling() && (
           <Skjema.Select
@@ -43,12 +48,9 @@ export const KnyttTilSak = (props) => {
             label="Velg behandlingstype"
             emptyFieldDisabled={false}
           >
-            {behandlingstyper &&
-              behandlingstyper.map((elem) => (
-                <option key={elem.kode} value={elem.kode}>
-                  {elem.term}
-                </option>
-              ))}
+            {behandlingstyper?.map((elem) => (
+              <option key={elem.kode} value={elem.kode} label={elem.term} />
+            ))}
           </Skjema.Select>
         )}
       </div>

--- a/src/sider/journalforing/komponenter/knyttTilSak.test.js
+++ b/src/sider/journalforing/komponenter/knyttTilSak.test.js
@@ -12,6 +12,9 @@ describe("KnyttTilSak", () => {
   beforeEach(() => {
     props = {
       sak: {
+        sakstype: {
+          kode: MKV.Koder.sakstyper.EU_EOS,
+        },
         behandlingOversikter: [
           {
             behandlingsstatus: { kode: MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET },
@@ -23,7 +26,7 @@ describe("KnyttTilSak", () => {
     };
   });
 
-  it(`vis knapp for å opprette ny behandling dersom ingen behandlinger har behandlingstype ${MKV.Koder.behandlinger.behandlingstyper.SED}`, () => {
+  it(`Vis knapp for å opprette ny behandling dersom ingen behandlinger har behandlingstype ${MKV.Koder.behandlinger.behandlingstyper.SED}`, () => {
     props.sak.behandlingOversikter[0].behandlingstype = { kode: MKV.Koder.behandlinger.behandlingstyper.SOEKNAD };
 
     const knyttTilSak = shallow(<KnyttTilSak {...props} />);
@@ -43,5 +46,17 @@ describe("KnyttTilSak", () => {
 
     expect(radios).toHaveLength(1);
     expect(radios.first().props().label).not.toBe("Opprett ny behandling");
+  });
+
+  it(`Ikke vis knapp for uten å opprette behandling dersom saktype er TRYGDEAVTALE`, () => {
+    props.sak.behandlingOversikter[0].behandlingstype = { kode: MKV.Koder.behandlinger.behandlingstyper.SOEKNAD };
+    props.sak.sakstype.kode = MKV.Koder.sakstyper.TRYGDEAVTALE;
+
+    const knyttTilSak = shallow(<KnyttTilSak {...props} />);
+
+    const radios = knyttTilSak.find(Skjema.Radio);
+
+    expect(radios).toHaveLength(1);
+    expect(radios.first().props().label).not.toBe("Uten å opprette behandling");
   });
 });


### PR DESCRIPTION
Legger til støtte i knyttTilSak.js for Trygdeavtale. 
Behandlingstyper sendt inn i props er nå avhengig av sakstype, og det samme gjelder om "Uten å opprette behandling"-valget.

https://jira.adeo.no/browse/MELOSYS-4842
https://github.com/navikt/melosys-api/pull/989