### PR TITLE
Litt mer padding over tom tabell

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.less
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.less
@@ -33,29 +33,33 @@
       }
     }
   }
-}
 
-.personstatus-tabell {
-  padding: 1em 0 2em 0.5em;
+  .personstatus-tabell {
+    padding: 1em 0 2em 0.5em;
 
-  &__header {
-    color: @navGra60;
+    &__header {
+      color: @navGra60;
 
-    > * {
-      padding-left: 0;
+      > * {
+        padding-left: 0;
+      }
+    }
+
+    &__row {
+      border-top: 1px solid @navGra60;
+      padding: 0.3em 0;
+
+      &:last-child {
+        border-bottom: 1px solid @navGra60;
+      }
+
+      > * {
+        padding-left: 0;
+      }
     }
   }
 
-  &__row {
-    border-top: 1px solid @navGra60;
-    padding: 0.3em 0;
-
-    &:last-child {
-      border-bottom: 1px solid @navGra60;
-    }
-
-    > * {
-      padding-left: 0;
-    }
+  .personstatus-tabell-tom {
+    margin-top: 0.5em;
   }
 }

--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.tsx
@@ -11,7 +11,11 @@ interface PersonstatusTabellProps {
 
 export const PersonstatusTabell = ({ personstatuser }: PersonstatusTabellProps) => {
   if (personstatuser.length < 1) {
-    return <Nav.Typo.Normaltekst>Ingen historikk registrert i folkeregisteret.</Nav.Typo.Normaltekst>;
+    return (
+      <Nav.Typo.Normaltekst className="personstatus-tabell-tom">
+        Ingen historikk registrert i folkeregisteret.
+      </Nav.Typo.Normaltekst>
+    );
   }
 
   const personstatusTabellCls = bem("personstatus-tabell");


### PR DESCRIPTION
La til padding som beskrevet i figma. Klarte ikke å replikere den andre feilen med feil venstrestilling av tekst under historikk, så gjerne dobbeltsjekk det den som tar denne PR-en (ser det bra ut for deg?)
https://www.figma.com/file/7valEmRFMgUIh4MIh7N0SC/Sidemeny?node-id=5518%3A18288