### PR TITLE
Melosys 5223 UI ux bugs

### DIFF
--- a/src/sider/forside/komponenter/saksplukker/saksplukker.tsx
+++ b/src/sider/forside/komponenter/saksplukker/saksplukker.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
+import { Action } from "redux";
 import { connect, ConnectedProps } from "react-redux";
-import { getFormValues, InjectedFormProps, reduxForm } from "redux-form";
+import { ThunkDispatch } from "redux-thunk";
+import { clearFields, getFormValues, InjectedFormProps, reduxForm } from "redux-form";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { KTObject } from "@navikt/melosys-kodeverk";
 import { RootState } from "AppTypes";
@@ -40,7 +42,12 @@ const mapStateToProps = (state: RootState) => ({
   formValues: getFormValues(KV.Form.SAKSPLUKKER_FORM)(state) as SaksplukkerFormData,
 });
 
-const connector = connect(mapStateToProps);
+const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
+  nullstillForm: () =>
+    dispatch(clearFields(KV.Form.SAKSPLUKKER_FORM, false, false, "sakstype", "sakstema", "behandlingstema")),
+});
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type SaksplukkerProps = PropsFromRedux & RouteComponentProps;
@@ -50,6 +57,7 @@ export const Saksplukker = ({
   history,
   formValues,
   change,
+  nullstillForm,
   invalid,
 }: InjectedFormProps<SaksplukkerFormData, SaksplukkerProps> & SaksplukkerProps) => {
   const folketrygdenToggle = useFeatureToggle("melosys.folketrygden.mvp");
@@ -125,12 +133,6 @@ export const Saksplukker = ({
     return true;
   };
 
-  const nullstill = () => {
-    change("sakstype", null);
-    change("sakstema", null);
-    change("behandlingstema", null);
-  };
-
   const ikkePlukkbareBehandlingstemaerEOS = [
     MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND,
     MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET,
@@ -154,7 +156,7 @@ export const Saksplukker = ({
       ) : (
         <p>Velg sakstype og behandlingstema for å få tildelt en sak.</p>
       )}
-      <form className="saksplukker__skjema" onSubmit={submitOgVideresend} onReset={nullstill}>
+      <form className="saksplukker__skjema" onSubmit={submitOgVideresend}>
         <Nav.Row>
           <Nav.Column md="12" lg={behandleFagsakMarginToggle}>
             <Skjema.Select feltNavn="sakstype" bredde="fullbredde" label="Sakstype">
@@ -205,7 +207,7 @@ export const Saksplukker = ({
           <Nav.Knapp className="saksplukker__knapp" disabled={invalid}>
             Behandle sak
           </Nav.Knapp>
-          {behandleAlleSakerToggle === "enabled" && <Nav.Flatknapp htmlType="reset">Nullstill</Nav.Flatknapp>}
+          {behandleAlleSakerToggle === "enabled" && <Nav.Flatknapp onClick={nullstillForm}>Nullstill</Nav.Flatknapp>}
         </Nav.Row>
       </form>
     </Nav.Panel>

--- a/src/sider/forside/komponenter/saksplukker/saksplukker.tsx
+++ b/src/sider/forside/komponenter/saksplukker/saksplukker.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { connect, ConnectedProps, useDispatch } from "react-redux";
+import { Action } from "redux";
+import { connect, ConnectedProps } from "react-redux";
+import { ThunkDispatch } from "redux-thunk";
 import { clearFields, getFormValues, InjectedFormProps, reduxForm } from "redux-form";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { KTObject } from "@navikt/melosys-kodeverk";
@@ -41,7 +43,12 @@ const mapStateToProps = (state: RootState) => ({
   formValues: getFormValues(KV.Form.SAKSPLUKKER_FORM)(state) as SaksplukkerFormData,
 });
 
-const connector = connect(mapStateToProps);
+const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
+  nullstillForm: () =>
+    dispatch(clearFields(KV.Form.SAKSPLUKKER_FORM, false, false, "sakstype", "sakstema", "behandlingstema")),
+});
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type SaksplukkerProps = PropsFromRedux & RouteComponentProps;
@@ -51,6 +58,7 @@ export const Saksplukker = ({
   history,
   formValues,
   change,
+  nullstillForm,
   invalid,
 }: InjectedFormProps<SaksplukkerFormData, SaksplukkerProps> & SaksplukkerProps) => {
   const folketrygdenToggle = useFeatureToggle("melosys.folketrygden.mvp");
@@ -61,7 +69,6 @@ export const Saksplukker = ({
   const [muligeBehandlingstemaer, setMuligeBehandlingstemaer] = useState([]);
   const [visIngenOppgaveFunnetAlert, setVisIngenOppgaveFunnetAlert] = useState(false);
 
-  const dispatch = useDispatch();
   const { sakstype, sakstema } = formValues || {};
 
   useEffect(() => {
@@ -139,9 +146,6 @@ export const Saksplukker = ({
       ? !ikkePlukkbareBehandlingstemaerEOS.includes(behandlingtemaKTObject.kode)
       : plukkbareBehandlingstemaerTrygdeavtale.includes(behandlingtemaKTObject.kode);
   };
-
-  const nullstillForm = () =>
-    dispatch(clearFields(KV.Form.SAKSPLUKKER_FORM, false, false, "sakstype", "sakstema", "behandlingstema"));
 
   const behandleFagsakMarginToggle = behandleAlleSakerToggle === "enabled" ? "4" : "6";
 

--- a/src/sider/forside/komponenter/saksplukker/saksplukker.tsx
+++ b/src/sider/forside/komponenter/saksplukker/saksplukker.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Action } from "redux";
-import { connect, ConnectedProps } from "react-redux";
-import { ThunkDispatch } from "redux-thunk";
+import { connect, ConnectedProps, useDispatch } from "react-redux";
 import { clearFields, getFormValues, InjectedFormProps, reduxForm } from "redux-form";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { KTObject } from "@navikt/melosys-kodeverk";
@@ -43,12 +41,7 @@ const mapStateToProps = (state: RootState) => ({
   formValues: getFormValues(KV.Form.SAKSPLUKKER_FORM)(state) as SaksplukkerFormData,
 });
 
-const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
-  nullstillForm: () =>
-    dispatch(clearFields(KV.Form.SAKSPLUKKER_FORM, false, false, "sakstype", "sakstema", "behandlingstema")),
-});
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
+const connector = connect(mapStateToProps);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type SaksplukkerProps = PropsFromRedux & RouteComponentProps;
@@ -58,7 +51,6 @@ export const Saksplukker = ({
   history,
   formValues,
   change,
-  nullstillForm,
   invalid,
 }: InjectedFormProps<SaksplukkerFormData, SaksplukkerProps> & SaksplukkerProps) => {
   const folketrygdenToggle = useFeatureToggle("melosys.folketrygden.mvp");
@@ -69,6 +61,7 @@ export const Saksplukker = ({
   const [muligeBehandlingstemaer, setMuligeBehandlingstemaer] = useState([]);
   const [visIngenOppgaveFunnetAlert, setVisIngenOppgaveFunnetAlert] = useState(false);
 
+  const dispatch = useDispatch();
   const { sakstype, sakstema } = formValues || {};
 
   useEffect(() => {
@@ -126,12 +119,10 @@ export const Saksplukker = ({
   const submitOgVideresend = async (form: any) => {
     const redirectURL = await handleSubmit(form);
 
-    /* eslint-disable no-alert */
     if (!redirectURL) {
       setVisIngenOppgaveFunnetAlert(true);
       return false;
     }
-    /* eslint-enable */
     history.push(redirectURL);
     return true;
   };
@@ -148,6 +139,9 @@ export const Saksplukker = ({
       ? !ikkePlukkbareBehandlingstemaerEOS.includes(behandlingtemaKTObject.kode)
       : plukkbareBehandlingstemaerTrygdeavtale.includes(behandlingtemaKTObject.kode);
   };
+
+  const nullstillForm = () =>
+    dispatch(clearFields(KV.Form.SAKSPLUKKER_FORM, false, false, "sakstype", "sakstema", "behandlingstema"));
 
   const behandleFagsakMarginToggle = behandleAlleSakerToggle === "enabled" ? "4" : "6";
 

--- a/src/sider/forside/komponenter/saksplukker/saksplukker.tsx
+++ b/src/sider/forside/komponenter/saksplukker/saksplukker.tsx
@@ -6,19 +6,20 @@ import { clearFields, getFormValues, InjectedFormProps, reduxForm } from "redux-
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { KTObject } from "@navikt/melosys-kodeverk";
 import { RootState } from "AppTypes";
+import { AlertStripeAdvarsel } from "nav-frontend-alertstriper";
 
 import MKV from "../../../../melosyskodeverk";
 import * as KV from "../../../../kodeverk";
+import saksplukkerSchema from "./saksplukkerSchema";
 import * as Nav from "../../../../navFrontend";
 import * as Skjema from "../../../../felleskomponenter/skjema";
+import * as Api from "../../../../services/api";
 
 import { oppgaverOperations } from "../../../../ducks/oppgaver";
 import { useFeatureToggle } from "../../../../featuretoggle";
-
 import { lagYupToReduxformErrorMapper } from "../../../../yup";
-import saksplukkerSchema from "./saksplukkerSchema";
+
 import "./saksplukker.css";
-import * as Api from "../../../../services/api";
 
 const { EU_EOS, TRYGDEAVTALE, FTRL } = MKV.Koder.sakstyper;
 
@@ -66,6 +67,7 @@ export const Saksplukker = ({
   const [muligeSakstyper, setMuligeSakstyper] = useState([]);
   const [muligeSakstemaer, setMuligeSakstemaer] = useState([]);
   const [muligeBehandlingstemaer, setMuligeBehandlingstemaer] = useState([]);
+  const [visIngenOppgaveFunnetAlert, setVisIngenOppgaveFunnetAlert] = useState(false);
 
   const { sakstype, sakstema } = formValues || {};
 
@@ -126,7 +128,8 @@ export const Saksplukker = ({
 
     /* eslint-disable no-alert */
     if (!redirectURL) {
-      return alert("Ingen oppgaver finnes");
+      setVisIngenOppgaveFunnetAlert(true);
+      return false;
     }
     /* eslint-enable */
     history.push(redirectURL);
@@ -203,6 +206,13 @@ export const Saksplukker = ({
             </Skjema.Select>
           </Nav.Column>
         </Nav.Row>
+        {visIngenOppgaveFunnetAlert && (
+          <Nav.Row>
+            <Nav.Column md="12">
+              <AlertStripeAdvarsel>Det fins ingen saker for valgt type/tema kombinasjon</AlertStripeAdvarsel>
+            </Nav.Column>
+          </Nav.Row>
+        )}
         <Nav.Row className="saksplukker__knapperad">
           <Nav.Knapp className="saksplukker__knapp" disabled={invalid}>
             Behandle sak


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5223

Fikser disse to feilene/manglene funnet under test:
- Feilmeldingen om ingen oppgave funnet kommer opp som en eget boks isteden at den blir vist på "plukkingsboksen". Se vedlagt bilde. Dette var sikkert slik som før. Om det er enkelt å tilpasse slik at det blir som vanlige feilmeldinger i Melosys er det fint.
- Knappen nullstill funker ikke som forventet. Se vedlagt bilde

Nullstill er fortsatt ikke helt riktig, får ikke fjernet validering og behandlingstema-feltet får feil om at den ikke kan være tom (er required i yup). Funket ikke med untouch, clearAsyncError, eller metoden som jeg bruker som egentlig skall resette alt. Så om noen vet hva som er feil/kan funke så er det supert. Hvis ikke er det nok godt nok(?)