### PR TITLE
Melosys 4828 html editor paste formatting

### DIFF
--- a/src/felleskomponenter/htmlEditor/htmlEditor.less
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.less
@@ -7,9 +7,11 @@
     border-radius: 4px;
     border: 1px solid @navGra60;
     font-family: "Source Sans Pro", Arial, sans-serif;
-    min-height: 10rem;
-    max-height: 25rem;
-    overflow-y: auto;
+    .rdw-editor-main {
+      min-height: 10rem;
+      max-height: 25rem;
+      overflow-y: auto;
+    }
     .rdw-editor-toolbar {
       border: none;
       margin-bottom: 0;

--- a/src/felleskomponenter/htmlEditor/htmlEditor.tsx
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.tsx
@@ -26,6 +26,10 @@ function HtmlEditor({ value, onChange, ...rest }: TextToHtmlEditorProps) {
     onChange(draftToHtml(convertToRaw(editorState.getCurrentContent())));
   };
 
+  const handlePastedText = () => {
+    return false; // Benyttes for å få default stateChange ved paste
+  };
+
   return (
     <div className={classNames("htmlEditor", rest?.className)}>
       {rest?.label ? <Nav.Typo.Element className="editor_label">{rest?.label}</Nav.Typo.Element> : ""}
@@ -35,7 +39,7 @@ function HtmlEditor({ value, onChange, ...rest }: TextToHtmlEditorProps) {
         wrapperClassName={classNames("wrapper", { "wrapper-disabled": rest?.disabled, "wrapper-feil": rest?.feil })}
         editorClassName="editor"
         onEditorStateChange={onEditorStateChange}
-        stripPastedStyles
+        handlePastedText={handlePastedText}
         ariaLabel={rest?.label}
         {...rest}
       />


### PR DESCRIPTION
Tillater klipp/lim av formattert tekst i HtmlEditor. @martonSkjevelandNav @janitamarielle @IsaSalemHame har dere noen innvendinger mot at dette blir lagt til? Kan evt. begrenses med en boolean prop slik at vi kontrollerer hvor denne funksjonaliteten er tilgjengelig, men fag ønsket det i utgangspunktet overalt hvor denne komponenten benyttes.