### PR TITLE
4747 Formaterer periode til ISO før vi sender til backend

### DIFF
--- a/src/sider/eu_eøs/registrering/unntaksperioder/saksopplysninger.js
+++ b/src/sider/eu_eøs/registrering/unntaksperioder/saksopplysninger.js
@@ -91,7 +91,11 @@ const Saksopplysninger = ({
 
   React.useEffect(() => {
     if (endrePeriodeFom && endrePeriodeTom) {
-      kontrollerUnntaksperiode(behandlingID, endrePeriodeFom, endrePeriodeTom);
+      kontrollerUnntaksperiode(
+        behandlingID,
+        Utils.dato.formatterDatoTilISO(endrePeriodeFom),
+        Utils.dato.formatterDatoTilISO(endrePeriodeTom)
+      );
     }
   }, [endrePeriodeFom, endrePeriodeTom]);
 


### PR DESCRIPTION
Oppdaget feil i dev (er også i prod, men har ikke blitt funnet av saksbehandler enda 🤞 )
Feilen var med melosys-api's LocalDateSerializer, som vi la inn i løsning av oppgave [MELOSYS-4747](https://jira.adeo.no/browse/MELOSYS-4747). 

Istedenfor å endre slik at melosys-trygdeavtale appen støtter den nye serialisereren, endrer vi frontend slik at vi ikke trenger serializer i det hele tatt. Dette følger også standard ellers i melosys-web: Norsk dato i frontend, ISO i backend. 

https://logs.adeo.no/app/discover#/doc/96e648c0-980a-11e9-830a-e17bbd64b4db/logstash-apps-test-002318?id=BPVMfIIBdH6avESXr_hp