### PR TITLE
5248 Feil periode i oversikt etter forkortet periode

### DIFF
--- a/src/felleskomponenter/stegvelger/Stegvelger.js
+++ b/src/felleskomponenter/stegvelger/Stegvelger.js
@@ -311,7 +311,7 @@ class Stegvelger extends Component {
     this.props.oppdaterAnmodningsPerioder(perioderStegState);
   };
 
-  endreDatoOgSendLovvalgsperioderHandler = (fomdato, tomdato) => {
+  endreLovvalgsperioderHandler = (fomdato, tomdato) => {
     const { behandlingID, lovvalgsperioder } = this.props;
 
     const forkortetPeriode = lovvalgsperioder.map((periode) => ({ ...periode, fomDato: fomdato, tomDato: tomdato }));
@@ -347,7 +347,7 @@ class Stegvelger extends Component {
       lagreVilkarHandler: this.props.lagreVilkarHandler,
       lagreAnmodningsperioderHandler: this.props.lagreAnmodningsperioderHandler,
       endreVedtak: this.endreVedtak,
-      endreDatoOgSendLovvalgsperioderHandler: this.endreDatoOgSendLovvalgsperioderHandler,
+      endreLovvalgsperioderHandler: this.endreLovvalgsperioderHandler,
       tilForsiden: this.props.tilForsiden,
       lagreOgBestillAnmodningsperioder: this.lagreOgBestillAnmodningsperioder,
       byggAnmodningsperioderHandler: this.byggAnmodningsperioderHandler,

--- a/src/sider/eu_eøs/saksbehandling/stegMap/endre_periode.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/endre_periode.js
@@ -27,8 +27,7 @@ class EndrePeriode extends Steg {
     this.handlers = {
       endreVedtak: this._propsLight.tilgjengeligeHandlers.endreVedtak,
       tilbake: propsLight.tilgjengeligeHandlers.tilbake,
-      endreDatoOgSendLovvalgsperioderHandler:
-        this._propsLight.tilgjengeligeHandlers.endreDatoOgSendLovvalgsperioderHandler,
+      endreLovvalgsperioderHandler: this._propsLight.tilgjengeligeHandlers.endreLovvalgsperioderHandler,
       oppdaterData: (felt, verdi) => this._propsLight.tilgjengeligeHandlers.oppdaterStegData(this.id, felt, verdi),
       slettData: (data) => this._propsLight.tilgjengeligeHandlers.slettStegData(this.id, data),
     };

--- a/src/sider/eu_eøs/stegKomponenter/vurderingEndrePeriode.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingEndrePeriode.js
@@ -90,12 +90,7 @@ export class VurderingEndrePeriode extends React.Component {
 
   lagrePeriodeForForhandsvisning = () => {
     if (this.validerTomDatoOgPeriode()) {
-      const {
-        nyTomDato,
-        opprinneligLovvalgsperiode: { fom },
-      } = this.state;
-
-      this.props.endreDatoOgSendLovvalgsperioderHandler(fom, Utils.dato.formatterDatoTilISO(nyTomDato));
+      this.oppdaterPeriodeOgSendEndretLovvalgsperiode();
     }
   };
 
@@ -138,13 +133,13 @@ export class VurderingEndrePeriode extends React.Component {
     this.setState({ vedtakFeilmelding: null });
 
     const { endreVedtak } = this.props;
-    const { sendEndretLovvalgsPeriode, validerAlt } = this;
+    const { oppdaterPeriodeOgSendEndretLovvalgsperiode, validerAlt } = this;
     const { begrunnelse, fritekstSed } = this.state;
 
     if (validerAlt()) {
       this.setState({ endringPending: true });
 
-      await sendEndretLovvalgsPeriode();
+      await oppdaterPeriodeOgSendEndretLovvalgsperiode();
 
       const data = {
         begrunnelseKode: begrunnelse,
@@ -164,13 +159,14 @@ export class VurderingEndrePeriode extends React.Component {
     }
   };
 
-  sendEndretLovvalgsPeriode = async () => {
+  oppdaterPeriodeOgSendEndretLovvalgsperiode = async () => {
     const {
       nyTomDato,
       opprinneligLovvalgsperiode: { fom },
     } = this.state;
 
-    this.props.endreDatoOgSendLovvalgsperioderHandler(fom, Utils.dato.formatterDatoTilISO(nyTomDato));
+    this.props.oppdaterPeriode({ fom, tom: nyTomDato });
+    this.props.endreLovvalgsperioderHandler(fom, Utils.dato.formatterDatoTilISO(nyTomDato));
   };
 
   validerAlt = () => {
@@ -322,11 +318,12 @@ export class VurderingEndrePeriode extends React.Component {
 VurderingEndrePeriode.propTypes = {
   behandlingID: PT.number.isRequired,
   lovvalgsPeriode: PT.object.isRequired,
-  endreDatoOgSendLovvalgsperioderHandler: PT.func.isRequired,
+  endreLovvalgsperioderHandler: PT.func.isRequired,
   fomDato: PT.string,
   endreVedtak: PT.func.isRequired,
   redigerbart: PT.bool.isRequired,
   oppdaterData: PT.func.isRequired,
+  oppdaterPeriode: PT.func.isRequired,
   slettData: PT.func.isRequired,
   tilstand: PT.shape({
     aarsakEndringPeriodeAvklartfakta: MPT.Avklartefakta.isRequired,

--- a/src/sider/eu_eøs/stegKomponenter/vurderingEndrePeriode.test.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingEndrePeriode.test.js
@@ -14,7 +14,7 @@ describe("vurderingEndrePeriode", () => {
     props = {
       behandlingID: 1,
       lovvalgsPeriode: {},
-      endreDatoOgSendLovvalgsperioderHandler: jest.fn(),
+      endreLovvalgsperioderHandler: jest.fn(),
       endreVedtak: jest.fn(),
       tilForsiden: jest.fn(),
       tilbake: jest.fn(),
@@ -23,6 +23,7 @@ describe("vurderingEndrePeriode", () => {
         aarsakEndringPeriodeAvklartfakta: lagAvklartfakta("a", "b", "c", [], "fritekst"),
       },
       oppdaterData: jest.fn(),
+      oppdaterPeriode: jest.fn(),
       slettData: jest.fn(),
       soknadsland: ["SE"],
     };
@@ -44,7 +45,8 @@ describe("vurderingEndrePeriode", () => {
       const stegKnapper = component.find("StegKnapper");
       component.instance().validerAlt = jest.fn(() => true);
       stegKnapper.props().bekreftKnappProps.onClick();
-      expect(props.endreDatoOgSendLovvalgsperioderHandler).toHaveBeenCalled();
+      expect(props.oppdaterPeriode).toHaveBeenCalled();
+      expect(props.endreLovvalgsperioderHandler).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Feilen stammer fra at søknadsperiode i behandlingsgrunnlag ikke ble oppdatert ved endring av lovvalgsperiode. 
- Endret slik at det oppdateres samtidig som lovvalgsperiode. 
- Endret navngivning av funksjon for lesbarhet.

https://jira.adeo.no/browse/MELOSYS-5248