### PR TITLE
Fjern "Send kopi til arbeidsgiver/virksomhet" checkbox i innsynsmodus

### DIFF
--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak.tsx
@@ -428,12 +428,14 @@ const VurderingVedtak = ({
         disabled={!redigerbart}
       />
 
-      <Skjema.Checkbox
-        feltNavn="kopiTilArbeidsgiver"
-        label="Send kopi til arbeidsgiver/virksomhet"
-        className={vurderingVedtakCls.element("kopiCheckbox")}
-        disabled={!redigerbart}
-      />
+      {redigerbart && (
+        <Skjema.Checkbox
+          feltNavn="kopiTilArbeidsgiver"
+          label="Send kopi til arbeidsgiver/virksomhet"
+          className={vurderingVedtakCls.element("kopiCheckbox")}
+          disabled={!redigerbart}
+        />
+      )}
 
       {redigerbart && (
         <MottakerTabell


### PR DESCRIPTION
På vedtakssteget er det automatisk huket av for kopi til arbeidsgiver/virksomhet selv om den var huket av.
Løsningen ble og fjerne checkboks siden det er mye jobb å sette denne korrekt. 
https://jira.adeo.no/browse/MELOSYS-4966