### PR TITLE
MELOSYS-5266: Separerer deploy-q2 og draft-release

### DIFF
--- a/.github/workflows/deploy-q2.yaml
+++ b/.github/workflows/deploy-q2.yaml
@@ -12,7 +12,7 @@ env:
   docker_image: docker.pkg.github.com/${{ github.repository }}/melosys-web-q2:${{ github.sha }}
 jobs:
   build:
-    name: Build, deploy to q2, and draft release
+    name: Build, deploy to q2
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code

--- a/.github/workflows/deploy-q2.yaml
+++ b/.github/workflows/deploy-q2.yaml
@@ -9,7 +9,7 @@ on:
     branches:
       - master
 env:
-  docker_image: docker.pkg.github.com/${{ github.repository }}/melosys-web:${{ github.sha }}
+  docker_image: docker.pkg.github.com/${{ github.repository }}/melosys-web-q2:${{ github.sha }}
 jobs:
   build:
     name: Build, deploy to q2, and draft release

--- a/.github/workflows/deploy-q2.yaml
+++ b/.github/workflows/deploy-q2.yaml
@@ -56,10 +56,6 @@ jobs:
           BRANCH_NAME=$GITHUB_REF
           BUILD_NUMBER="$(date "+%Y.%m.%d")-$(git rev-parse --short HEAD)"
           npm run build:q2
-      - name: pre-deploy
-        uses: navikt/digihot-deploy/actions/pre-deploy@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and publish Docker image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -88,7 +84,3 @@ jobs:
           SLACK_TITLE: ':clap: melosys-web ble deployet til q2 :rocket:'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: ${{ env.COMMIT_MSG }}
-      - name: post-deploy
-        uses: navikt/digihot-deploy/actions/post-deploy@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -12,7 +12,7 @@ env:
   docker_image: docker.pkg.github.com/${{ github.repository }}/melosys-web:${{ github.sha }}
 jobs:
   build:
-    name: Build, deploy to q2, and draft release
+    name: Build image for production and draft release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -70,6 +70,10 @@ jobs:
       - name: get commit message
         run: | # Må hentes med et script fordi workflow_dispatch ikke har github.event.head_commit
           echo "COMMIT_MSG=$(git log --format=%s -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
+      - name: post-deploy
+        uses: navikt/digihot-deploy/actions/post-deploy@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: draft release
         uses: softprops/action-gh-release@v1
         env:

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -1,4 +1,4 @@
-name: deploy-q2
+name: draft-release
 on:
   push:
     paths-ignore:
@@ -55,7 +55,7 @@ jobs:
         run: |
           BRANCH_NAME=$GITHUB_REF
           BUILD_NUMBER="$(date "+%Y.%m.%d")-$(git rev-parse --short HEAD)"
-          npm run build:q2
+          npm run build:prod
       - name: pre-deploy
         uses: navikt/digihot-deploy/actions/pre-deploy@v2
         env:
@@ -67,28 +67,16 @@ jobs:
           docker build --tag ${docker_image} .
           docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
           docker push ${docker_image}
-      - name: Deploy q2
-        uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-fss
-          RESOURCE: nais/nais.yaml
-          VAR: image=${{ env.docker_image }}
-          VARS: nais/vars-q2.json
       - name: get commit message
         run: | # Må hentes med et script fordi workflow_dispatch ikke har github.event.head_commit
           echo "COMMIT_MSG=$(git log --format=%s -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
-      - name: Slack Notification (deploy success)
-        if: success()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_COLOR: good
-          SLACK_USERNAME: Github Actions
-          SLACK_ICON: https://github.com/github.png?size=48
-          SLACK_TITLE: ':clap: melosys-web ble deployet til q2 :rocket:'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: ${{ env.COMMIT_MSG }}
-      - name: post-deploy
-        uses: navikt/digihot-deploy/actions/post-deploy@v2
+      - name: draft release
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION_TAG }}
+          name: ${{ env.APPLICATION }} ${{ env.VERSION_TAG }}
+          body: ${{ env.CHANGE_LOG }}
+          draft: true
+          prerelease: false


### PR DESCRIPTION
Environments blir flettet inn i React-appen ved build time. Ved merge til amster, blir "deploy-q2"-scriptet kjørt. Scriptet lager en draft relase image, og deployer det til q2. Samme image blir brukt igjen til deploy av prod.

Løsning nå: 
To forskjellige actions, en for bygg og deploy til q2, en annen for å bygge og lage release draft.