### PR TITLE
4828 TOGGLE Fikset forsvinnende text editor toolbar

### DIFF
--- a/src/felleskomponenter/htmlEditor/htmlEditor.less
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.less
@@ -7,9 +7,11 @@
     border-radius: 4px;
     border: 1px solid @navGra60;
     font-family: "Source Sans Pro", Arial, sans-serif;
-    min-height: 10rem;
-    max-height: 25rem;
-    overflow-y: auto;
+    .rdw-editor-main {
+      min-height: 10rem;
+      max-height: 25rem;
+      overflow-y: auto;
+    }
     .rdw-editor-toolbar {
       border: none;
       margin-bottom: 0;


### PR DESCRIPTION
Flyttet min/max height for htmlEditor fra toppelementet til tekstområ
det slik at toolbar ikke forsvinner ved scroll