### PR TITLE
5115 Kan ikke fatte vedtak når det er oppgitt åpen sluttdato

### DIFF
--- a/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_1_a_vedtak.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_1_a_vedtak.js
@@ -20,7 +20,6 @@ class Artikkel13_1_a_vedtak extends Steg {
       lagreOgFatteVedtak: this._propsLight.tilgjengeligeHandlers.lagreOgFatteVedtak,
       tilbake: propsLight.tilgjengeligeHandlers.tilbake,
       lagreLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.lagreLovvalgsperioder,
-      byggLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.byggLovvalgsperioder,
       kontrollerFerdigbehandling: this._propsLight.tilgjengeligeHandlers.kontrollerFerdigbehandling,
     };
     this._status = FANE_STATUS.OK;

--- a/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_1_b_vedtak.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_1_b_vedtak.js
@@ -20,7 +20,6 @@ class Artikkel13_1_b_vedtak extends Steg {
       lagreOgFatteVedtak: this._propsLight.tilgjengeligeHandlers.lagreOgFatteVedtak,
       tilbake: propsLight.tilgjengeligeHandlers.tilbake,
       lagreLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.lagreLovvalgsperioder,
-      byggLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.byggLovvalgsperioder,
       kontrollerFerdigbehandling: this._propsLight.tilgjengeligeHandlers.kontrollerFerdigbehandling,
     };
     this._status = FANE_STATUS.OK;

--- a/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_2_a_vedtak.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_2_a_vedtak.js
@@ -20,7 +20,6 @@ class Artikkel13_2_a_vedtak extends Steg {
       lagreOgFatteVedtak: this._propsLight.tilgjengeligeHandlers.lagreOgFatteVedtak,
       tilbake: propsLight.tilgjengeligeHandlers.tilbake,
       lagreLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.lagreLovvalgsperioder,
-      byggLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.byggLovvalgsperioder,
       kontrollerFerdigbehandling: this._propsLight.tilgjengeligeHandlers.kontrollerFerdigbehandling,
     };
     this._status = FANE_STATUS.OK;

--- a/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_2_b_norge.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_2_b_norge.js
@@ -20,7 +20,6 @@ class Artikkel13_2_b_norge extends Steg {
       lagreOgFatteVedtak: this._propsLight.tilgjengeligeHandlers.lagreOgFatteVedtak,
       tilbake: propsLight.tilgjengeligeHandlers.tilbake,
       lagreLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.lagreLovvalgsperioder,
-      byggLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.byggLovvalgsperioder,
       kontrollerFerdigbehandling: this._propsLight.tilgjengeligeHandlers.kontrollerFerdigbehandling,
     };
     this._status = FANE_STATUS.OK;

--- a/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_3_vedtak.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_3_vedtak.js
@@ -20,7 +20,6 @@ class Artikkel13_3_vedtak extends Steg {
       lagreOgFatteVedtak: this._propsLight.tilgjengeligeHandlers.lagreOgFatteVedtak,
       tilbake: propsLight.tilgjengeligeHandlers.tilbake,
       lagreLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.lagreLovvalgsperioder,
-      byggLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.byggLovvalgsperioder,
       kontrollerFerdigbehandling: this._propsLight.tilgjengeligeHandlers.kontrollerFerdigbehandling,
     };
     this._status = FANE_STATUS.OK;

--- a/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_4_vedtak.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/artikkel13_4_vedtak.js
@@ -20,7 +20,6 @@ class Artikkel13_4_vedtak extends Steg {
       lagreOgFatteVedtak: this._propsLight.tilgjengeligeHandlers.lagreOgFatteVedtak,
       tilbake: propsLight.tilgjengeligeHandlers.tilbake,
       lagreLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.lagreLovvalgsperioder,
-      byggLovvalgsperioder: this._propsLight.tilgjengeligeHandlers.byggLovvalgsperioder,
       kontrollerFerdigbehandling: this._propsLight.tilgjengeligeHandlers.kontrollerFerdigbehandling,
     };
     this._status = FANE_STATUS.OK;

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useCallback, useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { getFormValues, isValid, reduxForm } from "redux-form";
 import PT from "prop-types";
