### PR TITLE
5386 TOGGLE Oppdaterer logikk for når og hvordan vi lagrer behandlingsgrunnlag

### DIFF
--- a/src/ducks/behandlingsgrunnlag/operations.js
+++ b/src/ducks/behandlingsgrunnlag/operations.js
@@ -7,10 +7,13 @@ import * as Selectors from "./selectors";
 
 import MKV from "../../melosyskodeverk";
 
+import { erFeatureToggleEnabled } from "../../featuretoggle";
 import { doThenDispatch } from "../../services/utils";
+
 import { formSelectors } from "../form";
 import { behandlingerSelectors } from "../behandlinger";
 import { OrganisasjonOperations } from "../organisasjoner";
+import { fagsakSelectors } from "../fagsaker";
 
 export function hent(behandlingID) {
   return async (dispatch, getState) => {
@@ -124,7 +127,7 @@ const lagSedGrunnlagFelter = (behandlingsgrunnlag) => ({
   ytterligereInformasjon: behandlingsgrunnlag.ytterligereInformasjon || null,
 });
 
-const lagBehandlingsgrunnlagData = (behandlingstema, behandlingsgrunnlag) => {
+const lagBehandlingsgrunnlagDataEtterBehandlingstema = (behandlingstema, behandlingsgrunnlag) => {
   switch (behandlingstema) {
     case MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER:
     case MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG:
@@ -147,15 +150,36 @@ const lagBehandlingsgrunnlagData = (behandlingstema, behandlingsgrunnlag) => {
   }
 };
 
+const lagBehandlingsgrunnlagData = (sakstype, behandlingstema, behandlingsgrunnlag) => {
+  if (temaForSedGrunnlag(behandlingstema)) {
+    return lagSedGrunnlagFelter(behandlingsgrunnlag);
+  }
+
+  switch (sakstype) {
+    case MKV.Koder.sakstyper.EU_EOS:
+      return lagEØSFelter(behandlingsgrunnlag);
+    case MKV.Koder.sakstyper.FTRL:
+      return lagFTRLFelter(behandlingsgrunnlag);
+    case MKV.Koder.sakstyper.TRYGDEAVTALE:
+      return lagTrygdeavtaleFelter(behandlingsgrunnlag);
+    default:
+      throw new Error(`Vi støtter ikke sakstype: ${sakstype}`);
+  }
+};
+
 export function lagre() {
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     dispatch(oppdaterState());
+    const behandleAlleSakerToggleEnabled = await erFeatureToggleEnabled("melosys.behandle_alle_saker");
 
     const behandlingsgrunnlag = Selectors.BehandlingsgrunnlagDataSelector(getState());
     const bid = behandlingerSelectors.BehandlingIDSelector(getState());
+    const sakstype = fagsakSelectors.SakstypeKodeSelector(getState());
     const behandlingstema = behandlingerSelectors.BehandlingstemaKodeSelector(getState());
 
-    const data = lagBehandlingsgrunnlagData(behandlingstema, behandlingsgrunnlag);
+    const data = behandleAlleSakerToggleEnabled
+      ? lagBehandlingsgrunnlagData(sakstype, behandlingstema, behandlingsgrunnlag)
+      : lagBehandlingsgrunnlagDataEtterBehandlingstema(behandlingstema, behandlingsgrunnlag);
 
     return dispatch(send(bid, { data }));
   };

--- a/src/ducks/behandlingsgrunnlag/operations.test.js
+++ b/src/ducks/behandlingsgrunnlag/operations.test.js
@@ -64,6 +64,9 @@ describe("Behandlingsgrunnlag operations", () => {
           },
         },
       },
+      fagsaker: {
+        data: {},
+      },
     };
   });
 

--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -2,7 +2,7 @@ import MKV from "../../melosyskodeverk";
 
 import { avklartefaktaOperations } from "../avklartefakta";
 import { fagsakOperations, fagsakSelectors } from "../fagsaker";
-import { behandlingerOperations } from "../behandlinger";
+import { behandlingerOperations, behandlingerSelectors } from "../behandlinger";
 import { behandlingsresultatOperations } from "../behandlingsresultat";
 import { behandlingsgrunnlagOperations } from "../behandlingsgrunnlag";
 import { lovvalgsperioderOperations } from "../lovvalgsperioder";
