### PR TITLE
Reset skjema felter for opprett fagsak

### DIFF
--- a/src/sider/journalforing/journalforing.js
+++ b/src/sider/journalforing/journalforing.js
@@ -319,6 +319,7 @@ class Journalforing extends Component {
     settFeltInnhold("representantID", null);
     settFeltInnhold("representantKontaktPerson", null);
     settFeltInnhold("representantRepresenterer", null);
+    settFeltInnhold("representantNavn", null);
     settFeltInnhold("journalforingSoknadsland", []);
     settFeltInnhold("journalforingSoknadslandUkjenteEllerAlleEosLand", false);
   };


### PR DESCRIPTION
I schema forventes det at dersom representantNavn ikke er tom, så skal
vi sjekke representantRepresenterer, siden vi resetter alt av
representant kan vi også resette representantNavn. Tror jeg? :p
