### PR TITLE
5453 Innhenting av registeropplysninger så ut til å feile pga tom periode

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiode.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/utenlandsoppdraget/soknadsperiode/soknadsperiode.tsx
@@ -8,6 +8,7 @@ import MKV from "../../../../../melosyskodeverk";
 import * as Utils from "../../../../../utils";
 import * as Nav from "../../../../../navFrontend";
 import * as Symboler from "../../symboler";
+import * as Hooks from "../../../../../hooks";
 
 import { Periode } from "../../../../../services/modules/mottatteOpplysninger/types";
 import {
@@ -57,6 +58,7 @@ export const Soknadsperiode = ({
   const [soknadsperiodeTom, setSoknadsperiodeTom] = useState(props.soknadsperiodeTom);
   const [soknadsperiodeGammelFom, setSoknadsperiodeGammelFom] = useState(props.soknadsperiodeFom);
   const [soknadsperiodeGammelTom, setSoknadsperiodeGammelTom] = useState(props.soknadsperiodeTom);
+  const isMounted = Hooks.useIsMounted();
 
   const oppdaterPeriode = (fom: string, tom: string) => {
     props.oppdaterPeriode({
@@ -67,9 +69,9 @@ export const Soknadsperiode = ({
 
   useEffect(() => {
     return () => {
-      oppdaterPeriode(soknadsperiodeGammelFom, soknadsperiodeGammelTom);
+      if (!isMounted.current) oppdaterPeriode(soknadsperiodeGammelFom, soknadsperiodeGammelTom);
     };
-  }, []);
+  }, [soknadsperiodeGammelFom, soknadsperiodeGammelTom]);
 
   useEffect(() => {
     oppdaterPeriode(soknadsperiodeFom, soknadsperiodeTom);


### PR DESCRIPTION
Visning av arbeidsforhold vistes ikke når periode var null, så feilen stammet fra at vi resatte periode til null når vi trykket oss ut av Periode-menypanelet. Dette ble ikke oppdatert i backend siden vi har valideringer på dette, og det løste seg derfor når vi refreshet siden og fikk clean mottatteOpplysnigner.Periode.

Periode ble omskrevet til functional component ganske nylig så problemet har ikke vart lenge. 

Periode ble resatt til initial state for gammel periode istedenfor de oppdaterte statesene. Dette fordi useEffect uten dependency ikke når oppdaterte verdier for useState, men heller brukte initialValues - som i scenarioet saken beskriver var "tom periode". Enkel løsning på dette hadde vært å legge til dependencies (gammelFom, gammelTom) på useStaten som kjører onUnmount, men denne viste seg på kjøre hver gang disse endret seg - noe vi ikke ønsker. Brukte derfor vår egen hook som sjekker om klassen isMounted og kjørte onUnmount kun når denne var false.

https://jira.adeo.no/browse/MELOSYS-5453