### PR TITLE
Henter behandling på nytt dersom den ikke er redigerbar etter ny vurdering

### DIFF
--- a/src/sider/trygdeavtale/saksbehandling.js
+++ b/src/sider/trygdeavtale/saksbehandling.js
@@ -68,10 +68,11 @@ const Saksbehandling = ({
   const [saksopplysningerLastet, setSaksopplysningerLastet] = useState(false);
   const saksnummer = match?.params?.snr;
 
-  const debouncedSetBehandlingIDHarEndretSeg = useCallback(
-    Utils._debounce(() => setBehandlingIDHarEndretSeg(false), 250),
-    []
-  );
+  const handleNyVurdering = (skalHenteBehandling, nyVurderingBehandlingID) => {
+    if (skalHenteBehandling) hentBehandling(nyVurderingBehandlingID);
+    setBehandlingIDHarEndretSeg(false);
+  };
+  const debouncedHandleNyVurdering = useCallback(Utils._debounce(handleNyVurdering, 500), []);
 
   const oppdaterBehandlingIDState = () => {
     const behandlingIDFraParam = Utils.queryString.getParam(location, "behandlingID");
@@ -80,7 +81,7 @@ const Saksbehandling = ({
       if (behandlingID !== -1) setBehandlingIDHarEndretSeg(true);
       setBehandlingID(Utils._toInteger(behandlingIDFraParam));
     } else if (behandlingIDHarEndretSeg) {
-      debouncedSetBehandlingIDHarEndretSeg();
+      debouncedHandleNyVurdering(!redigerbart, behandlingIDFraParam);
     }
   };
 
@@ -121,9 +122,9 @@ const Saksbehandling = ({
     hentLandkoder();
 
     return () => {
+      resetFagsakState();
       resetBehandlingerState();
       resetBehandlingsgrunnlagState();
-      resetFagsakState();
       skjulMenypanel();
     };
   }, []);


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5138

Min nåværende teori er at oppgave/gosys er treigere i prod enn i dev, og at det er der feilen oppstår. 
Når man henter behandling bruker man oppgaveService for å finne ut om oppgaven tilhører den saksbehandleren som er logget inn, henter dette derfor på nytt dersom man har nettopp har lagt ny vurdering og ikke kan redigere.