### PR TITLE
5199 Valideringer i opprett ny sak

### DIFF
--- a/src/ducks/fagsaker/operations.ts
+++ b/src/ducks/fagsaker/operations.ts
@@ -32,9 +32,10 @@ export function hent(snr: string) {
   });
 }
 
+// Trenger denne i operations for å kunne bruke feiletRespons-reducer
 export function lagNySak(body: Api.Fagsaker.fagsak.OpprettReqDto) {
   return doThenDispatch(
-    () => Api.Fagsaker.fagsak.lagNySak(body),
+    () => Api.Fagsaker.fagsak.opprettNySak(body),
     {
       OK: Types.OK,
       FEILET: Types.FEILET,
@@ -48,9 +49,10 @@ export function lagNySak(body: Api.Fagsaker.fagsak.OpprettReqDto) {
   );
 }
 
+// Trenger denne i operations for å kunne bruke feiletRespons-reducer
 export function lagNyBehandlingForSak(saksnummer: string, body: Api.Fagsaker.fagsak.OpprettReqDto) {
   return doThenDispatch(
-    () => Api.Fagsaker.fagsak.lagNyBehandlingForSak(saksnummer, body),
+    () => Api.Fagsaker.fagsak.opprettNyBehandlingForSak(saksnummer, body),
     {
       OK: Types.OK,
       FEILET: Types.FEILET,

--- a/src/felleskomponenter/knapperad/knapperad.js
+++ b/src/felleskomponenter/knapperad/knapperad.js
@@ -17,6 +17,7 @@ const Knapperad = ({
   bekreftHtmlType,
   avbrytHtmlType,
   capitalCase,
+  autoDisableVedSpinner,
 }) => {
   const cls = classnames("container__knapperad");
 
@@ -29,6 +30,7 @@ const Knapperad = ({
         onClick={bekreft}
         disabled={!redigerbart || !bekreftRedigerbart}
         spinner={spinner}
+        autoDisableVedSpinner={autoDisableVedSpinner}
       >
         {bekreftTekst}
       </Mui.Knapp>
@@ -50,6 +52,7 @@ Knapperad.propTypes = {
   bekreftHtmlType: PT.string,
   avbrytHtmlType: PT.string,
   capitalCase: PT.bool,
+  autoDisableVedSpinner: PT.bool,
 };
 
 Knapperad.defaultProps = {
@@ -59,6 +62,7 @@ Knapperad.defaultProps = {
   bekreftHtmlType: undefined,
   avbrytHtmlType: undefined,
   capitalCase: false,
+  autoDisableVedSpinner: false,
 };
 
 export default Knapperad;

--- a/src/kodeverk/feilmeldinger.js
+++ b/src/kodeverk/feilmeldinger.js
@@ -5,4 +5,13 @@ export const SENERE_ENN_TOM = { melding: "Senere enn t.o.m.-dato" };
 export const SKRIV_INN_GYLDIG_DATO = { melding: "Skriv inn en gyldig dato" };
 export const UTENFOR_SOKNADSPERIODEN = { melding: "Utenfor søknadsperioden" };
 export const MAA_FYLLES_UT = { melding: "Må fylles ut" };
+export const SAK_HAR_AKTIV_BEHANDLING = {
+  melding: "Du kan ikke opprette en ny behandling på sak med en aktiv/pågående behandling",
+};
+export const SKRIV_INN_GYLDIG_FNR_ELLER_DNR = { melding: "Skriv inn gyldig f.nr. eller d-nr." };
+export const FANT_INGEN_NAVN_PA_FNR_ELLER_DNR = { melding: "Fant ingen navn på dette f.nr. eller d-nr." };
+export const SKRIV_INN_GYLDIG_ORGNR = { melding: "Skriv inn gyldig org.nr." };
+export const FANT_INGEN_NAVN_PA_ORGNR = { melding: "Fant ingen navn på dette organisasjonsnummeret" };
+export const VELG_MINST_ETT_LAND = { melding: "Velg minst ett land" };
+
 export const DU_KAN_IKKE_SKRIVE_MER_ENN_500_TEGN = "Du kan ikke skrive mer enn 500 tegn";

--- a/src/melosyskodeverk/utils.js
+++ b/src/melosyskodeverk/utils.js
@@ -1,5 +1,6 @@
 import MKV from "./filtrertmelosyskodeverk";
 
+// DEPRECATED. Vi vil ikke bruke denne i melosys.behandle_alle_saker
 export const erSoknad = (behandlingstema) =>
   [
     MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER,
@@ -12,6 +13,7 @@ export const erSoknad = (behandlingstema) =>
     MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND,
   ].includes(behandlingstema);
 
+// DEPRECATED. Vi vil ikke bruke denne i melosys.behandle_alle_saker
 export const erSedForesporsel = (behandlingstema) =>
   [
     MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,

--- a/src/services/modules/fagsaker/fagsak.ts
+++ b/src/services/modules/fagsaker/fagsak.ts
@@ -16,17 +16,21 @@ interface SoknadDto {
   };
 }
 export interface OpprettReqDto {
-  brukerID: string;
-  sakstype: string;
+  brukerID?: string;
+  virksomhetOrgnr?: string;
+  hovedpart?: string;
+  sakstype?: string;
+  sakstema?: string;
   behandlingstema: string;
   behandlingstype: string;
-  soknadDto: SoknadDto;
+  soknadDto?: SoknadDto;
   skalTilordnes: boolean;
-  oppgaveID: string;
+  oppgaveID?: string;
 }
-export const opprett = (body: OpprettReqDto) => postAsJson(`${API_BASE_URL}${FAGSAKER}/opprett`, body);
-export const lagNySak = (body: OpprettReqDto) => postAsJson(`${API_BASE_URL}${FAGSAKER}`, body);
-export const lagNyBehandlingForSak = (saksnummer: string, body: OpprettReqDto) =>
+
+export const opprettNySak = (body: OpprettReqDto) => postAsJson(`${API_BASE_URL}${FAGSAKER}`, body);
+
+export const opprettNyBehandlingForSak = (saksnummer: string, body: OpprettReqDto) =>
   postAsJson(`${API_BASE_URL}${FAGSAKER}/${saksnummer}/behandlinger`, body);
 
 interface HenleggReqDto {

--- a/src/sider/journalforing/komponenter/fagsakVelger.js
+++ b/src/sider/journalforing/komponenter/fagsakVelger.js
@@ -16,7 +16,6 @@ import EnkeltSak from "./enkeltSak";
 import KnyttTilSak from "./knyttTilSak";
 
 import "./fagsakVelger.css";
-import { useFeatureToggle } from "../../../featuretoggle";
 
 const EKSISTERENDE = "Eksisterende sak";
 const OPPRETT = "Opprett ny sak";
@@ -32,9 +31,9 @@ const FagsakVelger = (props) => {
     formValues,
     erOpprettNySak,
     nullstillFormVerdier,
+    nyOpprettSakToggleEnabled,
   } = props;
   const [valgtVisning, setValgtVisning] = useState(EKSISTERENDE);
-  const nyOpprettSakToggle = useFeatureToggle("melosys.ny_opprett_sak");
   const feltNavn = erOpprettNySak ? FormValuesOpprettNySak : FormValuesJournalforing;
   const dispatch = useDispatch();
   const ingenSakerFinnes = fagsakListe.length === 0;
@@ -44,6 +43,12 @@ const FagsakVelger = (props) => {
       nullstillFormVerdier();
     }
   }, [valgtVisning]);
+
+  useEffect(() => {
+    if (erOpprettNySak && !nyOpprettSakToggleEnabled) {
+      setValgtVisning(OPPRETT);
+    }
+  }, [nyOpprettSakToggleEnabled]);
 
   useEffect(() => {
     if (!behandleAlleSakerToggleEnabled) return;
@@ -92,7 +97,7 @@ const FagsakVelger = (props) => {
     });
   }
 
-  if (erOpprettNySak && nyOpprettSakToggle !== "enabled") {
+  if (erOpprettNySak && !nyOpprettSakToggleEnabled) {
     return (
       <OpprettSak
         behandleAlleSakerToggleEnabled={behandleAlleSakerToggleEnabled}
@@ -131,7 +136,7 @@ const FagsakVelger = (props) => {
           </div>
         )}
 
-        {(!erOpprettNySak || nyOpprettSakToggle === "enabled") && (
+        {(!erOpprettNySak || nyOpprettSakToggleEnabled) && (
           <>
             {valgtVisning === EKSISTERENDE && (
               <Skjema.CustomRadioPanelGruppe
@@ -164,6 +169,7 @@ FagsakVelger.propTypes = {
   fagsakListe: PT.array.isRequired,
   settJournalforingHensikt: PT.func,
   behandleAlleSakerToggleEnabled: PT.bool.isRequired,
+  nyOpprettSakToggleEnabled: PT.bool,
   landkoder: PT.arrayOf(MPT.Kodeverk).isRequired,
   formValues: PT.object.isRequired,
   erOpprettNySak: PT.bool,
@@ -174,6 +180,7 @@ FagsakVelger.defaultProps = {
   erOpprettNySak: false,
   nullstillFormVerdier: undefined,
   settJournalforingHensikt: undefined,
+  nyOpprettSakToggleEnabled: false,
 };
 
 export default FagsakVelger;

--- a/src/sider/journalforing/komponenter/journalforingSchema.js
+++ b/src/sider/journalforing/komponenter/journalforingSchema.js
@@ -6,28 +6,31 @@ import * as Konstanter from "../../../constants";
 import * as KV from "../../../kodeverk";
 import { skalViseSoknadsperiodeOgLand, skalViseSoknadsperiodeOgLandDeprecated } from "./opprettSak";
 
+const {
+  MAA_FYLLES_UT,
+  SKRIV_INN_GYLDIG_FNR_ELLER_DNR,
+  FANT_INGEN_NAVN_PA_FNR_ELLER_DNR,
+  SKRIV_INN_GYLDIG_ORGNR,
+  FANT_INGEN_NAVN_PA_ORGNR,
+  VELG_MINST_ETT_LAND,
+} = KV.Feilmeldinger;
+const { BRUKER, VIRKSOMHET } = MKV.Koder.aktoersroller;
+
 const SKRIV_INN_KUN_NUMMER = { melding: "Skriv inn kun nummer" };
-const SKRIV_INN_GYLDIG_FNR_ELLER_DNR = { melding: "Skriv inn gyldig f.nr. eller d-nr." };
-const FANT_INGEN_NAVN_PA_ORGNR = { melding: "Fant ingen navn på dette organisasjonsnummeret" };
-const FANT_INGEN_NAVN_PA_FNR_ELLER_DNR = { melding: "Fant ingen navn på dette f.nr. eller d-nr." };
-const FANT_INGEN_NAVN_PA_ORGNR_FNR_ELLER_DNR = { melding: "Fant ingen navn på oppgitt org.nr., f.nr. eller d-nr." };
 const FINNER_IKKE_NAVN_PA_AVSENDER = { melding: "Finner ikke navn på avsender" };
-const SKRIV_INN_GYLDIG_ORGNR = { melding: "Skriv inn gyldig org.nr." };
 const SKRIV_INN_GYLDIG_ORGNR_FNR_DNR = { melding: "Du må skrive et gyldig org.nr. eller f.nr./d-nr." };
+const FANT_INGEN_NAVN_PA_ORGNR_FNR_ELLER_DNR = { melding: "Fant ingen navn på oppgitt org.nr., f.nr. eller d-nr." };
 const VELG_DOKUMENTTITTEL_FRA_LISTEN_ELLER_SKRIV_DIN_EGEN = {
   melding: "Velg dokumenttittel fra listen eller skriv din egen",
 };
 const VELG_HVILKEN_SAK_DU_ONSKER_A_KNYTTE_JOURNALFORINGEN_MOT = {
   melding: "Velg hvilken sak du ønsker å knytte journalføringen mot",
 };
-const VELG_MINST_ETT_LAND = { melding: "Velg minst ett land" };
 const DU_MA_LAGRE_TITTEL_VEDLEGG = { melding: "Du må lagre tittel på vedlegg" };
 const DU_MA_LAGRE_TITTEL_HOVEDDOKUMENT = { melding: "Du må lagre tittel på hoveddokument" };
-const VELG_ETT_LAND = { melding: "Velg land til avsender: utenlandsk trygdemyndighet" };
+const VELG_ETT_LAND_UTENLANDSK_TRYGDEMYNDIGHET = { melding: "Velg land til avsender: utenlandsk trygdemyndighet" };
 const VELG_EN_AVSENDER = { melding: "Velg en avsender" };
 const VELG_REPRESENTERER = { melding: "Velg hvem fullmektig representerer" };
-const { MAA_FYLLES_UT } = KV.Feilmeldinger;
-const { BRUKER, VIRKSOMHET } = MKV.Koder.aktoersroller;
 
 const lagMelding = (felt) => ({ melding: `${felt} må fylles ut` });
 
@@ -251,7 +254,7 @@ const journalforing = object().shape({
   utenlandskTrygdemyndighetLandkode: string()
     .when("avsenderType", {
       is: MKV.Koder.avsendertyper.UTENLANDSK_TRYGDEMYNDIGHET,
-      then: string().required(VELG_ETT_LAND).nullable(),
+      then: string().required(VELG_ETT_LAND_UTENLANDSK_TRYGDEMYNDIGHET).nullable(),
     })
     .nullable(),
   representantRepresenterer: string()

--- a/src/sider/journalforing/komponenter/knyttTilSak.js
+++ b/src/sider/journalforing/komponenter/knyttTilSak.js
@@ -195,7 +195,7 @@ export const KnyttTilSak = (props) => {
       {erOpprettNySak ? (
         <div className="innrykk">
           <Nav.AlertStripeInfo>
-            Du kan ikke opprette en ny behandling på sak med en aktiv/pågående behandling.
+            Du kan ikke opprette en ny behandling på sak med en aktiv/pågående behandling
           </Nav.AlertStripeInfo>
         </div>
       ) : (

--- a/src/sider/journalforing/komponenter/opprettSak.js
+++ b/src/sider/journalforing/komponenter/opprettSak.js
@@ -58,6 +58,7 @@ const nullstillVerdier = (steg, endreFelt, feltNavn) => {
 
 export const skalViseSoknadsperiodeOgLand = (sakstype, sakstema, behandlingstema, behandlingstype) =>
   sakstype === MKV.Koder.sakstyper.EU_EOS &&
+  sakstema &&
   behandlingstema &&
   behandlingstype &&
   !skalViseTomFlytEllerErSedBehandling(sakstype, sakstema, behandlingstema, behandlingstype);

--- a/src/sider/journalforing/komponenter/opprettSak.test.js
+++ b/src/sider/journalforing/komponenter/opprettSak.test.js
@@ -68,6 +68,7 @@ describe("OpprettSak - journalføring", () => {
       props.formValues.opprettnysak_behandlingstema = behandlingstema;
       props.formValues.opprettnysak_behandlingstype = MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG;
       props.formValues.sakstype = MKV.Koder.sakstyper.EU_EOS;
+      props.formValues.sakstema = MKV.Koder.sakstemaer.MEDLEMSKAP_LOVVALG;
       props.formValues.journalforingGjelder = MKV.Koder.aktoersroller.BRUKER;
 
       props.formValues.journalforingSoknadsland = behandlingstema;
@@ -85,6 +86,7 @@ describe("OpprettSak - journalføring", () => {
 
   each([ARBEID_I_UTLANDET, YRKESAKTIV]).it(`Opprett sak, skal ikke ha tilvalg`, (behandlingstema) => {
     props.formValues.opprettnysak_behandlingstema = behandlingstema;
+    props.formValues.sakstema = MKV.Koder.sakstemaer.MEDLEMSKAP_LOVVALG;
     props.formValues.sakstype = MKV.Koder.sakstyper.TRYGDEAVTALE;
     props.formValues.journalforingGjelder = MKV.Koder.aktoersroller.BRUKER;
 
@@ -102,6 +104,7 @@ describe("OpprettSak - journalføring", () => {
     props.formValues.opprettnysak_behandlingstema = ARBEID_FLERE_LAND;
     props.formValues.opprettnysak_behandlingstype = MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG;
     props.formValues.journalforingSoknadsland = ARBEID_FLERE_LAND;
+    props.formValues.sakstema = MKV.Koder.sakstemaer.MEDLEMSKAP_LOVVALG;
     props.formValues.sakstype = MKV.Koder.sakstyper.EU_EOS;
     props.formValues.journalforingGjelder = MKV.Koder.aktoersroller.BRUKER;
 
@@ -167,6 +170,7 @@ describe("OpprettSak - opprett ny sak", () => {
     (behandlingstema) => {
       props.formValues.behandlingstema = behandlingstema;
       props.formValues.behandlingstype = MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG;
+      props.formValues.sakstema = MKV.Koder.sakstemaer.MEDLEMSKAP_LOVVALG;
       props.formValues.sakstype = MKV.Koder.sakstyper.EU_EOS;
       props.formValues.journalforingGjelder = MKV.Koder.aktoersroller.BRUKER;
 
@@ -185,6 +189,7 @@ describe("OpprettSak - opprett ny sak", () => {
 
   each([ARBEID_I_UTLANDET, YRKESAKTIV]).it(`Opprett sak, skal ikke ha tilvalg`, (behandlingstema) => {
     props.formValues.behandlingstema = behandlingstema;
+    props.formValues.sakstema = MKV.Koder.sakstemaer.MEDLEMSKAP_LOVVALG;
     props.formValues.sakstype = MKV.Koder.sakstyper.TRYGDEAVTALE;
     props.formValues.journalforingGjelder = MKV.Koder.aktoersroller.BRUKER;
 
@@ -202,6 +207,7 @@ describe("OpprettSak - opprett ny sak", () => {
     props.formValues.behandlingstema = ARBEID_FLERE_LAND;
     props.formValues.behandlingstype = MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG;
     props.formValues.journalforingSoknadsland = ARBEID_FLERE_LAND;
+    props.formValues.sakstema = MKV.Koder.sakstemaer.MEDLEMSKAP_LOVVALG;
     props.formValues.sakstype = MKV.Koder.sakstyper.EU_EOS;
     props.formValues.journalforingGjelder = MKV.Koder.aktoersroller.BRUKER;
 

--- a/src/sider/opprettnysak/komponenter/identOgNavn.tsx
+++ b/src/sider/opprettnysak/komponenter/identOgNavn.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import * as Nav from "../../navFrontend";
-import * as Mui from "../../felleskomponenter/ui";
-import * as Ikoner from "../../resources/images";
-import * as Utils from "../../utils";
-import * as Skjema from "../../felleskomponenter/skjema";
+import * as Nav from "../../../navFrontend";
+import * as Mui from "../../../felleskomponenter/ui";
+import * as Ikoner from "../../../resources/images";
+import * as Utils from "../../../utils";
+import * as Skjema from "../../../felleskomponenter/skjema";
 
 interface IdentOgNavnProps {
   tittel: string;

--- a/src/sider/opprettnysak/komponenter/oppgaveVelger.tsx
+++ b/src/sider/opprettnysak/komponenter/oppgaveVelger.tsx
@@ -7,7 +7,6 @@ import * as KV from "../../../kodeverk";
 import * as Nav from "../../../navFrontend";
 import * as Skjema from "../../../felleskomponenter/skjema";
 
-import { useFeatureToggle } from "../../../featuretoggle";
 import EnkeltDato from "../../../felleskomponenter/enkeltDato";
 
 import "./oppgaveVelger.css";
@@ -21,6 +20,7 @@ interface OppgaveVelgerProps {
   saksnummer: string;
   oppgaver: Api.Oppgaver.SokOppgaveResDto[];
   change: (field: string, value: any) => void;
+  nyOpprettSakToggleEnabled: boolean;
 }
 
 export const OppgaveVelger = ({
@@ -29,19 +29,19 @@ export const OppgaveVelger = ({
   saksnummer,
   oppgaver,
   change,
+  nyOpprettSakToggleEnabled,
 }: OppgaveVelgerProps) => {
-  const nyOpprettSakToggle = useFeatureToggle("melosys.ny_opprett_sak");
   const [valgtVisning, setValgtVisning] = useState(OPPRETT);
   const hovedpartErBruker = hovedpart === MKV.Koder.aktoersroller.BRUKER;
   const oppgaverFinnes = oppgaver.length > 0;
 
   useEffect(() => {
-    if (nyOpprettSakToggle === "enabled") {
+    if (nyOpprettSakToggleEnabled) {
       setValgtVisning(OPPRETT);
     } else {
       setValgtVisning(EKSISTERENDE);
     }
-  }, [nyOpprettSakToggle]);
+  }, [nyOpprettSakToggleEnabled]);
 
   const radioValg = oppgaver
     .filter((oppgave) => oppgave.journalpostID)
@@ -70,7 +70,7 @@ export const OppgaveVelger = ({
     change("journalpostID", oppgave?.journalpostID);
   };
 
-  if (saksnummer !== "-1" && nyOpprettSakToggle === "enabled") {
+  if (saksnummer !== "-1" && nyOpprettSakToggleEnabled) {
     return (
       <div className="oppgaveVelger">
         <Nav.AlertStripeInfo>
@@ -84,14 +84,13 @@ export const OppgaveVelger = ({
     ? "Skriv inn brukers f.nr eller d.nr for å hente oppgaver."
     : "Skriv inn virksomhetens organisasjonsnummer for å hente oppgaver.";
 
-  const ingenOppgaverMelding =
-    nyOpprettSakToggle === "enabled"
-      ? "Ingen eksisterende oppgaver funnet. Det blir opprettet en ny"
-      : `Det finnes ingen oppgaver på denne ${hovedpartErBruker ? "personen" : "organisasjonen"}.`;
+  const ingenOppgaverMelding = nyOpprettSakToggleEnabled
+    ? "Ingen eksisterende oppgaver funnet. Det blir opprettet en ny"
+    : `Det finnes ingen oppgaver på denne ${hovedpartErBruker ? "personen" : "organisasjonen"}.`;
 
   return (
     <div className="oppgaveVelger">
-      {nyOpprettSakToggle === "enabled" && (
+      {nyOpprettSakToggleEnabled && (
         <div className="velgVisning">
           <Nav.Radio
             label={OPPRETT}
@@ -118,7 +117,7 @@ export const OppgaveVelger = ({
         <>
           {oppgaverFinnes && (
             <>
-              {nyOpprettSakToggle === "enabled" && (
+              {nyOpprettSakToggleEnabled && (
                 <Nav.AlertStripeInfo className="marginMellomHeaderOgAlertStripe">
                   Det er kun følgende oppgaver med journalpost-id som kan tilknyttes
                 </Nav.AlertStripeInfo>
@@ -126,7 +125,7 @@ export const OppgaveVelger = ({
               <Skjema.CustomRadioPanelGruppe feltNavn="oppgaveID" radios={radioValg} notify={settJournalpostID} />
             </>
           )}
-          {!oppgaverFinnes && !oppgaverForsoktHentet && nyOpprettSakToggle !== "enabled" && (
+          {!oppgaverFinnes && !oppgaverForsoktHentet && !nyOpprettSakToggleEnabled && (
             <Nav.AlertStripeInfo>{oppgaverIkkeHentetMelding}</Nav.AlertStripeInfo>
           )}
           {!oppgaverFinnes && oppgaverForsoktHentet && (

--- a/src/sider/opprettnysak/komponenter/oppgaveVelger.tsx
+++ b/src/sider/opprettnysak/komponenter/oppgaveVelger.tsx
@@ -1,17 +1,16 @@
 import React, { useEffect, useState } from "react";
 import classNames from "classnames";
-import { useSelector } from "react-redux";
-import EnkeltDato from "../../../felleskomponenter/enkeltDato";
+
+import MKV from "../../../melosyskodeverk";
 import * as Api from "../../../services/api";
 import * as KV from "../../../kodeverk";
 import * as Nav from "../../../navFrontend";
-import MKV from "../../../melosyskodeverk";
-
 import * as Skjema from "../../../felleskomponenter/skjema";
+
 import { useFeatureToggle } from "../../../featuretoggle";
+import EnkeltDato from "../../../felleskomponenter/enkeltDato";
 
 import "./oppgaveVelger.css";
-import { OpprettNySakFormSelector } from "../../../ducks/form/selectors";
 
 const EKSISTERENDE = "Eksisterende oppgave";
 const OPPRETT = "Opprett ny oppgave";
@@ -19,21 +18,20 @@ const OPPRETT = "Opprett ny oppgave";
 interface OppgaveVelgerProps {
   oppgaverForsoktHentet: boolean;
   hovedpart: string;
+  saksnummer: string;
   oppgaver: Api.Oppgaver.SokOppgaveResDto[];
-  nullstillFormverdier: () => void;
   change: (field: string, value: any) => void;
 }
 
 export const OppgaveVelger = ({
   oppgaverForsoktHentet,
   hovedpart,
+  saksnummer,
   oppgaver,
   change,
-  nullstillFormverdier,
 }: OppgaveVelgerProps) => {
   const nyOpprettSakToggle = useFeatureToggle("melosys.ny_opprett_sak");
   const [valgtVisning, setValgtVisning] = useState(OPPRETT);
-  const { erAvsluttetSak, saksnummer } = useSelector((state: any) => OpprettNySakFormSelector(state).values);
   const hovedpartErBruker = hovedpart === MKV.Koder.aktoersroller.BRUKER;
   const oppgaverFinnes = oppgaver.length > 0;
 
@@ -72,7 +70,7 @@ export const OppgaveVelger = ({
     change("journalpostID", oppgave?.journalpostID);
   };
 
-  if (erAvsluttetSak && saksnummer !== -1 && nyOpprettSakToggle === "enabled") {
+  if (saksnummer !== "-1" && nyOpprettSakToggle === "enabled") {
     return (
       <div className="oppgaveVelger">
         <Nav.AlertStripeInfo>
@@ -81,6 +79,15 @@ export const OppgaveVelger = ({
       </div>
     );
   }
+
+  const oppgaverIkkeHentetMelding = hovedpartErBruker
+    ? "Skriv inn brukers f.nr eller d.nr for å hente oppgaver."
+    : "Skriv inn virksomhetens organisasjonsnummer for å hente oppgaver.";
+
+  const ingenOppgaverMelding =
+    nyOpprettSakToggle === "enabled"
+      ? "Ingen eksisterende oppgaver funnet. Det blir opprettet en ny"
+      : `Det finnes ingen oppgaver på denne ${hovedpartErBruker ? "personen" : "organisasjonen"}.`;
 
   return (
     <div className="oppgaveVelger">
@@ -92,7 +99,7 @@ export const OppgaveVelger = ({
             name="velgVisningOppgave"
             onChange={() => {
               setValgtVisning(OPPRETT);
-              nullstillFormverdier();
+              change("oppgaveID", null);
             }}
             checked={valgtVisning === OPPRETT}
             value={OPPRETT}
@@ -101,10 +108,7 @@ export const OppgaveVelger = ({
             label={EKSISTERENDE}
             className={classNames("visningValg", { "checked-valg": valgtVisning === EKSISTERENDE })}
             name="velgVisningOppgave"
-            onChange={() => {
-              setValgtVisning(EKSISTERENDE);
-              nullstillFormverdier();
-            }}
+            onChange={() => setValgtVisning(EKSISTERENDE)}
             checked={valgtVisning === EKSISTERENDE}
             value={EKSISTERENDE}
           />
@@ -123,18 +127,10 @@ export const OppgaveVelger = ({
             </>
           )}
           {!oppgaverFinnes && !oppgaverForsoktHentet && nyOpprettSakToggle !== "enabled" && (
-            <Nav.AlertStripeInfo>
-              {hovedpartErBruker
-                ? "Skriv inn brukers f.nr eller d.nr for å hente oppgaver."
-                : "Skriv inn virksomhetens organisasjonsnummer for å hente oppgaver."}
-            </Nav.AlertStripeInfo>
+            <Nav.AlertStripeInfo>{oppgaverIkkeHentetMelding}</Nav.AlertStripeInfo>
           )}
           {!oppgaverFinnes && oppgaverForsoktHentet && (
-            <Nav.AlertStripeAdvarsel>
-              {nyOpprettSakToggle === "enabled"
-                ? "Ingen eksisterende oppgaver funnet. Det blir opprettet en ny"
-                : `Det finnes ingen oppgaver på denne ${hovedpartErBruker ? "personen" : "organisasjonen"}.`}
-            </Nav.AlertStripeAdvarsel>
+            <Nav.AlertStripeAdvarsel>{ingenOppgaverMelding}</Nav.AlertStripeAdvarsel>
           )}
         </>
       ) : null}

--- a/src/sider/opprettnysak/opprettnysak.less
+++ b/src/sider/opprettnysak/opprettnysak.less
@@ -49,8 +49,15 @@
     }
   }
 
-  .formError {
-    margin-bottom: 1.5em;
+  .feilmelding {
+    p {
+      margin: 0;
+    }
+    ul {
+      margin: 0;
+      padding-left: 1rem;
+    }
+    margin: 0 0 1rem 0;
   }
 
   .hjelpetekst {

--- a/src/sider/opprettnysak/opprettnysak.tsx
+++ b/src/sider/opprettnysak/opprettnysak.tsx
@@ -65,10 +65,6 @@ const mapStateToProps = (state: RootState) => ({
   fagsakListe: sokSelectors.FagsakSokSelector(state),
   initialValues: {
     skalTilordnes: false,
-    behandlingstema: undefined,
-    behandlingstype: undefined,
-    sakstype: undefined,
-    sakstema: undefined,
     hovedpart: BRUKER,
     opprettBehandling: true,
   },

--- a/src/sider/opprettnysak/opprettnysak.tsx
+++ b/src/sider/opprettnysak/opprettnysak.tsx
@@ -106,7 +106,7 @@ const OpprettNySak = ({
 }: InjectedFormProps<OpprettNySakFormData, OpprettNySakProps> & OpprettNySakProps) => {
   const [oppgaver, setOppgaver] = useState<Api.Oppgaver.SokOppgaveResDto[]>([]);
   const [bekreftPending, setBekreftPending] = useState(false);
-  const [knappTrykketPå, setKnappTrykketPå] = useState(false);
+  const [visFeilmeldinger, setVisFeilmeldinger] = useState(false);
   const [oppgaverForsoktHentet, setOppgaverForsoktHentet] = useState(false);
   const behandleAlleSakerToggle = useFeatureToggle("melosys.behandle_alle_saker");
   const nyOpprettSakToggle = useFeatureToggle("melosys.ny_opprett_sak");
@@ -235,7 +235,7 @@ const OpprettNySak = ({
 
   const handleSubmit = () => {
     setBekreftPending(true);
-    setKnappTrykketPå(true);
+    setVisFeilmeldinger(true);
 
     touch(...Object.keys(errors));
 
@@ -363,7 +363,7 @@ const OpprettNySak = ({
 
             <div className="seksjon">
               <Skjema.Checkbox feltNavn="skalTilordnes" label="Legg behandlingen i mine oppgaver" />
-              {knappTrykketPå && !Utils._isEmpty(errors) && (
+              {visFeilmeldinger && !Utils._isEmpty(errors) && (
                 <Nav.AlertStripeFeil className="feilmelding">
                   {Utils.feilmelding.syncErrorsTilFeilmelding(errors)}
                 </Nav.AlertStripeFeil>

--- a/src/sider/opprettnysak/opprettnysak.tsx
+++ b/src/sider/opprettnysak/opprettnysak.tsx
@@ -337,6 +337,7 @@ const OpprettNySak = ({
                       erOpprettNySak
                       fagsakListe={fagsakListe}
                       behandleAlleSakerToggleEnabled={behandleAlleSakerToggle === "enabled"}
+                      nyOpprettSakToggleEnabled={nyOpprettSakToggle === "enabled"}
                       landkoder={landkoderListe}
                       nullstillFormVerdier={nullstillFormVerdier}
                       formValues={formValues}
@@ -352,6 +353,7 @@ const OpprettNySak = ({
                   />
                   <div className="innrykk">
                     <OppgaveVelger
+                      nyOpprettSakToggleEnabled={nyOpprettSakToggle === "enabled"}
                       oppgaverForsoktHentet={oppgaverForsoktHentet}
                       hovedpart={hovedpart}
                       saksnummer={saksnummer}

--- a/src/sider/opprettnysak/opprettnysak.tsx
+++ b/src/sider/opprettnysak/opprettnysak.tsx
@@ -1,11 +1,11 @@
-import React, { FormEvent, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
-import { getFormValues, InjectedFormProps, isValid, reduxForm } from "redux-form";
+import { getFormSyncErrors, getFormValues, InjectedFormProps, reduxForm } from "redux-form";
 import { RootState } from "AppTypes";
 import { ThunkDispatch } from "redux-thunk";
 import { AnyAction } from "redux";
 
-import MKV, { MKVUtils } from "../../melosyskodeverk";
+import MKV from "../../melosyskodeverk";
 import * as Nav from "../../navFrontend";
 import * as Skjema from "../../felleskomponenter/skjema";
 import * as Mui from "../../felleskomponenter/ui";
@@ -14,23 +14,28 @@ import * as KV from "../../kodeverk";
 import * as Api from "../../services/api";
 import * as Utils from "../../utils";
 
-import Knapperad from "../../felleskomponenter/knapperad";
-import { Feilmeldinger } from "../../felleskomponenter/feilmeldinger";
+import { landkoderOperations, landkoderSelectors } from "../../ducks/landkoder";
 import { OrganisasjonOperations } from "../../ducks/organisasjoner";
 import { feiletResponsSelectors } from "../../ducks/feiletRespons";
+import { sokOperations, sokSelectors } from "../../ducks/sok";
 import { fagsakOperations } from "../../ducks/fagsaker";
-import { formOperations, formSelectors } from "../../ducks/form";
+
+import Knapperad from "../../felleskomponenter/knapperad";
+import { Feilmeldinger } from "../../felleskomponenter/feilmeldinger";
 import { hentSammensattNavn } from "../../graphql/navn";
 import { useFeatureToggle } from "../../featuretoggle";
-import IdentOgNavn from "./identOgNavn";
+import FagsakVelger from "../journalforing/komponenter/fagsakVelger";
+import {
+  skalViseSoknadsperiodeOgLand,
+  skalViseSoknadsperiodeOgLandDeprecated,
+} from "../journalforing/komponenter/opprettSak";
+
+import { OppgaveVelger } from "./komponenter/oppgaveVelger";
+import IdentOgNavn from "./komponenter/identOgNavn";
 
 import { lagYupToReduxformErrorMapper } from "../../yup";
 import opprettNySakSchema from "./opprettnysakSchema";
 import "./opprettnysak.css";
-import { sokOperations, sokSelectors } from "../../ducks/sok";
-import { OppgaveVelger } from "./komponenter/oppgaveVelger";
-import { landkoderOperations, landkoderSelectors } from "../../ducks/landkoder";
-import FagsakVelger from "../journalforing/komponenter/fagsakVelger";
 
 const { BRUKER, VIRKSOMHET } = MKV.Koder.aktoersroller;
 
@@ -56,7 +61,7 @@ interface OpprettNySakFormData {
 
 const mapStateToProps = (state: RootState) => ({
   formValues: getFormValues(KV.Form.OPPRETT_NY_SAK)(state) as OpprettNySakFormData,
-  journalforingSkjemaVerdier: formSelectors.JournalforingFormSelector(state).values,
+  errors: getFormSyncErrors(KV.Form.OPPRETT_NY_SAK)(state),
   fagsakListe: sokSelectors.FagsakSokSelector(state),
   initialValues: {
     skalTilordnes: false,
@@ -69,11 +74,9 @@ const mapStateToProps = (state: RootState) => ({
   },
   landkoderListe: landkoderSelectors.LandkoderSelector(state),
   feilmeldinger: feiletResponsSelectors.FeilmeldingerSelector(state),
-  formIsValid: isValid(KV.Form.OPPRETT_NY_SAK)(state),
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, AnyAction>) => ({
-  touchAll: () => dispatch(formOperations.touchAll(KV.Form.OPPRETT_NY_SAK)),
   lagNySak: (body: Api.Fagsaker.fagsak.OpprettReqDto) => dispatch(fagsakOperations.lagNySak(body)),
   lagNyBehandlingForSak: (saksnummer: string, body: Api.Fagsaker.fagsak.OpprettReqDto) =>
     dispatch(fagsakOperations.lagNyBehandlingForSak(saksnummer, body)),
@@ -94,20 +97,20 @@ const OpprettNySak = ({
   formValues,
   tilForsiden,
   change,
-  error: formError,
+  touch,
+  errors,
   feilmeldinger,
   lagNySak,
   lagNyBehandlingForSak,
   hentFagsakListe,
   fagsakListe,
-  touchAll,
-  formIsValid,
   sokOrgnr,
   hentLandkoder,
   landkoderListe,
 }: InjectedFormProps<OpprettNySakFormData, OpprettNySakProps> & OpprettNySakProps) => {
   const [oppgaver, setOppgaver] = useState<Api.Oppgaver.SokOppgaveResDto[]>([]);
   const [bekreftPending, setBekreftPending] = useState(false);
+  const [knappTrykketPå, setKnappTrykketPå] = useState(false);
   const [oppgaverForsoktHentet, setOppgaverForsoktHentet] = useState(false);
   const behandleAlleSakerToggle = useFeatureToggle("melosys.behandle_alle_saker");
   const nyOpprettSakToggle = useFeatureToggle("melosys.ny_opprett_sak");
@@ -126,36 +129,20 @@ const OpprettNySak = ({
     periodeTilOgMed,
     soknadslandUkjenteEllerAlleEosLand,
     soknadsland,
+    skalTilordnes,
+    oppgaveID,
   } = formValues || {};
 
-  const [erRedigerbart, setErRedigerbart] = useState(false);
-  const { tom, fom, erUkjenteEllerAlleEosLand, landkoder } = {
-    fom: periodeFraOgMed,
-    tom: periodeTilOgMed,
-    erUkjenteEllerAlleEosLand: soknadslandUkjenteEllerAlleEosLand,
-    landkoder: soknadsland,
-  };
-  const soknadErValgt = MKVUtils.erSoknad(behandlingstema);
-
-  // TODO: Fjerner denne i en annen branch som omhandler å implementere feilmeldinger som journalføring.
-  useEffect(() => {
-    if (behandleAlleSakerToggle !== "enabled") {
-      setErRedigerbart(Boolean(sakstype && behandlingstema));
-    } else {
-      const opprettNySakKriterier = Boolean(sakstype && sakstema && behandlingstema && behandlingstype);
-      const eksisterendeSakKriterier = Boolean(behandlingstema && behandlingstype);
-      setErRedigerbart(saksnummer === "-1" ? opprettNySakKriterier : eksisterendeSakKriterier);
-    }
-  }, [sakstype, sakstema, behandlingstema, behandlingstype, saksnummer, behandleAlleSakerToggle]);
+  const nullstillFelt = (felt: string, verdi: any = null) => change(felt, verdi);
 
   useEffect(() => {
     hentLandkoder();
   }, []);
 
-  const validerForm = () => {
-    touchAll();
-    return formIsValid;
-  };
+  useEffect(() => {
+    // Fjernes med toggle melosys.behandle_alle_saker
+    change("behandleAlleSakerToggleEnabled", behandleAlleSakerToggle === "enabled");
+  }, [behandleAlleSakerToggle]);
 
   const hentOppgaver = async (value: string) => {
     if (Utils.person.erGyldigFnrEllerDnr(value) || Utils.organisasjon.erOrgnrGyldig(value)) {
@@ -179,12 +166,11 @@ const OpprettNySak = ({
     if (Utils.person.erGyldigFnrEllerDnr(personIdent)) {
       const navn = await hentSammensattNavn(personIdent);
       change("brukerNavn", navn);
+      await hentFagsakListe(personIdent);
+      await hentOppgaver(personIdent);
     } else {
-      change("brukerNavn", null);
-      return;
+      nullstillFelt("brukerNavn");
     }
-    await hentFagsakListe(personIdent);
-    await hentOppgaver(personIdent);
   };
 
   const hentVirksomhet = async (orgnr: string) => {
@@ -192,12 +178,11 @@ const OpprettNySak = ({
       const response = await sokOrgnr(orgnr);
       const navn = response?.data.navn;
       change("virksomhetNavn", navn);
+      await hentFagsakListe(virksomhetOrgnr);
+      await hentOppgaver(virksomhetOrgnr);
     } else {
-      change("virksomhetNavn", null);
-      return;
+      nullstillFelt("virksomhetNavn");
     }
-    await hentFagsakListe(virksomhetOrgnr);
-    await hentOppgaver(virksomhetOrgnr);
   };
 
   useEffect(() => {
@@ -210,71 +195,81 @@ const OpprettNySak = ({
 
   useEffect(() => {
     if (hovedpart === BRUKER) {
-      change("virksomhetOrgnr", null);
-      change("virksomhetNavn", null);
+      nullstillFelt("virksomhetOrgnr");
+      nullstillFelt("virksomhetNavn");
     }
     if (hovedpart === VIRKSOMHET) {
-      change("brukerID", null);
-      change("brukerNavn", null);
+      nullstillFelt("brukerID");
+      nullstillFelt("brukerNavn");
     }
-    change("oppgaveID", null);
-    change("journalpostID", null);
+    nullstillFelt("oppgaveID");
+    nullstillFelt("journalpostID");
     setOppgaver([]);
     setOppgaverForsoktHentet(false);
   }, [hovedpart]);
 
-  const opprettNySak = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!validerForm()) return;
-    setBekreftPending(true);
-    const fraOgMed = fom && soknadErValgt ? Utils.dato.formatterDatoTilISO(fom) : null;
-    const tilOgMed = tom && soknadErValgt ? Utils.dato.formatterDatoTilISO(tom) : null;
+  const dataForOpprettSak = (fellesData: Api.Fagsaker.fagsak.OpprettReqDto) => {
+    const skalSendePeriodeOgLand =
+      behandleAlleSakerToggle === "enabled"
+        ? skalViseSoknadsperiodeOgLand(sakstype, sakstema, behandlingstema, behandlingstype)
+        : skalViseSoknadsperiodeOgLandDeprecated(hovedpart, sakstype, behandlingstema);
+
+    const fom = skalSendePeriodeOgLand && periodeFraOgMed ? Utils.dato.formatterDatoTilISO(periodeFraOgMed) : null;
+    const tom = skalSendePeriodeOgLand && periodeTilOgMed ? Utils.dato.formatterDatoTilISO(periodeTilOgMed) : null;
 
     const soknadDto = {
-      periode: {
-        fom: fraOgMed,
-        tom: tilOgMed,
-      },
+      periode: { fom, tom },
       land: {
-        landkoder: soknadErValgt ? landkoder : [],
-        erUkjenteEllerAlleEosLand: soknadErValgt ? erUkjenteEllerAlleEosLand : false,
+        landkoder: skalSendePeriodeOgLand ? soknadsland : [],
+        erUkjenteEllerAlleEosLand: skalSendePeriodeOgLand && soknadslandUkjenteEllerAlleEosLand,
       },
     };
 
-    const { skalTilordnes, oppgaveID } = formValues;
-    const data = {
-      brukerID,
-      sakstype,
-      virksomhetOrgnr,
-      sakstema,
-      behandlingstema,
-      behandlingstype,
+    return {
+      ...fellesData,
       hovedpart,
+      brukerID,
+      virksomhetOrgnr,
+      sakstype,
+      sakstema,
       soknadDto,
-      skalTilordnes,
       oppgaveID,
     };
+  };
+
+  const handleSubmit = () => {
+    setBekreftPending(true);
+    setKnappTrykketPå(true);
+
+    touch(...Object.keys(errors));
+
+    if (!Utils._isEmpty(errors)) {
+      setBekreftPending(false);
+      return;
+    }
+
+    const fellesData = {
+      behandlingstema,
+      behandlingstype,
+      skalTilordnes,
+    };
+
     if (saksnummer !== "-1" && nyOpprettSakToggle === "enabled") {
-      lagNyBehandlingForSak(saksnummer, data).finally(() => setBekreftPending(false));
+      lagNyBehandlingForSak(saksnummer, fellesData).finally(() => setBekreftPending(false));
     } else {
-      lagNySak(data).finally(() => setBekreftPending(false));
+      lagNySak(dataForOpprettSak(fellesData)).finally(() => setBekreftPending(false));
     }
   };
 
   const nullstillFormVerdier = () => {
-    change("behandlingstema", null);
-    change("behandlingstype", null);
-    change("periodeFraOgMed", null);
-    change("periodeTilOgMed", null);
-    change("soknadslandUkjenteEllerAlleEosLand", null);
-    change("soknadsland", []);
-    change("sakstype", null);
-    change("sakstema", null);
-    change("erAvsluttetSak", null);
-  };
-
-  const nullstillOppgave = () => {
-    change("oppgaveID", null);
+    nullstillFelt("sakstype");
+    nullstillFelt("sakstema");
+    nullstillFelt("behandlingstema");
+    nullstillFelt("behandlingstype");
+    nullstillFelt("periodeFraOgMed");
+    nullstillFelt("periodeTilOgMed");
+    nullstillFelt("soknadslandUkjenteEllerAlleEosLand");
+    nullstillFelt("soknadsland", []);
   };
 
   const hovedpartErBruker = hovedpart === BRUKER;
@@ -282,112 +277,114 @@ const OpprettNySak = ({
 
   if (!formValues) return null;
   return (
-    <form className="opprettnysak" onSubmit={opprettNySak}>
-      <Nav.Container fluid>
-        <Nav.Row>
+    <Nav.Container fluid className="opprettnysak">
+      <Nav.Row>
+        <Nav.Column xs="8">
           <Nav.Column xs="8">
-            <Nav.Column xs="8">
-              {behandleAlleSakerToggle === "enabled" && (
+            {behandleAlleSakerToggle === "enabled" && (
+              <div className="seksjon">
+                <Mui.Undertittel
+                  tekst="Hvem skal saken opprettes på?"
+                  ikon={Ikoner.FindAccount}
+                  className="undertittel"
+                  understrek
+                />
+                <Nav.RadioPanelGruppe
+                  name="hovedpart"
+                  legend=""
+                  radios={[
+                    { label: "Bruker", value: BRUKER, id: BRUKER },
+                    { label: "Virksomhet", value: VIRKSOMHET, id: VIRKSOMHET },
+                  ]}
+                  checked={hovedpart}
+                  onChange={(event, value) => change("hovedpart", value)}
+                  className="hovedpart innrykk"
+                />
+              </div>
+            )}
+            <div className="seksjon">
+              {hovedpartErBruker ? (
+                <IdentOgNavn
+                  tittel="Informasjon om bruker"
+                  feltNavn="brukerID"
+                  label="Brukers f.nr eller d.nr:"
+                  navn={brukerNavn}
+                />
+              ) : (
+                <IdentOgNavn
+                  tittel="Informasjon om virksomhet"
+                  feltNavn="virksomhetOrgnr"
+                  label="Organisasjonsnummer:"
+                  navn={virksomhetNavn}
+                />
+              )}
+            </div>
+            {visFagsakOgOppgaveVelger && (
+              <>
                 <div className="seksjon">
                   <Mui.Undertittel
-                    tekst="Hvem skal saken opprettes på?"
-                    ikon={Ikoner.FindAccount}
+                    tekst={
+                      nyOpprettSakToggle === "enabled"
+                        ? "Knytt til eksisterende sak eller opprett ny"
+                        : "Informasjon om sak"
+                    }
+                    ikon={Ikoner.Links}
                     className="undertittel"
                     understrek
                   />
-                  <Nav.RadioPanelGruppe
-                    name="hovedpart"
-                    legend=""
-                    radios={[
-                      { label: "Bruker", value: BRUKER, id: BRUKER },
-                      { label: "Virksomhet", value: VIRKSOMHET, id: VIRKSOMHET },
-                    ]}
-                    checked={hovedpart}
-                    onChange={(event, value) => change("hovedpart", value)}
-                    className="hovedpart innrykk"
-                  />
+                  <div className="innrykk">
+                    <FagsakVelger
+                      erOpprettNySak
+                      fagsakListe={fagsakListe}
+                      behandleAlleSakerToggleEnabled={behandleAlleSakerToggle === "enabled"}
+                      landkoder={landkoderListe}
+                      nullstillFormVerdier={nullstillFormVerdier}
+                      formValues={formValues}
+                    />
+                  </div>
                 </div>
-              )}
-              <div className="seksjon">
-                {hovedpartErBruker ? (
-                  <IdentOgNavn
-                    tittel="Informasjon om bruker"
-                    feltNavn="brukerID"
-                    label="Brukers f.nr eller d.nr:"
-                    navn={brukerNavn}
+                <div className="seksjon">
+                  <Mui.Undertittel
+                    tekst="Knytt til eksisterende Gosys oppgave eller opprett ny"
+                    ikon={Ikoner.CheckList}
+                    className="undertittel"
+                    understrek
                   />
-                ) : (
-                  <IdentOgNavn
-                    tittel="Informasjon om virksomhet"
-                    feltNavn="virksomhetOrgnr"
-                    label="Organisasjonsnummer:"
-                    navn={virksomhetNavn}
-                  />
-                )}
-              </div>
-              {visFagsakOgOppgaveVelger && (
-                <>
-                  <div className="seksjon">
-                    <Mui.Undertittel
-                      tekst={
-                        nyOpprettSakToggle === "enabled"
-                          ? "Knytt til eksisterende sak eller opprett ny"
-                          : "Informasjon om sak"
-                      }
-                      ikon={Ikoner.Links}
-                      className="undertittel"
-                      understrek
+                  <div className="innrykk">
+                    <OppgaveVelger
+                      oppgaverForsoktHentet={oppgaverForsoktHentet}
+                      hovedpart={hovedpart}
+                      saksnummer={saksnummer}
+                      change={change}
+                      oppgaver={oppgaver}
                     />
-                    <div className="innrykk">
-                      <FagsakVelger
-                        erOpprettNySak
-                        fagsakListe={fagsakListe}
-                        behandleAlleSakerToggleEnabled={behandleAlleSakerToggle === "enabled"}
-                        landkoder={landkoderListe}
-                        nullstillFormVerdier={nullstillFormVerdier}
-                        formValues={formValues}
-                      />
-                    </div>
                   </div>
-                  <div className="seksjon">
-                    <Mui.Undertittel
-                      tekst="Knytt til eksisterende Gosys oppgave eller opprett ny"
-                      ikon={Ikoner.CheckList}
-                      className="undertittel"
-                      understrek
-                    />
-                    <div className="innrykk">
-                      <OppgaveVelger
-                        oppgaverForsoktHentet={oppgaverForsoktHentet}
-                        hovedpart={hovedpart}
-                        change={change}
-                        oppgaver={oppgaver}
-                        nullstillFormverdier={nullstillOppgave}
-                      />
-                    </div>
-                  </div>
-                </>
-              )}
+                </div>
+              </>
+            )}
 
-              <div className="seksjon">
-                <Feilmeldinger feilmeldinger={feilmeldinger} />
-                <Skjema.Checkbox feltNavn="skalTilordnes" label="Legg behandlingen i mine oppgaver" />
-                {formError && <Nav.AlertStripeAdvarsel className="formError">{formError}</Nav.AlertStripeAdvarsel>}
-                <Knapperad
-                  bekreftTekst={nyOpprettSakToggle === "enabled" ? "Opprett ny behandling" : "Opprett sak"}
-                  avbryt={tilForsiden}
-                  avbrytTekst="Avbryt"
-                  redigerbart
-                  bekreftRedigerbart={!bekreftPending && erRedigerbart}
-                  spinner={bekreftPending}
-                  bekreftHtmlType="submit"
-                />
-              </div>
-            </Nav.Column>
+            <div className="seksjon">
+              <Skjema.Checkbox feltNavn="skalTilordnes" label="Legg behandlingen i mine oppgaver" />
+              {knappTrykketPå && !Utils._isEmpty(errors) && (
+                <Nav.AlertStripeFeil className="feilmelding">
+                  {Utils.feilmelding.syncErrorsTilFeilmelding(errors)}
+                </Nav.AlertStripeFeil>
+              )}
+              <Feilmeldinger feilmeldinger={feilmeldinger} className="feilmelding" />
+              <Knapperad
+                bekreft={handleSubmit}
+                bekreftTekst={nyOpprettSakToggle === "enabled" ? "Opprett ny behandling" : "Opprett sak"}
+                avbryt={tilForsiden}
+                avbrytTekst="Avbryt"
+                redigerbart
+                spinner={bekreftPending}
+                autoDisableVedSpinner
+              />
+            </div>
           </Nav.Column>
-        </Nav.Row>
-      </Nav.Container>
-    </form>
+        </Nav.Column>
+      </Nav.Row>
+    </Nav.Container>
   );
 };
 

--- a/src/sider/opprettnysak/opprettnysakSchema.js
+++ b/src/sider/opprettnysak/opprettnysakSchema.js
@@ -76,11 +76,16 @@ const opprettnysak = object().shape({
     })
     .nullable(),
   virksomhetNavn: string().nullable(),
-  saksnummer: string().test(
-    "må settes når du knytter til eksisterende sak",
-    VELG_HVILKEN_SAK_DU_ONSKER_A_KNYTTE_BEHANDLINGEN_TIL,
-    (saksnummer) => skalOppretteNySak(saksnummer) || !Utils._isEmpty(saksnummer)
-  ),
+  saksnummer: string()
+    .nullable()
+    .when("behandleAlleSakerToggleEnabled", {
+      is: true,
+      then: string().test(
+        "må settes når du knytter til eksisterende sak",
+        VELG_HVILKEN_SAK_DU_ONSKER_A_KNYTTE_BEHANDLINGEN_TIL,
+        (saksnummer) => skalOppretteNySak(saksnummer) || !Utils._isEmpty(saksnummer)
+      ),
+    }),
   sakstype: string()
     .when("saksnummer", {
       is: skalOppretteNySak,

--- a/src/sider/opprettnysak/opprettnysakSchema.js
+++ b/src/sider/opprettnysak/opprettnysakSchema.js
@@ -1,66 +1,74 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-// TODO: fjern eslint-disable når toggle melosys.behandle_alle_saker fjernes
-import { object, string, mixed, boolean } from "yup";
+import { object, string, boolean, array } from "yup";
 
 import * as Utils from "../../utils";
 import * as KV from "../../kodeverk";
 
 import MKV from "../../melosyskodeverk";
+import {
+  skalViseSoknadsperiodeOgLand,
+  skalViseSoknadsperiodeOgLandDeprecated,
+} from "../journalforing/komponenter/opprettSak";
 
-const SKRIV_INN_FNR_ELLER_DNR = { melding: "Skriv inn f.nr eller d.nr" };
-const SKRIV_INN_GYLDIG_FNR_ELLER_DNR = { melding: "Skriv inn gyldig f.nr eller d.nr" };
-const FANT_INGEN_NAVN_PA_FNR_ELLER_DNR = { melding: "Fant ingen navn på dette f.nr eller d-nr." };
-const SKRIV_INN_ORGNR = { melding: "Skriv inn organisasjonsnummer" };
-const SKRIV_INN_GYLDIG_ORGNR = { melding: "Skriv inn gyldig organisasjonsnummer" };
-const FANT_INGEN_NAVN_PA_ORGNR = { melding: "Fant ingen navn på dette organisasjonsnummeret." };
-const VELG_SAKSTYPE = { melding: "Velg sakstype" };
-// TODO: Legg denne på når toggle melosys.behandle_alle_saker er på. Da skal sakstema og behandlingstype bli required
-// const VELG_SAKSTEMA = { melding: "Velg sakstema" };
-// const VELG_BEHANDLINGSTYPE = { melding: "Velg behandlingstype" };
-const VELG_BEHANDLINGSTEMA = { melding: "Velg behandlingstema" };
-const { MAA_FYLLES_UT } = KV.Feilmeldinger;
+const {
+  MAA_FYLLES_UT,
+  SAK_HAR_AKTIV_BEHANDLING,
+  SKRIV_INN_GYLDIG_FNR_ELLER_DNR,
+  FANT_INGEN_NAVN_PA_FNR_ELLER_DNR,
+  SKRIV_INN_GYLDIG_ORGNR,
+  FANT_INGEN_NAVN_PA_ORGNR,
+  VELG_MINST_ETT_LAND,
+} = KV.Feilmeldinger;
 const { BRUKER, VIRKSOMHET } = MKV.Koder.aktoersroller;
-const VELG_MINST_ETT_LAND = { melding: "Velg minst ett land." };
 
-// Trengs når toggle melosys.behandle_alle_saker fjernes
-// const soknadsinfo = object().shape({
-//   fom: string().erGyldigDato().required(MAA_FYLLES_UT),
-//   tom: lazy((value) =>
-//     !value ? string().ensure() : string().erGyldigDato().erEtterDatofelt("fom").required(MAA_FYLLES_UT)
-//   ),
-//   landkoder: array()
-//     .of(string())
-//     .when("erUkjenteEllerAlleEosLand", {
-//       is: false,
-//       then: array().of(string()).min(1, { _error: VELG_LAND }),
-//     }),
-//   erUkjenteEllerAlleEosLand: boolean(),
-// });
+const VELG_SAKSTYPE = { melding: "Velg sakstype" };
+const VELG_SAKSTEMA = { melding: "Velg sakstema" };
+const VELG_BEHANDLINGSTYPE = { melding: "Velg behandlingstype" };
+const VELG_BEHANDLINGSTEMA = { melding: "Velg behandlingstema" };
+const VELG_HVILKEN_SAK_DU_ONSKER_A_KNYTTE_BEHANDLINGEN_TIL = {
+  melding: "Velg hvilken sak du ønsker å knytte behandlingen til",
+};
 
-// const kreverPeriode = (hovedpart, sakstype, behandlingstema) =>
-// Her kan vi bruke erEksisterendeSak til å styre om vi trenger periode og land. Er den true skal man ikke trenge det.
-//   skalViseSoknadsperiodeOgLand(hovedpart, sakstype, behandlingstema);
-//
-// const kreverLand = (hovedpart, sakstype, behandlingstema, ukjentEllerAlleEosLand) =>
-//   !ukjentEllerAlleEosLand && kreverPeriode(hovedpart, sakstype, behandlingstema);
+const skalOppretteNySak = (saksnummer) => saksnummer === "-1";
+
+const kreverPeriode = (saksnummer, sakstype, sakstema, behandlingstema, behandlingstype) =>
+  skalOppretteNySak(saksnummer) && skalViseSoknadsperiodeOgLand(sakstype, sakstema, behandlingstema, behandlingstype);
+
+// Fjernes med toggle melosys.behandle_alle_saker
+const kreverPeriodeDeprecated = (saksnummer, hovedpart, sakstype, behandlingstema) =>
+  skalOppretteNySak(saksnummer) && skalViseSoknadsperiodeOgLandDeprecated(hovedpart, sakstype, behandlingstema);
+
+const kreverLand = (
+  saksnummer,
+  sakstype,
+  sakstema,
+  behandlingstema,
+  behandlingstype,
+  soknadslandUkjenteEllerAlleEosLand
+) =>
+  kreverPeriode(saksnummer, sakstype, sakstema, behandlingstema, behandlingstype) &&
+  !soknadslandUkjenteEllerAlleEosLand;
+
+// Fjernes med toggle melosys.behandle_alle_saker
+const kreverLandDeprecated = (saksnummer, hovedpart, sakstype, behandlingstema, soknadslandUkjenteEllerAlleEosLand) =>
+  kreverPeriodeDeprecated(hovedpart, sakstype, behandlingstema) && !soknadslandUkjenteEllerAlleEosLand;
 
 const opprettnysak = object().shape({
   hovedpart: string().required(MAA_FYLLES_UT),
   brukerID: string()
     .when("hovedpart", {
       is: (hovedpart) => hovedpart === BRUKER,
-      then: string().erFnrEllerDnr(SKRIV_INN_GYLDIG_FNR_ELLER_DNR).required(SKRIV_INN_FNR_ELLER_DNR).nullable(),
+      then: string().erFnrEllerDnr(SKRIV_INN_GYLDIG_FNR_ELLER_DNR).required(SKRIV_INN_GYLDIG_FNR_ELLER_DNR).nullable(),
     })
     .when(["hovedpart", "brukerNavn"], {
       is: (hovedpart, brukerNavn) => hovedpart === BRUKER && Utils._isEmpty(brukerNavn),
       then: string().harIkkeFnrEllerDnrLengde(FANT_INGEN_NAVN_PA_FNR_ELLER_DNR).nullable(),
     })
     .nullable(),
-  brukerNavn: mixed(),
+  brukerNavn: string().nullable(),
   virksomhetOrgnr: string()
     .when("hovedpart", {
       is: (hovedpart) => hovedpart === VIRKSOMHET,
-      then: string().erOrgnr(SKRIV_INN_GYLDIG_ORGNR).required(SKRIV_INN_ORGNR).nullable(),
+      then: string().erOrgnr(SKRIV_INN_GYLDIG_ORGNR).required(SKRIV_INN_GYLDIG_ORGNR).nullable(),
     })
     .when(["hovedpart", "virksomhetNavn"], {
       is: (hovedpart, virksomhetNavn) => hovedpart === VIRKSOMHET && Utils._isEmpty(virksomhetNavn),
@@ -68,44 +76,108 @@ const opprettnysak = object().shape({
     })
     .nullable(),
   virksomhetNavn: string().nullable(),
-  sakstype: string().required(VELG_SAKSTYPE).nullable(),
-  sakstema: string().nullable(),
-  behandlingstype: string().nullable(),
-  behandlingstema: string()
-    .when("hovedpart", {
-      is: (hovedpart) => hovedpart !== VIRKSOMHET,
-      then: string().required(VELG_BEHANDLINGSTEMA).nullable(),
+  saksnummer: string().test(
+    "må settes når du knytter til eksisterende sak",
+    VELG_HVILKEN_SAK_DU_ONSKER_A_KNYTTE_BEHANDLINGEN_TIL,
+    (saksnummer) => skalOppretteNySak(saksnummer) || !Utils._isEmpty(saksnummer)
+  ),
+  sakstype: string()
+    .when("saksnummer", {
+      is: skalOppretteNySak,
+      then: string().required(VELG_SAKSTYPE).nullable(),
     })
     .nullable(),
-  // TODO: skru på validering når toggle melosys.behandle_alle_saker fjernes
-  // soknadsinfo: object().when(["sakstype", "behandlingstema", "behandlingstype"], {
-  //   is: (sakstype, behandlingstema, behandlingstype) =>
-  //     skalViseSoknadsperiodeOgLand(sakstype, behandlingstema, behandlingstype),
-  //   then: soknadsinfo,
-  // }),
+  sakstema: string()
+    .nullable()
+    .when("behandleAlleSakerToggleEnabled", {
+      is: true,
+      then: string()
+        .when("saksnummer", {
+          is: skalOppretteNySak,
+          then: string().required(VELG_SAKSTEMA).nullable(),
+        })
+        .nullable(),
+    }),
+  behandlingstema: string().required(VELG_BEHANDLINGSTEMA).nullable(),
+  behandlingstype: string()
+    .nullable()
+    .when("behandleAlleSakerToggleEnabled", {
+      is: true,
+      then: string().required(VELG_BEHANDLINGSTYPE).nullable(),
+    }),
   oppgaveID: string().nullable(),
-  // TODO: skru på validering når toggle melosys.behandle_alle_saker fjernes
-  // periodeFraOgMed: string().when(["hovedpart", "sakstype", "behandlingstema"], {
-  //   is: kreverPeriode,
-  //   then: string().erGyldigDato().required(MAA_FYLLES_UT),
-  // }),
-  // periodeTilOgMed: lazy((value) =>
-  //   !value
-  //     ? string().ensure()
-  //     : string().when(["hovedpart", "sakstype", "behandlingstema"], {
-  //         is: kreverPeriode,
-  //         then: string().erEtterDatofelt("periodeFraOgMed").erGyldigDato().required(MAA_FYLLES_UT),
-  //       })
-  // ),
-  soknadslandUkjenteEllerAlleEosLand: boolean(),
-  // TODO: skru på validering når toggle melosys.behandle_alle_saker fjernes
-  // soknadsland: array()
-  //   .of(string())
-  //   .ensure()
-  //   .when(["hovedpart", "sakstype", "behandlingstema", "soknadslandUkjenteEllerAlleEosLand"], {
-  //     is: kreverLand,
-  //     then: array().of(string()).min(1, { _error: VELG_MINST_ETT_LAND }),
-  //   }),
+  periodeFraOgMed: string()
+    .nullable()
+    .when("behandleAlleSakerToggleEnabled", {
+      is: true,
+      then: string()
+        .nullable()
+        .when(["saksnummer", "sakstype", "sakstema", "behandlingstema", "behandlingstype"], {
+          is: kreverPeriode,
+          then: string().required(MAA_FYLLES_UT).nullable(),
+        }),
+      otherwise: string()
+        .nullable()
+        .when(["saksnummer", "hovedpart", "sakstype", "behandlingstema"], {
+          is: kreverPeriodeDeprecated,
+          then: string().required(MAA_FYLLES_UT).nullable(),
+        }),
+    }),
+  periodeTilOgMed: string()
+    .nullable()
+    .when("behandleAlleSakerToggleEnabled", {
+      is: true,
+      then: string()
+        .nullable()
+        .when(["saksnummer", "sakstype", "sakstema", "behandlingstema", "behandlingstype"], {
+          is: (saksnummer, sakstype, sakstema, behandlingstema, behandlingstype) =>
+            skalOppretteNySak(saksnummer) &&
+            skalViseSoknadsperiodeOgLand(sakstype, sakstema, behandlingstema, behandlingstype),
+          then: string().erEtterDatofelt("periodeFraOgMed").erGyldigDato().required(MAA_FYLLES_UT).nullable(),
+        }),
+      otherwise: string()
+        .nullable()
+        .when(["saksnummer", "hovedpart", "sakstype", "behandlingstema"], {
+          is: (saksnummer, hovedpart, sakstype, behandlingstema) =>
+            skalOppretteNySak(saksnummer) && skalViseSoknadsperiodeOgLandDeprecated(sakstype, behandlingstema),
+          then: string().erEtterDatofelt("periodeFraOgMed").erGyldigDato().required(MAA_FYLLES_UT).nullable(),
+        }),
+    }),
+  soknadslandUkjenteEllerAlleEosLand: boolean().nullable(),
+  soknadsland: array().when("$behandleAlleSakerToggleEnabled", {
+    is: true,
+    then: array()
+      .of(string())
+      .ensure()
+      .when(
+        [
+          "saksnummer",
+          "sakstype",
+          "sakstema",
+          "behandlingstema",
+          "behandlingstype",
+          "soknadslandUkjenteEllerAlleEosLand",
+        ],
+        {
+          is: kreverLand,
+          then: array().of(string()).min(1, { _error: VELG_MINST_ETT_LAND }),
+        }
+      ),
+    otherwise: array()
+      .of(string())
+      .ensure()
+      .when(["saksnummer", "hovedpart", "sakstype", "behandlingstema", "soknadslandUkjenteEllerAlleEosLand"], {
+        is: kreverLandDeprecated(),
+        then: array().of(string()).min(1, { _error: VELG_MINST_ETT_LAND }),
+      }),
+  }),
+  behandleAlleSakerToggleEnabled: boolean(),
+  erAvsluttetSak: boolean()
+    .nullable()
+    .when("saksnummer", {
+      is: (saksnummer) => !skalOppretteNySak(saksnummer) && !Utils._isEmpty(saksnummer),
+      then: boolean().nullable().oneOf([true], SAK_HAR_AKTIV_BEHANDLING),
+    }),
 });
 
 export default opprettnysak;

--- a/src/utils/feilmelding.tsx
+++ b/src/utils/feilmelding.tsx
@@ -1,8 +1,9 @@
 import React from "react";
+import { FormErrors } from "redux-form";
 import * as Utils from "./index";
 
 export function syncErrorsTilFeilmelding(
-  syncErrors: { [key: string]: { melding?: string; _error?: { melding: string } } },
+  syncErrors: { [key: string]: { melding?: string; _error?: { melding: string } } } | FormErrors<any>,
   tittel: string = "Følgende feil ble funnet"
 ) {
   if (Utils._isEmpty(syncErrors)) return null;


### PR DESCRIPTION
La til valideringer for opprett ny sak, tilsvarende journalføringen. Laget også samme visning av disse.
La til hjelpefunksjon nullstillFelt.
Trakk ut mapping av data som var spesifikt for opprett ny sak (og ikke opprett behandling). 
Satte feilmeldingene som var felles for journalføring og opprettnysak i filen feilmeldinger i /kodeverk. 
Slettet gammel endepunkt som ikke finnes i backend lengre.

https://jira.adeo.no/browse/MELOSYS-5199