@@ -43,7 +43,6 @@ export const VurderingArtikkel13_x_vedtak = ({
   endreLovvalgsPeriode,
   tilstand: { overskrift },
   lagreLovvalgsperioder,
-  byggLovvalgsperioder: gjenopprettOpprinneligLovvalgsperiode,
   behandlingstype,
   soknadsperiode,
   kontrollerFerdigbehandling,
@@ -56,20 +55,51 @@ export const VurderingArtikkel13_x_vedtak = ({
 
   const erNyVurdering = behandlingstype === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING;
 
-  const forkortLovvalgsperiode = () =>
-    endreLovvalgsPeriode(lovvalgsperiode.fomDato, Utils.dato.formatterDatoTilISO(formValues.tomDato));
+  const fom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.fom);
+  const tom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.tom);
+
+  const kontrollerSteg = () => {
+    return kontrollerFerdigbehandling({
+      behandlingID,
+      vedtakstype: formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
+      behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FORELOEPIG_FASTSATT_LOVVALGSLAND,
+      skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
+    });
+  };
+  const kontroller = async (data) => {
+    if (data.aktivtSteg && data.formIsValid) {
+      setVedtakPending(true);
+      await kontrollerSteg();
+      setOppdaterFoerKontroll(false);
+      setVedtakPending(false);
+    }
+  };
+  const debouncedKontroller = useCallback(Utils._debounce(kontroller, 250), [kontrollerFerdigbehandling]);
+
+  useEffect(() => {
+    debouncedKontroller({ aktivtSteg, formIsValid });
+  }, [aktivtSteg, formIsValid, formValues?.tomDato]);
+
+  const oppdaterLovvalgsperiode = async (fomdato, tomdato) => {
+    await endreLovvalgsPeriode(fomdato, tomdato);
+    lagreLovvalgsperioder();
+  };
+
+  useEffect(() => {
+    if (!Utils._isEmpty(formValues?.tomDato)) {
+      oppdaterLovvalgsperiode(lovvalgsperiode.fomDato, Utils.dato.formatterDatoTilISO(formValues.tomDato));
+    }
+  }, [formValues?.tomDato]);
+
+  const gjenopprettOpprinneligLovvalgsperiode = () => {
+    oppdaterLovvalgsperiode(fom, tom);
+  };
 
   const vedKlikkForhandsvis = async () => {
     if (!formIsValid) {
       touchAll();
       return false;
     }
-
-    if (formValues.forkortLovvalgsperiode) {
-      await forkortLovvalgsperiode();
-    }
-
-    lagreLovvalgsperioder();
     return formIsValid;
   };
 
@@ -97,9 +127,6 @@ export const VurderingArtikkel13_x_vedtak = ({
     });
   }
 
-  const fom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.fom);
-  const tom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.tom);
-
   const lagFattVedtakEOSReqDto = () => {
     return {
       behandlingsresultatTypeKode: MKV.Koder.behandlinger.behandlingsresultattyper.FORELOEPIG_FASTSATT_LOVVALGSLAND,
@@ -113,29 +140,8 @@ export const VurderingArtikkel13_x_vedtak = ({
     };
   };
 
-  useEffect(() => {
-    async function kontroller() {
-      if (aktivtSteg && formIsValid) {
-        setVedtakPending(true);
-        await kontrollerFerdigbehandling({
-          behandlingID,
-          vedtakstype: formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-          behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FORELOEPIG_FASTSATT_LOVVALGSLAND,
-          skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-        });
-        setOppdaterFoerKontroll(false);
-        setVedtakPending(false);
-      }
-    }
-    kontroller();
-  }, [aktivtSteg, formIsValid]);
-
   const fattVedtak = async (values, dispatch, props) => {
     setVedtakPending(true);
-
-    if (values.forkortLovvalgsperiode) {
-      await props.endreLovvalgsPeriode(props.lovvalgsperiode.fomDato, Utils.dato.formatterDatoTilISO(values.tomDato));
-    }
 
     await props.lagreOgFatteVedtak(lagFattVedtakEOSReqDto());
 
@@ -248,7 +254,6 @@ VurderingArtikkel13_x_vedtak.propTypes = {
   formValues: PT.object,
   touchAll: PT.func.isRequired,
   endreLovvalgsPeriode: PT.func.isRequired,
-  byggLovvalgsperioder: PT.func.isRequired,
   lagreLovvalgsperioder: PT.func.isRequired,
   behandlingstype: PT.string.isRequired,
   form: PT.string.isRequired,

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.js
@@ -77,7 +77,7 @@ export const VurderingArtikkel13_x_vedtak = ({
 
   useEffect(() => {
     debouncedKontrollerBehandling({ aktivtSteg, formIsValid, formValues });
-  }, [aktivtSteg, formIsValid, formValues?.tomDato]);
+  }, [aktivtSteg, formIsValid]);
 
   const oppdaterLovvalgsperiode = async (fomdato, tomdato) => {
     await endreLovvalgsPeriode(fomdato, tomdato);
@@ -88,6 +88,7 @@ export const VurderingArtikkel13_x_vedtak = ({
     if (!Utils._isEmpty(formValues?.tomDato)) {
       oppdaterLovvalgsperiode(lovvalgsperiode.fomDato, Utils.dato.formatterDatoTilISO(formValues.tomDato));
     }
+    debouncedKontrollerBehandling({ aktivtSteg, formIsValid, formValues });
   }, [formValues?.tomDato]);
 
   const gjenopprettOpprinneligLovvalgsperiode = () => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.js
@@ -58,26 +58,25 @@ export const VurderingArtikkel13_x_vedtak = ({
   const fom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.fom);
   const tom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.tom);
 
-  const kontrollerSteg = () => {
-    return kontrollerFerdigbehandling({
-      behandlingID,
-      vedtakstype: formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-      behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FORELOEPIG_FASTSATT_LOVVALGSLAND,
-      skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-    });
-  };
-  const kontroller = async (data) => {
+  const kontrollerBehandling = async (data) => {
     if (data.aktivtSteg && data.formIsValid) {
       setVedtakPending(true);
-      await kontrollerSteg();
+      await kontrollerFerdigbehandling({
+        behandlingID,
+        vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
+        behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FORELOEPIG_FASTSATT_LOVVALGSLAND,
+        skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
+      });
       setOppdaterFoerKontroll(false);
       setVedtakPending(false);
     }
   };
-  const debouncedKontroller = useCallback(Utils._debounce(kontroller, 250), [kontrollerFerdigbehandling]);
+  const debouncedKontrollerBehandling = useCallback(Utils._debounce(kontrollerBehandling, 250), [
+    kontrollerFerdigbehandling,
+  ]);
 
   useEffect(() => {
-    debouncedKontroller({ aktivtSteg, formIsValid });
+    debouncedKontrollerBehandling({ aktivtSteg, formIsValid, formValues });
   }, [aktivtSteg, formIsValid, formValues?.tomDato]);
 
   const oppdaterLovvalgsperiode = async (fomdato, tomdato) => {
@@ -92,7 +91,7 @@ export const VurderingArtikkel13_x_vedtak = ({
   }, [formValues?.tomDato]);
 
   const gjenopprettOpprinneligLovvalgsperiode = () => {
-    oppdaterLovvalgsperiode(fom, tom);
+    oppdaterLovvalgsperiode(soknadsperiode.fom, soknadsperiode.tom);
   };
 
   const vedKlikkForhandsvis = async () => {
@@ -260,7 +259,7 @@ VurderingArtikkel13_x_vedtak.propTypes = {
   handleSubmit: PT.func.isRequired,
   soknadsperiode: PT.shape({
     fom: PT.string.isRequired,
-    tom: PT.string.isRequired,
+    tom: PT.string,
   }).isRequired,
   kontrollerFerdigbehandling: PT.func.isRequired,
   harFeilmeldinger: PT.bool.isRequired,


### PR DESCRIPTION
Feilen oppsto fordi vi ikke oppdaterte lovvalgsperiode i backend - kun i frontend. Derfor tok ikke kontrollerFerdigbehandling hensyn til nåværende periode. 

Oppdaterer lovvalgsperiode i backend kontinuerlig slik at kontrollerFerdigbehandling sjekker nåværende periode. 
La med dette inn litt endret logikk som oppdaterer lovvalgsperioder ved endring, og kontrollerer etter endring i tom-dato. La også til gjennopprett-lovvalgsperiode logikk som bruker soknadsperioden (som ikke ender seg) til å resette lovvalgsperiode. Dette gjør at vi kan fjerne avhengigheten til byggLovvalgsperioder fra Stegvelgeren.

https://jira.adeo.no/browse/MELOSYS-5115