### PR TITLE
GraphQL-tester krever timeout for å unngå feil

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmerFraPDL/familiemedlemmerFraPDL.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmerFraPDL/familiemedlemmerFraPDL.test.tsx
@@ -103,7 +103,7 @@ describe("FamiliemedlemmerFraPDL", () => {
         },
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 15));
+      await new Promise((resolve) => setTimeout(resolve, 20));
       familiemedlemmerFraPDL.update();
 
       const familiemedlemGrupper = familiemedlemmerFraPDL.find(FamiliemedlemGruppe);


### PR DESCRIPTION
Dette ser ut til å ha blitt verre etter oppdatering fra **@apollo/client** versjon `3.3 -> 3.4`. Før da var det allerede laget en timeout med `duration = 0`. Etter oppdatering ble denne endret til `duration = 15`. 

Denne spesifikke testen i PR-en har feilet iallefall to ganger så hever duration på akkurat denne. 

Denne kan dras inn slik det er, men er det noen som ser noen løsning på dette som ikke inkluderer timeouts?