### PR TITLE
Melosys 5094 henlegge fritekst formattering

### DIFF
--- a/src/felleskomponenter/dialogboks/avslagSoknad/dialogboksAvslagSoknad.tsx
+++ b/src/felleskomponenter/dialogboks/avslagSoknad/dialogboksAvslagSoknad.tsx
@@ -117,9 +117,9 @@ export const DialogboksAvslagSoknad = (props: DialogboksAvslagSoknadProps & Prop
           <div className="knapperadcontainer">
             <Knapperad
               avbryt={avbryt}
-              avbrytTekst="AVBRYT"
+              avbrytTekst="Avbryt"
               bekreft={avslaaSoknad}
-              bekreftTekst="AVSLÅ SØKNAD"
+              bekreftTekst="Avslå søknad"
               redigerbart={redigerbart}
               bekreftRedigerbart={bekreftRedigerbart}
             />

--- a/src/felleskomponenter/dialogboks/avsluttSakSomBortfalt/dialogboksAvsluttSakSomBortfalt.js
+++ b/src/felleskomponenter/dialogboks/avsluttSakSomBortfalt/dialogboksAvsluttSakSomBortfalt.js
@@ -26,9 +26,9 @@ export const DialogboksAvsluttSakSomBortfalt = ({ avsluttSakSomBortfalt, avbryt,
     </Nav.Typo.Normaltekst>
     <Knapperad
       bekreft={avsluttSakSomBortfalt}
-      bekreftTekst="BEKREFT"
+      bekreftTekst="Bekreft"
       avbryt={avbryt}
-      avbrytTekst="AVBRYT"
+      avbrytTekst="Avbryt"
       redigerbart={redigerbart}
     />
   </Nav.Modal>

--- a/src/felleskomponenter/dialogboks/ferdigbehandleNyVurdering/dialogboksFerdigbehandleNyVurdering.js
+++ b/src/felleskomponenter/dialogboks/ferdigbehandleNyVurdering/dialogboksFerdigbehandleNyVurdering.js
@@ -31,9 +31,9 @@ export const DialogboksFerdigbehandleNyVurdering = ({
     </Nav.Typo.Normaltekst>
     <Knapperad
       bekreft={ferdigbehandleNyVurdering}
-      bekreftTekst="BEKREFT"
+      bekreftTekst="Bekreft"
       avbryt={avbryt}
-      avbrytTekst="AVBRYT"
+      avbrytTekst="Avbryt"
       redigerbart={redigerbart}
     />
   </Nav.Modal>

--- a/src/felleskomponenter/dialogboks/henlegg/dialogboksHenlegg.tsx
+++ b/src/felleskomponenter/dialogboks/henlegg/dialogboksHenlegg.tsx
@@ -169,10 +169,10 @@ export const DialogboksHenleggSak = ({
         )}
         <Knapperad
           bekreft={handleHenlegg}
-          bekreftTekst="HENLEGG SAKEN"
+          bekreftTekst="Henlegg saken"
           bekreftRedigerbart={erBegrunnelseValgt && harIngenFeilmeldinger}
           avbryt={avbryt}
-          avbrytTekst="AVBRYT"
+          avbrytTekst="Avbryt"
           redigerbart={redigerbart}
         />
       </div>

--- a/src/felleskomponenter/dialogboks/revurderFagsak/dialogboksRevurderFagsak.js
+++ b/src/felleskomponenter/dialogboks/revurderFagsak/dialogboksRevurderFagsak.js
@@ -20,9 +20,9 @@ export const DialogboksRevurderFagsak = ({ bekreft, avbryt, ariaHideApp, spinner
     <Nav.Typo.Systemtittel className="overskrift">Vurder saken på nytt</Nav.Typo.Systemtittel>
     <Knapperad
       bekreft={bekreft}
-      bekreftTekst="BEKREFT"
+      bekreftTekst="Bekreft"
       avbryt={avbryt}
-      avbrytTekst="AVBRYT"
+      avbrytTekst="Avbryt"
       redigerbart
       spinner={spinner}
     />

--- a/src/felleskomponenter/sideDialog/sideDialogNotater/sideDialogNotater.js
+++ b/src/felleskomponenter/sideDialog/sideDialogNotater/sideDialogNotater.js
@@ -139,9 +139,9 @@ const SideDialogNotater = ({ saksnummer, redigerbart }) => {
             />
             <Knapperad
               avbryt={avbrytLeggTilNotat}
-              avbrytTekst="AVBRYT"
+              avbrytTekst="Avbryt"
               bekreft={opprettNotat}
-              bekreftTekst="LAGRE NOTAT"
+              bekreftTekst="Lagre notat"
               bekreftRedigerbart={!disableLagreKnapp}
               redigerbart
             />

--- a/src/sider/eu_eøs/saksbehandling/komponenter/stegErstatter/stegerstatterBase.js
+++ b/src/sider/eu_eøs/saksbehandling/komponenter/stegErstatter/stegerstatterBase.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PT from "prop-types";
+import parse from "html-react-parser";
 
 import * as Nav from "../../../../../navFrontend";
 
@@ -11,7 +12,7 @@ const StegerstatterBase = ({ tittel, beskrivelse }) => (
       <Nav.Row>
         <Nav.Typo.Systemtittel>{tittel}</Nav.Typo.Systemtittel>
       </Nav.Row>
-      <p>{beskrivelse}</p>
+      <p>{parse(beskrivelse)}</p>
     </Nav.Panel>
   </section>
 );

--- a/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
+++ b/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
@@ -52,7 +52,7 @@ class GodkjennUtpekingNorge extends Steg {
     this.handlers = {
       lagreOgFatteVedtak: propsLight.tilgjengeligeHandlers.lagreOgFatteVedtak,
       tilbake: propsLight.tilgjengeligeHandlers.tilbake,
-      kontrollerFerdigbehandling: this._propsLight.tilgjengeligeHandlers.kontrollerFerdigbehandling,
+      kontrollerFerdigbehandling: propsLight.tilgjengeligeHandlers.kontrollerFerdigbehandling,
     };
     this._status = FANE_STATUS.OK;
   }


### PR DESCRIPTION
Fritekst fra henleggelsesbegrunnelse har formattering. Denne ble ikke påført i visning.
I tillegg ble jeg gjort oppmerksom på at oppdatert design har gått bort fra CAPS-LOCK i knapper etc. Gjorde et kjapt søk på `AVBRYT` og oppdaterte for disse