### PR TITLE
5304: TOGGLE DAPI Angi behandlingsresultat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@apollo/client": "^3.6.8",
         "@loadable/component": "^5.10.3",
         "@navikt/fnrvalidator": "^1.1.4",
-        "@navikt/melosys-kodeverk": "5.15.125",
+        "@navikt/melosys-kodeverk": "5.15.126",
         "classnames": "^2.2.6",
         "connected-react-router": "^6.6.1",
         "date-fns": "^2.28.0",
@@ -4828,9 +4828,9 @@
       "license": "MIT"
     },
     "node_modules/@navikt/melosys-kodeverk": {
-      "version": "5.15.125",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.125/e4483c7b7b4bc451887092fe60f87bc15406194c",
-      "integrity": "sha512-JtX1uyAR4IFNn8xQpMYpJHgBONEMLBmpEH0zxdYhnijmBW1JxK1bjs8lyr71uV1mThHdXMZR/h7A1IS/9RBAlQ==",
+      "version": "5.15.126",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.126/aaccc917091c35844d6f1899fb0241c014dd0718",
+      "integrity": "sha512-MwyjA6TrWfdipATope56Ob2cfBhuB7/sgHgxQAKmY9Oa3tLU4x8zwJn9la9YWr+hrU/Wrx5P0YV81vpaT3j4nQ==",
       "license": "ISC",
       "engines": {
         "node": ">=10.0.0"
@@ -35233,9 +35233,9 @@
       "integrity": "sha512-EZBwlNhp886E57GuknLB6G9Bnv4nl+e5K12B/2BeLpWZENxCmcQ+5oFvIThvEsU+LVOdfJxxGOxSvrwe5ZB3pQ=="
     },
     "@navikt/melosys-kodeverk": {
-      "version": "5.15.125",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.125/e4483c7b7b4bc451887092fe60f87bc15406194c",
-      "integrity": "sha512-JtX1uyAR4IFNn8xQpMYpJHgBONEMLBmpEH0zxdYhnijmBW1JxK1bjs8lyr71uV1mThHdXMZR/h7A1IS/9RBAlQ=="
+      "version": "5.15.126",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.126/aaccc917091c35844d6f1899fb0241c014dd0718",
+      "integrity": "sha512-MwyjA6TrWfdipATope56Ob2cfBhuB7/sgHgxQAKmY9Oa3tLU4x8zwJn9la9YWr+hrU/Wrx5P0YV81vpaT3j4nQ=="
     },
     "@navikt/textparser": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@apollo/client": "^3.6.8",
     "@loadable/component": "^5.10.3",
     "@navikt/fnrvalidator": "^1.1.4",
-    "@navikt/melosys-kodeverk": "5.15.125",
+    "@navikt/melosys-kodeverk": "5.15.126",
     "classnames": "^2.2.6",
     "connected-react-router": "^6.6.1",
     "date-fns": "^2.28.0",

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
@@ -15,6 +15,8 @@ const {
   UTSENDT_ARBEIDSTAKER,
   REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE,
   REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING,
+  ANMODNING_OM_UNNTAK_HOVEDREGEL,
+  REGISTRERING_UNNTAK,
 } = MKV.Koder.behandlinger.behandlingstema;
 const { NY_VURDERING, FØRSTEGANG, HENVENDELSE, KLAGE } = MKV.Koder.behandlinger.behandlingstyper;
 const { FTRL, TRYGDEAVTALE, EU_EOS } = MKV.Koder.sakstyper;
@@ -299,6 +301,36 @@ describe("AvsluttSak", () => {
       expect(
         avsluttSak.findWhere((n) => n.type() === Handling && n.props().tekst === "Vedtaket er omgjort (fvl § 35)")
       ).toHaveLength(0);
+    });
+  });
+
+  describe("Unntak-handlinger", () => {
+    it(`viser Unntak-handlinger dersom behandlingstema er ${ANMODNING_OM_UNNTAK_HOVEDREGEL} og sakstype er ${TRYGDEAVTALE}`, () => {
+      setupProps(props);
+      props.behandlingstema = ANMODNING_OM_UNNTAK_HOVEDREGEL;
+      props.sakstype = TRYGDEAVTALE;
+
+      const avsluttSak = shallow(<AvsluttSak {...props} />);
+      const handlinger = avsluttSak.find(Handling);
+
+      expect(handlinger).toHaveLength(3);
+      expect(handlinger.at(0).props().tekst).toBe("Perioden er godkjent");
+      expect(handlinger.at(1).props().tekst).toBe("Perioden er delvis godkjent");
+      expect(handlinger.at(2).props().tekst).toBe("Medlem i folketrygden");
+    });
+
+    it(`viser Unntak-handlinger dersom behandlingstema er ${REGISTRERING_UNNTAK} og sakstype er ${TRYGDEAVTALE}`, () => {
+      setupProps(props);
+      props.behandlingstema = REGISTRERING_UNNTAK;
+      props.sakstype = TRYGDEAVTALE;
+
+      const avsluttSak = shallow(<AvsluttSak {...props} />);
+      const handlinger = avsluttSak.find(Handling);
+
+      expect(handlinger).toHaveLength(3);
+      expect(handlinger.at(0).props().tekst).toBe("Perioden er godkjent");
+      expect(handlinger.at(1).props().tekst).toBe("Perioden er delvis godkjent");
+      expect(handlinger.at(2).props().tekst).toBe("Medlem i folketrygden");
     });
   });
 });

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
@@ -17,6 +17,8 @@ const {
   UNNTAK_MEDLEMSKAP,
   ARBEID_ETT_LAND_ØVRIG,
   ARBEID_TJENESTEPERSON_ELLER_FLY,
+  ANMODNING_OM_UNNTAK_HOVEDREGEL,
+  REGISTRERING_UNNTAK,
 } = MKV.Koder.behandlinger.behandlingstema;
 const { NY_VURDERING, ENDRET_PERIODE, FØRSTEGANG, KLAGE } = MKV.Koder.behandlinger.behandlingstyper;
 const { EU_EOS, FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
@@ -30,6 +32,8 @@ const {
   KLAGEINNSTILLING,
   AVVIST_KLAGE,
   OMGJORT,
+  REGISTRERT_UNNTAK,
+  DELVIS_GODKJENT_UNNTAK,
 } = MKV.Koder.behandlinger.behandlingsresultattyper;
 
 type avsluttSakProps = {
@@ -70,6 +74,9 @@ const AvsluttSak = ({
   const behandlingstemaErUnntakNorskTrygdØvrigEllerUtstasjonering =
     behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE ||
     behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING;
+  const behandlingstemaErUnntakOgSakstemaErTrygdeavtale =
+    (behandlingstema === ANMODNING_OM_UNNTAK_HOVEDREGEL || behandlingstema === REGISTRERING_UNNTAK) &&
+    sakstype === TRYGDEAVTALE;
 
   const skalViseAvslåPgaManglendeOpplysninger = () => {
     switch (behandlingskategori) {
@@ -137,8 +144,9 @@ const AvsluttSak = ({
   };
 
   const skalViseKlageHandlinger = sakstemaToggle === "enabled" && redigerbart && behandlingstypeErKlage;
-
   const skalViseVedtakOmgjort = sakstemaToggle === "enabled" && redigerbart && behandlingstypeErNyVurdering;
+  const skalViseUnntaksHandlinger =
+    sakstemaToggle === "enabled" && redigerbart && behandlingstemaErUnntakOgSakstemaErTrygdeavtale;
 
   const skalViseSøknadenErInnvilget = () => {
     if (sakstemaToggle !== "enabled" || !redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) {
@@ -201,7 +209,8 @@ const AvsluttSak = ({
     skalViseSøknadenErAvslått() ||
     skalViseAvslåPgaManglendeOpplysninger() ||
     skalViseVedtakOmgjort ||
-    skalViseKlageHandlinger;
+    skalViseKlageHandlinger ||
+    skalViseUnntaksHandlinger;
 
   if (!skalViseHenleggSak() && !skalViseAvsluttSak() && !skalViseFerdigbehandlet() && !skalKunneAngiBehandlingsresultat)
     return null;
@@ -236,6 +245,19 @@ const AvsluttSak = ({
           )}
           {skalViseVedtakOmgjort && (
             <Handling tekst="Vedtaket er omgjort (fvl § 35)" onClick={() => angiBehandlingsresultattype(OMGJORT)} />
+          )}
+          {skalViseUnntaksHandlinger && (
+            <>
+              <Handling tekst="Perioden er godkjent" onClick={() => angiBehandlingsresultattype(REGISTRERT_UNNTAK)} />
+              <Handling
+                tekst="Perioden er delvis godkjent"
+                onClick={() => angiBehandlingsresultattype(DELVIS_GODKJENT_UNNTAK)}
+              />
+              <Handling
+                tekst="Medlem i folketrygden"
+                onClick={() => angiBehandlingsresultattype(MEDLEM_I_FOLKETRYGDEN)}
+              />
+            </>
           )}
         </div>
       )}

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
@@ -75,8 +75,7 @@ const AvsluttSak = ({
     behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE ||
     behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING;
   const behandlingstemaErUnntakOgSakstemaErTrygdeavtale =
-    (behandlingstema === ANMODNING_OM_UNNTAK_HOVEDREGEL || behandlingstema === REGISTRERING_UNNTAK) &&
-    sakstype === TRYGDEAVTALE;
+    behandlingstema === ANMODNING_OM_UNNTAK_HOVEDREGEL || behandlingstema === REGISTRERING_UNNTAK;
 
   const skalViseAvslåPgaManglendeOpplysninger = () => {
     switch (behandlingskategori) {
@@ -146,7 +145,10 @@ const AvsluttSak = ({
   const skalViseKlageHandlinger = sakstemaToggle === "enabled" && redigerbart && behandlingstypeErKlage;
   const skalViseVedtakOmgjort = sakstemaToggle === "enabled" && redigerbart && behandlingstypeErNyVurdering;
   const skalViseUnntaksHandlinger =
-    sakstemaToggle === "enabled" && redigerbart && behandlingstemaErUnntakOgSakstemaErTrygdeavtale;
+    sakstemaToggle === "enabled" &&
+    redigerbart &&
+    behandlingstemaErUnntakOgSakstemaErTrygdeavtale &&
+    sakstype === TRYGDEAVTALE;
 
   const skalViseSøknadenErInnvilget = () => {
     if (sakstemaToggle !== "enabled" || !redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) {

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
@@ -74,7 +74,7 @@ const AvsluttSak = ({
   const behandlingstemaErUnntakNorskTrygdØvrigEllerUtstasjonering =
     behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE ||
     behandlingstema === REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING;
-  const behandlingstemaErUnntakOgSakstemaErTrygdeavtale =
+  const behandlingstemaErUnntak =
     behandlingstema === ANMODNING_OM_UNNTAK_HOVEDREGEL || behandlingstema === REGISTRERING_UNNTAK;
 
   const skalViseAvslåPgaManglendeOpplysninger = () => {
@@ -145,10 +145,7 @@ const AvsluttSak = ({
   const skalViseKlageHandlinger = sakstemaToggle === "enabled" && redigerbart && behandlingstypeErKlage;
   const skalViseVedtakOmgjort = sakstemaToggle === "enabled" && redigerbart && behandlingstypeErNyVurdering;
   const skalViseUnntaksHandlinger =
-    sakstemaToggle === "enabled" &&
-    redigerbart &&
-    behandlingstemaErUnntakOgSakstemaErTrygdeavtale &&
-    sakstype === TRYGDEAVTALE;
+    sakstemaToggle === "enabled" && redigerbart && behandlingstemaErUnntak && sakstype === TRYGDEAVTALE;
 
   const skalViseSøknadenErInnvilget = () => {
     if (sakstemaToggle !== "enabled" || !redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) {


### PR DESCRIPTION
Dersom behandlingstema = ANMODNING_OM_UNNTAK_HOVEDREGEL eller REGISTRERING_UNNTAK og sakstype = TRYGDEAVTALE skal behandlingsresultatene REGISTRERT_UNNTAK, DELVIS_GODKJENT_UNNTAK og MEDLEM_I_FOLKETRYGDEN kunne velges.

Link til API: https://github.com/navikt/melosys-api/pull/1356

ref: https://jira.adeo.no/browse/MELOSYS-5304