### PR TITLE
4798 TOGGLE Nullstille valgene for behandlingstema og behandlingstype.

### DIFF
--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -155,25 +155,28 @@ export const OpprettSak = (props) => {
       Api.LovligeKombinasjoner.hentSakstemaer(journalforingGjelder, valgtSakstype).then((muligeSakstemaer) => {
         setSakstemaer(muligeSakstemaer);
       });
+      setBehandlingstemaer([]);
+      setBehandlingstyper([]);
     }
   }, [behandleAlleSakerToggleEnabled, journalforingGjelder, valgtSakstype]);
 
   useEffect(() => {
     if (!behandleAlleSakerToggleEnabled) return;
 
-    if (valgtSakstema && valgtSakstype) {
+    if (valgtSakstype && valgtSakstema) {
       Api.LovligeKombinasjoner.hentBehandlingstemaer(journalforingGjelder, valgtSakstype, valgtSakstema).then(
         (muligeBehandlingstemaer) => {
           setBehandlingstemaer(muligeBehandlingstemaer);
         }
       );
+      setBehandlingstyper([]);
     }
   }, [behandleAlleSakerToggleEnabled, journalforingGjelder, valgtSakstype, valgtSakstema]);
 
   useEffect(() => {
     if (!behandleAlleSakerToggleEnabled) return;
 
-    if (valgtSakstema && valgtSakstype && valgtBehandlingstema) {
+    if (valgtSakstype && valgtSakstema && valgtBehandlingstema) {
       Api.LovligeKombinasjoner.hentBehandlingstyper(
         journalforingGjelder,
         valgtSakstype,


### PR DESCRIPTION
Nullstille valgene for behandlingstema og behandlingstype når sakstype endres, siden disse ikke skal være hentet lengre. Samme for behandlingstyper når sakstema velges.

Siste kommentar i jira-saken (med bilde): 
> Fortsatt en liten feil
>Når jeg først har valgt en sakstype og sakstema, og deretter endrer sakstype, så husker fortsatt melosys de behandlingstemaene som på forrige sakstype FØR man angir en verdi i sakstema (se bilde for mer tydelig beskrivelse). Selve valget på behandlingstema er nullstilt, men nedtrekksmenyen er ikke det. Ikke en kritisk feil, siden de riktige behandlingstemaene dukker opp når man velger sakstema, men heller ikke helt riktig siden alle menyene skal nullstilles.

https://jira.adeo.no/browse/MELOSYS-4798