### PR TITLE
5357: Fjerner window.confirm når man trykker på hjem-knappen på topplinjen

### DIFF
--- a/src/sider/rammeverk/komponenter/topplinje.js
+++ b/src/sider/rammeverk/komponenter/topplinje.js
@@ -21,16 +21,8 @@ const Topplinje = (props) => {
     event.preventDefault();
     const { hentOppgaveOversikt, history } = props;
     const { push } = history;
-    if (process.env.NODE_ENV !== "production") {
-      hentOppgaveOversikt();
-      push("/");
-      return;
-    }
-    /* eslint no-alert: off */
-    if (window.confirm("Noen endringer vil kanskje ikke bli lagret. Vil du fortsette?")) {
-      hentOppgaveOversikt();
-      push("/");
-    }
+    hentOppgaveOversikt();
+    push("/");
   };
 
   return (


### PR DESCRIPTION
Fjerner varselet som kommer opp i det man trykker på NAV-logoen på topplinjen. 

https://jira.adeo.no/browse/MELOSYS-5357 
(per 27. sept 17:25 er ikke den oppgaven oppdatert, men vil oppdateres til å si at vi skal fjerne det)