### PR TITLE
Validerer ikke gateadresse om søknad er A003

### DIFF
--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -263,7 +263,7 @@ const soknad = object().when("$behandlingstema", {
       .nullable(),
     oppgittAdresseGatenavn: string()
       .nullable()
-      .when("$skalOppgittAdresseValideres", {
+      .when("$skalOppgittAdresseGateadresseValideres", {
         is: true,
         then: string()
           .nullable()

--- a/src/felleskomponenter/menypanelForm/soknad.tsx
+++ b/src/felleskomponenter/menypanelForm/soknad.tsx
@@ -7,6 +7,7 @@ import { ThunkDispatch } from "redux-thunk";
 
 import { lagYupToReduxformErrorMapper } from "../../yup";
 import soknadSchema from "../../ducks/form/soknadSchema";
+import MKV from "../../melosyskodeverk";
 import * as KV from "../../kodeverk";
 import * as Utils from "../../utils";
 
@@ -243,6 +244,9 @@ const MenypanelForm = reduxForm<KV.Form.SoknadFormData, SoknadProps>({
     const settings = {
       context: {
         skalOppgittAdresseValideres: props.oppgittAdresseHarVerdier,
+        skalOppgittAdresseGateadresseValideres:
+          props.oppgittAdresseHarVerdier &&
+          props.behandlingstema !== MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE,
         behandlingstema: props.behandlingstema,
         behandlingsgrunnlagtype: props.behandlingsgrunnlagtype,
         sakstype: props.sakstype,


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5116
"I saker der det foreligger "annen adresse" hentet fra SED A003 skal vi ikke validere på gateadresse."