### PR TITLE
MELOSYS-5266: Fjerner ekstra ingress mens vi finner ut hvordan det skal gjøres

### DIFF
--- a/nais/vars-q2.json
+++ b/nais/vars-q2.json
@@ -3,9 +3,6 @@
   "REDIS_APP_NAME": "melosys-web-redis",
   "APP_URL_TRYGDEAVTALE": "http://melosys-trygdeavtale.teammelosys",
   "APP_URL_MELOSYS": "http://melosys.teammelosys",
-  "INGRESS": [
-    "https://melosys.dev.intern.nav.no",
-    "https://melosys-q2.dev.intern.nav.no"
-  ],
+  "INGRESS": "https://melosys.dev.intern.nav.no",
   "OIDC_HOST_URL": "https://isso-q.adeo.no"
 }


### PR DESCRIPTION
Deploy feiler fordi vi har to ingresser. Vi har tydeligvis ikke gjort det på en riktig måte. Fjerner mens vi finner ut hvordan vi får inn ny ingress.