### PR TITLE
Legger til ytterligereInfoFritekst i fritekstfeltet ved forhåndsvisning

### DIFF
--- a/src/sider/eu_eøs/registrering/anmodningunntak/saksopplysninger.js
+++ b/src/sider/eu_eøs/registrering/anmodningunntak/saksopplysninger.js
@@ -29,13 +29,7 @@ import PdfLenkeListe from "../../../../felleskomponenter/pdfLenkeListe";
 
 const uuid = require("uuid/v4");
 
-const LinkForhandsvisningSed = ({
-  redigerbart,
-  behandlingID,
-  anmodningsperiodeSvarType,
-  vedKlikk,
-  fritekst = null,
-}) => {
+const LinkForhandsvisningSed = ({ redigerbart, behandlingID, anmodningsperiodeSvarType, vedKlikk, fritekst }) => {
   let pdfDokument = [];
   if (anmodningsperiodeSvarType === MKV.Koder.anmodningsperiodesvartyper.INNVILGELSE) {
     pdfDokument = [{ navn: "Forhåndsvis SED A011", type: EKV.Koder.sedtyper.A011, erSed: true, data: { fritekst } }];

--- a/src/sider/eu_eøs/registrering/anmodningunntak/saksopplysninger.js
+++ b/src/sider/eu_eøs/registrering/anmodningunntak/saksopplysninger.js
@@ -29,7 +29,13 @@ import PdfLenkeListe from "../../../../felleskomponenter/pdfLenkeListe";
 
 const uuid = require("uuid/v4");
 
-const LinkForhandsvisningSed = ({ redigerbart, behandlingID, anmodningsperiodeSvarType, vedKlikk, fritekst }) => {
+const LinkForhandsvisningSed = ({
+  redigerbart,
+  behandlingID,
+  anmodningsperiodeSvarType,
+  vedKlikk,
+  fritekst = null,
+}) => {
   let pdfDokument = [];
   if (anmodningsperiodeSvarType === MKV.Koder.anmodningsperiodesvartyper.INNVILGELSE) {
     pdfDokument = [{ navn: "Forhåndsvis SED A011", type: EKV.Koder.sedtyper.A011, erSed: true, data: { fritekst } }];
@@ -48,7 +54,11 @@ LinkForhandsvisningSed.propTypes = {
   behandlingID: PT.number.isRequired,
   anmodningsperiodeSvarType: PT.string.isRequired,
   vedKlikk: PT.func.isRequired,
-  fritekst: PT.string.isRequired,
+  fritekst: PT.string,
+};
+
+LinkForhandsvisningSed.defaultProps = {
+  fritekst: null,
 };
 
 const Saksopplysninger = ({
@@ -286,23 +296,25 @@ const Saksopplysninger = ({
     </Nav.Row>
   );
 
+  const renderYtterligereInformasjonRow = () => (
+    <Nav.Row>
+      <Nav.Column xs="6">
+        <Nav.Textarea
+          disabled={!redigerbart}
+          label="Ytterligere informasjon til SED (valgfri)"
+          onChange={ytterligereInfoTextAreaOnChange}
+          value={ytterligereInfoFritekst}
+          maxLength={500}
+          bredde="fullbredde"
+        />
+      </Nav.Column>
+    </Nav.Row>
+  );
+
   const renderInputfelter = (utfall) => {
     switch (utfall) {
       case MKV.Koder.anmodningsperiodesvartyper.INNVILGELSE:
-        return (
-          <Nav.Row>
-            <Nav.Column xs="6">
-              <Nav.Textarea
-                disabled={!redigerbart}
-                label="Ytterligere informasjon til SED (valgfri)"
-                onChange={ytterligereInfoTextAreaOnChange}
-                value={ytterligereInfoFritekst}
-                maxLength={500}
-                bredde="fullbredde"
-              />
-            </Nav.Column>
-          </Nav.Row>
-        );
+        return renderYtterligereInformasjonRow();
       case MKV.Koder.anmodningsperiodesvartyper.DELVIS_INNVILGELSE:
         return (
           <Fragment>
@@ -331,10 +343,16 @@ const Saksopplysninger = ({
               </Nav.Column>
             </Nav.Row>
             {renderBegrunnelseFritekstRow()}
+            {renderYtterligereInformasjonRow()}
           </Fragment>
         );
       case MKV.Koder.anmodningsperiodesvartyper.AVSLAG:
-        return renderBegrunnelseFritekstRow();
+        return (
+          <Fragment>
+            {renderBegrunnelseFritekstRow()}
+            {renderYtterligereInformasjonRow()}
+          </Fragment>
+        );
       default:
         return null;
     }
@@ -417,7 +435,7 @@ const Saksopplysninger = ({
                   behandlingID={behandlingID}
                   anmodningsperiodeSvarType={anmodningsperiodeSvarType}
                   vedKlikk={oppdaterAnmodningsperiodeSvar}
-                  fritekst={erGodkjent() ? ytterligereInfoFritekst : begrunnelseFritekst}
+                  fritekst={ytterligereInfoFritekst}
                 />
               </Nav.Row>
               {durationWarningMessage && visPeriodeVarselStripe()}


### PR DESCRIPTION
[MELOSYS-5053](https://jira.adeo.no/browse/MELOSYS-5053)

Denne PR'en legger til ytterligereInformasjon ved "Delvis godkjent" og "Avslag". I tillegg så retter vi en feil der man brukte ytterligereInformasjon i "fritekstfelt"  (som i backend mappes om til ytterligereInformasjon) bare dersom man hadde "Godkjenn".

Slik det er nå så lagrer vi begrunnelse i det man trykker "Forhåndsvis" og "Send", før vi gjør requestene. I requesten sender vi altså ytterligereInformasjon ved forhåndsvis/send (kun det fordi vi allerede har lagret begrunnelse i database). 
I all tid så har jeg prøvd å gå bort fra denne måten å gjøre det på, og heller lagre ytterligereInformasjon i databasen for Anmodningsperiode_svar, ettersom det uansett virker å være behov for å kunne se ytterligereInformasjon ved senere anledning. Fant ut at dette er langt større jobb enn jeg hadde trodd, ettersom ytterligereInformasjon ikke bare blir brukt for anmodningsperioder, men også flere andre vedtak.