### PR TITLE
5534 TOGGLE DAPI Vise korrekt mottaksdato

### DIFF
--- a/src/felleskomponenter/oppsummering/oppsummering.tsx
+++ b/src/felleskomponenter/oppsummering/oppsummering.tsx
@@ -1,16 +1,19 @@
-import React, { useState } from "react";
-import PT from "prop-types";
+import React, { useEffect, useState } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { RootState } from "AppTypes";
 import classNames from "classnames";
 import { KTObject } from "@navikt/melosys-kodeverk";
 
 import MKV, { MKVUtils } from "../../melosyskodeverk";
 import * as KV from "../../kodeverk";
-import * as MPT from "../../proptypes";
 import * as Nav from "../../navFrontend";
 import * as Api from "../../services/api";
 import * as Ikoner from "../../resources/images";
 import * as Utils from "../../utils";
 import * as Mui from "../ui";
+
+import { fagsakSelectors } from "../../ducks/fagsaker";
+import { behandlingerSelectors } from "../../ducks/behandlinger";
 
 import { useFeatureToggle } from "../../featuretoggle";
 import { BehandlingsstatusMedSvarfrist } from "../behandlingsstatus";
@@ -20,41 +23,46 @@ import EndreBehandlingModal from "./endreBehandlingModal";
 
 import "./oppsummering.css";
 
