### PR TITLE
Melosys 4948 TOGGLE DAPI Angi behandlingsresultat for klage og omgjøring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@apollo/client": "^3.6.8",
         "@loadable/component": "^5.10.3",
         "@navikt/fnrvalidator": "^1.1.4",
-        "@navikt/melosys-kodeverk": "5.15.123",
+        "@navikt/melosys-kodeverk": "5.15.125",
         "classnames": "^2.2.6",
         "connected-react-router": "^6.6.1",
         "date-fns": "^2.28.0",
@@ -4828,10 +4828,13 @@
       "license": "MIT"
     },
     "node_modules/@navikt/melosys-kodeverk": {
-      "version": "5.15.123",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.123/14fae7c6b802c12b9ecdcec1d85a928b52acc66c1d53121e0e58e57f71197fdc",
-      "integrity": "sha512-OxltacTOoJT6LerHqaVNeLGS1iOPuZm9vCRaiDEv60pd2WgngB8U5nzO2dp8IdGL8trtOMRea1LBhP9EBF4vQg==",
-      "license": "ISC"
+      "version": "5.15.125",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.125/e4483c7b7b4bc451887092fe60f87bc15406194c",
+      "integrity": "sha512-JtX1uyAR4IFNn8xQpMYpJHgBONEMLBmpEH0zxdYhnijmBW1JxK1bjs8lyr71uV1mThHdXMZR/h7A1IS/9RBAlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/@navikt/textparser": {
       "version": "2.2.0",
@@ -35230,9 +35233,9 @@
       "integrity": "sha512-EZBwlNhp886E57GuknLB6G9Bnv4nl+e5K12B/2BeLpWZENxCmcQ+5oFvIThvEsU+LVOdfJxxGOxSvrwe5ZB3pQ=="
     },
     "@navikt/melosys-kodeverk": {
-      "version": "5.15.123",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.123/14fae7c6b802c12b9ecdcec1d85a928b52acc66c1d53121e0e58e57f71197fdc",
-      "integrity": "sha512-OxltacTOoJT6LerHqaVNeLGS1iOPuZm9vCRaiDEv60pd2WgngB8U5nzO2dp8IdGL8trtOMRea1LBhP9EBF4vQg=="
+      "version": "5.15.125",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.125/e4483c7b7b4bc451887092fe60f87bc15406194c",
+      "integrity": "sha512-JtX1uyAR4IFNn8xQpMYpJHgBONEMLBmpEH0zxdYhnijmBW1JxK1bjs8lyr71uV1mThHdXMZR/h7A1IS/9RBAlQ=="
     },
     "@navikt/textparser": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@apollo/client": "^3.6.8",
     "@loadable/component": "^5.10.3",
     "@navikt/fnrvalidator": "^1.1.4",
-    "@navikt/melosys-kodeverk": "5.15.123",
+    "@navikt/melosys-kodeverk": "5.15.125",
     "classnames": "^2.2.6",
     "connected-react-router": "^6.6.1",
     "date-fns": "^2.28.0",

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
@@ -44,8 +44,8 @@ describe("AvsluttSak", () => {
 
     expect(handlinger).toHaveLength(3);
     expect(handlinger.at(0).props().tekst).toBe("Avslå søknad pga. manglende opplysninger");
-    expect(handlinger.at(1).props().tekst).toBe("Søknaden er henlagt/trukket");
-    expect(handlinger.at(2).props().tekst).toBe("Kan ikke behandles i Melosys");
+    expect(handlinger.at(1).props().tekst).toBe("Søknaden/klagen er trukket");
+    expect(handlinger.at(2).props().tekst).toBe("Behandlingen er bortfalt");
   });
 
   it("viser bare avsluttSak om tema er trygdetid", () => {
@@ -56,7 +56,7 @@ describe("AvsluttSak", () => {
     const handlinger = avsluttSak.find(Handling);
 
     expect(handlinger).toHaveLength(1);
-    expect(handlinger.props().tekst).toBe("Kan ikke behandles i Melosys");
+    expect(handlinger.props().tekst).toBe("Behandlingen er bortfalt");
   });
 
   it("viser ferdigBehandlet om tema er yrkesaktiv", () => {
@@ -68,7 +68,7 @@ describe("AvsluttSak", () => {
     const handlinger = avsluttSak.find(Handling);
 
     expect(handlinger).toHaveLength(4);
-    expect(handlinger.at(3).props().tekst).toBe("Ferdigbehandlet");
+    expect(handlinger.at(1).props().tekst).toBe("Ferdigbehandlet");
   });
 
   it("returerer null om EØS_VURDER_UTPEKING og ikke redigerbart", () => {
@@ -93,8 +93,8 @@ describe("AvsluttSak", () => {
     expect(avsluttSakSomBortfalt).toHaveLength(0);
   });
 
-  describe("Kan ikke behandles i Melosys", () => {
-    it(`viser 'Kan ikke behandles i Melosys' dersom behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE} og behandlingsstatus er ${VURDER_DOKUMENT}`, () => {
+  describe("Behandlingen er bortfalt", () => {
+    it(`viser 'Behandlingen er bortfalt' dersom behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE} og behandlingsstatus er ${VURDER_DOKUMENT}`, () => {
       props.behandlingstema = REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE;
       props.behandlingsstatus = VURDER_DOKUMENT;
 
@@ -102,10 +102,10 @@ describe("AvsluttSak", () => {
       const handlinger = avsluttSak.find(Handling);
 
       expect(handlinger).toHaveLength(1);
-      expect(handlinger.at(0).props().tekst).toBe("Kan ikke behandles i Melosys");
+      expect(handlinger.at(0).props().tekst).toBe("Behandlingen er bortfalt");
     });
 
-    it(`viser 'Kan ikke behandles i Melosys' dersom behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING} og behandlingsstatus er ${VURDER_DOKUMENT}`, () => {
+    it(`viser 'Behandlingen er bortfalt' dersom behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING} og behandlingsstatus er ${VURDER_DOKUMENT}`, () => {
       props.behandlingstema = REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING;
       props.behandlingsstatus = VURDER_DOKUMENT;
 
@@ -113,7 +113,7 @@ describe("AvsluttSak", () => {
       const handlinger = avsluttSak.find(Handling);
 
       expect(handlinger).toHaveLength(1);
-      expect(handlinger.at(0).props().tekst).toBe("Kan ikke behandles i Melosys");
+      expect(handlinger.at(0).props().tekst).toBe("Behandlingen er bortfalt");
     });
   });
 

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
@@ -16,7 +16,7 @@ const {
   REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE,
   REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING,
 } = MKV.Koder.behandlinger.behandlingstema;
-const { NY_VURDERING, FØRSTEGANG, HENVENDELSE } = MKV.Koder.behandlinger.behandlingstyper;
+const { NY_VURDERING, FØRSTEGANG, HENVENDELSE, KLAGE } = MKV.Koder.behandlinger.behandlingstyper;
 const { FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
 const { MEDLEMSKAP_LOVVALG, UNNTAK } = MKV.Koder.sakstemaer;
 const { VURDER_DOKUMENT } = MKV.Koder.behandlinger.behandlingsstatus;
@@ -67,8 +67,8 @@ describe("AvsluttSak", () => {
     const avsluttSak = shallow(<AvsluttSak {...props} />);
     const handlinger = avsluttSak.find(Handling);
 
-    expect(handlinger).toHaveLength(4);
-    expect(handlinger.at(1).props().tekst).toBe("Ferdigbehandlet");
+    expect(handlinger).toHaveLength(5);
+    expect(handlinger.at(2).props().tekst).toBe("Ferdigbehandlet");
   });
 
   it("returerer null om EØS_VURDER_UTPEKING og ikke redigerbart", () => {
@@ -242,6 +242,70 @@ describe("AvsluttSak", () => {
       const handlinger = avsluttSak.find(Handling);
 
       expect(handlinger).toHaveLength(0);
+    });
+  });
+
+  describe("Klage-handlinger", () => {
+    it(`viser Klage-handlinger dersom behandlingstype er ${KLAGE}`, () => {
+      props.redigerbart = true;
+      props.behandlingstema = YRKESAKTIV;
+      props.behandlingstype = KLAGE;
+
+      const avsluttSak = shallow(<AvsluttSak {...props} />);
+      const handlinger = avsluttSak.find(Handling);
+
+      expect(handlinger).toHaveLength(6);
+      expect(handlinger.at(0).props().tekst).toBe("Medhold på klage");
+      expect(handlinger.at(1).props().tekst).toBe("Klageinnstilling er oversendt til klageinstansen");
+      expect(handlinger.at(2).props().tekst).toBe("Klage er avvist");
+    });
+
+    it(`viser ikke Klage-handlinger dersom behandlingstype er ${FØRSTEGANG}`, () => {
+      props.redigerbart = true;
+      props.behandlingstema = YRKESAKTIV;
+      props.behandlingstype = FØRSTEGANG;
+
+      const avsluttSak = shallow(<AvsluttSak {...props} />);
+
+      expect(avsluttSak.findWhere((n) => n.type() === Handling && n.props().tekst === "Medhold på klage")).toHaveLength(
+        0
+      );
+
+      expect(
+        avsluttSak.findWhere(
+          (n) => n.type() === Handling && n.props().tekst === "Klageinnstilling er oversendt til klageinstansen"
+        )
+      ).toHaveLength(0);
+
+      expect(avsluttSak.findWhere((n) => n.type() === Handling && n.props().tekst === "Klage er avvist")).toHaveLength(
+        0
+      );
+    });
+  });
+
+  describe("Vedtaket er omgjort (fvl § 35)", () => {
+    it(`viser 'Vedtaket er omgjort (fvl § 35)' dersom behandlingstype er ${NY_VURDERING}`, () => {
+      props.redigerbart = true;
+      props.behandlingstema = YRKESAKTIV;
+      props.behandlingstype = NY_VURDERING;
+
+      const avsluttSak = shallow(<AvsluttSak {...props} />);
+      const handlinger = avsluttSak.find(Handling);
+
+      expect(handlinger).toHaveLength(5);
+      expect(handlinger.at(1).props().tekst).toBe("Vedtaket er omgjort (fvl § 35)");
+    });
+
+    it(`viser ikke 'Vedtaket er omgjort (fvl § 35)' dersom behandlingstype er ${FØRSTEGANG}`, () => {
+      props.redigerbart = true;
+      props.behandlingstema = YRKESAKTIV;
+      props.behandlingstype = FØRSTEGANG;
+
+      const avsluttSak = shallow(<AvsluttSak {...props} />);
+
+      expect(
+        avsluttSak.findWhere((n) => n.type() === Handling && n.props().tekst === "Vedtaket er omgjort (fvl § 35)")
+      ).toHaveLength(0);
     });
   });
 });

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
@@ -17,7 +17,7 @@ const {
   REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING,
 } = MKV.Koder.behandlinger.behandlingstema;
 const { NY_VURDERING, FØRSTEGANG, HENVENDELSE, KLAGE } = MKV.Koder.behandlinger.behandlingstyper;
-const { FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
+const { FTRL, TRYGDEAVTALE, EU_EOS } = MKV.Koder.sakstyper;
 const { MEDLEMSKAP_LOVVALG, UNNTAK } = MKV.Koder.sakstemaer;
 const { VURDER_DOKUMENT } = MKV.Koder.behandlinger.behandlingsstatus;
 
@@ -35,9 +35,18 @@ describe("AvsluttSak", () => {
     props = instance(mockedProps);
   });
 
-  it("viser alle valg om FTRL_SAKSBEHANDLING og redigerbart", () => {
+  const setupProps = (initialProps: typeof mockedProps) => {
+    initialProps.redigerbart = true;
+    initialProps.sakstype = EU_EOS;
+    initialProps.sakstema = MEDLEMSKAP_LOVVALG;
+    initialProps.behandlingstema = UTSENDT_ARBEIDSTAKER;
+    initialProps.behandlingstype = FØRSTEGANG;
+  };
+
+  it("viser alle valg dersom behandlingskategori FTRL_SAKSBEHANDLING og redigerbart", () => {
+    setupProps(props);
+    props.sakstype = FTRL;
     props.behandlingstema = ARBEID_I_UTLANDET;
-    props.redigerbart = true;
 
     const avsluttSak = shallow(<AvsluttSak {...props} />);
     const handlinger = avsluttSak.find(Handling);
@@ -48,9 +57,9 @@ describe("AvsluttSak", () => {
     expect(handlinger.at(2).props().tekst).toBe("Behandlingen er bortfalt");
   });
 
-  it("viser bare avsluttSak om tema er trygdetid", () => {
+  it("viser bare avsluttSak dersom tema er trygdetid", () => {
+    setupProps(props);
     props.behandlingstema = TRYGDETID;
-    props.redigerbart = true;
 
     const avsluttSak = shallow(<AvsluttSak {...props} />);
     const handlinger = avsluttSak.find(Handling);
@@ -59,19 +68,20 @@ describe("AvsluttSak", () => {
     expect(handlinger.props().tekst).toBe("Behandlingen er bortfalt");
   });
 
-  it("viser ferdigBehandlet om tema er yrkesaktiv", () => {
+  it("viser ferdigBehandlet dersom tema er yrkesaktiv og type er ny vurdering", () => {
+    setupProps(props);
     props.behandlingstema = YRKESAKTIV;
-    props.redigerbart = true;
     props.behandlingstype = NY_VURDERING;
 
     const avsluttSak = shallow(<AvsluttSak {...props} />);
     const handlinger = avsluttSak.find(Handling);
 
-    expect(handlinger).toHaveLength(5);
-    expect(handlinger.at(2).props().tekst).toBe("Ferdigbehandlet");
+    expect(handlinger).toHaveLength(7);
+    expect(handlinger.at(4).props().tekst).toBe("Ferdigbehandlet");
   });
 
   it("returerer null om EØS_VURDER_UTPEKING og ikke redigerbart", () => {
+    setupProps(props);
     props.redigerbart = false;
     props.behandlingstema = BESLUTNING_LOVVALG_NORGE;
 
@@ -81,7 +91,7 @@ describe("AvsluttSak", () => {
   });
 
   it(`viser ikke 'Avslutt sak som bortfalt' dersom behandlingstema er ${UTSENDT_ARBEIDSTAKER} og behandlingstype er ${NY_VURDERING}`, () => {
-    props.redigerbart = true;
+    setupProps(props);
     props.behandlingstema = UTSENDT_ARBEIDSTAKER;
     props.behandlingstype = NY_VURDERING;
 
@@ -95,6 +105,7 @@ describe("AvsluttSak", () => {
 
   describe("Behandlingen er bortfalt", () => {
     it(`viser 'Behandlingen er bortfalt' dersom behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE} og behandlingsstatus er ${VURDER_DOKUMENT}`, () => {
+      setupProps(props);
       props.behandlingstema = REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE;
       props.behandlingsstatus = VURDER_DOKUMENT;
 
@@ -106,6 +117,7 @@ describe("AvsluttSak", () => {
     });
 
     it(`viser 'Behandlingen er bortfalt' dersom behandlingstema er ${REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING} og behandlingsstatus er ${VURDER_DOKUMENT}`, () => {
+      setupProps(props);
       props.behandlingstema = REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING;
       props.behandlingsstatus = VURDER_DOKUMENT;
 
@@ -119,21 +131,19 @@ describe("AvsluttSak", () => {
 
   describe("Søknaden er avslått", () => {
     it(`viser 'Søknaden er avslått' dersom behandlingstype er ${FØRSTEGANG} og behandlingstema er ${YRKESAKTIV}`, () => {
-      props.redigerbart = true;
-      props.sakstema = MEDLEMSKAP_LOVVALG;
+      setupProps(props);
       props.behandlingstype = FØRSTEGANG;
       props.behandlingstema = YRKESAKTIV;
 
       const avsluttSak = shallow(<AvsluttSak {...props} />);
       const handlinger = avsluttSak.find(Handling);
 
-      expect(handlinger).toHaveLength(4);
-      expect(handlinger.at(0).props().tekst).toBe("Søknaden er avslått");
+      expect(handlinger).toHaveLength(5);
+      expect(handlinger.at(1).props().tekst).toBe("Søknaden er avslått");
     });
 
     it(`viser ikke 'Søknaden er avslått' dersom behandlingstype er ${HENVENDELSE} og behandlingstema er ${YRKESAKTIV}`, () => {
-      props.redigerbart = true;
-      props.sakstema = MEDLEMSKAP_LOVVALG;
+      setupProps(props);
       props.behandlingstype = HENVENDELSE;
       props.behandlingstema = YRKESAKTIV;
 
@@ -146,10 +156,8 @@ describe("AvsluttSak", () => {
     });
 
     it(`viser ikke 'Søknaden er avslått' dersom sakstema er ${UNNTAK}`, () => {
-      props.redigerbart = true;
+      setupProps(props);
       props.sakstema = UNNTAK;
-      props.behandlingstype = FØRSTEGANG;
-      props.behandlingstema = YRKESAKTIV;
 
       const avsluttSak = shallow(<AvsluttSak {...props} />);
       const soknadenErAvslatt = avsluttSak.findWhere(
@@ -160,10 +168,8 @@ describe("AvsluttSak", () => {
     });
 
     it(`viser ikke 'Søknaden er avslått' dersom redigerbart er false`, () => {
+      setupProps(props);
       props.redigerbart = false;
-      props.sakstema = MEDLEMSKAP_LOVVALG;
-      props.behandlingstype = FØRSTEGANG;
-      props.behandlingstema = YRKESAKTIV;
 
       const avsluttSak = shallow(<AvsluttSak {...props} />);
       const handlinger = avsluttSak.find(Handling);
@@ -174,8 +180,7 @@ describe("AvsluttSak", () => {
 
   describe("Søknaden er innvilget", () => {
     it(`viser 'Søknaden er innvilget' dersom sakstype er ${FTRL} og behandlingstype er ${FØRSTEGANG} og behandlingstema er ${YRKESAKTIV}`, () => {
-      props.redigerbart = true;
-      props.sakstema = MEDLEMSKAP_LOVVALG;
+      setupProps(props);
       props.sakstype = FTRL;
       props.behandlingstype = FØRSTEGANG;
       props.behandlingstema = YRKESAKTIV;
@@ -188,8 +193,7 @@ describe("AvsluttSak", () => {
     });
 
     it(`viser 'Søknaden er innvilget' dersom sakstype er ${TRYGDEAVTALE} og behandlingstype er ${FØRSTEGANG} og behandlingstema er ${YRKESAKTIV}`, () => {
-      props.redigerbart = true;
-      props.sakstema = MEDLEMSKAP_LOVVALG;
+      setupProps(props);
       props.sakstype = TRYGDEAVTALE;
       props.behandlingstype = FØRSTEGANG;
       props.behandlingstema = YRKESAKTIV;
@@ -202,8 +206,7 @@ describe("AvsluttSak", () => {
     });
 
     it(`viser ikke 'Søknaden er innvilget' dersom sakstype er ${TRYGDEAVTALE} og behandlingstype er ${HENVENDELSE} og behandlingstema er ${YRKESAKTIV}`, () => {
-      props.redigerbart = true;
-      props.sakstema = MEDLEMSKAP_LOVVALG;
+      setupProps(props);
       props.sakstype = TRYGDEAVTALE;
       props.behandlingstype = HENVENDELSE;
       props.behandlingstema = YRKESAKTIV;
@@ -217,11 +220,8 @@ describe("AvsluttSak", () => {
     });
 
     it(`viser ikke 'Søknaden er innvilget' dersom sakstema er ${UNNTAK}`, () => {
-      props.redigerbart = true;
+      setupProps(props);
       props.sakstema = UNNTAK;
-      props.sakstype = TRYGDEAVTALE;
-      props.behandlingstype = FØRSTEGANG;
-      props.behandlingstema = YRKESAKTIV;
 
       const avsluttSak = shallow(<AvsluttSak {...props} />);
       const soknadenErInnvilget = avsluttSak.findWhere(
@@ -232,11 +232,8 @@ describe("AvsluttSak", () => {
     });
 
     it(`viser ikke 'Søknaden er innvilget' dersom redigerbart er false`, () => {
+      setupProps(props);
       props.redigerbart = false;
-      props.sakstema = MEDLEMSKAP_LOVVALG;
-      props.sakstype = TRYGDEAVTALE;
-      props.behandlingstype = FØRSTEGANG;
-      props.behandlingstema = YRKESAKTIV;
 
       const avsluttSak = shallow(<AvsluttSak {...props} />);
       const handlinger = avsluttSak.find(Handling);
@@ -247,8 +244,7 @@ describe("AvsluttSak", () => {
 
   describe("Klage-handlinger", () => {
     it(`viser Klage-handlinger dersom behandlingstype er ${KLAGE}`, () => {
-      props.redigerbart = true;
-      props.behandlingstema = YRKESAKTIV;
+      setupProps(props);
       props.behandlingstype = KLAGE;
 
       const avsluttSak = shallow(<AvsluttSak {...props} />);
@@ -261,8 +257,7 @@ describe("AvsluttSak", () => {
     });
 
     it(`viser ikke Klage-handlinger dersom behandlingstype er ${FØRSTEGANG}`, () => {
-      props.redigerbart = true;
-      props.behandlingstema = YRKESAKTIV;
+      setupProps(props);
       props.behandlingstype = FØRSTEGANG;
 
       const avsluttSak = shallow(<AvsluttSak {...props} />);
@@ -285,8 +280,7 @@ describe("AvsluttSak", () => {
 
   describe("Vedtaket er omgjort (fvl § 35)", () => {
     it(`viser 'Vedtaket er omgjort (fvl § 35)' dersom behandlingstype er ${NY_VURDERING}`, () => {
-      props.redigerbart = true;
-      props.behandlingstema = YRKESAKTIV;
+      setupProps(props);
       props.behandlingstype = NY_VURDERING;
 
       const avsluttSak = shallow(<AvsluttSak {...props} />);
@@ -297,8 +291,7 @@ describe("AvsluttSak", () => {
     });
 
     it(`viser ikke 'Vedtaket er omgjort (fvl § 35)' dersom behandlingstype er ${FØRSTEGANG}`, () => {
-      props.redigerbart = true;
-      props.behandlingstema = YRKESAKTIV;
+      setupProps(props);
       props.behandlingstype = FØRSTEGANG;
 
       const avsluttSak = shallow(<AvsluttSak {...props} />);

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
@@ -207,9 +207,9 @@ const AvsluttSak = ({
       {skalViseAvslåPgaManglendeOpplysninger() && (
         <Handling tekst="Avslå søknad pga. manglende opplysninger" onClick={avslaaSoknad} />
       )}
-      {skalViseHenleggSak() && <Handling tekst="Søknaden er henlagt/trukket" onClick={henleggSak} />}
-      {skalViseAvsluttSak() && <Handling tekst="Kan ikke behandles i Melosys" onClick={avsluttSakSomBortfalt} />}
       {skalViseFerdigbehandlet() && <Handling tekst="Ferdigbehandlet" onClick={ferdigbehandleNyVurdering} />}
+      {skalViseHenleggSak() && <Handling tekst="Søknaden/klagen er trukket" onClick={henleggSak} />}
+      {skalViseAvsluttSak() && <Handling tekst="Behandlingen er bortfalt" onClick={avsluttSakSomBortfalt} />}
     </Nav.Ekspanderbartpanel>
   );
 };

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
@@ -18,11 +18,19 @@ const {
   ARBEID_ETT_LAND_ØVRIG,
   ARBEID_TJENESTEPERSON_ELLER_FLY,
 } = MKV.Koder.behandlinger.behandlingstema;
-const { NY_VURDERING, ENDRET_PERIODE, FØRSTEGANG } = MKV.Koder.behandlinger.behandlingstyper;
+const { NY_VURDERING, ENDRET_PERIODE, FØRSTEGANG, KLAGE } = MKV.Koder.behandlinger.behandlingstyper;
 const { EU_EOS, FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
 const { MEDLEMSKAP_LOVVALG } = MKV.Koder.sakstemaer;
-const { MEDLEM_I_FOLKETRYGDEN, UNNTATT_MEDLEMSKAP, FASTSATT_LOVVALGSLAND, AVSLAG_SØKNAD } =
-  MKV.Koder.behandlinger.behandlingsresultattyper;
+const {
+  MEDLEM_I_FOLKETRYGDEN,
+  UNNTATT_MEDLEMSKAP,
+  FASTSATT_LOVVALGSLAND,
+  AVSLAG_SØKNAD,
+  MEDHOLD,
+  KLAGEINNSTILLING,
+  AVVIST_KLAGE,
+  OMGJORT,
+} = MKV.Koder.behandlinger.behandlingsresultattyper;
 
 type avsluttSakProps = {
   avslaaSoknad: () => void;
@@ -58,6 +66,7 @@ const AvsluttSak = ({
   const behandlingstemaErTrygdetid = behandlingstema === TRYGDETID;
   const behandlingstypeErNyVurdering = behandlingstype === NY_VURDERING;
   const behandlingstypeErEndretPeriode = behandlingstype === ENDRET_PERIODE;
+  const behandlingstypeErKlage = behandlingstype === KLAGE;
   const behandlingstemaErUnntakNorskTrygdØvrigEllerUtstasjonering =
     behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE ||
     behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING;
@@ -127,6 +136,10 @@ const AvsluttSak = ({
     }
   };
 
+  const skalViseKlageHandlinger = sakstemaToggle === "enabled" && redigerbart && behandlingstypeErKlage;
+
+  const skalViseVedtakOmgjort = sakstemaToggle === "enabled" && redigerbart && behandlingstypeErNyVurdering;
+
   const skalViseSøknadenErInnvilget = () => {
     if (sakstemaToggle !== "enabled" || !redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) {
       return false;
@@ -183,14 +196,14 @@ const AvsluttSak = ({
     tilForsiden();
   };
 
-  if (
-    !skalViseSøknadenErInnvilget() &&
-    !skalViseSøknadenErAvslått() &&
-    !skalViseAvslåPgaManglendeOpplysninger() &&
-    !skalViseHenleggSak() &&
-    !skalViseAvsluttSak() &&
-    !skalViseFerdigbehandlet()
-  )
+  const skalKunneAngiBehandlingsresultat =
+    skalViseSøknadenErInnvilget() ||
+    skalViseSøknadenErAvslått() ||
+    skalViseAvslåPgaManglendeOpplysninger() ||
+    skalViseVedtakOmgjort ||
+    skalViseKlageHandlinger;
+
+  if (!skalViseHenleggSak() && !skalViseAvsluttSak() && !skalViseFerdigbehandlet() && !skalKunneAngiBehandlingsresultat)
     return null;
 
   return (
@@ -198,15 +211,35 @@ const AvsluttSak = ({
       className="behandlingsmeny__meny__avslutt-sak"
       tittel={<div className="title">Avslutt sak</div>}
     >
-      {skalViseSøknadenErInnvilget() && (
-        <Handling tekst="Søknaden er innvilget" onClick={() => angiBehandlingsresultattype(mapType())} />
+      {skalKunneAngiBehandlingsresultat && (
+        <div className="skillestrek">
+          {skalViseKlageHandlinger && (
+            <Handling tekst="Medhold på klage" onClick={() => angiBehandlingsresultattype(MEDHOLD)} />
+          )}
+          {skalViseKlageHandlinger && (
+            <Handling
+              tekst="Klageinnstilling er oversendt til klageinstansen"
+              onClick={() => angiBehandlingsresultattype(KLAGEINNSTILLING)}
+            />
+          )}
+          {skalViseKlageHandlinger && (
+            <Handling tekst="Klage er avvist" onClick={() => angiBehandlingsresultattype(AVVIST_KLAGE)} />
+          )}
+          {skalViseSøknadenErInnvilget() && (
+            <Handling tekst="Søknaden er innvilget" onClick={() => angiBehandlingsresultattype(mapType())} />
+          )}
+          {skalViseSøknadenErAvslått() && (
+            <Handling tekst="Søknaden er avslått" onClick={() => angiBehandlingsresultattype(AVSLAG_SØKNAD)} />
+          )}
+          {skalViseAvslåPgaManglendeOpplysninger() && (
+            <Handling tekst="Avslå søknad pga. manglende opplysninger" onClick={avslaaSoknad} />
+          )}
+          {skalViseVedtakOmgjort && (
+            <Handling tekst="Vedtaket er omgjort (fvl § 35)" onClick={() => angiBehandlingsresultattype(OMGJORT)} />
+          )}
+        </div>
       )}
-      {skalViseSøknadenErAvslått() && (
-        <Handling tekst="Søknaden er avslått" onClick={() => angiBehandlingsresultattype(AVSLAG_SØKNAD)} />
-      )}
-      {skalViseAvslåPgaManglendeOpplysninger() && (
-        <Handling tekst="Avslå søknad pga. manglende opplysninger" onClick={avslaaSoknad} />
-      )}
+
       {skalViseFerdigbehandlet() && <Handling tekst="Ferdigbehandlet" onClick={ferdigbehandleNyVurdering} />}
       {skalViseHenleggSak() && <Handling tekst="Søknaden/klagen er trukket" onClick={henleggSak} />}
       {skalViseAvsluttSak() && <Handling tekst="Behandlingen er bortfalt" onClick={avsluttSakSomBortfalt} />}

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/behandlingsmeny.less
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/behandlingsmeny.less
@@ -48,6 +48,11 @@
       border-radius: 0;
       border: 1px solid @navMorkGra;
       border-top: 0;
+
+      .skillestrek {
+        border-bottom: 1px solid #d8d8d8;
+        padding-bottom: 0.5rem;
+      }
     }
     &__handlinger {
       background-color: #fff;


### PR DESCRIPTION
- Endret beskrivelse og rekkefølge. 
- Lagt til nye valg for klage og ny vurdering.
- Gruppert alle angibehandlingsresultattype-handlingene i én div med skillelinje under. (avslag pga manglende opplysninger skal være endel av disse. Ble avklart på skissene).
- Tester.

Avhengig av melosys.api: https://github.com/navikt/melosys-api/pull/1347

https://jira.adeo.no/browse/MELOSYS-4948