### PR TITLE
Validerer antall arbeidsgivere før brev blir sendt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@apollo/client": "^3.5.9",
         "@loadable/component": "^5.10.3",
         "@navikt/fnrvalidator": "^1.1.4",
-        "@navikt/melosys-kodeverk": "5.15.109",
+        "@navikt/melosys-kodeverk": "5.15.110",
         "classnames": "^2.2.6",
         "connected-react-router": "^6.6.1",
         "date-fns": "^2.28.0",
@@ -89,7 +89,7 @@
         "react-motion": "^0.5.2",
         "react-on-screen": "^2.1.1",
         "react-pdf": "5.6.0",
-        "react-promise-suspense": "^0.3.3",
+        "react-promise-suspense": "0.3.3",
         "react-redux": "^7.1.3",
         "react-router-dom": "^5.1.2",
         "react-scripts": "^4.0.3",
@@ -4884,9 +4884,9 @@
       "license": "MIT"
     },
     "node_modules/@navikt/melosys-kodeverk": {
-      "version": "5.15.109",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.109/000bc6d4f98ff5972130d57b265776ba88e66910a9f2245dcab6ec28b6fb198a",
-      "integrity": "sha512-3cCHYS9QMlQ6iOQtNGT2j+C+Pvtx7jkfATrXJQ0E9C3wI0DG2vN7yn95d89lRaixweoOmXV8knc/y263ZBrMmw==",
+      "version": "5.15.110",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.110/e42cee897be0d8561fcb7c8dabb8c424058bd89e924e768011c4ad01ba486b31",
+      "integrity": "sha512-alB5MrpUHtzZBLyKaNZf2pvxSilL16f9W9h+rWYsAAkXuT4C2CMwTY8ndtPFZ5ensWHP7wagzHFkwniyTntB5w==",
       "license": "ISC"
     },
     "node_modules/@navikt/textparser": {
@@ -37578,9 +37578,9 @@
       "integrity": "sha512-EZBwlNhp886E57GuknLB6G9Bnv4nl+e5K12B/2BeLpWZENxCmcQ+5oFvIThvEsU+LVOdfJxxGOxSvrwe5ZB3pQ=="
     },
     "@navikt/melosys-kodeverk": {
-      "version": "5.15.109",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.109/000bc6d4f98ff5972130d57b265776ba88e66910a9f2245dcab6ec28b6fb198a",
-      "integrity": "sha512-3cCHYS9QMlQ6iOQtNGT2j+C+Pvtx7jkfATrXJQ0E9C3wI0DG2vN7yn95d89lRaixweoOmXV8knc/y263ZBrMmw=="
+      "version": "5.15.110",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.110/e42cee897be0d8561fcb7c8dabb8c424058bd89e924e768011c4ad01ba486b31",
+      "integrity": "sha512-alB5MrpUHtzZBLyKaNZf2pvxSilL16f9W9h+rWYsAAkXuT4C2CMwTY8ndtPFZ5ensWHP7wagzHFkwniyTntB5w=="
     },
     "@navikt/textparser": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@apollo/client": "^3.5.9",
     "@loadable/component": "^5.10.3",
     "@navikt/fnrvalidator": "^1.1.4",
-    "@navikt/melosys-kodeverk": "5.15.109",
+    "@navikt/melosys-kodeverk": "5.15.110",
     "classnames": "^2.2.6",
     "connected-react-router": "^6.6.1",
     "date-fns": "^2.28.0",

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning.js
@@ -116,6 +116,7 @@ class VurderingArtikkel16Anmodning extends Component {
     begrunnelserFeilmelding: undefined,
     begrunnelseFritekstBrevFeilmelding: undefined,
     begrunnelseFritekstSedFeilmelding: undefined,
+    sendBrevFeilmelding: undefined,
     anmodningPending: false,
     valgteVedlegg: [],
   };
@@ -219,6 +220,15 @@ class VurderingArtikkel16Anmodning extends Component {
     this.lagreVilkar();
   };
 
