### PR TITLE
Fjernet krav om redigerbart for mulighet til Vurder sak på nytt

### DIFF
--- a/src/felleskomponenter/personlinje/behandlingsmeny/behandlingsmeny.tsx
+++ b/src/felleskomponenter/personlinje/behandlingsmeny/behandlingsmeny.tsx
@@ -88,7 +88,6 @@ export const Behandlingsmeny = ({
       case KV.Koder.Behandlingskategori.EØS_REGISTRERING:
         return behandlingErAvsluttet && behandlingstemaErRegistreringOmUnntakNorskTrygd;
       case KV.Koder.Behandlingskategori.EØS_VURDER_UTPEKING:
-        return redigerbart && behandlingErAvsluttet;
       case KV.Koder.Behandlingskategori.FTRL_SAKSBEHANDLING:
       case KV.Koder.Behandlingskategori.TRYGDEAVTALE_SAKSBEHANDLING:
         return behandlingErAvsluttet;


### PR DESCRIPTION
Etter diskusjon med Mina:
Redigerbart innebærer at behandling ikke er avsluttet, ville dermed aldri være true. Gamle behandlingsmeny for vurder utpeking hadde bare sjekk på behandlingErAvsluttet