### PR TITLE
5395 TOGGLE bug tom periode land

### DIFF
--- a/src/ducks/behandlingsgrunnlag/selectors.js
+++ b/src/ducks/behandlingsgrunnlag/selectors.js
@@ -224,15 +224,20 @@ export const PeriodeTomSelector = createSelector(
   (soknadsperiode) => soknadsperiode.tom
 );
 
-export const HarPeriodeOgLandSelector = createSelector(
-  PeriodeFomSelector,
-  SoknadslandSelector,
-  (periodeFom, soeknadsland) => {
-    const harPeriode = periodeFom != null;
-    const harLand = !Utils._isEmpty(soeknadsland.landkoder) || soeknadsland.erUkjenteEllerAlleEosLand;
+export const HarPeriodeSelector = createSelector(
+  (state) => PeriodeFomSelector(state),
+  (periodeFom) => !Utils._isEmpty(periodeFom)
+);
 
-    return harPeriode && harLand;
-  }
+export const HarLandSelector = createSelector(
+  SoknadslandSelector,
+  (soeknadsland) => !Utils._isEmpty(soeknadsland.landkoder) || soeknadsland.erUkjenteEllerAlleEosLand
+);
+
+export const HarPeriodeOgLandSelector = createSelector(
+  HarPeriodeSelector,
+  HarLandSelector,
+  (harPeriode, harLand) => harPeriode && harLand
 );
 
 export const PersonOpplysningerSelector = createSelector(

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/periode.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/periode.tsx
@@ -34,7 +34,10 @@ const Periode = ({
         />
       </Nav.Column>
       <Nav.Column xs="6">
-        <Soknadslandvelger redigerbart={redigerbart} />
+        <Soknadslandvelger
+          redigerbart={redigerbart}
+          lagreSoknadOgOppfriskSaksopplysninger={lagreSoknadOgOppfriskSaksopplysninger}
+        />
       </Nav.Column>
     </Nav.Row>
   </div>

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/soknadslandvelger.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/soknadslandvelger.tsx
@@ -4,6 +4,7 @@ import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
 import { RootState } from "AppTypes";
 
+import MKV from "../../../../../melosyskodeverk";
 import * as Mui from "../../../../ui";
 import * as Symboler from "../../symboler";
 
@@ -11,6 +12,7 @@ import { Status } from "../../editerbartElement";
 import RedigererKomponent from "./redigerer";
 import RedigeringUtfortKomponent from "./redigeringUtfort";
 
+import { useFeatureToggle } from "../../../../../featuretoggle";
 import { behandlingsgrunnlagOperations } from "../../../../../ducks/behandlingsgrunnlag";
 
 import "./soknadslandvelger.css";
@@ -18,28 +20,39 @@ import "./soknadslandvelger.css";
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
   oppdaterBehandlingsgrunnlagState: () => dispatch(behandlingsgrunnlagOperations.oppdaterState()),
 });
+
 const connector = connect(null, mapDispatchToProps);
+
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type SoknadslandvelgerProps = PropsFromRedux & {
   redigerbart: boolean;
+  lagreSoknadOgOppfriskSaksopplysninger: () => void;
 };
 
-const Soknadslandvelger = ({ redigerbart, oppdaterBehandlingsgrunnlagState }: SoknadslandvelgerProps) => {
+const Soknadslandvelger = ({
+  redigerbart,
+  oppdaterBehandlingsgrunnlagState,
+  lagreSoknadOgOppfriskSaksopplysninger,
+}: SoknadslandvelgerProps) => {
   const [status, setStatus] = useState<Status>(Status.RedigeringUtfort);
+  const tomLandOgPeriodeToggle = useFeatureToggle("melosys.tom_periode_og_land");
+  const flytMedInngangsvilkår = window.location.pathname.indexOf(`${MKV.Koder.sakstyper.EU_EOS}/saksbehandling/`) > -1;
 
+  const lagre = () => {
+    setStatus(Status.RedigeringUtfort);
+    if (tomLandOgPeriodeToggle === "enabled" && flytMedInngangsvilkår) {
+      lagreSoknadOgOppfriskSaksopplysninger();
+    } else {
+      oppdaterBehandlingsgrunnlagState();
+    }
+  };
   return (
     <div className="soknadslandvelger">
       {redigerbart && status === Status.Redigerer ? (
         <>
           <RedigererKomponent />
-          <Mui.Knapp
-            onClick={() => {
-              setStatus(Status.RedigeringUtfort);
-              oppdaterBehandlingsgrunnlagState();
-            }}
-            className="lagreknapp"
-          >
+          <Mui.Knapp onClick={lagre} className="lagreknapp">
             Lagre
           </Mui.Knapp>
         </>

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/soknadslandvelger.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/soknadslandvelger.tsx
@@ -1,8 +1,5 @@
 import React, { useState } from "react";
-import { connect, ConnectedProps } from "react-redux";
-import { ThunkDispatch } from "redux-thunk";
-import { Action } from "redux";
-import { RootState } from "AppTypes";
+import { useDispatch, useSelector } from "react-redux";
 
 import MKV from "../../../../../melosyskodeverk";
 import * as Mui from "../../../../ui";
@@ -17,31 +14,17 @@ import { behandlingsgrunnlagOperations, behandlingsgrunnlagSelectors } from "../
 
 import "./soknadslandvelger.css";
 
-const mapStateToProps = (state: RootState) => ({
-  behandlingHarPeriode: behandlingsgrunnlagSelectors.HarPeriodeSelector(state),
-});
-
-const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
-  oppdaterBehandlingsgrunnlagState: () => dispatch(behandlingsgrunnlagOperations.oppdaterState()),
-});
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
-
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-type SoknadslandvelgerProps = PropsFromRedux & {
+interface SoknadslandvelgerProps {
   redigerbart: boolean;
   lagreSoknadOgOppfriskSaksopplysninger: () => void;
-};
+}
 
-const Soknadslandvelger = ({
-  redigerbart,
-  oppdaterBehandlingsgrunnlagState,
-  lagreSoknadOgOppfriskSaksopplysninger,
-  behandlingHarPeriode,
-}: SoknadslandvelgerProps) => {
+const Soknadslandvelger = ({ redigerbart, lagreSoknadOgOppfriskSaksopplysninger }: SoknadslandvelgerProps) => {
+  const dispatch = useDispatch();
   const [status, setStatus] = useState<Status>(Status.RedigeringUtfort);
+  const behandlingHarPeriode = useSelector(behandlingsgrunnlagSelectors.HarPeriodeSelector);
   const tomLandOgPeriodeToggle = useFeatureToggle("melosys.tom_periode_og_land");
+
   const flytMedInngangsvilkår = window.location.pathname.indexOf(`${MKV.Koder.sakstyper.EU_EOS}/saksbehandling/`) > -1;
 
   const lagre = () => {
@@ -49,7 +32,7 @@ const Soknadslandvelger = ({
     if (tomLandOgPeriodeToggle === "enabled" && flytMedInngangsvilkår && behandlingHarPeriode) {
       lagreSoknadOgOppfriskSaksopplysninger();
     } else {
-      oppdaterBehandlingsgrunnlagState();
+      dispatch(behandlingsgrunnlagOperations.oppdaterState());
     }
   };
   return (
@@ -73,4 +56,4 @@ const Soknadslandvelger = ({
   );
 };
 
-export default connector(Soknadslandvelger);
+export default Soknadslandvelger;

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/soknadslandvelger.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadslandvelger/soknadslandvelger.tsx
@@ -13,15 +13,19 @@ import RedigererKomponent from "./redigerer";
 import RedigeringUtfortKomponent from "./redigeringUtfort";
 
 import { useFeatureToggle } from "../../../../../featuretoggle";
-import { behandlingsgrunnlagOperations } from "../../../../../ducks/behandlingsgrunnlag";
+import { behandlingsgrunnlagOperations, behandlingsgrunnlagSelectors } from "../../../../../ducks/behandlingsgrunnlag";
 
 import "./soknadslandvelger.css";
+
+const mapStateToProps = (state: RootState) => ({
+  behandlingHarPeriode: behandlingsgrunnlagSelectors.HarPeriodeSelector(state),
+});
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
   oppdaterBehandlingsgrunnlagState: () => dispatch(behandlingsgrunnlagOperations.oppdaterState()),
 });
 
-const connector = connect(null, mapDispatchToProps);
+const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
@@ -34,6 +38,7 @@ const Soknadslandvelger = ({
   redigerbart,
   oppdaterBehandlingsgrunnlagState,
   lagreSoknadOgOppfriskSaksopplysninger,
+  behandlingHarPeriode,
 }: SoknadslandvelgerProps) => {
   const [status, setStatus] = useState<Status>(Status.RedigeringUtfort);
   const tomLandOgPeriodeToggle = useFeatureToggle("melosys.tom_periode_og_land");
@@ -41,7 +46,7 @@ const Soknadslandvelger = ({
 
   const lagre = () => {
     setStatus(Status.RedigeringUtfort);
-    if (tomLandOgPeriodeToggle === "enabled" && flytMedInngangsvilkår) {
+    if (tomLandOgPeriodeToggle === "enabled" && flytMedInngangsvilkår && behandlingHarPeriode) {
       lagreSoknadOgOppfriskSaksopplysninger();
     } else {
       oppdaterBehandlingsgrunnlagState();

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiode.js
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiode.js
@@ -3,12 +3,14 @@ import { connect } from "react-redux";
 
 import PT from "prop-types";
 
+import MKV from "../../../../../melosyskodeverk";
 import * as Utils from "../../../../../utils";
 import * as Nav from "../../../../../navFrontend";
 import * as Symboler from "../../symboler";
 
 import { behandlingsgrunnlagSelectors, behandlingsgrunnlagOperations } from "../../../../../ducks/behandlingsgrunnlag";
 import { formSelectors } from "../../../../../ducks/form";
+import { erFeatureToggleEnabled } from "../../../../../featuretoggle";
 
 import SoknadsperiodeEndring from "./soknadsperiodeEndring";
 
@@ -52,19 +54,38 @@ export class Soknadsperiode extends Component {
     });
   };
 
+  oppfriskSaksopplysingerVedLagre = async () => {
+    const { skjulEndrePeriode } = this;
+    const { behandlingHarLand, lagreSoknadOgOppfriskSaksopplysninger } = this.props;
+    const tomLandOgPeriodeToggleEnabled = await erFeatureToggleEnabled("melosys.tom_periode_og_land");
+
+    if (tomLandOgPeriodeToggleEnabled) {
+      const flytMedInngangsvilkår =
+        window.location.pathname.indexOf(`${MKV.Koder.sakstyper.EU_EOS}/saksbehandling/`) > -1;
+
+      if (!behandlingHarLand && flytMedInngangsvilkår) {
+        skjulEndrePeriode();
+      } else {
+        // Når melosys.tom_periode_og_land fjernes må vi forsikre oss om at den nyeste perioden
+        // konsekvent lagres før vi oppfrisker saksopplysningene.
+        // Se history på filen for å se tidligere hack.
+        lagreSoknadOgOppfriskSaksopplysninger();
+        skjulEndrePeriode();
+      }
+    } else {
+      lagreSoknadOgOppfriskSaksopplysninger();
+      skjulEndrePeriode();
+    }
+  };
+
   lagre = () => {
     const { soknadsperiodeFom, soknadsperiodeTom } = this.state;
+    this.oppdaterPeriode(soknadsperiodeFom, soknadsperiodeTom);
     this.setState({
       soknadsperiodeGammelFom: soknadsperiodeFom,
       soknadsperiodeGammelTom: soknadsperiodeTom,
     });
-    this.oppdaterPeriode(soknadsperiodeFom, soknadsperiodeTom);
-    // Todo: Denne er hacky. Bakgrunn: oppdatert soknad rekker ikke å re-propagate til parent før
-    // funksjonen nedenfor kalles. Vurder å skrive om til en async await-aktig løsning.
-    setTimeout(() => {
-      this.props.lagreSoknadOgOppfriskSaksopplysninger();
-      this.skjulEndrePeriode();
-    }, 0);
+    this.oppfriskSaksopplysingerVedLagre();
   };
 
   avbryt = () => {
@@ -115,6 +136,7 @@ Soknadsperiode.propTypes = {
   soknadsperiodeFomErrors: PT.string,
   soknadsperiodeTomErrors: PT.string,
   tittel: PT.string.isRequired,
+  behandlingHarLand: PT.bool.isRequired,
 };
 
 Soknadsperiode.defaultProps = {
@@ -127,6 +149,7 @@ const mapStateToProps = (state) => ({
   soknadsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingsgrunnlagSelectors.PeriodeSelector(state).tom),
   soknadsperiodeFomErrors: formSelectors.SoknadsperiodeFomErrorsSelector(state),
   soknadsperiodeTomErrors: formSelectors.SoknadsperiodeTomErrorsSelector(state),
+  behandlingHarLand: behandlingsgrunnlagSelectors.HarLandSelector(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiode.js
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiode.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 
 import PT from "prop-types";
@@ -16,47 +16,48 @@ import SoknadsperiodeEndring from "./soknadsperiodeEndring";
 
 import "./soknadsperiode.css";
 
-export class Soknadsperiode extends Component {
-  state = {
-    erEndrePeriodeSynlig: false,
-    soknadsperiodeFom: this.props.soknadsperiodeFom,
-    soknadsperiodeTom: this.props.soknadsperiodeTom,
-    soknadsperiodeGammelFom: this.props.soknadsperiodeFom,
-    soknadsperiodeGammelTom: this.props.soknadsperiodeTom,
-  };
+export const Soknadsperiode = ({
+  redigerbart,
+  tittel,
+  soknadsperiodeFomErrors,
+  soknadsperiodeTomErrors,
+  lagreSoknadOgOppfriskSaksopplysninger,
+  behandlingHarLand,
+  ...props
+}) => {
+  const [erEndrePeriodeSynlig, setErEndrePeriodeSynlig] = useState(false);
+  const [soknadsperiodeFom, setSoknadsperiodeFom] = useState(props.soknadsperiodeFom);
+  const [soknadsperiodeTom, setSoknadsperiodeTom] = useState(props.soknadsperiodeTom);
+  const [soknadsperiodeGammelFom, setSoknadsperiodeGammelFom] = useState(props.soknadsperiodeFom);
+  const [soknadsperiodeGammelTom, setSoknadsperiodeGammelTom] = useState(props.soknadsperiodeTom);
 
-  componentDidUpdate() {
-    this.oppdaterPeriode(this.state.soknadsperiodeFom, this.state.soknadsperiodeTom);
-  }
-
-  componentWillUnmount() {
-    this.oppdaterPeriode(this.state.soknadsperiodeGammelFom, this.state.soknadsperiodeGammelTom);
-  }
-
-  visEndrePeriode = () => this.setState({ erEndrePeriodeSynlig: true });
-
-  skjulEndrePeriode = () => this.setState({ erEndrePeriodeSynlig: false });
-
-  oppdaterFelt = (feltNavn, verdi) => this.setState({ [feltNavn]: verdi });
-
-  oppdaterPeriode = (fom, tom) => {
-    this.props.oppdaterPeriode({
+  const oppdaterPeriode = (fom, tom) => {
+    props.oppdaterPeriode({
       fom: fom ? Utils.dato.formatterDatoTilISO(fom) : "",
       tom: tom ? Utils.dato.formatterDatoTilISO(tom) : "",
     });
   };
 
-  resetLokalPeriode = () => {
-    const { soknadsperiodeGammelFom, soknadsperiodeGammelTom } = this.state;
-    this.setState({
-      soknadsperiodeFom: soknadsperiodeGammelFom,
-      soknadsperiodeTom: soknadsperiodeGammelTom,
-    });
+  useEffect(() => {
+    return () => {
+      oppdaterPeriode(soknadsperiodeGammelFom, soknadsperiodeGammelTom);
+    };
+  }, []);
+
+  useEffect(() => {
+    oppdaterPeriode(soknadsperiodeFom, soknadsperiodeTom);
+  }, [soknadsperiodeFom, soknadsperiodeTom]);
+
+  const visEndrePeriode = () => setErEndrePeriodeSynlig(true);
+
+  const skjulEndrePeriode = () => setErEndrePeriodeSynlig(false);
+
+  const resetLokalPeriode = () => {
+    setSoknadsperiodeFom(soknadsperiodeGammelFom);
+    setSoknadsperiodeTom(soknadsperiodeGammelTom);
   };
 
-  oppfriskSaksopplysingerVedLagre = async () => {
-    const { skjulEndrePeriode } = this;
-    const { behandlingHarLand, lagreSoknadOgOppfriskSaksopplysninger } = this.props;
+  const oppfriskSaksopplysingerVedLagre = async () => {
     const tomLandOgPeriodeToggleEnabled = await erFeatureToggleEnabled("melosys.tom_periode_og_land");
 
     if (tomLandOgPeriodeToggleEnabled) {
@@ -78,54 +79,45 @@ export class Soknadsperiode extends Component {
     }
   };
 
-  lagre = () => {
-    const { soknadsperiodeFom, soknadsperiodeTom } = this.state;
-    this.oppdaterPeriode(soknadsperiodeFom, soknadsperiodeTom);
-    this.setState({
-      soknadsperiodeGammelFom: soknadsperiodeFom,
-      soknadsperiodeGammelTom: soknadsperiodeTom,
-    });
-    this.oppfriskSaksopplysingerVedLagre();
+  const lagre = () => {
+    oppdaterPeriode(soknadsperiodeFom, soknadsperiodeTom);
+    setSoknadsperiodeGammelFom(soknadsperiodeFom);
+    setSoknadsperiodeGammelTom(soknadsperiodeTom);
+    oppfriskSaksopplysingerVedLagre();
   };
 
-  avbryt = () => {
-    this.resetLokalPeriode();
-    this.skjulEndrePeriode();
+  const avbryt = () => {
+    resetLokalPeriode();
+    skjulEndrePeriode();
   };
 
-  render() {
-    const { redigerbart, soknadsperiodeFomErrors, soknadsperiodeTomErrors, tittel } = this.props;
-    const { visEndrePeriode, skjulEndrePeriode, lagre, oppdaterFelt, avbryt } = this;
-
-    const { erEndrePeriodeSynlig, soknadsperiodeFom, soknadsperiodeTom } = this.state;
-
-    return (
-      <div className="soknadsperiode">
-        <Nav.Typo.Normaltekst className="soknadsperiode__etikett">{tittel}</Nav.Typo.Normaltekst>
-        {!erEndrePeriodeSynlig && (
-          <div className="periode__container">
-            <Nav.Typo.Element className="periode">
-              {soknadsperiodeFom} - {soknadsperiodeTom}
-            </Nav.Typo.Element>
-            {redigerbart && <Symboler.Rediger onClick={visEndrePeriode} />}
-          </div>
-        )}
-        {erEndrePeriodeSynlig && (
-          <SoknadsperiodeEndring
-            soknadsperiodeFom={soknadsperiodeFom}
-            soknadsperiodeTom={soknadsperiodeTom}
-            soknadsperiodeFomErrors={soknadsperiodeFomErrors}
-            soknadsperiodeTomErrors={soknadsperiodeTomErrors}
-            skjulEndrePeriode={skjulEndrePeriode}
-            lagre={lagre}
-            vedFeltEndring={oppdaterFelt}
-            avbryt={avbryt}
-          />
-        )}
-      </div>
-    );
-  }
-}
+  return (
+    <div className="soknadsperiode">
+      <Nav.Typo.Normaltekst className="soknadsperiode__etikett">{tittel}</Nav.Typo.Normaltekst>
+      {!erEndrePeriodeSynlig && (
+        <div className="periode__container">
+          <Nav.Typo.Element className="periode">
+            {soknadsperiodeFom} - {soknadsperiodeTom}
+          </Nav.Typo.Element>
+          {redigerbart && <Symboler.Rediger onClick={visEndrePeriode} />}
+        </div>
+      )}
+      {erEndrePeriodeSynlig && (
+        <SoknadsperiodeEndring
+          soknadsperiodeFom={soknadsperiodeFom}
+          soknadsperiodeTom={soknadsperiodeTom}
+          soknadsperiodeFomErrors={soknadsperiodeFomErrors}
+          soknadsperiodeTomErrors={soknadsperiodeTomErrors}
+          skjulEndrePeriode={skjulEndrePeriode}
+          lagre={lagre}
+          setSoknadsperiodeFom={setSoknadsperiodeFom}
+          setSoknadsperiodeTom={setSoknadsperiodeTom}
+          avbryt={avbryt}
+        />
+      )}
+    </div>
+  );
+};
 
 Soknadsperiode.propTypes = {
   redigerbart: PT.bool.isRequired,

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiode.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiode.tsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useState } from "react";
-import { connect } from "react-redux";
-
-import PT from "prop-types";
+import { connect, ConnectedProps } from "react-redux";
+import { RootState } from "AppTypes";
+import { ThunkDispatch } from "redux-thunk";
+import { Action } from "redux";
 
 import MKV from "../../../../../melosyskodeverk";
 import * as Utils from "../../../../../utils";
 import * as Nav from "../../../../../navFrontend";
 import * as Symboler from "../../symboler";
 
+import { Periode } from "../../../../../services/modules/behandlingsgrunnlag/types";
 import { behandlingsgrunnlagSelectors, behandlingsgrunnlagOperations } from "../../../../../ducks/behandlingsgrunnlag";
 import { formSelectors } from "../../../../../ducks/form";
 import { erFeatureToggleEnabled } from "../../../../../featuretoggle";
@@ -15,6 +17,28 @@ import { erFeatureToggleEnabled } from "../../../../../featuretoggle";
 import SoknadsperiodeEndring from "./soknadsperiodeEndring";
 
 import "./soknadsperiode.css";
+
+const mapStateToProps = (state: RootState) => ({
+  soknadsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingsgrunnlagSelectors.PeriodeSelector(state).fom),
+  soknadsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingsgrunnlagSelectors.PeriodeSelector(state).tom),
+  soknadsperiodeFomErrors: formSelectors.SoknadsperiodeFomErrorsSelector(state),
+  soknadsperiodeTomErrors: formSelectors.SoknadsperiodeTomErrorsSelector(state),
+  behandlingHarLand: behandlingsgrunnlagSelectors.HarLandSelector(state),
+});
+
+const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
+  oppdaterPeriode: (periode: Periode) => dispatch(behandlingsgrunnlagOperations.oppdaterPeriode(periode)),
+});
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+type SoknadsperiodeProps = PropsFromRedux & {
+  redigerbart: boolean;
+  lagreSoknadOgOppfriskSaksopplysninger: () => void;
+  tittel: string;
+};
 
 export const Soknadsperiode = ({
   redigerbart,
@@ -24,14 +48,14 @@ export const Soknadsperiode = ({
   lagreSoknadOgOppfriskSaksopplysninger,
   behandlingHarLand,
   ...props
-}) => {
+}: SoknadsperiodeProps) => {
   const [erEndrePeriodeSynlig, setErEndrePeriodeSynlig] = useState(false);
   const [soknadsperiodeFom, setSoknadsperiodeFom] = useState(props.soknadsperiodeFom);
   const [soknadsperiodeTom, setSoknadsperiodeTom] = useState(props.soknadsperiodeTom);
   const [soknadsperiodeGammelFom, setSoknadsperiodeGammelFom] = useState(props.soknadsperiodeFom);
   const [soknadsperiodeGammelTom, setSoknadsperiodeGammelTom] = useState(props.soknadsperiodeTom);
 
-  const oppdaterPeriode = (fom, tom) => {
+  const oppdaterPeriode = (fom: string, tom: string) => {
     props.oppdaterPeriode({
       fom: fom ? Utils.dato.formatterDatoTilISO(fom) : "",
       tom: tom ? Utils.dato.formatterDatoTilISO(tom) : "",
@@ -108,7 +132,6 @@ export const Soknadsperiode = ({
           soknadsperiodeTom={soknadsperiodeTom}
           soknadsperiodeFomErrors={soknadsperiodeFomErrors}
           soknadsperiodeTomErrors={soknadsperiodeTomErrors}
-          skjulEndrePeriode={skjulEndrePeriode}
           lagre={lagre}
           setSoknadsperiodeFom={setSoknadsperiodeFom}
           setSoknadsperiodeTom={setSoknadsperiodeTom}
@@ -119,33 +142,4 @@ export const Soknadsperiode = ({
   );
 };
 
-Soknadsperiode.propTypes = {
-  redigerbart: PT.bool.isRequired,
-  oppdaterPeriode: PT.func.isRequired,
-  lagreSoknadOgOppfriskSaksopplysninger: PT.func.isRequired,
-  soknadsperiodeFom: PT.string.isRequired,
-  soknadsperiodeTom: PT.string.isRequired,
-  soknadsperiodeFomErrors: PT.string,
-  soknadsperiodeTomErrors: PT.string,
-  tittel: PT.string.isRequired,
-  behandlingHarLand: PT.bool.isRequired,
-};
-
-Soknadsperiode.defaultProps = {
-  soknadsperiodeFomErrors: undefined,
-  soknadsperiodeTomErrors: undefined,
-};
-
-const mapStateToProps = (state) => ({
-  soknadsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingsgrunnlagSelectors.PeriodeSelector(state).fom),
-  soknadsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingsgrunnlagSelectors.PeriodeSelector(state).tom),
-  soknadsperiodeFomErrors: formSelectors.SoknadsperiodeFomErrorsSelector(state),
-  soknadsperiodeTomErrors: formSelectors.SoknadsperiodeTomErrorsSelector(state),
-  behandlingHarLand: behandlingsgrunnlagSelectors.HarLandSelector(state),
-});
-
-const mapDispatchToProps = (dispatch) => ({
-  oppdaterPeriode: (periode) => dispatch(behandlingsgrunnlagOperations.oppdaterPeriode(periode)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(Soknadsperiode);
+export default connector(Soknadsperiode);

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiodeEndring.js
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiodeEndring.js
@@ -17,13 +17,14 @@ const SoknadsperiodeEndring = (props) => {
     soknadsperiodeTom,
     soknadsperiodeFomErrors,
     soknadsperiodeTomErrors,
-    vedFeltEndring,
+    setSoknadsperiodeFom,
+    setSoknadsperiodeTom,
     avbryt,
     lagre,
   } = props;
 
-  const vedFomEndring = (nyDato) => vedFeltEndring("soknadsperiodeFom", Utils.dateTilNorskString(nyDato));
-  const vedTomEndring = (nyDato) => vedFeltEndring("soknadsperiodeTom", Utils.dateTilNorskString(nyDato));
+  const vedFomEndring = (nyDato) => setSoknadsperiodeFom(Utils.dateTilNorskString(nyDato));
+  const vedTomEndring = (nyDato) => setSoknadsperiodeTom(Utils.dateTilNorskString(nyDato));
 
   return (
     <Nav.Fieldset legend="" className="soknadsperiode-endring">
@@ -71,7 +72,8 @@ SoknadsperiodeEndring.propTypes = {
   soknadsperiodeTom: PT.string.isRequired,
   soknadsperiodeFomErrors: PT.string,
   soknadsperiodeTomErrors: PT.string,
-  vedFeltEndring: PT.func.isRequired,
+  setSoknadsperiodeFom: PT.func.isRequired,
+  setSoknadsperiodeTom: PT.func.isRequired,
 };
 
 SoknadsperiodeEndring.defaultProps = {

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiodeEndring.test.js
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiodeEndring.test.js
@@ -14,7 +14,8 @@ describe("SoknadsperiodeEndring", () => {
     soknadsperiodeTom: "11.12.2035",
     soknadsperiodeFomErrors: undefined,
     soknadsperiodeTomErrors: undefined,
-    vedFeltEndring: jest.fn(),
+    setSoknadsperiodeFom: jest.fn(),
+    setSoknadsperiodeTom: jest.fn(),
   });
 
   describe("fom inputfelt", () => {
@@ -34,8 +35,8 @@ describe("SoknadsperiodeEndring", () => {
       const nyDato = "01.01.2011";
       fomInput.simulate("change", Utils.dato.norskStringTilDate(nyDato));
 
-      expect(props.vedFeltEndring).toHaveBeenCalledTimes(1);
-      expect(props.vedFeltEndring).toHaveBeenLastCalledWith("soknadsperiodeFom", nyDato);
+      expect(props.setSoknadsperiodeFom).toHaveBeenCalledTimes(1);
+      expect(props.setSoknadsperiodeFom).toHaveBeenLastCalledWith(nyDato);
     });
   });
 
@@ -56,8 +57,8 @@ describe("SoknadsperiodeEndring", () => {
       const nyDato = "02.02.2012";
       tomInput.simulate("change", Utils.dato.norskStringTilDate(nyDato));
 
-      expect(props.vedFeltEndring).toHaveBeenCalledTimes(1);
-      expect(props.vedFeltEndring).toHaveBeenLastCalledWith("soknadsperiodeTom", nyDato);
+      expect(props.setSoknadsperiodeTom).toHaveBeenCalledTimes(1);
+      expect(props.setSoknadsperiodeTom).toHaveBeenLastCalledWith(nyDato);
     });
   });
 

--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/utenlandsoppdraget.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/utenlandsoppdraget.tsx
@@ -66,7 +66,10 @@ export const Utenlandsoppdraget = ({
         </Nav.Column>
         {behandlingsgrunnlagtype !== SØKNAD_FOLKETRYGDEN && (
           <Nav.Column xs="6">
-            <Soknadslandvelger redigerbart={redigerbart} />
+            <Soknadslandvelger
+              redigerbart={redigerbart}
+              lagreSoknadOgOppfriskSaksopplysninger={lagreSoknadOgOppfriskSaksopplysninger}
+            />
           </Nav.Column>
         )}
       </Nav.Row>

--- a/src/services/modules/behandlingsgrunnlag/types.ts
+++ b/src/services/modules/behandlingsgrunnlag/types.ts
@@ -319,7 +319,7 @@ export interface Soeknadsland {
   landkoder: string[];
   erUkjenteEllerAlleEosLand: boolean;
 }
-interface Periode {
+export interface Periode {
   fom: string;
   tom: string | null;
 }

--- a/src/sider/eu_eøs/stegKomponenter/vurderingInngang.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingInngang.tsx
@@ -41,15 +41,12 @@ export const Varsler = ({
 }: VarslerProps) => {
   const inngangsvilkaarBegrunnelseKoder = inngangsvilkaar?.begrunnelseKoder || [];
 
-  const visbareInngangsvilkaarBegrunnelseKoder = inngangsvilkaarBegrunnelseKoder.filter(
-    (kode) => kode !== OVERSTYRT_AV_SAKSBEHANDLER
-  );
-
   const inngangsvilkaarErOverstyrtAvSaksbehandler =
     inngangsvilkaarBegrunnelseKoder.includes(OVERSTYRT_AV_SAKSBEHANDLER);
 
   const inngangsvilkaarErOverstyrtEllerIkkeOppfylt =
     inngangsvilkaarErOverstyrtAvSaksbehandler || !oppfyllerInngangsvilkar;
+
   const inngangsvilkaarErOppfyltOgIkkeOverstyrt = oppfyllerInngangsvilkar && !inngangsvilkaarErOverstyrtAvSaksbehandler;
 
   const oppfyllerInngangsvilkarCl = classNames({
@@ -57,10 +54,6 @@ export const Varsler = ({
     "liste__element--oppfylt": inngangsvilkaarErOppfyltOgIkkeOverstyrt,
     "liste__element--ikkeoppfylt": inngangsvilkaarErOverstyrtEllerIkkeOppfylt,
   });
-
-  const oppfyltTekst = `Søknaden oppfyller${
-    inngangsvilkaarErOppfyltOgIkkeOverstyrt ? " " : " ikke "
-  }inngangsvilkårene for EU/EØS-saker etter forordning 883/2004.`;
 
   if (Utils._isEmpty(inngangsvilkaar)) {
     if (tomLandOgPeriodeToggleEnabled && !behandlingHarPeriodeOgLand) {
@@ -78,6 +71,14 @@ export const Varsler = ({
       </ul>
     );
   }
+
+  const oppfyltTekst = `Søknaden oppfyller${
+    inngangsvilkaarErOppfyltOgIkkeOverstyrt ? " " : " ikke "
+  }inngangsvilkårene for EU/EØS-saker etter forordning 883/2004.`;
+
+  const visbareInngangsvilkaarBegrunnelseKoder = inngangsvilkaarBegrunnelseKoder.filter(
+    (kode) => kode !== OVERSTYRT_AV_SAKSBEHANDLER
+  );
 
   const flereSoknadslandEnnTillatt = landkoder.length > 1 && !MKVUtils.kanHaFlereSoknadsland(behandlingstema);
 


### PR DESCRIPTION
Etter diskusjon med Annette: 
- Vi oppfrisker saksopplysninger når man endrer land på lik linje som man gjør med periode allerede.*
- I flyt med inngangsvilkår (aka eøs) skal denne oppfriskningen kun skje når både periode og land er satt. I praksis skjer dette kun når man kommer inn i flyten uten periode og land - siden det ellers er krevd i journalføringen.
- Man slipper da å endre feilmeldingen i selve steget - siden man alltid har tomme inngangsvilkår og der har vi allerede feilmelding. 

https://jira.adeo.no/browse/MELOSYS-5395