+  validerArbeidsgivere = () => {
+    if (this.props.arbeidsgivereIPerioden?.length === 1) {
+      this.setState({sendBrevFeilmelding: undefined})
+      return true;
+    }
+    this.setState({sendBrevFeilmelding: "Ingen eller flere enn én norsk eller utenlandsk virksomhet oppgitt for avslag eller art 16.1"})
+    return false;
+  };
+
   validerUnntakFraBestemmelse = () => {
     const valid = this.props.unntakFraBestemmelse;
     if (!valid) this.setState({ lovvalgFeilmelding: "Velg lovvalg" });
@@ -246,6 +256,7 @@ class VurderingArtikkel16Anmodning extends Component {
     const { begrunnelseKoder } = this.props.tilstand.art16_1;
     const { touch, formIsValid } = this.props;
 
+    const arbeidsgivereValid = this.validerArbeidsgivere();
     const lovvalgValid = this.validerUnntakFraBestemmelse();
     const begrunnelserValid = this.validerBegrunnelser();
     const fritekstValid = begrunnelseKoder.includes(MKV.Koder.begrunnelser.art16_1_anmodning.SAERLIG_GRUNN)
@@ -253,7 +264,7 @@ class VurderingArtikkel16Anmodning extends Component {
       : true;
     touch("mottakerinstitusjon");
 
-    return lovvalgValid && begrunnelserValid && fritekstValid && formIsValid;
+    return arbeidsgivereValid && lovvalgValid && begrunnelserValid && fritekstValid && formIsValid;
   };
 
   validerOgLagreBehandling = async () => {
@@ -301,6 +312,7 @@ class VurderingArtikkel16Anmodning extends Component {
       begrunnelseFritekstBrevFeilmelding,
       begrunnelseFritekstSedFeilmelding,
       lovvalgFeilmelding,
+      sendBrevFeilmelding,
       anmodningPending,
       valgteVedlegg,
     } = this.state;
@@ -528,6 +540,7 @@ class VurderingArtikkel16Anmodning extends Component {
               </Nav.Column>
             </Nav.Row>
           )}
+          {sendBrevFeilmelding && <Nav.AlertStripe type="advarsel" className="varsel">{sendBrevFeilmelding}</Nav.AlertStripe>}
           <Nav.Row className="artikkel16__ekstratopp">
             <Mui.StegKnapper
               bekreftTekst="Send brevene"
@@ -551,6 +564,7 @@ class VurderingArtikkel16Anmodning extends Component {
 
 VurderingArtikkel16Anmodning.propTypes = {
   anmodningsperiode: PT.object,
+  arbeidsgivereIPerioden: PT.arrayOf(MPT.Virksomhet).isRequired,
   medlemskap: MPT.Medlemskap.isRequired,
   lagreOgBestillAnmodningsperioder: PT.func.isRequired,
   arbeidsland: PT.arrayOf(MPT.Kodeverk).isRequired,
@@ -585,6 +599,7 @@ VurderingArtikkel16Anmodning.defaultProps = {
 const mapStateToProps = (state) => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
   anmodningsperiode: anmodningsperioderSelectors.AnmodningsperiodeSelector(state),
+  arbeidsgivereIPerioden: avklartefaktaSelectors.VirksomheterIPeriodenSelector(state),
   arbeidsland: avklartefaktaSelectors.ArbeidslandKTSelector(state),
   medlemskap: behandlingerSelectors.MedlemskapSelector(state),
   unntakFraBestemmelse: anmodningsperioderSelectors.UnntakFraBestemmelseSelector(state),

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning.js
@@ -226,8 +226,7 @@ class VurderingArtikkel16Anmodning extends Component {
       return true;
     }
     this.setState({
-      sendBrevFeilmelding:
-        "Ingen eller flere enn én norsk eller utenlandsk virksomhet oppgitt for avslag eller art 16.1",
+      sendBrevFeilmelding: MKV.Terms.begrunnelser.kontroll_begrunnelser.IKKE_KUN_EN_VIRKSOMHET,
     });
     return false;
   };

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning.js
@@ -222,10 +222,13 @@ class VurderingArtikkel16Anmodning extends Component {
 
   validerArbeidsgivere = () => {
     if (this.props.arbeidsgivereIPerioden?.length === 1) {
-      this.setState({sendBrevFeilmelding: undefined})
+      this.setState({ sendBrevFeilmelding: undefined });
       return true;
     }
-    this.setState({sendBrevFeilmelding: "Ingen eller flere enn én norsk eller utenlandsk virksomhet oppgitt for avslag eller art 16.1"})
+    this.setState({
+      sendBrevFeilmelding:
+        "Ingen eller flere enn én norsk eller utenlandsk virksomhet oppgitt for avslag eller art 16.1",
+    });
     return false;
   };
 
@@ -540,7 +543,11 @@ class VurderingArtikkel16Anmodning extends Component {
               </Nav.Column>
             </Nav.Row>
           )}
-          {sendBrevFeilmelding && <Nav.AlertStripe type="advarsel" className="varsel">{sendBrevFeilmelding}</Nav.AlertStripe>}
+          {sendBrevFeilmelding && (
+            <Nav.AlertStripe type="advarsel" className="varsel">
+              {sendBrevFeilmelding}
+            </Nav.AlertStripe>
+          )}
           <Nav.Row className="artikkel16__ekstratopp">
             <Mui.StegKnapper
               bekreftTekst="Send brevene"


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5067
Lagt på "ekstra" validering frontend slik at saksbehandler får beskrivende feilmelding om antall arbeidsgivere != 1
Faktisk validering i prosesinstans i backend også lagt til: https://github.com/navikt/melosys-api/pull/1081