### PR TITLE
Legger til region i MottakerAdresse

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/mottakerAdresse.test.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/mottakerAdresse.test.tsx
@@ -1,0 +1,52 @@
+import React, { ComponentProps } from "react";
+import { mock, instance } from "ts-mockito";
+import { shallow } from "enzyme";
+import MottakerAdresse from "./mottakerAdresse";
+
+describe("MottakerAdresse", () => {
+  const lagProps = () => {
+    const mockedProps = mock<ComponentProps<typeof MottakerAdresse>>();
+    const propsObject = instance(mockedProps);
+
+    propsObject.tittel = {
+      orgnr: "orgnr",
+      mottakerNavn: "mottakerNavn",
+    };
+    return propsObject;
+  };
+
+  it("Viser komplett adresse", () => {
+    const props = lagProps();
+    props.adresselinjer = ["Adresselinje 1", "Adresselinje 2", "Adresselinje 3"];
+    props.postnr = "1234";
+    props.poststed = "Poststed";
+    props.region = "Region";
+    props.land = "Land";
+    const mottakerAdresse = shallow(<MottakerAdresse {...props} />);
+
+    expect(mottakerAdresse.text()).toBe("Adresselinje 1, Adresselinje 2, Adresselinje 3, 1234 Poststed, Region, Land");
+  });
+
+  it("Viser adresse med tomme adresselinje", () => {
+    const props = lagProps();
+    props.adresselinjer = [];
+    props.postnr = "1234";
+    props.poststed = "Poststed";
+    props.region = "Region";
+    props.land = "Land";
+    const mottakerAdresse = shallow(<MottakerAdresse {...props} />);
+
+    expect(mottakerAdresse.text()).toBe("1234 Poststed, Region, Land");
+  });
+
+  it("Viser adresse med tom region", () => {
+    const props = lagProps();
+    props.adresselinjer = ["Adresselinje 1", "Adresselinje 2", "Adresselinje 3"];
+    props.postnr = "1234";
+    props.poststed = "Poststed";
+    props.land = "Land";
+    const mottakerAdresse = shallow(<MottakerAdresse {...props} />);
+
+    expect(mottakerAdresse.text()).toBe("Adresselinje 1, Adresselinje 2, Adresselinje 3, 1234 Poststed, Land");
+  });
+});

--- a/src/felleskomponenter/sideDialog/sendBrev/mottakerAdresse.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/mottakerAdresse.tsx
@@ -7,27 +7,27 @@ const MottakerAdresse = ({
   adresselinjer,
   postnr,
   poststed,
+  region,
   land,
   className,
-}: DokumenterV2.MottakerAdresse & { className: string }) => {
-  return (
-    <div className={className}>
-      {!tittel?.orgnr && (
-        <div>
-          <b>{tittel.mottakerNavn}</b>
-        </div>
-      )}
+}: DokumenterV2.MottakerAdresse & { className: string }) => (
+  <div className={className}>
+    {!tittel?.orgnr && (
+      <div>
+        <b>{tittel.mottakerNavn}</b>
+      </div>
+    )}
 
-      {adresselinjer.map((linje) => (
-        <span key={Utils._uuid()} className="mottaker__adresselinje">
-          {linje},{" "}
-        </span>
-      ))}
-      <span className="mottaker__adresselinje">
-        {postnr} {poststed}, {land}
+    {adresselinjer.map((linje) => (
+      <span key={Utils._uuid()} className="mottaker__adresselinje">
+        {`${linje}, `}
       </span>
-    </div>
-  );
-};
+    ))}
+    <span className="mottaker__adresselinje">
+      {postnr} {poststed}
+      {region && `, ${region}`}, {land}
+    </span>
+  </div>
+);
 
 export default MottakerAdresse;

--- a/src/services/modules/dokumenter-v2.ts
+++ b/src/services/modules/dokumenter-v2.ts
@@ -10,6 +10,7 @@ export type MottakerAdresse = {
   adresselinjer: string[];
   postnr: string;
   poststed: string;
+  region: string;
   land: string;
 };
 


### PR DESCRIPTION
Mangler region i mottakers adresse dersom mottaker var bruker. Lagt til region i objektet man får fra melosys-api[(kommer PR i melosys-api](https://github.com/navikt/melosys-api/pull/1084)) og viser det dersom det finnes. 


https://jira.adeo.no/browse/MELOSYS-5031