@@ -14,6 +14,8 @@ import { utpekingsperioderOperations } from "../utpekingsperioder";
 import { dokumenterOperations } from "../dokumenter";
 import { oppsummertfaktaOperations } from "../oppsummertfakta";
 import { medlemskapsperioderOperations } from "../medlemskapsperioder";
+import { skalViseTomFlytEllerErSedBehandling } from "../../routing";
+import { erFeatureToggleEnabled } from "../../featuretoggle";
 
 export const lastInnSaksopplysninger = (sakstype, saksnummer, behandlingID) => (dispatch) => {
   dispatch(fagsakOperations.hent(saksnummer));
@@ -70,19 +72,33 @@ export const resetSaksopplysninger = () => (dispatch) => {
   dispatch(dokumenterOperations.resetDokument());
 };
 
+const harIkkeTomFlyt = async (sakstype, state) => {
+  const behandlingstema = behandlingerSelectors.BehandlingstemaKodeSelector(state);
+  const behandlingstype = behandlingerSelectors.BehandlingstypeKodeSelector(state);
+  const behandleAlleSakerToggleEnabled = await erFeatureToggleEnabled("melosys.behandle_alle_saker");
+
+  return behandleAlleSakerToggleEnabled
+    ? !skalViseTomFlytEllerErSedBehandling(sakstype, behandlingstema, behandlingstype)
+    : true;
+};
+
 export const lagreAllData = () => async (dispatch, getState) => {
   const sakstype = fagsakSelectors.SakstypeKodeSelector(getState());
+  const skalLagreBehandlingsgrunnlag = await harIkkeTomFlyt(sakstype, getState());
 
   switch (sakstype) {
     case MKV.Koder.sakstyper.FTRL:
-      return Promise.all([dispatch(behandlingsgrunnlagOperations.lagre()), dispatch(vilkarOperations.lagre())]);
+      return Promise.all([
+        ...(skalLagreBehandlingsgrunnlag ? [dispatch(behandlingsgrunnlagOperations.lagre())] : []),
+        dispatch(vilkarOperations.lagre()),
+      ]);
     case MKV.Koder.sakstyper.TRYGDEAVTALE:
-      return Promise.all[dispatch(behandlingsgrunnlagOperations.lagre())];
+      return Promise.all([...(skalLagreBehandlingsgrunnlag ? [dispatch(behandlingsgrunnlagOperations.lagre())] : [])]);
     case MKV.Koder.sakstyper.EU_EOS: {
       const anmodningErSendtUtland = anmodningsperioderSelectors.AlleAnmodningsperioderSendtUtlandSelector(getState());
 
       await Promise.all([
-        dispatch(behandlingsgrunnlagOperations.lagre()),
+        ...(skalLagreBehandlingsgrunnlag ? [dispatch(behandlingsgrunnlagOperations.lagre())] : []),
         ...(anmodningErSendtUtland ? [] : [dispatch(vilkarOperations.lagre())]),
         ...(anmodningErSendtUtland ? [] : [dispatch(avklartefaktaOperations.lagre())]),
         ...(anmodningErSendtUtland ? [] : [dispatch(behandlingsperioderOperations.lagre())]),

--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -93,7 +93,9 @@ export const lagreAllData = () => async (dispatch, getState) => {
         dispatch(vilkarOperations.lagre()),
       ]);
     case MKV.Koder.sakstyper.TRYGDEAVTALE:
-      return Promise.all([...(skalLagreBehandlingsgrunnlag ? [dispatch(behandlingsgrunnlagOperations.lagre())] : [])]);
+      return skalLagreBehandlingsgrunnlag
+        ? Promise.all[dispatch(behandlingsgrunnlagOperations.lagre())]
+        : Promise.resolve();
     case MKV.Koder.sakstyper.EU_EOS: {
       const anmodningErSendtUtland = anmodningsperioderSelectors.AlleAnmodningsperioderSendtUtlandSelector(getState());
 


### PR DESCRIPTION
Oppdaterer logikk for lagBehandlingsgrunnlag basert på sakstyper når som behandlingstema kan være på kryss og tvers.

Ikke lagre/oppdater behandlingsgrunnlag i tom flyt - der finnes ikke behandlingsgrunnlag og det er ulogisk.


Dette ble oppdaget i testing av jira-sak for støtte av avslå pga manglende opplysninger. Vi prøvde å oppdatere og lagre behandlingsgrunnlag når vi ikke hadde behandlingsgrunnlag. 

https://jira.adeo.no/browse/MELOSYS-5386

Api: https://github.com/navikt/melosys-api/pull/1427