### PR TITLE
5408: Html-Editor endre fontSizeUnit fra px til pt

### DIFF
--- a/src/felleskomponenter/htmlEditor/htmlEditor.tsx
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.tsx
@@ -10,6 +10,9 @@ const toolbar = {
   options: ["inline", "fontSize", "list", "link", "history"],
   inline: { options: ["bold", "italic", "underline", "strikethrough"] },
   list: { inDropdown: true },
+  fontSize: {
+    options: ["11pt", "12pt", "14pt", "16pt"],
+  },
 };
 
 type TextToHtmlEditorProps = {


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5408
Html editor brukte fontstørrelse med px, dokgen og saksbehandlere jobber med pt.
Selve feilen med feil størrelse i brev går ut på ikke beholdt formatering av copy-paste i editoren som @fredrik-oh  ser på i en annen oppgave.