### PR TITLE
Bug der oppsummerings-boks prøvde å vises før nødvendig saksinformasjon var hentet

### DIFF
--- a/src/sider/eu_eøs/registrering/registrering.js
+++ b/src/sider/eu_eøs/registrering/registrering.js
@@ -155,6 +155,7 @@ export const Registrering = (props) => {
   };
 
   if (Utils._isNil(redigerbart)) return null;
+  if (!saksopplysningerErHentet) return null;
 
   const behandlingErAvsluttet = [AVSLUTTET, MIDLERTIDIG_LOVVALGSBESLUTNING].includes(behandlingsstatus);
   const visRevurderFagsak =
@@ -171,17 +172,15 @@ export const Registrering = (props) => {
           <Nav.Container fluid>
             <Nav.Row>
               <Nav.Column xs="7">
-                {saksopplysningerErHentet && (
-                  <Saksopplysninger
-                    redigerbart={redigerbart}
-                    behandlingID={behandlingID}
-                    saksnummer={saksnummer}
-                    sed={sed}
-                    vurderingBegrunnelser={vurderingBegrunnelser}
-                    tilForsiden={tilForsiden}
-                    startOgVisOppfriskModal={startOgVisOppfriskModal}
-                  />
-                )}
+                <Saksopplysninger
+                  redigerbart={redigerbart}
+                  behandlingID={behandlingID}
+                  saksnummer={saksnummer}
+                  sed={sed}
+                  vurderingBegrunnelser={vurderingBegrunnelser}
+                  tilForsiden={tilForsiden}
+                  startOgVisOppfriskModal={startOgVisOppfriskModal}
+                />
               </Nav.Column>
               <Nav.Column xs="5">
                 <SideOppsummering

--- a/src/sider/eu_eøs/registrering/registrering.test.js
+++ b/src/sider/eu_eøs/registrering/registrering.test.js
@@ -16,6 +16,7 @@ describe("Registrering", () => {
   let props = null;
 
   beforeEach(() => {
+    React.useState = jest.fn().mockReturnValue([true, {}]);
     props = {
       Saksopplysninger: () => <span />,
       hentAvklartefakta: jest.fn(),

--- a/src/sider/eu_eøs/sedbehandling/sedbehandling.js
+++ b/src/sider/eu_eøs/sedbehandling/sedbehandling.js
@@ -175,6 +175,10 @@ const SedBehandling = ({
     return Api.Behandlinger.status.oppdaterStatus(behandlingID, behandlingsstatus);
   };
 
+  if (Utils._isNil(redigerbart)) return null;
+  if (!behandlingID) return null;
+  if (!behandlingstema) return null;
+
   return (
     <>
       <FeatureToggle togglename="melosys.design.PERSONLINJE">

--- a/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
+++ b/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
@@ -138,7 +138,7 @@ const Vurderutpeking = ({
   }, []);
 
   if (Utils._isNil(redigerbart)) return null;
-  if (!behandlingID || behandlingID < 0) return null;
+  if (!behandlingID) return null;
   if (!behandlingstema) return null;
 
   const behandlingsgrunnlagErKlart = !(


### PR DESCRIPTION
Venter til saksbehandling er lastet til å vise siden. 
Bruker behandlingstema i sedbehandling (tilsvarende vurderutpeking) som en sjekk på at saksbehandling er lastet.