### PR TITLE
5239: TOGGLE Tok ikke hensyn til visMenypanel som kommer fra ErMenypanelSynlig

### DIFF
--- a/src/ducks/menypanel/selectors.js
+++ b/src/ducks/menypanel/selectors.js
@@ -16,6 +16,6 @@ export const ErMenypanelSynlig = createSelector(
   behandlingerSelectors.BehandlingstypeKodeSelector,
   (menypanel, sakstype, behandlingstema, behandlingstype) =>
     sakstype === MKV.Koder.sakstyper.EU_EOS ||
-    (menypanel && menypanel.synlig) ||
+    menypanel?.synlig ||
     skalViseTomFlytEllerErSedBehandling(sakstype, behandlingstema, behandlingstype)
 );

--- a/src/ducks/menypanel/selectors.js
+++ b/src/ducks/menypanel/selectors.js
@@ -1,6 +1,8 @@
 import { createSelector } from "reselect";
 import { fagsakSelectors } from "../fagsaker";
 import MKV from "../../melosyskodeverk";
+import { behandlingerSelectors } from "../behandlinger";
+import { skalViseTomFlytEllerErSedBehandling } from "../../routing";
 
 export const MenypanelSelector = createSelector(
   (state) => state.menypanel.data,
@@ -10,5 +12,10 @@ export const MenypanelSelector = createSelector(
 export const ErMenypanelSynlig = createSelector(
   MenypanelSelector,
   fagsakSelectors.SakstypeKodeSelector,
-  (menypanel, sakstype) => sakstype === MKV.Koder.sakstyper.EU_EOS || (menypanel && menypanel.synlig)
+  behandlingerSelectors.BehandlingstemaKodeSelector,
+  behandlingerSelectors.BehandlingstypeKodeSelector,
+  (menypanel, sakstype, behandlingstema, behandlingstype) =>
+    sakstype === MKV.Koder.sakstyper.EU_EOS ||
+    (menypanel && menypanel.synlig) ||
+    skalViseTomFlytEllerErSedBehandling(sakstype, behandlingstema, behandlingstype)
 );

--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
@@ -1,6 +1,6 @@
 import MKV from "../../../melosyskodeverk";
 
-import { skalViseTomFlyt } from "../../../routing";
+import { skalViseTomFlytEllerErSedBehandling } from "../../../routing";
 import { LinkGroup, ContentProps } from "./types";
 import LinkgroupsBuilder from "./linkgroupsBuilder";
 import LinksBuilder from "./linksBuilder";
@@ -9,7 +9,6 @@ const {
   UTSENDT_ARBEIDSTAKER,
   UTSENDT_SELVSTENDIG,
   ARBEID_FLERE_LAND,
-  IKKE_YRKESAKTIV,
   ARBEID_ETT_LAND_ØVRIG,
   ARBEID_TJENESTEPERSON_ELLER_FLY,
   ARBEID_KUN_NORGE,
@@ -19,9 +18,6 @@ const {
   ANMODNING_OM_UNNTAK_HOVEDREGEL,
   BESLUTNING_LOVVALG_NORGE,
   BESLUTNING_LOVVALG_ANNET_LAND,
-  ØVRIGE_SED_MED,
-  ØVRIGE_SED_UFM,
-  TRYGDETID,
   ARBEID_I_UTLANDET,
   YRKESAKTIV,
 } = MKV.Koder.behandlinger.behandlingstema;
@@ -44,7 +40,8 @@ class LinkGroupsFactory {
     behandlingstema,
     behandlingstype,
   }: LinkGroupsConfig): LinkGroup[] {
-    if (skalViseTomFlyt(sakstype, behandlingstema, behandlingstype)) return visKunFullmektig(contentProps);
+    if (skalViseTomFlytEllerErSedBehandling(sakstype, behandlingstema, behandlingstype))
+      return new LinkgroupsBuilder().addUtenLabel(new LinksBuilder(contentProps).addFullmektig().build()).build();
 
     switch (behandlingstema) {
       case UTSENDT_ARBEIDSTAKER:
@@ -80,12 +77,6 @@ class LinkGroupsFactory {
             new LinksBuilder(contentProps).addPerson().addFamilieForhold().addMedlemskap().addEUEOSBarnetrygd().build()
           )
           .build();
-      }
-      case IKKE_YRKESAKTIV:
-      case TRYGDETID:
-      case ØVRIGE_SED_MED:
-      case ØVRIGE_SED_UFM: {
-        return visKunFullmektig(contentProps);
       }
       case BESLUTNING_LOVVALG_ANNET_LAND:
       case ANMODNING_OM_UNNTAK_HOVEDREGEL: {
@@ -142,8 +133,5 @@ class LinkGroupsFactory {
     }
   }
 }
-
-const visKunFullmektig = (contentProps: ContentProps) =>
-  new LinkgroupsBuilder().addUtenLabel(new LinksBuilder(contentProps).addFullmektig().build()).build();
 
 export default LinkGroupsFactory;

--- a/src/routing/index.js
+++ b/src/routing/index.js
@@ -1,5 +1,5 @@
 import Routing from "./routing";
-import { lagUrlFraBehandlingstema, nyFane, lagUrl, skalViseTomFlyt } from "./url";
+import { lagUrlFraBehandlingstema, nyFane, lagUrl, skalViseTomFlytEllerErSedBehandling } from "./url";
 
 export default Routing;
-export { lagUrlFraBehandlingstema, nyFane, lagUrl, skalViseTomFlyt };
+export { lagUrlFraBehandlingstema, nyFane, lagUrl, skalViseTomFlytEllerErSedBehandling };

--- a/src/routing/url.ts
+++ b/src/routing/url.ts
@@ -4,11 +4,23 @@ import * as Constants from "../constants";
 const { EU_EOS, FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
 const { HENVENDELSE, KLAGE } = MKV.Koder.behandlinger.behandlingstyper;
 
+const erSedBehandling = (behandlingstema: string) => {
+  return [
+    MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV,
+    MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
+    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
+    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
+  ].includes(behandlingstema);
+};
+
 export const lagUrlFraBehandlingstema = (
   saksnummer: number | string,
   behandlingID: number,
   behandlingstemaKode: string
 ) => {
+  if (erSedBehandling(behandlingstemaKode)) {
+    return `/${EU_EOS}/sedbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
+  }
   switch (behandlingstemaKode) {
     case MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING:
     case MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE:
@@ -22,11 +34,6 @@ export const lagUrlFraBehandlingstema = (
     case MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND:
     case MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND:
       return `/${EU_EOS}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
-    case MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV:
-    case MKV.Koder.behandlinger.behandlingstema.TRYGDETID:
-    case MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED:
-    case MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM:
-      return `/${EU_EOS}/sedbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
     case MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE:
     case MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND:
       return `/${EU_EOS}/vurderutpeking/${saksnummer}/?behandlingID=${behandlingID}`;
@@ -80,15 +87,7 @@ export const skalViseTomFlytEllerErSedBehandling = (
   behandlingstema: string,
   behandlingstype: string
 ) => {
-  return (
-    skalViseTomFlyt(sakstype, behandlingstema, behandlingstype) ||
-    [
-      MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV,
-      MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
-      MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
-      MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
-    ].includes(behandlingstema)
-  );
+  return skalViseTomFlyt(sakstype, behandlingstema, behandlingstype) || erSedBehandling(behandlingstema);
 };
 
 export const nyFane = (url: string) => {

--- a/src/routing/url.ts
+++ b/src/routing/url.ts
@@ -52,7 +52,7 @@ export const lagUrl = (
   return lagUrlFraBehandlingstema(saksnummer, behandlingID, behandlingstemaKode);
 };
 
-export const skalViseTomFlyt = (sakstype: string, behandlingstema: string, behandlingstype: string) => {
+const skalViseTomFlyt = (sakstype: string, behandlingstema: string, behandlingstype: string) => {
   if ([HENVENDELSE, KLAGE].includes(behandlingstype)) {
     return true;
   }
@@ -73,6 +73,22 @@ export const skalViseTomFlyt = (sakstype: string, behandlingstema: string, behan
     MKV.Koder.behandlinger.behandlingstema.UNNTAK_MEDLEMSKAP,
     MKV.Koder.behandlinger.behandlingstema.FORESPØRSEL_TRYGDEMYNDIGHET,
   ].includes(behandlingstema);
+};
+
+export const skalViseTomFlytEllerErSedBehandling = (
+  sakstype: string,
+  behandlingstema: string,
+  behandlingstype: string
+) => {
+  return (
+    skalViseTomFlyt(sakstype, behandlingstema, behandlingstype) ||
+    [
+      MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV,
+      MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
+      MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
+      MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
+    ].includes(behandlingstema)
+  );
 };
 
 export const nyFane = (url: string) => {


### PR DESCRIPTION
Tok ikke hensyn til visMenypanel som kommer fra ErMenypanelSynlig. Gjør denne alltid synlig når det er tom flyt.

Fra test: 
> HENVENDELSE + sakstype TRYGDEAVTALE
> YRKESAKTIV + sakstype FTRL

Fungerte ikke. Dette fordi Trygdeavtale og FTRL fra før av ikke skal vise behandlingsmenyen før periode er satt.

https://jira.adeo.no/browse/MELOSYS-5239