### PR TITLE
4964 Filterer hvem som kan velge LA_BUC_01

### DIFF
--- a/src/felleskomponenter/sideDialog/sideDialog.tsx
+++ b/src/felleskomponenter/sideDialog/sideDialog.tsx
@@ -1,9 +1,16 @@
 import React, { useState } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { RootState } from "AppTypes";
 import classnames from "classnames";
 import { DokumentOversikt, FysiskDokument } from "Domene";
 
 import * as Nav from "../../navFrontend";
 import * as Utils from "../../utils";
+
+import { behandlingerSelectors } from "../../ducks/behandlinger";
+import { redigerbartSelectors } from "../../ducks/redigerbart";
+import { dokumenterSelectors } from "../../ducks/dokumenter";
+import { fagsakSelectors } from "../../ducks/fagsaker";
 
 import SideDialogSendBrev from "./sendBrev";
 import SideDialogOpprettNyBuc from "./sideDialogOpprettNyBuc";
@@ -18,7 +25,9 @@ type FaneNavn = "sedbestilling" | "dokumenter" | "notat" | "brevbestilling" | "b
 export interface FaneViserProps {
   navn: FaneNavn;
   saksnummer: string;
+  sakstype: string;
   behandlingID: number;
+  behandlingstema: string;
   redigerbart: boolean;
   dokumentOversikt: DokumentOversikt[];
   dokumenter: FysiskDokument[];
@@ -27,7 +36,9 @@ export interface FaneViserProps {
 export const FaneViser = ({
   navn,
   behandlingID,
+  behandlingstema,
   saksnummer,
+  sakstype,
   redigerbart,
   dokumentOversikt,
   dokumenter,
@@ -45,7 +56,14 @@ export const FaneViser = ({
         />
       );
     case "sedbestilling":
-      return <SideDialogOpprettNyBuc behandlingID={behandlingID} dokumenter={dokumenter} />;
+      return (
+        <SideDialogOpprettNyBuc
+          behandlingID={behandlingID}
+          behandlingstema={behandlingstema}
+          sakstype={sakstype}
+          dokumenter={dokumenter}
+        />
+      );
     case "besvarsed":
       return <SideDialogBesvarSed behandlingID={behandlingID} />;
     case "notat":
@@ -57,23 +75,33 @@ export const FaneViser = ({
 
 type Fane = { navn: FaneNavn; tittel: string };
 
+const mapStateToProps = (state: RootState) => ({
+  behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
+  behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
+  dokumenter: dokumenterSelectors.AlleFysiskeDokumentSelector(state),
+  dokumentOversikt: dokumenterSelectors.DokumentOversiktSelector(state),
+  saksnummer: fagsakSelectors.SaksnummerSelector(state),
+  sakstype: fagsakSelectors.SakstypeKodeSelector(state),
+  redigerbart: redigerbartSelectors.RedigerbartSelector(state),
+});
+
+const connector = connect(mapStateToProps);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
 interface SideDialogProps {
   faner?: Fane[];
-  saksnummer: string;
-  behandlingID: number;
-  redigerbart: boolean;
-  dokumentOversikt: DokumentOversikt[];
-  dokumenter: FysiskDokument[];
 }
 
 const SideDialog = ({
   behandlingID,
+  behandlingstema,
   saksnummer,
+  sakstype,
   redigerbart,
   dokumentOversikt,
   dokumenter,
   faner = defaultFaner,
-}: SideDialogProps) => {
+}: SideDialogProps & PropsFromRedux) => {
   const [aktivFane, setAktivFane] = useState<FaneNavn>(faner[0].navn);
 
   return (
@@ -95,7 +123,9 @@ const SideDialog = ({
           <FaneViser
             navn={aktivFane}
             behandlingID={behandlingID}
+            behandlingstema={behandlingstema}
             saksnummer={saksnummer}
+            sakstype={sakstype}
             redigerbart={redigerbart}
             dokumentOversikt={dokumentOversikt}
             dokumenter={dokumenter}
@@ -120,4 +150,4 @@ export const fanerUtenBucOgSed: Fane[] = [
   { navn: "brevbestilling", tittel: "Send brev" },
 ];
 
-export default SideDialog;
+export default connector(SideDialog);

--- a/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.js
+++ b/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.js
@@ -139,7 +139,7 @@ const SideDialogOpprettNyBuc = ({ behandlingID, behandlingstema, sakstype, dokum
   ];
   const ignorerteHBucer = EKV.KTObjects.buctyper.horizontal.filter(({ kode }) => !tilgjengeligeHBucer.includes(kode));
 
-  const kanVelgeLABUC01 = () => {
+  const kanVelgeLA_BUC_01 = () => {
     switch (behandlingstema) {
       case MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER:
       case MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG:
@@ -151,7 +151,7 @@ const SideDialogOpprettNyBuc = ({ behandlingID, behandlingstema, sakstype, dokum
     }
   };
   const ignorerteLABucer = EKV.KTObjects.buctyper.legislation.filter(
-    ({ kode }) => !kanVelgeLABUC01() && kode === EKV.Koder.buctyper.legislation.LA_BUC_01
+    ({ kode }) => kode === EKV.Koder.buctyper.legislation.LA_BUC_01 && !kanVelgeLA_BUC_01()
   );
 
   const tilgjengeligeBucer = (fagomrade) =>

--- a/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.js
+++ b/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.js
@@ -25,7 +25,7 @@ TomtFelt.defaultProps = {
   tekst: "Velg...",
 };
 
-const SideDialogOpprettNyBuc = ({ behandlingID, dokumenter }) => {
+const SideDialogOpprettNyBuc = ({ behandlingID, behandlingstema, sakstype, dokumenter }) => {
   const [tilgjengeligeMottakerinstitusjoner, setTilgjengeligeMottakerinstitusjoner] = useState([]);
 
   const [valgtFagomrade, setValgtFagomrade] = useState(EKV.Koder.sektor.LA);
@@ -139,8 +139,25 @@ const SideDialogOpprettNyBuc = ({ behandlingID, dokumenter }) => {
   ];
   const ignorerteHBucer = EKV.KTObjects.buctyper.horizontal.filter(({ kode }) => !tilgjengeligeHBucer.includes(kode));
 
+  const kanVelgeLABUC01 = () => {
+    switch (behandlingstema) {
+      case MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER:
+      case MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG:
+        return true;
+      case MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV:
+        return sakstype === MKV.Koder.sakstyper.EU_EOS;
+      default:
+        return false;
+    }
+  };
+  const ignorerteLABucer = EKV.KTObjects.buctyper.legislation.filter(
+    ({ kode }) => !kanVelgeLABUC01() && kode === EKV.Koder.buctyper.legislation.LA_BUC_01
+  );
+
   const tilgjengeligeBucer = (fagomrade) =>
-    EKV.Selectors.hentBucTyperForFagomrade(fagomrade).filter((buc) => !ignorerteHBucer.includes(buc));
+    EKV.Selectors.hentBucTyperForFagomrade(fagomrade)
+      .filter((buc) => !ignorerteHBucer.includes(buc))
+      .filter((buc) => !ignorerteLABucer.includes(buc));
 
   const tilgjengeligeSeder = (buc) => EKV.Selectors.hentSedTyperForBuc(buc);
 
@@ -262,6 +279,8 @@ const SideDialogOpprettNyBuc = ({ behandlingID, dokumenter }) => {
 
 SideDialogOpprettNyBuc.propTypes = {
   behandlingID: PT.number.isRequired,
+  behandlingstema: PT.string.isRequired,
+  sakstype: PT.string.isRequired,
   dokumenter: PT.arrayOf(PT.object).isRequired,
 };
 

--- a/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.test.js
+++ b/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.test.js
@@ -1,0 +1,74 @@
+import React from "react";
+
+import * as EKV from "eessi-kodeverk";
+import * as Nav from "../../navFrontend";
+import MKV from "../../melosyskodeverk";
+
+import SideDialogOpprettNyBuc from "./sideDialogOpprettNyBuc";
+
+describe("SideDialogOpprettNyBuc", () => {
+  describe("Tilgjengelige BUC", () => {
+    let props;
+
+    beforeEach(() => {
+      props = {
+        behandlingID: 1,
+        behandlingstema: "",
+        dokumenter: [],
+        sakstype: "",
+      };
+    });
+
+    it("LA_BUC_01 vises for behandlingstema UTSENDT_ARBEIDSGIVER", () => {
+      props.behandlingstema = MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER;
+      const sideDialogOpprettNyBuc = shallow(<SideDialogOpprettNyBuc {...props} />);
+
+      const tilgjengeligeBuc = sideDialogOpprettNyBuc.find(Nav.Select).get(1).props.children[1];
+
+      expect(tilgjengeligeBuc).toHaveLength(6);
+      expect(tilgjengeligeBuc[0].props.value).toBe(EKV.Koder.buctyper.legislation.LA_BUC_01);
+    });
+
+    it("LA_BUC_01 vises for behandlingstema UTSENDT_SELVSTENDIG", () => {
+      props.behandlingstema = MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG;
+      const sideDialogOpprettNyBuc = shallow(<SideDialogOpprettNyBuc {...props} />);
+
+      const tilgjengeligeBuc = sideDialogOpprettNyBuc.find(Nav.Select).get(1).props.children[1];
+
+      expect(tilgjengeligeBuc).toHaveLength(6);
+      expect(tilgjengeligeBuc[0].props.value).toBe(EKV.Koder.buctyper.legislation.LA_BUC_01);
+    });
+
+    it("LA_BUC_01 vises for behandlingstema IKKE_YRKESAKTIV og sakstype EU_EØS", () => {
+      props.behandlingstema = MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV;
+      props.sakstype = MKV.Koder.sakstyper.EU_EOS;
+      const sideDialogOpprettNyBuc = shallow(<SideDialogOpprettNyBuc {...props} />);
+
+      const tilgjengeligeBuc = sideDialogOpprettNyBuc.find(Nav.Select).get(1).props.children[1];
+
+      expect(tilgjengeligeBuc).toHaveLength(6);
+      expect(tilgjengeligeBuc[0].props.value).toBe(EKV.Koder.buctyper.legislation.LA_BUC_01);
+    });
+
+    it("LA_BUC_01 vises ikke for behandlingstema YRKESAKTIV", () => {
+      props.behandlingstema = MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV;
+      const sideDialogOpprettNyBuc = shallow(<SideDialogOpprettNyBuc {...props} />);
+
+      const tilgjengeligeBuc = sideDialogOpprettNyBuc.find(Nav.Select).get(1).props.children[1];
+
+      expect(tilgjengeligeBuc).toHaveLength(5);
+      expect(tilgjengeligeBuc[0].props.value).not.toBe(EKV.Koder.buctyper.legislation.LA_BUC_01);
+    });
+
+    it("LA_BUC_01 vises ikke for behandlingstema IKKE_YRKESAKTIV og sakstype FTRL", () => {
+      props.behandlingstema = MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV;
+      props.sakstype = MKV.Koder.sakstyper.FTRL;
+      const sideDialogOpprettNyBuc = shallow(<SideDialogOpprettNyBuc {...props} />);
+
+      const tilgjengeligeBuc = sideDialogOpprettNyBuc.find(Nav.Select).get(1).props.children[1];
+
+      expect(tilgjengeligeBuc).toHaveLength(5);
+      expect(tilgjengeligeBuc[0].props.value).not.toBe(EKV.Koder.buctyper.legislation.LA_BUC_01);
+    });
+  });
+});

--- a/src/sider/eu_eøs/registrering/registrering.js
+++ b/src/sider/eu_eøs/registrering/registrering.js
@@ -19,7 +19,6 @@ import { avklartefaktaOperations, avklartefaktaSelectors } from "../../../ducks/
 import { lovvalgsperioderOperations, lovvalgsperioderSelectors } from "../../../ducks/lovvalgsperioder";
 import { behandlingsresultatSelectors } from "../../../ducks/behandlingsresultat";
 import { redigerbartSelectors } from "../../../ducks/redigerbart";
-import { dokumenterSelectors } from "../../../ducks/dokumenter";
 
 import "./registrering.css";
 
@@ -45,8 +44,6 @@ export const Registrering = ({
   lovvalgsland,
   visOppfriskModal,
   behandlingOppfriskes,
-  dokumentOversikt,
-  dokumenter,
   startOgVisOppfriskModal,
   resetFagsakState,
 }) => {
@@ -113,14 +110,7 @@ export const Registrering = ({
                   lovvalgsperiodeTom={lovvalgsperiodeTom}
                 />
                 <SaksoversiktLenke />
-                <SideDialog
-                  saksnummer={saksnummer}
-                  behandlingID={behandlingID}
-                  redigerbart={redigerbart}
-                  dokumentOversikt={dokumentOversikt}
-                  dokumenter={dokumenter}
-                  faner={hovedpartErVirksomhet ? fanerUtenBucOgSed : defaultFaner}
-                />
+                <SideDialog faner={hovedpartErVirksomhet ? fanerUtenBucOgSed : defaultFaner} />
               </Nav.Column>
             </Nav.Row>
           </Nav.Container>
@@ -152,8 +142,6 @@ Registrering.propTypes = {
   visOppfriskModal: PT.func.isRequired,
   behandlingOppfriskes: PT.bool.isRequired,
   hovedpartRolle: PT.string.isRequired,
-  dokumentOversikt: PT.array.isRequired,
-  dokumenter: PT.array.isRequired,
   startOgVisOppfriskModal: PT.func.isRequired,
 };
 Registrering.defaultProps = {
@@ -178,8 +166,6 @@ const mapStateToProps = (state) => ({
   lovvalgsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeFomSelector(state)),
   lovvalgsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeTomSelector(state)),
   lovvalgsland: behandlingerSelectors.LovvalgslandSelector(state),
-  dokumenter: dokumenterSelectors.AlleFysiskeDokumentSelector(state),
-  dokumentOversikt: dokumenterSelectors.DokumentOversiktSelector(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/sider/eu_eøs/saksbehandling/saksbehandling.js
+++ b/src/sider/eu_eøs/saksbehandling/saksbehandling.js
@@ -28,7 +28,7 @@ import { behandlingsgrunnlagOperations, behandlingsgrunnlagSelectors } from "../
 import { behandlingsperioderOperations, behandlingsperioderSelectors } from "../../../ducks/behandlingsperioder";
 import { formSelectors } from "../../../ducks/form";
 import { datalastingOperations } from "../../../ducks/datalasting";
-import { dokumenterOperations, dokumenterSelectors } from "../../../ducks/dokumenter";
+import { dokumenterOperations } from "../../../ducks/dokumenter";
 import { anmodningsperiodesvarOperations } from "../../../ducks/anmodningsperiodesvar";
 import { landkoderOperations } from "../../../ducks/landkoder";
 import { feiletResponsOperations } from "../../../ducks/feiletRespons";
@@ -158,7 +158,6 @@ class Saksbehandling extends Component {
   render() {
     const {
       redigerbart,
-      match,
       fagsak,
       oppsummering,
       lovvalgsperiodeFom,
@@ -171,12 +170,7 @@ class Saksbehandling extends Component {
       behandlingsgrunnlagMottaksdato,
       tilForsiden,
       startOgVisOppfriskModal,
-      dokumentOversikt,
-      dokumenter,
     } = this.props;
-    const {
-      params: { snr: saksnummer },
-    } = match;
     const { behandlingID, saksopplysningerLastet } = this.state;
 
     if (Utils._isNil(redigerbart)) return null;
@@ -223,14 +217,7 @@ class Saksbehandling extends Component {
                     behandlingsgrunnlagPeriodeTom={behandlingsgrunnlagPeriodeTom}
                   />
                   <SaksoversiktLenke />
-                  <SideDialog
-                    behandlingID={behandlingID}
-                    saksnummer={saksnummer}
-                    redigerbart={redigerbart}
-                    dokumentOversikt={dokumentOversikt}
-                    dokumenter={dokumenter}
-                    faner={hovedpartErVirksomhet ? fanerUtenBucOgSed : defaultFaner}
-                  />
+                  <SideDialog faner={hovedpartErVirksomhet ? fanerUtenBucOgSed : defaultFaner} />
                 </Nav.Column>
               </Nav.Row>
             </Nav.Container>
@@ -292,8 +279,6 @@ Saksbehandling.propTypes = {
   behandlingOppfriskes: PT.bool.isRequired,
   startOgVisOppfriskModal: PT.func.isRequired,
   hentDokumentOversikt: PT.func.isRequired,
-  dokumentOversikt: PT.array.isRequired,
-  dokumenter: PT.array.isRequired,
   hentAnmodningsperiodesvar: PT.func.isRequired,
   resetFeiletrespons: PT.func.isRequired,
 };
@@ -341,8 +326,6 @@ const mapStateToProps = (state) => ({
   behandlingsgrunnlagMottaksdato: Utils.dato.formatterDatoTilNorsk(
     behandlingsgrunnlagSelectors.MottaksdatoSelector(state)
   ),
-  dokumenter: dokumenterSelectors.AlleFysiskeDokumentSelector(state),
-  dokumentOversikt: dokumenterSelectors.DokumentOversiktSelector(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/sider/eu_eøs/sedbehandling/sedbehandling.js
+++ b/src/sider/eu_eøs/sedbehandling/sedbehandling.js
@@ -17,7 +17,6 @@ import { behandlingerSelectors } from "../../../ducks/behandlinger";
 import { redigerbartSelectors } from "../../../ducks/redigerbart";
 import { datalastingOperations } from "../../../ducks/datalasting";
 import { behandlingsgrunnlagOperations, behandlingsgrunnlagSelectors } from "../../../ducks/behandlingsgrunnlag";
-import { dokumenterSelectors } from "../../../ducks/dokumenter";
 
 import "./sedbehandling.css";
 
@@ -36,8 +35,6 @@ const SedBehandling = ({
   lastInnSaksopplysninger,
   resetSaksopplysninger,
   hentBehandlingsgrunnlag,
-  dokumentOversikt,
-  dokumenter,
 }) => {
   const behandlingID = Utils._toInteger(Utils.queryString.getParam(location, "behandlingID"));
   const {
@@ -87,13 +84,7 @@ const SedBehandling = ({
                   }
                 />
                 <SaksoversiktLenke />
-                <SideDialog
-                  behandlingID={behandlingID}
-                  saksnummer={saksnummer}
-                  redigerbart={redigerbart}
-                  dokumentOversikt={dokumentOversikt}
-                  dokumenter={dokumenter}
-                />
+                <SideDialog />
               </Nav.Column>
             </Nav.Row>
           </Nav.Container>
@@ -119,8 +110,6 @@ SedBehandling.propTypes = {
   resetSaksopplysninger: PT.func.isRequired,
   hentBehandlingsgrunnlag: PT.func.isRequired,
   behandlingOppfriskes: PT.bool.isRequired,
-  dokumentOversikt: PT.array.isRequired,
-  dokumenter: PT.array.isRequired,
 };
 
 SedBehandling.defaultProps = {
@@ -146,8 +135,6 @@ const mapStateToProps = (state) => ({
   ),
   lovvalgsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeFomSelector(state)),
   lovvalgsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeTomSelector(state)),
-  dokumenter: dokumenterSelectors.AlleFysiskeDokumentSelector(state),
-  dokumentOversikt: dokumenterSelectors.DokumentOversiktSelector(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
+++ b/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
@@ -28,7 +28,6 @@ import { anmodningsperioderOperations } from "../../../ducks/anmodningsperioder"
 import { lovvalgsperioderOperations } from "../../../ducks/lovvalgsperioder";
 import { behandlingsperioderOperations } from "../../../ducks/behandlingsperioder";
 import { landkoderOperations } from "../../../ducks/landkoder";
-import { dokumenterSelectors } from "../../../ducks/dokumenter";
 
 import stegMap from "./stegMap";
 import "./vurderutpeking.css";
@@ -71,8 +70,6 @@ const Vurderutpeking = ({
   startOgVisOppfriskModal,
   soknadForm,
   behandlingsgrunnlag,
-  dokumentOversikt,
-  dokumenter,
   vurderUtpekingFormValues,
   hentLandkoder,
 }) => {
@@ -152,14 +149,7 @@ const Vurderutpeking = ({
                   behandlingsgrunnlagPeriodeTom={behandlingsgrunnlagPeriodeTom}
                 />
                 <SaksoversiktLenke />
-                <SideDialog
-                  behandlingID={behandlingID}
-                  saksnummer={saksnummer}
-                  redigerbart={redigerbart}
-                  dokumentOversikt={dokumentOversikt}
-                  dokumenter={dokumenter}
-                  faner={hovedpartErVirksomhet ? fanerUtenBucOgSed : defaultFaner}
-                />
+                <SideDialog faner={hovedpartErVirksomhet ? fanerUtenBucOgSed : defaultFaner} />
               </Nav.Column>
             </Nav.Row>
           </Nav.Container>
@@ -196,8 +186,6 @@ Vurderutpeking.propTypes = {
   behandlingsgrunnlag: MPT.Behandlingsgrunnlag,
   soknadForm: PT.object.isRequired,
   behandlingOppfriskes: PT.bool.isRequired,
-  dokumentOversikt: PT.array.isRequired,
-  dokumenter: PT.array.isRequired,
   vurderUtpekingFormValues: PT.object,
   hentLandkoder: PT.func.isRequired,
 };
@@ -224,8 +212,6 @@ const mapStateToProps = (state) => ({
   ),
   behandlingsgrunnlag: behandlingsgrunnlagSelectors.BehandlingsgrunnlagDataSelector(state),
   soknadForm: formSelectors.SoknadenFormSelector(state),
-  dokumenter: dokumenterSelectors.AlleFysiskeDokumentSelector(state),
-  dokumentOversikt: dokumenterSelectors.DokumentOversiktSelector(state),
   vurderUtpekingFormValues: getFormValues(KV.Form.VURDER_UTPEKING)(state),
 });
 

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -25,7 +25,7 @@ import { avklartefaktaOperations } from "../../../ducks/avklartefakta";
 import { redigerbartSelectors } from "../../../ducks/redigerbart";
 import { behandlingsgrunnlagOperations, behandlingsgrunnlagSelectors } from "../../../ducks/behandlingsgrunnlag";
 import { datalastingOperations } from "../../../ducks/datalasting";
-import { dokumenterOperations, dokumenterSelectors } from "../../../ducks/dokumenter";
+import { dokumenterOperations } from "../../../ducks/dokumenter";
 import { formSelectors } from "../../../ducks/form";
 import { menypanelOperations } from "../../../ducks/menypanel";
 import { folketrygdenkodeverkOperations } from "../../../ducks/folketrygdenkodeverk";
@@ -50,8 +50,6 @@ const Saksbehandling = ({
   behandlingsgrunnlagPeriodeTom,
   behandlingsgrunnlagMottaksdato,
   behandlingsresultat,
-  dokumenter,
-  dokumentOversikt,
   fagsak,
   fagsakStatusKode,
   hentBehandling,
@@ -155,10 +153,6 @@ const Saksbehandling = ({
     oppdaterBehandlingIDState();
   });
 
-  const {
-    params: { snr: saksnummer },
-  } = match;
-
   if (Utils._isNil(redigerbart)) return null;
   if (!behandlingID || behandlingID < 0) return null;
   if (!saksopplysningerLastet) return null;
@@ -231,14 +225,7 @@ const Saksbehandling = ({
                   behandlingsgrunnlagPeriodeTom={behandlingsgrunnlagPeriodeTom}
                 />
                 <SaksoversiktLenke />
-                <SideDialog
-                  behandlingID={behandlingID}
-                  saksnummer={saksnummer}
-                  redigerbart={redigerbart}
-                  dokumentOversikt={dokumentOversikt}
-                  dokumenter={dokumenter}
-                  faner={hovedpartErVirksomhet ? fanerUtenBucOgSed : defaultFaner}
-                />
+                <SideDialog faner={hovedpartErVirksomhet ? fanerUtenBucOgSed : defaultFaner} />
               </Nav.Column>
             </Nav.Row>
           </Nav.Container>
@@ -258,8 +245,6 @@ Saksbehandling.propTypes = {
   behandlingsgrunnlagPeriodeTom: PT.string.isRequired,
   behandlingsgrunnlagMottaksdato: PT.string.isRequired,
   behandlingsresultat: MPT.Behandlingsresultat.isRequired,
-  dokumenter: PT.array.isRequired,
-  dokumentOversikt: PT.array.isRequired,
   fagsak: MPT.Fagsak,
   fagsakStatusKode: PT.string.isRequired,
   hovedpartRolle: PT.string.isRequired,
@@ -320,8 +305,6 @@ const mapStateToProps = (state) => ({
     behandlingsgrunnlagSelectors.MottaksdatoSelector(state)
   ),
   behandlingsresultat: behandlingsresultatSelectors.BehandlingsresultatSelector(state),
-  dokumenter: dokumenterSelectors.AlleFysiskeDokumentSelector(state),
-  dokumentOversikt: dokumenterSelectors.DokumentOversiktSelector(state),
   fagsak: fagsakSelectors.FagsakSelector(state),
   fagsakStatusKode: fagsakSelectors.FagsakStatusSelector(state),
   landkoder: landkoderSelectors.LandkoderFraSakstypeSelector(state),

--- a/src/sider/trygdeavtale/saksbehandling.js
+++ b/src/sider/trygdeavtale/saksbehandling.js
@@ -17,7 +17,7 @@ import { SoknadMenypanelForm } from "../../felleskomponenter/menypanelForm";
 import { behandlingsgrunnlagOperations, behandlingsgrunnlagSelectors } from "../../ducks/behandlingsgrunnlag";
 import { behandlingsresultatOperations, behandlingsresultatSelectors } from "../../ducks/behandlingsresultat";
 import { behandlingerOperations, behandlingerSelectors } from "../../ducks/behandlinger";
-import { dokumenterOperations, dokumenterSelectors } from "../../ducks/dokumenter";
+import { dokumenterOperations } from "../../ducks/dokumenter";
 import { fagsakOperations, fagsakSelectors } from "../../ducks/fagsaker";
 import { lovvalgsperioderOperations, lovvalgsperioderSelectors } from "../../ducks/lovvalgsperioder";
 import { redigerbartSelectors } from "../../ducks/redigerbart";
@@ -39,8 +39,6 @@ const Saksbehandling = ({
   behandlingsgrunnlagPeriodeFom,
   behandlingsgrunnlagPeriodeTom,
   behandlingsresultat,
-  dokumenter,
-  dokumentOversikt,
   fagsak,
   fagsakStatusKode,
   hentBehandling,
@@ -178,14 +176,7 @@ const Saksbehandling = ({
                   behandlingsgrunnlagPeriodeTom={behandlingsgrunnlagPeriodeTom}
                 />
                 <SaksoversiktLenke />
-                <SideDialog
-                  dokumentOversikt={dokumentOversikt}
-                  saksnummer={saksnummer}
-                  redigerbart={redigerbart}
-                  behandlingID={behandlingID}
-                  dokumenter={dokumenter}
-                  faner={hovedpartErVirksomhet ? fanerUtenBucOgSed : defaultFaner}
-                />
+                <SideDialog faner={hovedpartErVirksomhet ? fanerUtenBucOgSed : defaultFaner} />
               </Nav.Column>
             </Nav.Row>
           </Nav.Container>
@@ -205,8 +196,6 @@ Saksbehandling.propTypes = {
   behandlingsgrunnlagPeriodeTom: PT.string.isRequired,
   behandlingsgrunnlagMottaksdato: PT.string.isRequired,
   behandlingsresultat: MPT.Behandlingsresultat.isRequired,
-  dokumenter: PT.array.isRequired,
-  dokumentOversikt: PT.array.isRequired,
   fagsak: MPT.Fagsak,
   fagsakStatusKode: PT.string.isRequired,
   hovedpartRolle: PT.string.isRequired,
@@ -256,8 +245,6 @@ const mapStateToProps = (state) => ({
     behandlingsgrunnlagSelectors.MottaksdatoSelector(state)
   ),
   behandlingsresultat: behandlingsresultatSelectors.BehandlingsresultatSelector(state),
-  dokumenter: dokumenterSelectors.AlleFysiskeDokumentSelector(state),
-  dokumentOversikt: dokumenterSelectors.DokumentOversiktSelector(state),
   fagsak: fagsakSelectors.FagsakSelector(state),
   fagsakStatusKode: fagsakSelectors.FagsakStatusSelector(state),
   oppsummering: behandlingerSelectors.OppsummeringSelector(state),


### PR DESCRIPTION
- Dro inn sakstype og behandlingstema i sideDialogOpprettNyBuc.js siden man nå skal filtrere legislation-bucene basert på disse.
- Skrev tester for denne logikken : sideDialogOpprettNyBuc.test.js.
- Istedenfor å sende disse nye parameterene helt fra saksbehandling-filene som bruker sideDialog.tsx, endret jeg til at sideDialog.tsx selv henter disse fra redux.
    -  Dette gjorde at vi slapp å sende inn saksnummer, behandlingsid, redigerbart, dokumenter, og dokumentoversikt også. Dette ble da også fjernet fra filene som brukte sideDialog.tsx.


https://jira.adeo.no/browse/MELOSYS-4964