### PR TITLE
5461 TOGGLE Gjør lagUrl avhengig av sakstype

### DIFF
--- a/src/kodeverk/utils.ts
+++ b/src/kodeverk/utils.ts
@@ -1,6 +1,7 @@
 import * as Koder from "./koder";
 import MKV from "../melosyskodeverk";
 
+// DEPRECATED: fjernes med melosys.behandle_alle_saker
 export const mapBehandlingstemaToBehandlingskategori = (behandlingstemaKode: string) => {
   switch (behandlingstemaKode) {
     case MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING:

--- a/src/routing/index.js
+++ b/src/routing/index.js
@@ -1,5 +1,6 @@
 import Routing from "./routing";
-import { lagUrlFraBehandlingstema, nyFane, lagUrl, skalViseTomFlytEllerErSedBehandling } from "./url";
+import { nyFane, lagUrl, skalViseTomFlytEllerErSedBehandling } from "./url";
+import { lagUrlFraBehandlingstema } from "./url-gammel";
 
 export default Routing;
 export { lagUrlFraBehandlingstema, nyFane, lagUrl, skalViseTomFlytEllerErSedBehandling };

--- a/src/routing/url-gammel.ts
+++ b/src/routing/url-gammel.ts
@@ -1,0 +1,45 @@
+import MKV from "../melosyskodeverk";
+
+const { EU_EOS, FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
+
+const erSedBehandling = (behandlingstema: string) => {
+  return [
+    MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV,
+    MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
+    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
+    MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
+  ].includes(behandlingstema);
+};
+
+export const lagUrlFraBehandlingstema = (
+  saksnummer: number | string,
+  behandlingID: number,
+  behandlingstemaKode: string
+) => {
+  if (erSedBehandling(behandlingstemaKode)) {
+    return `/${EU_EOS}/sedbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
+  }
+  switch (behandlingstemaKode) {
+    case MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING:
+    case MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE:
+      return `/${EU_EOS}/registrering/${saksnummer}/unntaksperioder/?behandlingID=${behandlingID}`;
+    case MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL:
+      return `/${EU_EOS}/registrering/${saksnummer}/anmodningunntak/?behandlingID=${behandlingID}`;
+    case MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER:
+    case MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG:
+    case MKV.Koder.behandlinger.behandlingstema.ARBEID_ETT_LAND_ØVRIG:
+    case MKV.Koder.behandlinger.behandlingstema.ARBEID_TJENESTEPERSON_ELLER_FLY:
+    case MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND:
+    case MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND:
+      return `/${EU_EOS}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
+    case MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE:
+    case MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND:
+      return `/${EU_EOS}/vurderutpeking/${saksnummer}/?behandlingID=${behandlingID}`;
+    case MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET:
+      return `/${FTRL}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
+    case MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV:
+      return `/${TRYGDEAVTALE}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
+    default:
+      return null;
+  }
+};

--- a/src/routing/url.test.ts
+++ b/src/routing/url.test.ts
@@ -71,7 +71,7 @@ describe("url", () => {
         "MEL-1",
         1,
         EU_EOS,
-        MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV
+        MKV.Koder.behandlinger.behandlingstema.TRYGDETID
       );
 
       expect(url).toContain("/EU_EOS/sedbehandling/");

--- a/src/routing/url.test.ts
+++ b/src/routing/url.test.ts
@@ -1,0 +1,116 @@
+import { lagUrlFraSakstypeOgBehandlingstema } from "./url";
+import MKV from "../melosyskodeverk";
+
+const { EU_EOS, FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
+
+describe("url", () => {
+  describe("lagUrlFraSakstypeOgBehandlingstema", () => {
+    it("sakstype finnes ikke kaster feil", () => {
+      const hentUrl = () =>
+        lagUrlFraSakstypeOgBehandlingstema("MEL-1", 1, "En sakstype vi ikke støtter", "tilfeldig behandlingstemaKode");
+
+      expect(hentUrl).toThrowError("Støtter ikke sakstype:");
+    });
+
+    it("Sakstype EU_EOS med ustøttet behandlingstemaKode kaster feil", () => {
+      const hentUrl = () => lagUrlFraSakstypeOgBehandlingstema("MEL-1", 1, EU_EOS, "tilfeldig behandlingstemaKode");
+
+      expect(hentUrl).toThrowError("Finner ikke EuEøs-flyt for behandlingstema:");
+    });
+
+    it("Sakstype FTRL med ustøttet behandlingstemaKode kaster feil", () => {
+      const hentUrl = () => lagUrlFraSakstypeOgBehandlingstema("MEL-1", 1, FTRL, "tilfeldig behandlingstemaKode");
+
+      expect(hentUrl).toThrowError("Finner ikke folketrygden-flyt for behandlingstema:");
+    });
+
+    it("Sakstype TRYGDEAVTALE med ustøttet behandlingstemaKode kaster feil", () => {
+      const hentUrl = () =>
+        lagUrlFraSakstypeOgBehandlingstema("MEL-1", 1, TRYGDEAVTALE, "tilfeldig behandlingstemaKode");
+
+      expect(hentUrl).toThrowError("Finner ikke trygdeavtale-flyt for behandlingstema:");
+    });
+
+    it("Sakstype EU_EOS med støttet behandlingstemaKode returnerer url", () => {
+      const url = lagUrlFraSakstypeOgBehandlingstema(
+        "MEL-1",
+        1,
+        EU_EOS,
+        MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER
+      );
+
+      expect(url).toContain("/EU_EOS/saksbehandling/");
+    });
+
+    it("Sakstype FTRL med støttet behandlingstemaKode returnerer url", () => {
+      const url = lagUrlFraSakstypeOgBehandlingstema(
+        "MEL-1",
+        1,
+        FTRL,
+        MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET
+      );
+
+      expect(url).toContain("/FTRL/saksbehandling/");
+    });
+
+    it("Sakstype TRYGDEAVTALE med støttet behandlingstemaKode returnerer url", () => {
+      const url = lagUrlFraSakstypeOgBehandlingstema(
+        "MEL-1",
+        1,
+        TRYGDEAVTALE,
+        MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV
+      );
+
+      expect(url).toContain("/TRYGDEAVTALE/saksbehandling/");
+    });
+  });
+
+  describe("lagUrlForEuEøsFlyter", () => {
+    it("Sakstype EU_EOS med sed-behandlingstema returnerer url", () => {
+      const url = lagUrlFraSakstypeOgBehandlingstema(
+        "MEL-1",
+        1,
+        EU_EOS,
+        MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV
+      );
+
+      expect(url).toContain("/EU_EOS/sedbehandling/");
+    });
+
+    it("Sakstype EU_EOS med registrering/unntaksperioder-behandlingstema returnerer url", () => {
+      const url = lagUrlFraSakstypeOgBehandlingstema(
+        "MEL-1",
+        1,
+        EU_EOS,
+        MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING
+      );
+
+      expect(url).toContain("/EU_EOS/registrering/");
+      expect(url).toContain("unntaksperioder");
+    });
+
+    it("Sakstype EU_EOS med registrering/anmodningunntak-behandlingstema returnerer url", () => {
+      const url = lagUrlFraSakstypeOgBehandlingstema(
+        "MEL-1",
+        1,
+        EU_EOS,
+        MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL
+      );
+
+      expect(url).toContain("/EU_EOS/registrering/");
+      expect(url).toContain("anmodningunntak");
+    });
+
+    it("Sakstype EU_EOS med vurderutpeking-behandlingstema returnerer url", () => {
+      const url = lagUrlFraSakstypeOgBehandlingstema(
+        "MEL-1",
+        1,
+        EU_EOS,
+        MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE
+      );
+
+      expect(url).toContain("/EU_EOS/vurderutpeking/");
+    });
+  });
+});
+export {};

--- a/src/routing/url.test.ts
+++ b/src/routing/url.test.ts
@@ -1,4 +1,4 @@
-import { lagUrlFraSakstypeOgBehandlingstema } from "./url";
+import { lagUrl, lagUrlFraSakstypeOgBehandlingstema } from "./url";
 import MKV from "../melosyskodeverk";
 
 const { EU_EOS, FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
@@ -110,6 +110,21 @@ describe("url", () => {
       );
 
       expect(url).toContain("/EU_EOS/vurderutpeking/");
+    });
+  });
+
+  describe("tom flyt", () => {
+    it("IKKE_YRKESAKTIV får tom flyt", () => {
+      const url = lagUrl(
+        "MEL-1",
+        1,
+        EU_EOS,
+        MKV.Koder.sakstemaer.MEDLEMSKAP_LOVVALG,
+        MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV,
+        MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG
+      );
+
+      expect(url).toContain("/EU_EOS/behandling/");
     });
   });
 });

--- a/src/routing/url.ts
+++ b/src/routing/url.ts
@@ -46,6 +46,63 @@ export const lagUrlFraBehandlingstema = (
   }
 };
 