-interface OppsummeringProps {
-  oppsummering: Api.Behandlinger.behandling.Oppsummering;
-  fagsak: Api.Fagsak;
-  arbeidsland: KTObject[];
-  lovvalgsland: KTObject;
-  mottattDato: string;
+const { AVSLUTTET, IVERKSETTER_VEDTAK, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Koder.behandlinger.behandlingsstatus;
+const behandlingsStatusMedBegrensetRettigheter = [AVSLUTTET, IVERKSETTER_VEDTAK, MIDLERTIDIG_LOVVALGSBESLUTNING];
+
+const mapStateToProps = (state: RootState) => ({
+  behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
+  fagsak: fagsakSelectors.FagsakSelector(state),
+  oppsummering: behandlingerSelectors.OppsummeringSelector(state),
+});
+
+const connector = connect(mapStateToProps);
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+type OppsummeringProps = PropsFromRedux & {
+  arbeidsland?: KTObject[];
+  lovvalgsland?: KTObject;
+  mottattDato?: string;
   lovvalgsperiodeFom: string;
   lovvalgsperiodeTom: string;
   mottatteOpplysningerPeriodeFom: string;
   mottatteOpplysningerPeriodeTom: string;
   className?: string;
-}
-const { AVSLUTTET, IVERKSETTER_VEDTAK, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Koder.behandlinger.behandlingsstatus;
-const behandlingsStatusMedBegrensetRettigheter = [AVSLUTTET, IVERKSETTER_VEDTAK, MIDLERTIDIG_LOVVALGSBESLUTNING];
+};
 
-const Oppsummering = (props: OppsummeringProps) => {
-  const {
-    oppsummering,
-    fagsak,
-    arbeidsland,
-    lovvalgsland,
-    mottattDato,
-    lovvalgsperiodeFom,
-    lovvalgsperiodeTom,
-    mottatteOpplysningerPeriodeFom,
-    mottatteOpplysningerPeriodeTom,
-    className,
-  } = props;
+const Oppsummering = ({
+  oppsummering,
+  fagsak,
+  arbeidsland,
+  lovvalgsland,
+  lovvalgsperiodeFom,
+  lovvalgsperiodeTom,
+  mottatteOpplysningerPeriodeFom,
+  mottatteOpplysningerPeriodeTom,
+  className,
+  behandlingID,
+  ...props
+}: OppsummeringProps) => {
   const behandleAlleSakerToggle = useFeatureToggle("melosys.behandle_alle_saker");
   const [skalViseEndreModal, setSkalViseEndreModal] = useState(false);
-
-  const disableEndreKnapp = behandlingsStatusMedBegrensetRettigheter.includes(oppsummering.behandlingsstatus.kode);
-  const erLitenSkjerm = Utils.mediaQuery.useMediaQuery({ maxWidth: 1440 });
-
-  if (!oppsummering || !fagsak?.sakstype) return <div />;
+  const [mottaksdato, setMottaksdato] = useState<string | undefined>(props.mottattDato);
 
   const { saksnummer, sakstype, sakstema, registrertDato, hovedpartRolle } = fagsak;
   const {
@@ -67,22 +75,31 @@ const Oppsummering = (props: OppsummeringProps) => {
     behandlingsstatus,
     behandlingsresultattype,
   } = oppsummering;
-  const lovvalgsperiode = `${lovvalgsperiodeFom} - ${lovvalgsperiodeTom}`;
-  const mottatteOpplysningerperiode = `${mottatteOpplysningerPeriodeFom} - ${mottatteOpplysningerPeriodeTom}`;
 
-  const landStorBokstav = (land: KTObject) =>
+  const disableEndreKnapp = behandlingsStatusMedBegrensetRettigheter.includes(oppsummering.behandlingsstatus.kode);
+  const erLitenSkjerm = Utils.mediaQuery.useMediaQuery({ maxWidth: 1440 });
+
+  const erSed = behandlingstype?.kode === MKV.Koder.behandlinger.behandlingstyper.SED;
+  const erTrygdeavtale = sakstype?.kode === MKV.Koder.sakstyper.TRYGDEAVTALE;
+  const hovedpartErVirksomhet = hovedpartRolle === MKV.Koder.aktoersroller.VIRKSOMHET;
+
+  useEffect(() => {
+    if (behandleAlleSakerToggle === "enabled") {
+      Api.Behandlinger.aarsak
+        .hentMottaksdato(behandlingID)
+        .then((response) => setMottaksdato(Utils.dato.formatterDatoTilNorsk(response.mottaksdato)));
+    }
+  }, [behandleAlleSakerToggle]);
+
+  const landStorBokstav = (land?: KTObject) =>
     land?.term ? Utils.streng.storeForbokstaverForLand(land.term) : "Ukjent";
 
-  const landTilSetning = (land: KTObject[]) =>
+  const landTilSetning = (land?: KTObject[]) =>
     land && land.length > 0
       ? Utils.streng.arrayTilKonjunksjon(
           land.map((enkeltLand) => Utils.streng.storeForbokstaverForLand(enkeltLand.term || ""))
         )
       : "Ukjent";
-
-  const erSed = behandlingstype && KV.objektTilKode(behandlingstype) === MKV.Koder.behandlinger.behandlingstyper.SED;
-  const erTrygdeavtale = sakstype && KV.objektTilKode(sakstype) === MKV.Koder.sakstyper.TRYGDEAVTALE;
-  const hovedpartErVirksomhet = hovedpartRolle === MKV.Koder.aktoersroller.VIRKSOMHET;
 
   const tabellEnKolonne = (data: string[][]) => {
     const rows: JSX.Element[] = [];
@@ -132,12 +149,15 @@ const Oppsummering = (props: OppsummeringProps) => {
       col1 = [["Beh. opprettet", Utils.dato.formatterDatoTilNorsk(registrertDato)]];
       col2 = [["Sist oppdatert", Utils.dato.formatterDatoTilNorsk(endretDato), `  ${endretAvNavn}`]];
     } else {
+      const lovvalgsperiode = `${lovvalgsperiodeFom} - ${lovvalgsperiodeTom}`;
+      const mottatteOpplysningerperiode = `${mottatteOpplysningerPeriodeFom} - ${mottatteOpplysningerPeriodeTom}`;
+
       col1 = [erSed ? ["Periode fra SED", lovvalgsperiode] : ["Søknadsperiode", mottatteOpplysningerperiode]];
       if (erTrygdeavtale) col1.push(["Lovvalgsperiode", lovvalgsperiode]);
       col1.push(["Land", erSed ? landStorBokstav(lovvalgsland) : landTilSetning(arbeidsland)]);
 
       col2 = [
-        ["Søknad mottatt", mottattDato || "-"],
+        ["Søknad mottatt", mottaksdato || "-"],
         ["Beh. opprettet", Utils.dato.formatterDatoTilNorsk(registrertDato)],
         ["Sist oppdatert", Utils.dato.formatterDatoTilNorsk(endretDato), `  ${endretAvNavn}`],
       ];
@@ -145,6 +165,9 @@ const Oppsummering = (props: OppsummeringProps) => {
 
     return erLitenSkjerm ? tabellEnKolonne(col1.concat(col2)) : tabellToKolonner(col1, col2);
   };
+
+  if (!fagsak?.sakstype) return <div />;
+
   return (
     <section aria-label="oppsummeringer" className="oppsummering panelSeksjon">
       <EndreBehandlingModal
@@ -232,25 +255,4 @@ const Oppsummering = (props: OppsummeringProps) => {
   );
 };
 
-Oppsummering.propTypes = {
-  arbeidsland: PT.arrayOf(MPT.Kodeverk),
-  lovvalgsland: MPT.Kodeverk,
-  fagsak: MPT.Fagsak.isRequired,
-  oppsummering: MPT.Behandlinger.Oppsummering.isRequired,
-  mottatteOpplysningerperiode: PT.string,
-  lovvalgsperiode: PT.string,
-  lovvalgsperiodeFom: PT.string,
-  lovvalgsperiodeTom: PT.string,
-  mottattDato: PT.string,
-  className: PT.string,
-};
-Oppsummering.defaultProps = {
-  arbeidsland: [],
-  lovvalgsland: {},
-  mottatteOpplysningerperiode: undefined,
-  lovvalgsperiode: undefined,
-  mottattDato: undefined,
-  className: undefined,
-};
-
-export default Oppsummering;
+export default connector(Oppsummering);

--- a/src/services/modules/behandlinger/aarsak.tsx
+++ b/src/services/modules/behandlinger/aarsak.tsx
@@ -1,8 +1,8 @@
 import { getAsJson } from "../../utils";
-import { API_BASE_URL } from "../../api-constants";
+import { API_BASE_URL, BEHANDLINGER } from "../../api-constants";
 
 export type MottaksdatoResponse = {
   mottaksdato?: string;
 };
 export const hentMottaksdato = (behandlingID: string): Promise<MottaksdatoResponse> =>
-  getAsJson(`${API_BASE_URL}behandlingsaarsak/${behandlingID}/mottaksdato`);
+  getAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/aarsak/mottaksdato`);

--- a/src/services/modules/behandlinger/aarsak.tsx
+++ b/src/services/modules/behandlinger/aarsak.tsx
@@ -1,0 +1,8 @@
+import { getAsJson } from "../../utils";
+import { API_BASE_URL } from "../../api-constants";
+
+export type MottaksdatoResponse = {
+  mottaksdato?: string;
+};
+export const hentMottaksdato = (behandlingID: string): Promise<MottaksdatoResponse> =>
+  getAsJson(`${API_BASE_URL}behandlingsaarsak/${behandlingID}/mottaksdato`);

--- a/src/services/modules/behandlinger/index.js
+++ b/src/services/modules/behandlinger/index.js
@@ -5,5 +5,6 @@ import * as status from "./status";
 import * as tema from "./tema";
 import * as type from "./type";
 import * as behandlingsfrist from "./behandlingsfrist";
+import * as aarsak from "./aarsak";
 
-export { behandling, perioder, resultat, status, tema, type, behandlingsfrist };
+export { behandling, perioder, resultat, status, tema, type, behandlingsfrist, aarsak };

--- a/src/sider/eu_eøs/registrering/registrering.js
+++ b/src/sider/eu_eøs/registrering/registrering.js
@@ -38,8 +38,6 @@ export const Registrering = ({
   sed,
   redigerbart,
   Saksopplysninger,
-  fagsak,
-  oppsummering,
   lovvalgsperiodeFom,
   lovvalgsperiodeTom,
   lovvalgsland,
@@ -102,8 +100,6 @@ export const Registrering = ({
               </Nav.Column>
               <Nav.Column xs="5">
                 <Oppsummering
-                  oppsummering={oppsummering}
-                  fagsak={fagsak}
                   lovvalgsland={lovvalgsland}
                   lovvalgsperiodeFom={lovvalgsperiodeFom}
                   lovvalgsperiodeTom={lovvalgsperiodeTom}
@@ -128,9 +124,7 @@ Registrering.propTypes = {
   redigerbart: PT.bool,
   avklartefakta: MPT.AvklartefaktaListe,
   vurderingBegrunnelser: PT.arrayOf(PT.string),
-  fagsak: MPT.Fagsak,
   lovvalgsperioder: PT.array.isRequired, // TODO lag proptype
-  oppsummering: MPT.Behandlinger.Oppsummering,
   sed: MPT.Behandlinger.Saksopplysninger.SED,
   match: PT.object.isRequired,
   location: PT.object.isRequired,
@@ -146,8 +140,6 @@ Registrering.propTypes = {
 Registrering.defaultProps = {
   redigerbart: null,
   avklartefakta: [],
-  fagsak: {},
-  oppsummering: {},
   sed: {},
   lovvalgsperiodeFom: undefined,
   lovvalgsperiodeTom: undefined,
@@ -158,9 +150,7 @@ const mapStateToProps = (state) => ({
   hovedpartRolle: fagsakSelectors.HovedpartRolleSelector(state),
   avklartefakta: avklartefaktaSelectors.AvklartefaktaSelector(state),
   vurderingBegrunnelser: behandlingsresultatSelectors.KontrollresultatBegrunnelseKoderSelector(state),
-  fagsak: fagsakSelectors.FagsakSelector(state),
   lovvalgsperioder: lovvalgsperioderSelectors.LovvalgsperioderSelector(state),
-  oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   sed: behandlingerSelectors.SEDSelector(state),
   lovvalgsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeFomSelector(state)),
   lovvalgsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeTomSelector(state)),

--- a/src/sider/eu_eøs/saksbehandling/saksbehandling.js
+++ b/src/sider/eu_eøs/saksbehandling/saksbehandling.js
@@ -159,8 +159,6 @@ class Saksbehandling extends Component {
   render() {
     const {
       redigerbart,
-      fagsak,
-      oppsummering,
       lovvalgsperiodeFom,
       lovvalgsperiodeTom,
       visOppfriskModal,
@@ -205,8 +203,6 @@ class Saksbehandling extends Component {
                 </Nav.Column>
                 <Nav.Column xs="5">
                   <Oppsummering
-                    oppsummering={oppsummering}
-                    fagsak={fagsak}
                     arbeidsland={arbeidsland}
                     mottattDato={mottatteOpplysningerMottaksdato}
                     lovvalgsperiodeFom={lovvalgsperiodeFom}
@@ -231,7 +227,6 @@ Saksbehandling.propTypes = {
   hovedpartRolle: PT.string.isRequired,
   redigerbart: PT.bool,
   avklartefakta: MPT.AvklartefaktaListe,
-  fagsak: MPT.Fagsak,
   vilkar: PT.array, // TODO lag proptype
   behandlingsPeriode: PT.object.isRequired, // TODO lag proptype
   lovvalgsperioder: PT.array.isRequired, // TODO lag proptype
@@ -264,7 +259,6 @@ Saksbehandling.propTypes = {
   sendAnmodningsperioder: PT.func.isRequired,
   anmodningsperioderErSendtUtlandet: PT.bool.isRequired,
   resetSaksopplysninger: PT.func.isRequired,
-  oppsummering: MPT.Behandlinger.Oppsummering,
   lovvalgsperiodeFom: PT.string,
   lovvalgsperiodeTom: PT.string,
   arbeidsland: PT.arrayOf(MPT.Kodeverk).isRequired,
@@ -283,12 +277,10 @@ Saksbehandling.propTypes = {
 Saksbehandling.defaultProps = {
   redigerbart: null,
   avklartefakta: [],
-  fagsak: {},
   vilkar: [],
   skjema: {},
   anmodningsperioder: [],
   artikkel16_skjema: {},
-  oppsummering: undefined,
   lovvalgsperiodeFom: undefined,
   lovvalgsperiodeTom: undefined,
 };
@@ -299,8 +291,6 @@ Saksbehandling.defaultProps = {
 const mapStateToProps = (state) => ({
   redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   avklartefakta: avklartefaktaSelectors.AvklartefaktaSelector(state),
-  fagsak: fagsakSelectors.FagsakSelector(state),
-  oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   lovvalgsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeFomSelector(state)),
   lovvalgsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeTomSelector(state)),
   oppfriskning: saksopplysningerSelectors.SaksopplysningerSelector(state),

--- a/src/sider/eu_eøs/sedbehandling/sedbehandling.tsx
+++ b/src/sider/eu_eøs/sedbehandling/sedbehandling.tsx
@@ -17,8 +17,6 @@ import SaksoversiktLenke from "../../../felleskomponenter/saksoversiktLenke";
 import { TomFlytMelding } from "../../../felleskomponenter/alertmeldinger";
 import { SoknadMenypanelForm } from "../../../felleskomponenter/menypanelForm";
 import { useFeatureToggle } from "../../../featuretoggle";
-
-import { fagsakSelectors } from "../../../ducks/fagsaker";
 import { behandlingerSelectors } from "../../../ducks/behandlinger";
 import { redigerbartSelectors } from "../../../ducks/redigerbart";
 import { datalastingOperations } from "../../../ducks/datalasting";
@@ -27,8 +25,6 @@ import { mottatteOpplysningerOperations, mottatteOpplysningerSelectors } from ".
 import "./sedbehandling.css";
 
 const mapStateToProps = (state: RootState) => ({
-  fagsak: fagsakSelectors.FagsakSelector(state),
-  oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
   lovvalgsland: behandlingerSelectors.LovvalgslandSelector(state),
@@ -62,8 +58,6 @@ const SedBehandling = ({
   match,
   behandlingstema,
   redigerbart,
-  fagsak,
-  oppsummering,
   lovvalgsland,
   mottatteOpplysningerPeriodeFom,
   mottatteOpplysningerPeriodeTom,
@@ -117,8 +111,6 @@ const SedBehandling = ({
               </Nav.Column>
               <Nav.Column xs="5">
                 <Oppsummering
-                  oppsummering={oppsummering}
-                  fagsak={fagsak}
                   lovvalgsland={behandlingstemaErIkkeYrkesaktiv ? lovvalgsland : null}
                   lovvalgsperiodeFom={lovvalgsperiodeFom}
                   lovvalgsperiodeTom={lovvalgsperiodeTom}

--- a/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
+++ b/src/sider/eu_eøs/vurderutpeking/vurderutpeking.js
@@ -52,8 +52,6 @@ const Vurderutpeking = ({
   behandlingstema,
   hovedpartRolle,
   redigerbart,
-  fagsak,
-  oppsummering,
   lovvalgsperiodeFom,
   lovvalgsperiodeTom,
   arbeidsland,
@@ -134,8 +132,6 @@ const Vurderutpeking = ({
               </Nav.Column>
               <Nav.Column xs="5">
                 <Oppsummering
-                  oppsummering={oppsummering}
-                  fagsak={fagsak}
                   arbeidsland={arbeidsland}
                   lovvalgsland={lovvalgslandKTOBject}
                   lovvalgsperiodeFom={lovvalgsperiodeFom}
@@ -161,8 +157,6 @@ Vurderutpeking.propTypes = {
   behandlingstema: PT.string.isRequired,
   hovedpartRolle: PT.string.isRequired,
   redigerbart: PT.bool.isRequired,
-  fagsak: MPT.Fagsak.isRequired,
-  oppsummering: MPT.Behandlinger.Oppsummering.isRequired,
   lovvalgsperiodeFom: PT.string.isRequired,
   lovvalgsperiodeTom: PT.string.isRequired,
   arbeidsland: PT.arrayOf(MPT.Kodeverk).isRequired,
@@ -192,8 +186,6 @@ const mapStateToProps = (state) => ({
   behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
   hovedpartRolle: fagsakSelectors.HovedpartRolleSelector(state),
   redigerbart: redigerbartSelectors.RedigerbartSelector(state),
-  fagsak: fagsakSelectors.FagsakSelector(state),
-  oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   lovvalgsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeFomSelector(state)),
   lovvalgsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeTomSelector(state)),
   arbeidsland: avklartefaktaSelectors.ArbeidslandKTSelector(state),

--- a/src/sider/ftrl/saksbehandling/saksbehandling.js
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.js
@@ -50,7 +50,6 @@ const Saksbehandling = ({
   mottatteOpplysningerPeriodeTom,
   mottatteOpplysningerMottaksdato,
   behandlingsresultat,
-  fagsak,
   fagsakStatusKode,
   hentBehandling,
   hentMottatteOpplysninger,
@@ -67,7 +66,6 @@ const Saksbehandling = ({
   landkoder,
   location,
   match,
-  oppsummering,
   redigerbart,
   resetBehandlingerState,
   resetMottatteOpplysningerState,
@@ -207,8 +205,6 @@ const Saksbehandling = ({
               </Nav.Column>
               <Nav.Column xs="5">
                 <Oppsummering
-                  oppsummering={oppsummering}
-                  fagsak={fagsak}
                   arbeidsland={
                     landkoder && landkoder.filter((landkodeObjekt) => arbeidsland.includes(landkodeObjekt.kode))
                   }
@@ -239,14 +235,12 @@ Saksbehandling.propTypes = {
   mottatteOpplysningerPeriodeTom: PT.string.isRequired,
   mottatteOpplysningerMottaksdato: PT.string.isRequired,
   behandlingsresultat: MPT.Behandlingsresultat.isRequired,
-  fagsak: MPT.Fagsak,
   fagsakStatusKode: PT.string.isRequired,
   hovedpartRolle: PT.string.isRequired,
   history: PT.object.isRequired,
   landkoder: PT.arrayOf(MPT.Kodeverk).isRequired,
   location: PT.object.isRequired,
   match: PT.object.isRequired,
-  oppsummering: MPT.Behandlinger.Oppsummering,
   redigerbart: PT.bool,
   soknadForm: PT.object.isRequired,
   // Funcs
@@ -277,8 +271,6 @@ Saksbehandling.propTypes = {
 
 Saksbehandling.defaultProps = {
   mottatteOpplysninger: {},
-  fagsak: {},
-  oppsummering: undefined,
   redigerbart: null,
 };
 

--- a/src/sider/tomFlyt/behandling.tsx
+++ b/src/sider/tomFlyt/behandling.tsx
@@ -21,7 +21,7 @@ import Informasjonlinje from "../../felleskomponenter/informasjonlinje";
 import { SoknadMenypanelForm } from "../../felleskomponenter/menypanelForm";
 import Oppsummering from "../../felleskomponenter/oppsummering";
 import SaksoversiktLenke from "../../felleskomponenter/saksoversiktLenke";
-import { VirksomhetMelding, TomFlytMelding } from "../../felleskomponenter/alertmeldinger";
+import { TomFlytMelding, VirksomhetMelding } from "../../felleskomponenter/alertmeldinger";
 import SideDialog, { defaultFaner, fanerUtenBucOgSed } from "../../felleskomponenter/sideDialog";
 
 import "./behandling.css";
@@ -35,13 +35,11 @@ const mapStateToProps = (state: RootState) => ({
     mottatteOpplysningerSelectors.PeriodeTomSelector(state)
   ),
   behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
-  fagsak: fagsakSelectors.FagsakSelector(state),
   hovedpartRolle: fagsakSelectors.HovedpartRolleSelector(state),
   lovvalgsland: lovvalgsperioderSelectors.LovvalgslandSelector(state),
   lovvalgsperiodeFom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeFomSelector(state)),
   lovvalgsperiodeTom: Utils.dato.formatterDatoTilNorsk(behandlingerSelectors.LovvalgsperiodeTomSelector(state)),
   mottaksdato: mottatteOpplysningerSelectors.MottaksdatoSelector(state),
-  oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   redigerbart: redigerbartSelectors.RedigerbartSelector(state),
 });
 
@@ -62,7 +60,6 @@ const Behandling = ({
   mottatteOpplysningerPeriodeFom,
   mottatteOpplysningerPeriodeTom,
   behandlingstema,
-  fagsak,
   hovedpartRolle,
   lastInnSaksopplysninger,
   location,
@@ -70,7 +67,6 @@ const Behandling = ({
   lovvalgsperiodeFom,
   lovvalgsperiodeTom,
   mottaksdato,
-  oppsummering,
   match: {
     params: { saksnr: saksnummer, sakstype },
   },
@@ -111,8 +107,6 @@ const Behandling = ({
             </Nav.Column>
             <Nav.Column xs="5">
               <Oppsummering
-                oppsummering={oppsummering}
-                fagsak={fagsak}
                 arbeidsland={arbeidsland}
                 lovvalgsland={lovvalgsland}
                 mottattDato={mottaksdato}

--- a/src/sider/trygdeavtale/saksbehandling.js
+++ b/src/sider/trygdeavtale/saksbehandling.js
@@ -40,7 +40,6 @@ const Saksbehandling = ({
   mottatteOpplysningerPeriodeFom,
   mottatteOpplysningerPeriodeTom,
   behandlingsresultat,
-  fagsak,
   fagsakStatusKode,
   hentBehandling,
   hentMottatteOpplysninger,
@@ -52,7 +51,6 @@ const Saksbehandling = ({
   location,
   match,
   oppfriskOgLastInnSaksopplysninger,
-  oppsummering,
   redigerbart,
   resetBehandlingerState,
   resetMottatteOpplysningerState,
@@ -165,8 +163,6 @@ const Saksbehandling = ({
               </Nav.Column>
               <Nav.Column xs="5">
                 <Oppsummering
-                  oppsummering={oppsummering}
-                  fagsak={fagsak}
                   arbeidsland={arbeidsland}
                   mottattDato={mottatteOpplysningerMottaksdato}
                   lovvalgsperiodeFom={mottatteOpplysningerPeriodeFom}
@@ -195,12 +191,10 @@ Saksbehandling.propTypes = {
   mottatteOpplysningerPeriodeTom: PT.string.isRequired,
   mottatteOpplysningerMottaksdato: PT.string.isRequired,
   behandlingsresultat: MPT.Behandlingsresultat.isRequired,
-  fagsak: MPT.Fagsak,
   fagsakStatusKode: PT.string.isRequired,
   hovedpartRolle: PT.string.isRequired,
   location: PT.object.isRequired,
   match: PT.object.isRequired,
-  oppsummering: MPT.Behandlinger.Oppsummering,
   redigerbart: PT.bool,
   soknadForm: PT.object.isRequired,
   // Funcs
@@ -224,8 +218,6 @@ Saksbehandling.propTypes = {
 
 Saksbehandling.defaultProps = {
   mottatteOpplysninger: {},
-  fagsak: {},
-  oppsummering: undefined,
   redigerbart: null,
 };
 
@@ -244,9 +236,7 @@ const mapStateToProps = (state) => ({
     mottatteOpplysningerSelectors.MottaksdatoSelector(state)
   ),
   behandlingsresultat: behandlingsresultatSelectors.BehandlingsresultatSelector(state),
-  fagsak: fagsakSelectors.FagsakSelector(state),
   fagsakStatusKode: fagsakSelectors.FagsakStatusSelector(state),
-  oppsummering: behandlingerSelectors.OppsummeringSelector(state),
   redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   soknadForm: formSelectors.SoknadenFormSelector(state),
   lovvalgsperiodeTom: Utils.dato.formatterDatoTilNorsk(lovvalgsperioderSelectors.TomDatoSelector(state)),


### PR DESCRIPTION
- Henter oppsummering og fagsak fra redux siden disse er like fra hvert sted som bruker Oppsummering. Da slapp vi også å hente disse i alle klassene som brukte Oppsummering.
- Henter mottaksdato fra backend dersom toggle er på, men viser default mottaksdato fra props - som typisk er fra mottatteopplysninger. 
- Justerte endel rekkefølge - beklager om det ble stygg PR av det. 
- Fjernet Proptypes.

Melosys-api: https://github.com/navikt/melosys-api/pull/1528

https://jira.adeo.no/browse/MELOSYS-5534