### PR TITLE
MELOSYS-4815: Fjerner toggle melosys.behandling.AVSLUTTE_UTEN_ENDRING

### DIFF
--- a/src/felleskomponenter/personlinje/behandlingsmeny/avsluttsak.test.tsx
+++ b/src/felleskomponenter/personlinje/behandlingsmeny/avsluttsak.test.tsx
@@ -13,11 +13,6 @@ const { NY_VURDERING } = MKV.Koder.behandlinger.behandlingstyper;
 
 const mockedProps = mock<ComponentProps<typeof AvsluttSak>>();
 
-jest.mock("../../../featuretoggle", () => ({
-  __esModule: true,
-  useFeatureToggle: () => "enabled",
-}));
-
 describe("AvsluttSak", () => {
   let props = instance(mockedProps);
 

--- a/src/felleskomponenter/personlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/personlinje/behandlingsmeny/avsluttsak.tsx
@@ -3,7 +3,6 @@ import * as Nav from "../../../navFrontend";
 import * as KV from "../../../kodeverk";
 import MKV from "../../../melosyskodeverk";
 import Handling from "./handling";
-import { useFeatureToggle } from "../../../featuretoggle";
 
 type avsluttSakProps = {
   avslaaSoknad: () => void;
@@ -30,14 +29,10 @@ const AvsluttSak = ({
   const behandlingstypeErNyVurdering = behandlingstype === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING;
   const behandlingstypeErEndretPeriode = behandlingstype === MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE;
 
-  const avsluttUtenEndringToggle = useFeatureToggle("melosys.behandling.AVSLUTTE_UTEN_ENDRING");
-
   const skalViseAvslaaSoknad = () => {
     switch (behandlingskategori) {
       case KV.Koder.Behandlingskategori.EØS_SAKSBEHANDLING:
-        return (
-          (redigerbart && avsluttUtenEndringToggle === "enabled") || (redigerbart && !behandlingstypeErNyVurdering)
-        ); // TODO: Sjekk på redigerbart alene er nok ved fjerning av toggle
+        return redigerbart;
       case KV.Koder.Behandlingskategori.EØS_SED_BEHANDLING:
         return redigerbart && !behandlingstemaErTrygdetid;
       case KV.Koder.Behandlingskategori.EØS_REGISTRERING:
@@ -71,9 +66,6 @@ const AvsluttSak = ({
   const skalViseAvsluttSak = () => {
     switch (behandlingskategori) {
       case KV.Koder.Behandlingskategori.EØS_SAKSBEHANDLING:
-        return (
-          (redigerbart && avsluttUtenEndringToggle === "enabled") || (redigerbart && !behandlingstypeErNyVurdering)
-        ); // TODO: Denne linjen kan fjernes ved fjerning av toggle
       case KV.Koder.Behandlingskategori.EØS_SED_BEHANDLING:
       case KV.Koder.Behandlingskategori.EØS_VURDER_UTPEKING:
       case KV.Koder.Behandlingskategori.FTRL_SAKSBEHANDLING:
@@ -92,7 +84,7 @@ const AvsluttSak = ({
       case KV.Koder.Behandlingskategori.EØS_VURDER_UTPEKING:
       case KV.Koder.Behandlingskategori.FTRL_SAKSBEHANDLING:
       case KV.Koder.Behandlingskategori.TRYGDEAVTALE_SAKSBEHANDLING:
-        return redigerbart && behandlingstypeErNyVurdering && avsluttUtenEndringToggle === "enabled";
+        return redigerbart && behandlingstypeErNyVurdering;
       case KV.Koder.Behandlingskategori.EØS_REGISTRERING:
       default:
         return false;


### PR DESCRIPTION
[MELOSYS-4815](https://jira.adeo.no/browse/MELOSYS-4815)
Ang. ene TODOen som er fjernet: https://nav-it.slack.com/archives/C01CFP7SL4Q/p1648635109250389