### PR TITLE
Midlertidig disabling av knapp på sokkel/skip steg

### DIFF
--- a/src/sider/eu_eøs/saksbehandling/stegMap/sokkel_skip.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/sokkel_skip.js
@@ -46,6 +46,7 @@ class SokkelSkip extends Steg {
     this.komponent = VurderingSokkelSkip;
     this.samleRelevanteData = (_propsLight) => ({
       begrunnelser: _propsLight.begrunnelser.sokkel,
+      behandlingstema: _propsLight.behandlingstema,
       redigerbart: _propsLight.generiskStegRedigerbart,
     });
     this.beregnRelevantUI = (_propsLight) => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingSokkelSkip.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingSokkelSkip.js
@@ -2,6 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 import PT from "prop-types";
 
+import MKV from "@navikt/melosys-kodeverk";
 import * as Nav from "../../../navFrontend";
 import * as KV from "../../../kodeverk";
 import * as MPT from "../../../proptypes";
@@ -61,8 +62,17 @@ class VurderingSokkelSkip extends React.Component {
   render() {
     // Merknad fra møte 12.12.18: Vi må huske å gå innom “vurdering antall land”
     // dersom man har valgt “to sokler / skip i flere land” siden vi går inn i artikkel 13.
-    const { bekreftOgFortsett, tilstand, begrunnelser, redigerbart, oppdaterData, slettData, maritimtArbeid, tilbake } =
-      this.props;
+    const {
+      bekreftOgFortsett,
+      behandlingstema,
+      tilstand,
+      begrunnelser,
+      redigerbart,
+      oppdaterData,
+      slettData,
+      maritimtArbeid,
+      tilbake,
+    } = this.props;
 
     const {
       sokkelEllerSkipListe,
@@ -110,7 +120,9 @@ class VurderingSokkelSkip extends React.Component {
         <Nav.Fieldset legend="Hvordan arbeider søkeren:">
           <Nav.Radio
             name={KV.Koder.avklartefaktaKoder.ARBEID_SOKKEL_SKIP}
-            disabled={!redigerbart}
+            disabled={
+              !redigerbart || behandlingstema?.kode === MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER
+            }
             onChange={konklusjonEndretHandler}
             checked={fakta === VurderingSokkelSkipTyper.SOKKEL_NORSK}
             value={VurderingSokkelSkipTyper.SOKKEL_NORSK}
@@ -159,6 +171,7 @@ class VurderingSokkelSkip extends React.Component {
 
 VurderingSokkelSkip.propTypes = {
   begrunnelser: PT.arrayOf(MPT.Kodeverk).isRequired,
+  behandlingstema: MPT.Behandlingsresultat.isRequired,
   bekreftOgFortsett: PT.func.isRequired,
   maritimtArbeid: PT.array,
   tilstand: PT.object,


### PR DESCRIPTION
ARBEID_SOKKEL_SKIP-verdi: "På norsk sokkel eller innenfor norsk territorialfarvann (art. 11.3.a)" er ikke støttet enda for UTSENDT_ARBEIDSTAKER-behandlingstema. Setter det disabled frem til det er på plass

https://nav-it.slack.com/archives/CPSMP2GKT/p1650967501588579?thread_ts=1650952544.759809&cid=CPSMP2GKT

Fra Mina: 
> Den skal være disablet hvis man velger "Yrkesaktiv på sokkel eller skip" i Utsendt arbeidstaker-flyten. Så den jeg har valgt på bildet skal være grået ut på samme måte som den siste radiobutton er her:
![image](https://user-images.githubusercontent.com/56385061/165284333-00756d59-1fbd-4798-9c92-5807b767f22f.png)
