### PR TITLE
Justerte visning av utfyltutenlandskident.tsx

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/person/utenlandskident/utfyltutenlandskident.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/utenlandskident/utfyltutenlandskident.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 
 import * as Nav from "../../../../../navFrontend";
-import * as KV from "../../../../../kodeverk";
-
-import MKV from "../../../../../melosyskodeverk";
 
 import { UtenlandskIdent } from "./types";
 
@@ -17,6 +14,9 @@ const UtfyltUtenlandskIdent = ({ utenlandskeIdenter }: UtfyltUtenlandskIdentProp
       <Nav.Column xs="6">
         <Nav.Typo.Normaltekst>ID-nummer</Nav.Typo.Normaltekst>
       </Nav.Column>
+      <Nav.Column xs="6">
+        <Nav.Typo.Normaltekst>Land</Nav.Typo.Normaltekst>
+      </Nav.Column>
     </Nav.Row>
     <Nav.Row>
       {utenlandskeIdenter.map(({ ident, landkode }, indeks) => (
@@ -25,11 +25,7 @@ const UtfyltUtenlandskIdent = ({ utenlandskeIdenter }: UtfyltUtenlandskIdentProp
           <Nav.Column xs="6">
             <Nav.Typo.Element>{ident}</Nav.Typo.Element>
           </Nav.Column>
-          <Nav.Column xs="6">
-            {landkode && (
-              <Nav.Typo.Normaltekst>{KV.kodeTilTerm(landkode, MKV.KTObjects.landkoder)}</Nav.Typo.Normaltekst>
-            )}
-          </Nav.Column>
+          <Nav.Column xs="6">{landkode && <Nav.Typo.Element>{landkode}</Nav.Typo.Element>}</Nav.Column>
         </div>
       ))}
     </Nav.Row>

--- a/src/felleskomponenter/menypanel/menypunkter/person/utenlandskident/utfyltutenlandskident.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/utenlandskident/utfyltutenlandskident.tsx
@@ -1,14 +1,23 @@
 import React from "react";
 
-import * as Nav from "../../../../../navFrontend";
+import { RootState } from "AppTypes";
+import { connect, ConnectedProps } from "react-redux";
 
 import { UtenlandskIdent } from "./types";
+import { landkoderSelectors } from "../../../../../ducks/landkoder";
+import * as Nav from "../../../../../navFrontend";
+import * as KV from "../../../../../kodeverk";
 
-interface UtfyltUtenlandskIdentProps {
+const mapStateToProps = (state: RootState) => ({
+  landkoder: landkoderSelectors.LandkoderSelector(state),
+});
+const connector = connect(mapStateToProps);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+type UtfyltUtenlandskIdentProps = PropsFromRedux & {
   utenlandskeIdenter: UtenlandskIdent[];
-}
+};
 
-const UtfyltUtenlandskIdent = ({ utenlandskeIdenter }: UtfyltUtenlandskIdentProps) => (
+const UtfyltUtenlandskIdent = ({ utenlandskeIdenter, landkoder }: UtfyltUtenlandskIdentProps) => (
   <>
     <Nav.Row>
       <Nav.Column xs="6">
@@ -25,11 +34,13 @@ const UtfyltUtenlandskIdent = ({ utenlandskeIdenter }: UtfyltUtenlandskIdentProp
           <Nav.Column xs="6">
             <Nav.Typo.Element>{ident}</Nav.Typo.Element>
           </Nav.Column>
-          <Nav.Column xs="6">{landkode && <Nav.Typo.Element>{landkode}</Nav.Typo.Element>}</Nav.Column>
+          <Nav.Column xs="6">
+            {landkode && <Nav.Typo.Element>{KV.kodeTilTerm(landkode, landkoder)}</Nav.Typo.Element>}
+          </Nav.Column>
         </div>
       ))}
     </Nav.Row>
   </>
 );
 
-export default UtfyltUtenlandskIdent;
+export default connector(UtfyltUtenlandskIdent);


### PR DESCRIPTION
Fjernet mapping av landkode til landenavn for å gjøre det likt som i Fødested og -land. Denne mappingen feilet på land utenfor EØS da disse ikke finnes i MKV.KTObjects.landkoder