### PR TITLE
4709 Skjema var feil mtp når periode og land krevdes. 

### DIFF
--- a/src/sider/journalforing/komponenter/journalforingSchema.js
+++ b/src/sider/journalforing/komponenter/journalforingSchema.js
@@ -4,6 +4,7 @@ import MKV from "../../../melosyskodeverk";
 import * as Utils from "../../../utils";
 import * as Konstanter from "../../../constants";
 import * as KV from "../../../kodeverk";
+import { skalViseSoknadsperiodeOgLand } from "./opprettSak";
 
 const SKRIV_INN_KUN_NUMMER = { melding: "Skriv inn kun nummer." };
 const SKRIV_INN_GYLDIG_FNR_ELLER_DNR = { melding: "Skriv inn gyldig fnr eller dnr." };
@@ -26,18 +27,12 @@ const VELG_REPRESENTERER = { melding: "Velg hvem fullmektig representerer" };
 const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 const { BRUKER, VIRKSOMHET } = MKV.Koder.aktoersroller;
 
-const kreverPeriode = (journalforingHensikt, behandlingstema) =>
+const kreverPeriode = (journalforingHensikt, hovedpart, sakstype, behandlingstema) =>
   journalforingHensikt === Konstanter.JOURNALFORING_HENSIKT.OPPRETT &&
-  ![
-    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
-    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
-    MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
-    MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET,
-    MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV,
-  ].includes(behandlingstema);
+  skalViseSoknadsperiodeOgLand(hovedpart, sakstype, behandlingstema);
 
-const kreverLand = (journalforingHensikt, behandlingstema, ukjentEllerAlleEosLand) =>
-  !ukjentEllerAlleEosLand && kreverPeriode(journalforingHensikt, behandlingstema);
+const kreverLand = (journalforingHensikt, hovedpart, sakstype, behandlingstema, ukjentEllerAlleEosLand) =>
+  !ukjentEllerAlleEosLand && kreverPeriode(journalforingHensikt, hovedpart, sakstype, behandlingstema);
 
 const arbeidsgiverOgIkkePreutfyltAvsender = (avsenderType, erAvsenderPreutfylt) => {
   return avsenderType === KV.AvsenderTyper.ARBEIDSGIVER && !erAvsenderPreutfylt;
@@ -127,14 +122,17 @@ const journalforing = object().shape({
       hensikt === Konstanter.JOURNALFORING_HENSIKT.KNYTT || hensikt === Konstanter.JOURNALFORING_HENSIKT.NY_VURDERING,
     then: string().required(VELG_HVILKEN_SAK_DU_ONSKER_A_KNYTTE_JOURNALFORINGEN_MOT),
   }),
-  journalforingPeriodeFraOgMed: string().when(["journalforingHensikt", "opprettnysak_behandlingstema"], {
-    is: kreverPeriode,
-    then: string().erGyldigDato().required(MAA_FYLLES_UT),
-  }),
+  journalforingPeriodeFraOgMed: string().when(
+    ["journalforingHensikt", "journalforingGjelder", "sakstype", "opprettnysak_behandlingstema"],
+    {
+      is: kreverPeriode,
+      then: string().erGyldigDato().required(MAA_FYLLES_UT),
+    }
+  ),
   journalforingPeriodeTilOgMed: lazy((value) =>
     !value
       ? string().ensure()
-      : string().when(["journalforingHensikt", "opprettnysak_behandlingstema"], {
+      : string().when(["journalforingHensikt", "journalforingGjelder", "sakstype", "opprettnysak_behandlingstema"], {
           is: kreverPeriode,
           then: string().erEtterDatofelt("journalforingPeriodeFraOgMed").erGyldigDato().required(MAA_FYLLES_UT),
         })
@@ -142,10 +140,19 @@ const journalforing = object().shape({
   journalforingSoknadsland: array()
     .of(string())
     .ensure()
-    .when(["journalforingHensikt", "opprettnysak_behandlingstema", "journalforingSoknadslandUkjenteEllerAlleEosLand"], {
-      is: kreverLand,
-      then: array().of(string()).min(1, { _error: VELG_MINST_ETT_LAND }),
-    }),
+    .when(
+      [
+        "journalforingHensikt",
+        "journalforingGjelder",
+        "sakstype",
+        "opprettnysak_behandlingstema",
+        "journalforingSoknadslandUkjenteEllerAlleEosLand",
+      ],
+      {
+        is: kreverLand,
+        then: array().of(string()).min(1, { _error: VELG_MINST_ETT_LAND }),
+      }
+    ),
   utenlandskTrygdemyndighetLandkode: string().when("avsenderType", {
     is: MKV.Koder.avsendertyper.UTENLANDSK_TRYGDEMYNDIGHET,
     then: string().required(VELG_ETT_LAND),

--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -39,6 +39,15 @@ const trygdeavtaleBehandlingstemaer = MKV.KTObjects.behandlinger.behandlingstema
   ({ kode }) => kode === MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV
 );
 
+export const skalViseSoknadsperiodeOgLand = (hovedpart, sakstype, behandlingstema) =>
+  hovedpart !== MKV.Koder.aktoersroller.VIRKSOMHET &&
+  sakstype === MKV.Koder.sakstyper.EU_EOS &&
+  ![
+    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
+    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
+    MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
+  ].includes(behandlingstema);
+
 export const OpprettSakTittel = () => (
   <div className="enkeltSak__meta">
     <Nav.Typo.Element>Opprett ny sak</Nav.Typo.Element>
@@ -158,15 +167,6 @@ export const OpprettSak = (props) => {
     }
   }, [sakstemaToggleEnabled, journalforingGjelder, valgtSakstype, valgtSakstema, valgtBehandlingstema]);
 
-  const skalViseSoknadsperiodeOgLand =
-    journalforingGjelder !== MKV.Koder.aktoersroller.VIRKSOMHET &&
-    valgtSakstype === MKV.Koder.sakstyper.EU_EOS &&
-    ![
-      MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
-      MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
-      MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
-    ].includes(valgtBehandlingstema);
-
   const visMuligeBehandlingstema = sakstemaToggleEnabled
     ? journalforingGjelder === MKV.Koder.aktoersroller.BRUKER
     : true;
@@ -231,7 +231,7 @@ export const OpprettSak = (props) => {
           ))}
         </Skjema.Select>
       )}
-      {skalViseSoknadsperiodeOgLand && (
+      {skalViseSoknadsperiodeOgLand(journalforingGjelder, valgtSakstype, valgtBehandlingstema) && (
         <Fragment>
           <Nav.Fieldset legend="Søknadsperiode:" className="opprettnysak__soknadsperiode">
             <Nav.Row className="">


### PR DESCRIPTION
Skjema var feil mtp når periode og land krevdes. Gjorde logikken på denne felles, og tok utgangspunkt i den som fantes i opprettSak siden de var ulike. Dette kom etter lovlige-kombinasjoner gjorde det mulig å velge flere ting enn vi hadde tatt hensyn til fra før - men det er nok fortsatt en del av journalføringssaken. Legger med begge jira-oppgavene.

https://jira.adeo.no/browse/MELOSYS-4798
https://jira.adeo.no/browse/MELOSYS-5215