### PR TITLE
5239 Sjekk på om panel er redigerbart måtte oppdateres for nye kombinasjoner

### DIFF
--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -14,6 +14,7 @@ import * as KV from "../../kodeverk";
 import * as behandlingsgrunnlagSelectors from "../behandlingsgrunnlag/selectors";
 import * as Utils from "../../utils";
 import * as lovvalgsperioderSelectors from "../lovvalgsperioder/selectors";
+import { SakstypeKodeSelector } from "../fagsaker/selectors";
 
 export const BehandlingerSelector = createSelector(
   (state) => (state.behandlinger.data ? state.behandlinger.data : {}),
@@ -390,9 +391,12 @@ export const ErEndretPeriodeSelector = createSelector(
   (behandlingstype) => behandlingstype === MKV.Koder.behandlinger.behandlingstyper.ENDRET_PERIODE
 );
 
-export const ErAnmodningOmUnntakHovedRegelSelector = createSelector(
+export const ErAnmodningOmUnntakHovedRegelOgHarFlytSelector = createSelector(
   BehandlingstemaKodeSelector,
-  (behandlingstema) => behandlingstema === MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL
+  SakstypeKodeSelector,
+  (behandlingstema, sakstype) =>
+    behandlingstema === MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL &&
+    sakstype !== MKV.Koder.sakstyper.TRYGDEAVTALE
 );
 
 export const ErRegistreringUnntakNorskTrygdUtstasjoneringSelector = createSelector(

--- a/src/ducks/behandlinger/selectors.test.js
+++ b/src/ducks/behandlinger/selectors.test.js
@@ -3,7 +3,7 @@ import * as selectors from "./selectors";
 import MKV from "../../melosyskodeverk";
 
 describe("Behandlingerselectors", () => {
-  const lagState = ({ lovvalgsperiode, soknadsperiode, behandlingstema }) => ({
+  const lagState = ({ lovvalgsperiode, soknadsperiode, behandlingstema, sakstype }) => ({
     behandlingsgrunnlag: {
       data: {
         data: {
@@ -64,6 +64,13 @@ describe("Behandlingerselectors", () => {
     lovvalgsperioder: {
       data: [],
     },
+    fagsaker: {
+      data: {
+        sakstype: {
+          kode: sakstype,
+        },
+      },
+    },
   });
 
   describe("ArbeidsgivereNorgeSelector", () => {
@@ -116,17 +123,24 @@ describe("Behandlingerselectors", () => {
     );
   });
 
-  describe("ErAnmodningOmUnntakHovedRegelSelector", () => {
+  describe("ErAnmodningOmUnntakHovedRegelOgHarFlytSelector", () => {
     each([
-      [true, MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL],
-      [false, MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG],
-    ]).it("returnerer korrekte verdier", (forventetResultat, behandlingstema) => {
-      const state = lagState({
-        behandlingstema,
-      });
+      [true, MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL, MKV.Koder.sakstyper.EU_EOS],
+      [true, MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL, MKV.Koder.sakstyper.FTRL],
+      [false, MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL, MKV.Koder.sakstyper.TRYGDEAVTALE],
+      [false, MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG, MKV.Koder.sakstyper.EU_EOS],
+      [false, MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG, MKV.Koder.sakstyper.FTRL],
+    ]).it(
+      "returnerer korrekte verdier (%s) for behandlingstema %s og sakstype %s",
+      (forventetResultat, behandlingstema, sakstype) => {
+        const state = lagState({
+          behandlingstema,
+          sakstype,
+        });
 
-      expect(selectors.ErAnmodningOmUnntakHovedRegelSelector(state)).toBe(forventetResultat);
-    });
+        expect(selectors.ErAnmodningOmUnntakHovedRegelOgHarFlytSelector(state)).toBe(forventetResultat);
+      }
+    );
   });
 
   describe("ErRegistreringUnntakNorskTrygdUtstasjoneringSelector", () => {

--- a/src/ducks/redigerbart/selectors.js
+++ b/src/ducks/redigerbart/selectors.js
@@ -20,7 +20,7 @@ export const PanelerRedigerbartSelector = createSelector(
   RedigerbartSelector,
   anmodningsperioderSelectors.AlleAnmodningsperioderSendtUtlandSelector,
   behandlingerSelectors.ErEndretPeriodeSelector,
-  behandlingerSelectors.ErAnmodningOmUnntakHovedRegelSelector,
+  behandlingerSelectors.ErAnmodningOmUnntakHovedRegelOgHarFlytSelector,
   behandlingerSelectors.ErRegistreringUnntakNorskTrygdUtstasjoneringSelector,
   behandlingerSelectors.ErRegistreringUnntakNorskTrygdOvrigeSelector,
   (

--- a/src/ducks/redigerbart/selectors.test.js
+++ b/src/ducks/redigerbart/selectors.test.js
@@ -17,6 +17,9 @@ describe("Redigerbartselectors", () => {
         },
       },
     },
+    fagsaker: {
+      data: {},
+    },
   });
 
   describe("BehandlingsmenyredigerbartSelector", () => {


### PR DESCRIPTION
Oppdaterer sjekk på redigerbar for å matche de nye mulige sakstypene for ANMODNING_OM_UNNTAK_HOVEDREGEL

Denne må ikke toggles, siden prod kun tillater ANMODNING_OM_UNNTAK_HOVEDREGEL for EUEØS og denne kombinasjonen har fortsatt samme oppførsel som før.

https://jira.adeo.no/browse/MELOSYS-5239