### PR TITLE
Rar border i behandlingsmenyen i noen tilfeller

### DIFF
--- a/src/felleskomponenter/personlinje/behandlingsmeny/behandlingsmeny.less
+++ b/src/felleskomponenter/personlinje/behandlingsmeny/behandlingsmeny.less
@@ -48,11 +48,13 @@
       border-radius: 0;
       border-left: 1px solid @navMorkGra;
       border-right: 1px solid @navMorkGra;
+      border-bottom: 1px solid @navMorkGra;
     }
     &__handlinger {
       background-color: #fff;
       border-radius: 0 0 3px 3px;
       border: 1px solid @navMorkGra;
+      border-top: 0;
       padding: 1rem;
     }
     .ekspanderbartPanel--apen .ekspanderbartPanel__hode {


### PR DESCRIPTION
Flytter border-en mellom komponentene fra handlinger til avslutt-sak 

Kommet kommentar fra test der det ønskes samme bottom-border uavhengig av om Vurder saken på nytt vises.