+const lagUrlForEuEøsFlyter = (saksnummer: number | string, behandlingID: number, behandlingstemaKode: string) => {
+  if (erSedBehandling(behandlingstemaKode)) {
+    return `/${EU_EOS}/sedbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
+  }
+  switch (behandlingstemaKode) {
+    case MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING:
+    case MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE:
+      return `/${EU_EOS}/registrering/${saksnummer}/unntaksperioder/?behandlingID=${behandlingID}`;
+    case MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL:
+      return `/${EU_EOS}/registrering/${saksnummer}/anmodningunntak/?behandlingID=${behandlingID}`;
+    case MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER:
+    case MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG:
+    case MKV.Koder.behandlinger.behandlingstema.ARBEID_ETT_LAND_ØVRIG:
+    case MKV.Koder.behandlinger.behandlingstema.ARBEID_TJENESTEPERSON_ELLER_FLY:
+    case MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND:
+    case MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND:
+      return `/${EU_EOS}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
+    case MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE:
+    case MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND:
+      return `/${EU_EOS}/vurderutpeking/${saksnummer}/?behandlingID=${behandlingID}`;
+    default:
+      throw new Error(`Finner ikke EuEøs-flyt for behandlingstema: ${behandlingstemaKode}`);
+  }
+};
+
+const lagUrlForFtrlFlyt = (saksnummer: number | string, behandlingID: number, behandlingstemaKode: string) => {
+  if (behandlingstemaKode === MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET) {
+    return `/${FTRL}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
+  }
+  throw new Error(`Finner ikke folketrygden-flyt for behandlingstema: ${behandlingstemaKode}`);
+};
+
+const lagUrlForTrygdeavtaleFlyt = (saksnummer: number | string, behandlingID: number, behandlingstemaKode: string) => {
+  if (behandlingstemaKode === MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV) {
+    return `/${TRYGDEAVTALE}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
+  }
+  throw new Error(`Finner ikke trygdeavtale-flyt for behandlingstema: ${behandlingstemaKode}`);
+};
+
+export const lagUrlFraSakstypeOgBehandlingstema = (
+  saksnummer: number | string,
+  behandlingID: number,
+  sakstypeKode: string,
+  behandlingstemaKode: string
+) => {
+  if (sakstypeKode === EU_EOS) {
+    return lagUrlForEuEøsFlyter(saksnummer, behandlingID, behandlingstemaKode);
+  }
+  if (sakstypeKode === FTRL) {
+    return lagUrlForFtrlFlyt(saksnummer, behandlingID, behandlingstemaKode);
+  }
+  if (sakstypeKode === TRYGDEAVTALE) {
+    return lagUrlForTrygdeavtaleFlyt(saksnummer, behandlingID, behandlingstemaKode);
+  }
+  throw new Error(`Støtter ikke sakstype: ${sakstypeKode}`);
+};
+
 export const lagUrl = (
   saksnummer: number | string,
   behandlingID: number,
@@ -57,7 +114,7 @@ export const lagUrl = (
   if (skalViseTomFlyt(sakstypeKode, sakstemaKode, behandlingstemaKode, behandlingstypeKode)) {
     return `/${sakstypeKode}/behandling/${saksnummer}/?behandlingID=${behandlingID}`;
   }
-  return lagUrlFraBehandlingstema(saksnummer, behandlingID, behandlingstemaKode);
+  return lagUrlFraSakstypeOgBehandlingstema(saksnummer, behandlingID, sakstypeKode, behandlingstemaKode);
 };
 
 const skalViseTomFlyt = (sakstype: string, sakstema: string, behandlingstema: string, behandlingstype: string) => {
@@ -73,6 +130,12 @@ const skalViseTomFlyt = (sakstype: string, sakstema: string, behandlingstema: st
   if (
     sakstype === TRYGDEAVTALE &&
     behandlingstema === MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL
+  ) {
+    return true;
+  }
+  if (
+    [FTRL, TRYGDEAVTALE].includes(sakstype) &&
+    behandlingstema === MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV
   ) {
     return true;
   }

--- a/src/routing/url.ts
+++ b/src/routing/url.ts
@@ -6,44 +6,10 @@ const { HENVENDELSE, KLAGE } = MKV.Koder.behandlinger.behandlingstyper;
 
 const erSedBehandling = (behandlingstema: string) => {
   return [
-    MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV,
     MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
     MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_MED,
     MKV.Koder.behandlinger.behandlingstema.ØVRIGE_SED_UFM,
   ].includes(behandlingstema);
-};
-
-export const lagUrlFraBehandlingstema = (
-  saksnummer: number | string,
-  behandlingID: number,
-  behandlingstemaKode: string
-) => {
-  if (erSedBehandling(behandlingstemaKode)) {
-    return `/${EU_EOS}/sedbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
-  }
-  switch (behandlingstemaKode) {
-    case MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING:
-    case MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE:
-      return `/${EU_EOS}/registrering/${saksnummer}/unntaksperioder/?behandlingID=${behandlingID}`;
-    case MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL:
-      return `/${EU_EOS}/registrering/${saksnummer}/anmodningunntak/?behandlingID=${behandlingID}`;
-    case MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER:
-    case MKV.Koder.behandlinger.behandlingstema.UTSENDT_SELVSTENDIG:
-    case MKV.Koder.behandlinger.behandlingstema.ARBEID_ETT_LAND_ØVRIG:
-    case MKV.Koder.behandlinger.behandlingstema.ARBEID_TJENESTEPERSON_ELLER_FLY:
-    case MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND:
-    case MKV.Koder.behandlinger.behandlingstema.ARBEID_NORGE_BOSATT_ANNET_LAND:
-      return `/${EU_EOS}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
-    case MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE:
-    case MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_ANNET_LAND:
-      return `/${EU_EOS}/vurderutpeking/${saksnummer}/?behandlingID=${behandlingID}`;
-    case MKV.Koder.behandlinger.behandlingstema.ARBEID_I_UTLANDET:
-      return `/${FTRL}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
-    case MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV:
-      return `/${TRYGDEAVTALE}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
-    default:
-      return null;
-  }
 };
 
 const lagUrlForEuEøsFlyter = (saksnummer: number | string, behandlingID: number, behandlingstemaKode: string) => {
@@ -133,14 +99,9 @@ const skalViseTomFlyt = (sakstype: string, sakstema: string, behandlingstema: st
   ) {
     return true;
   }
-  if (
-    [FTRL, TRYGDEAVTALE].includes(sakstype) &&
-    behandlingstema === MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV
-  ) {
-    return true;
-  }
 
   return [
+    MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV,
     MKV.Koder.behandlinger.behandlingstema.ARBEID_KUN_NORGE,
     MKV.Koder.behandlinger.behandlingstema.PENSJONIST,
     MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK,


### PR DESCRIPTION
Gjør lagUrl avhengig av sakstype hele veien ikke bare for tom flyt.

Dukket opp underveis under test at det kan dukke opp misvisende url-er: feks sakstype TRYGDEAVTALE men EUEØS i url-en. Dette fordi vi tidligere hadde mapping av url basert kun på behandlingstema. Nå kan flere sakstyper ha samme behandlingstema, og det må vi støtte. 

~Tar opp med fag om IKKE_YRKESAKTIV skal bruke "eueøs" sin sedflyt, eller om den skal ha tom flyt istedenfor når det er FTRL eller TRYGDEAVTALE. Det temaet skal ha tom flyt: https://jira.adeo.no/browse/MELOSYS-5205, men sedbehandling er i prinsipp også tom flyt.~
Avklart med Mina. Vi flytter IKKE_YRKESAKTIV for EU_EØS over til tom flyt slik at det blir likt for alle sakstyper. Endrer dette i koden også.


https://jira.adeo.no/browse/MELOSYS-5461