### PR TITLE
5199 TOGGLE opprett ny sak bugs

### DIFF
--- a/src/kodeverk/feilmeldinger.js
+++ b/src/kodeverk/feilmeldinger.js
@@ -6,7 +6,7 @@ export const SKRIV_INN_GYLDIG_DATO = { melding: "Skriv inn en gyldig dato" };
 export const UTENFOR_SOKNADSPERIODEN = { melding: "Utenfor søknadsperioden" };
 export const MAA_FYLLES_UT = { melding: "Må fylles ut" };
 export const SAK_HAR_AKTIV_BEHANDLING = {
-  melding: "Du kan ikke opprette en ny behandling på sak med en aktiv/pågående behandling",
+  melding: "Du kan ikke opprette en ny behandling på eksisterende sak med en aktiv/pågående behandling",
 };
 export const SKRIV_INN_GYLDIG_FNR_ELLER_DNR = { melding: "Skriv inn gyldig f.nr. eller d-nr." };
 export const FANT_INGEN_NAVN_PA_FNR_ELLER_DNR = { melding: "Fant ingen navn på dette f.nr. eller d-nr." };

--- a/src/sider/journalforing/komponenter/knyttTilSak.js
+++ b/src/sider/journalforing/komponenter/knyttTilSak.js
@@ -194,9 +194,9 @@ export const KnyttTilSak = (props) => {
     <div className="knyttTilSak__behandlingspanel">
       {erOpprettNySak ? (
         <div className="innrykk">
-          <Nav.AlertStripeInfo>
-            Du kan ikke opprette en ny behandling på sak med en aktiv/pågående behandling.
-          </Nav.AlertStripeInfo>
+          <Nav.AlertStripeAdvarsel>
+            Du kan ikke opprette en ny behandling på eksisterende sak med en aktiv/pågående behandling
+          </Nav.AlertStripeAdvarsel>
         </div>
       ) : (
         visUtenVidereBehandling && (

--- a/src/sider/opprettnysak/opprettnysak.tsx
+++ b/src/sider/opprettnysak/opprettnysak.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useState } from "react";
-import { connect, ConnectedProps } from "react-redux";
+import { connect, ConnectedProps, useDispatch } from "react-redux";
 import { getFormValues, InjectedFormProps, isValid, reduxForm } from "redux-form";
 import { RootState } from "AppTypes";
 import { ThunkDispatch } from "redux-thunk";
@@ -111,6 +111,7 @@ const OpprettNySak = ({
   const [oppgaverForsoktHentet, setOppgaverForsoktHentet] = useState(false);
   const behandleAlleSakerToggle = useFeatureToggle("melosys.behandle_alle_saker");
   const nyOpprettSakToggle = useFeatureToggle("melosys.ny_opprett_sak");
+  const dispatch = useDispatch();
   const {
     behandlingstema,
     behandlingstype,
@@ -150,6 +151,9 @@ const OpprettNySak = ({
 
   useEffect(() => {
     hentLandkoder();
+    return () => {
+      dispatch(fagsakOperations.resetFagsakState());
+    };
   }, []);
 
   const validerForm = () => {


### PR DESCRIPTION
Alertstripen skal være av type Advarsel.
Resetter feil i fagsakOperations på unmount slik at de ikke vises når man endrer side.

Oversikt over kommentarene i saken: 
> Teksten må justeres, men det er kanskje en egen story på dette?

All validering-endring gjøres i annen PR: https://github.com/navikt/melosys-web/pull/1666

> Iht skissene skal "Opprett ny oppgave" være default valgt om man prøver å knytte til en eksisterende sak som har status "pågående". Det er ikke det resultatet jeg får nå:

Snakket med Cathrin, og den skal være sånn den er nå. Dette fordi man må opprette ny oppgave når man velger eksisterende sak.

> Har snakket med Cathrin og Janita; det er ønskelig at resultatet ikke blir som i skissene (se bildet under) når man åpner "Opprett ny sak/ behandling", det skal være helt tomt der det er "knytt til eksisterende sak eller opprett ny", og der det er "knytt til gosys oppgave eller opprett ny": 

Ble fikset underveis i annen PR.

> Kommentar til kommentaren min lagt inn 13.10.2022:
[Cathrin Engen](https://jira.adeo.no/secure/ViewProfile.jspa?name=E162585) oppretter egen sak angående feilmeldinger; vi må få inn en egen database for hvilke input skal ha hvilken feilmelding.
Jeg har meldt ifra til [Thang Quoc Ly Phan](https://jira.adeo.no/secure/ViewProfile.jspa?name=P165973) angående feilmeldingen når man legger inn tidligere sluttdato og ikke land men vi får bare feilmelding om at det mangler land for å opprette behandling.

Skjer i annen PR: https://github.com/navikt/melosys-web/pull/1666

> Det står i skissene at knappen skal bli aktiv etter at man har lagt inn riktig fnr/dnr og person er funnet. Akkurat nå er resultatet at knappen ikke er aktiv etter at jeg har lagt inn riktig person.

Skjer i annen PR: https://github.com/navikt/melosys-web/pull/1666

> Når jeg har lagt inn fnr/dnr i feltet, så må jeg trykke utenfor feltet eller et annet sted for at vinduet faktisk henter person og gjør valgene i "Opprett ny behandling" tilgjengelig.

Fikset allerede.

> Når man har lagt inn en ident som ikke har noen oppgaver, skal det komme infomelding under "Knytt til eksisterende Gosys oppgave eller opprett ny" (se i skissen). Nå får vi ikke infomeldingen om at "Ingen eksisterende oppgaver funnet. Det blir opprettet en ny". Nå er dette resultatet:

Denne mener jeg er fikset.

> Akseptansekriterie 5 er ikke oppfylt:

Skjer i annen PR: https://github.com/navikt/melosys-web/pull/1666

> Akseptansekriterie 7 blir ikke oppfylt:

Testet selv i dev, og fikk opp. Ser ut som det er løst. Må nok testes på nytt.

> Akseptansekriterie 8 blir ikke oppfylt:

Ikke meningen å støtte VUR ifølge Mina. Men kan filtrere det fra listen - blir egen sak.

> Og når jeg prøver å komme til forsiden i Melosys, får jeg denne feilmeldingen, selv om jeg har prøvd å oppdatere siden flere ganger (bare ved å trykke på NAV ikonet øverst til venstre på siden da):

Dette løses i denne PR-en. Der vi resetter fagsaker-state.

https://jira.adeo.no/browse/MELOSYS-5199