### PR TITLE
Fikset for bred hjelpetekst og manglende info om tom liste

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.less
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.less
@@ -27,6 +27,10 @@
 
     .hjelpetekst {
       margin-left: 0.5rem;
+
+      .popover {
+        max-width: 50%;
+      }
     }
   }
 }

--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.tsx
@@ -10,7 +10,9 @@ interface PersonstatusTabellProps {
 }
 
 export const PersonstatusTabell = ({ personstatuser }: PersonstatusTabellProps) => {
-  if (personstatuser.length < 1) return null;
+  if (personstatuser.length < 1) {
+    return <Nav.Typo.Normaltekst>Ingen historikk registrert i folkeregisteret.</Nav.Typo.Normaltekst>;
+  }
 
   const personstatusTabellCls = bem("personstatus-tabell");
 


### PR DESCRIPTION
To bugs ble varslet på ny personstatus fra PDL detaljemodal:
1. endre størrelse på hjelpetekst
2. legge til en tekst dersom det ikke er noe historikk