### PR TITLE
5373 TOGGLE: Kan ikke endre når behandle_alle_saker er enabled, og vi har ikke_end…

### DIFF
--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -109,6 +109,9 @@ function EndreBehandlingModal({
   const [muligeBehandlingstyper, setMuligeBehandlingstyper] = useState([]);
   const [nyLink, setNyLink] = useState<string | undefined>(undefined);
   const behandleAlleSakerToggle = useFeatureToggle("melosys.behandle_alle_saker");
+  const kanEndre = !(
+    useFeatureToggle("melosys.behandle_alle_saker.ikke_endre") === "enabled" && behandleAlleSakerToggle === "enabled"
+  );
 
   useEffect(() => {
     if (behandleAlleSakerToggle !== "enabled") return;
@@ -258,7 +261,7 @@ function EndreBehandlingModal({
                 behandleAlleSakerToggle === "enabled" ? muligeSakstyper : muligeSakstyper_gammel
               )}
               disableForsteValg
-              redigerbart={!endringerErBegrenset}
+              redigerbart={!endringerErBegrenset && kanEndre}
             />
             {behandleAlleSakerToggle === "enabled" && (
               <Mui.KodeTermSelect
@@ -270,7 +273,7 @@ function EndreBehandlingModal({
                 value={sakstema}
                 koder={muligeSakstemaer}
                 disableForsteValg
-                redigerbart={!endringerErBegrenset}
+                redigerbart={!endringerErBegrenset && kanEndre}
               />
             )}
             <Mui.KodeTermSelect
@@ -286,7 +289,7 @@ function EndreBehandlingModal({
                   : muligeVerdierPlussValgt(oppsummering.behandlingstema, muligeBehandlingstemaer_gammel)
               }
               disableForsteValg
-              redigerbart={!endringerErBegrenset}
+              redigerbart={!endringerErBegrenset && kanEndre}
             />
             <Mui.KodeTermSelect
               onChange={(e) => setBehandlingstype(e.target.value)}
@@ -298,7 +301,7 @@ function EndreBehandlingModal({
                   : muligeVerdierPlussValgt(oppsummering.behandlingstype, muligeBehandlingstyper_gammel)
               }
               disableForsteValg
-              redigerbart={!endringerErBegrenset}
+              redigerbart={!endringerErBegrenset && kanEndre}
             />
             <Datovelger onChange={setBehandlingsfrist} label="Frist" value={behandlingsfrist} />
             <Mui.KodeTermSelect


### PR DESCRIPTION
Ref: https://jira.adeo.no/browse/MELOSYS-5373

Endret slik at vi kan toggle muligheten til å endre. Denne toggle er avhengig av at behandle_alle_saker er på, ellers så kan vi endre uavhengig av hva denne togglen er satt på.

## ikke_endre er **av** + behandle_alle_saker er **på**

![image](https://user-images.githubusercontent.com/6776092/194267379-e93e7fe1-4b91-47c8-a127-e3097b20a127.png)


## ikke_endre er **på** + behandle_alle_saker er **på**

![image](https://user-images.githubusercontent.com/6776092/194267646-13ab726b-8214-4d84-a11b-d34756edebec.png)


## ikke_endre er **på** + behandle_alle_saker er **av**

![image](https://user-images.githubusercontent.com/6776092/194267833-c09f6006-e381-4f5c-a3ba-ae0f682815c1.png)

