### PR TITLE
5283 TOGGLE Egen feilmelding for når periode og/eller land er tom.

### DIFF
--- a/src/ducks/behandlingsgrunnlag/selectors.js
+++ b/src/ducks/behandlingsgrunnlag/selectors.js
@@ -224,6 +224,17 @@ export const PeriodeTomSelector = createSelector(
   (soknadsperiode) => soknadsperiode.tom
 );
 
+export const HarPeriodeOgLandSelector = createSelector(
+  PeriodeFomSelector,
+  SoknadslandSelector,
+  (periodeFom, soeknadsland) => {
+    const harPeriode = periodeFom != null;
+    const harLand = !Utils._isEmpty(soeknadsland.landkoder) || soeknadsland.erUkjenteEllerAlleEosLand;
+
+    return harPeriode && harLand;
+  }
+);
+
 export const PersonOpplysningerSelector = createSelector(
   (state) => BehandlingsgrunnlagDataSelector(state),
   (behandlingsgrunnlag) => behandlingsgrunnlag.personOpplysninger || {}

--- a/src/sider/eu_eøs/stegKomponenter/vurderingInngang.test.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingInngang.test.tsx
@@ -99,9 +99,10 @@ describe("Varsler", () => {
     expect(lis.first().text()).toBe("Teknisk feil, finner ingen inngangsvilkår.");
   });
 
-  it("Viser feilmelding ved manglende inngangsvilkår når melosys.tom_periode_og_land er enabled", () => {
+  it("Viser feilmelding ved manglende periode og land når det mangler og melosys.tom_periode_og_land er enabled", () => {
     props.inngangsvilkaar = undefined;
     props.tomLandOgPeriodeToggleEnabled = true;
+    props.behandlingHarPeriodeOgLand = false;
 
     const varsler = shallow(<Varsler {...props} />);
     const lis = varsler.find("li");
@@ -154,6 +155,7 @@ describe("VurderingInngang", () => {
       hentVilkar: jest.fn(),
       landkoder: ["DK"],
       behandlingstema: MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND.kode,
+      behandlingHarPeriodeOgLand: true,
     };
   });
 

--- a/src/sider/eu_eøs/stegKomponenter/vurderingInngang.test.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingInngang.test.tsx
@@ -99,6 +99,19 @@ describe("Varsler", () => {
     expect(lis.first().text()).toBe("Teknisk feil, finner ingen inngangsvilkår.");
   });
 
+  it("Viser feilmelding ved manglende inngangsvilkår når melosys.tom_periode_og_land er enabled", () => {
+    props.inngangsvilkaar = undefined;
+    props.tomLandOgPeriodeToggleEnabled = true;
+
+    const varsler = shallow(<Varsler {...props} />);
+    const lis = varsler.find("li");
+
+    expect(lis).toHaveLength(1);
+    expect(lis.first().text()).toBe(
+      "Det mangler periode og/eller land. Fyll disse inn i sidemenyen nedenfor og oppdater registeropplysninger."
+    );
+  });
+
   it("Viser feilmelding ved flere valgte land og ikke tema ARBEID_FLERE_LAND", () => {
     props.oppfyllerInngangsvilkar = true;
     props.inngangsvilkaar = {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingInngang.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingInngang.tsx
@@ -14,6 +14,7 @@ import * as Mui from "../../../felleskomponenter/ui";
 import MKV, { MKVUtils } from "../../../melosyskodeverk";
 
 import { useFeatureToggle } from "../../../featuretoggle";
+import { behandlingsgrunnlagSelectors } from "../../../ducks/behandlingsgrunnlag";
 import { behandlingerSelectors } from "../../../ducks/behandlinger";
 import { vilkarOperations } from "../../../ducks/vilkar";
 
@@ -27,6 +28,7 @@ interface VarslerProps {
   landkoder: Array<string>;
   behandlingstema: string;
   tomLandOgPeriodeToggleEnabled: boolean;
+  behandlingHarPeriodeOgLand: boolean;
 }
 
 export const Varsler = ({
@@ -35,6 +37,7 @@ export const Varsler = ({
   landkoder,
   behandlingstema,
   tomLandOgPeriodeToggleEnabled,
+  behandlingHarPeriodeOgLand,
 }: VarslerProps) => {
   const inngangsvilkaarBegrunnelseKoder = inngangsvilkaar?.begrunnelseKoder || [];
 
@@ -60,7 +63,7 @@ export const Varsler = ({
   }inngangsvilkårene for EU/EØS-saker etter forordning 883/2004.`;
 
   if (Utils._isEmpty(inngangsvilkaar)) {
-    if (tomLandOgPeriodeToggleEnabled) {
+    if (tomLandOgPeriodeToggleEnabled && !behandlingHarPeriodeOgLand) {
       return (
         <ul className="betingelser__liste">
           <li className={oppfyllerInngangsvilkarCl}>
@@ -111,6 +114,7 @@ export const Varsler = ({
 
 const mapStateToProps = (state: RootState) => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
+  behandlingHarPeriodeOgLand: behandlingsgrunnlagSelectors.HarPeriodeOgLandSelector(state),
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
@@ -127,6 +131,7 @@ type VurderingInngangProps = PropsFromRedux & {
   inngangsvilkaar: Api.Vilkar.Vilkaar | undefined;
   landkoder: Array<string>;
   behandlingstema: string;
+  behandlingHarPeriodeOgLand: boolean;
 };
 
 export const VurderingInngang = ({
@@ -138,6 +143,7 @@ export const VurderingInngang = ({
   hentVilkar,
   landkoder,
   behandlingstema,
+  behandlingHarPeriodeOgLand,
 }: VurderingInngangProps) => {
   const tomLandOgPeriodeToggle = useFeatureToggle("melosys.tom_periode_og_land");
 
@@ -159,6 +165,7 @@ export const VurderingInngang = ({
         landkoder={landkoder}
         behandlingstema={behandlingstema}
         tomLandOgPeriodeToggleEnabled={tomLandOgPeriodeToggle === "enabled"}
+        behandlingHarPeriodeOgLand={behandlingHarPeriodeOgLand}
       />
       <Mui.StegKnapper
         bekreftKnappProps={{

--- a/src/sider/eu_eøs/stegKomponenter/vurderingInngang.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingInngang.tsx
@@ -13,6 +13,7 @@ import * as Mui from "../../../felleskomponenter/ui";
 
 import MKV, { MKVUtils } from "../../../melosyskodeverk";
 
+import { useFeatureToggle } from "../../../featuretoggle";
 import { behandlingerSelectors } from "../../../ducks/behandlinger";
 import { vilkarOperations } from "../../../ducks/vilkar";
 
@@ -25,9 +26,16 @@ interface VarslerProps {
   inngangsvilkaar: Api.Vilkar.Vilkaar | undefined;
   landkoder: Array<string>;
   behandlingstema: string;
+  tomLandOgPeriodeToggleEnabled: boolean;
 }
 
-export const Varsler = ({ oppfyllerInngangsvilkar, inngangsvilkaar, landkoder, behandlingstema }: VarslerProps) => {
+export const Varsler = ({
+  oppfyllerInngangsvilkar,
+  inngangsvilkaar,
+  landkoder,
+  behandlingstema,
+  tomLandOgPeriodeToggleEnabled,
+}: VarslerProps) => {
   const inngangsvilkaarBegrunnelseKoder = inngangsvilkaar?.begrunnelseKoder || [];
 
   const visbareInngangsvilkaarBegrunnelseKoder = inngangsvilkaarBegrunnelseKoder.filter(
@@ -52,6 +60,15 @@ export const Varsler = ({ oppfyllerInngangsvilkar, inngangsvilkaar, landkoder, b
   }inngangsvilkårene for EU/EØS-saker etter forordning 883/2004.`;
 
   if (Utils._isEmpty(inngangsvilkaar)) {
+    if (tomLandOgPeriodeToggleEnabled) {
+      return (
+        <ul className="betingelser__liste">
+          <li className={oppfyllerInngangsvilkarCl}>
+            Det mangler periode og/eller land. Fyll disse inn i sidemenyen nedenfor og oppdater registeropplysninger.
+          </li>
+        </ul>
+      );
+    }
     return (
       <ul className="betingelser__liste">
         <li className={oppfyllerInngangsvilkarCl}>Teknisk feil, finner ingen inngangsvilkår.</li>
@@ -122,6 +139,8 @@ export const VurderingInngang = ({
   landkoder,
   behandlingstema,
 }: VurderingInngangProps) => {
+  const tomLandOgPeriodeToggle = useFeatureToggle("melosys.tom_periode_og_land");
+
   const knappClickHandler = async () => {
     if (!oppfyllerInngangsvilkar) {
       await Api.Vilkar.overstyrInngangvilkaar(behandlingID);
@@ -139,6 +158,7 @@ export const VurderingInngang = ({
         inngangsvilkaar={inngangsvilkaar}
         landkoder={landkoder}
         behandlingstema={behandlingstema}
+        tomLandOgPeriodeToggleEnabled={tomLandOgPeriodeToggle === "enabled"}
       />
       <Mui.StegKnapper
         bekreftKnappProps={{


### PR DESCRIPTION
Egen toggle : "melosys.tom_periode_og_land"

Legger til ny og klarere feilmelding når man ikke har inngangsvilkår, da dette i dette tilfellet mest sannsynlig er land og periode som mangler. _Burde jeg samtidig sjekke at land og periode faktisk mangler i behandlingsgrunnlaget?_

Backend: https://github.com/navikt/melosys-api/pull/1420