### PR TITLE
5556 TOGGLE Henter ikke mottatte opplysninger for tom flyt

### DIFF
--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -38,6 +38,13 @@ export const lastInnSaksopplysninger = (sakstype, saksnummer, behandlingID) => (
   }
 };
 
+export const lastInnSaksopplysningerTomFlyt = (saksnummer, behandlingID) => (dispatch) => {
+  dispatch(fagsakOperations.hent(saksnummer));
+  dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
+  dispatch(behandlingerOperations.hentBehandling(behandlingID));
+  dispatch(behandlingsresultatOperations.hent(behandlingID));
+};
+
 export const lastInnSaksopplysningerSedBehandling = (saksnummer, behandlingID) => (dispatch) => {
   dispatch(fagsakOperations.hent(saksnummer));
   dispatch(behandlingerOperations.hentBehandling(behandlingID));

--- a/src/sider/tomFlyt/behandling.tsx
+++ b/src/sider/tomFlyt/behandling.tsx
@@ -44,8 +44,8 @@ const mapStateToProps = (state: RootState) => ({
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
-  lastInnSaksopplysninger: (sakstype: string, saksnummer: string, behandlingID: number) =>
-    dispatch(datalastingOperations.lastInnSaksopplysninger(sakstype, saksnummer, behandlingID)),
+  lastInnSaksopplysninger: (saksnummer: string, behandlingID: number) =>
+    dispatch(datalastingOperations.lastInnSaksopplysningerTomFlyt(saksnummer, behandlingID)),
   resetSaksopplysninger: () => dispatch(datalastingOperations.resetSaksopplysninger()),
 });
 
@@ -68,7 +68,7 @@ const Behandling = ({
   lovvalgsperiodeTom,
   mottaksdato,
   match: {
-    params: { saksnr: saksnummer, sakstype },
+    params: { saksnr: saksnummer },
   },
   redigerbart,
   resetSaksopplysninger,
@@ -77,7 +77,7 @@ const Behandling = ({
   const saksopplysningerErLastet = !!behandlingstema;
 
   useEffect(() => {
-    lastInnSaksopplysninger(sakstype, saksnummer, behandlingID);
+    lastInnSaksopplysninger(saksnummer, behandlingID);
     return () => {
       resetSaksopplysninger();
     };


### PR DESCRIPTION
Lager egen lastInnSaksopplysninger for tom flyt og bruker denne tom flyt. De delen av tom flyt som gjelder SED har allerede egen lastInnSaksopplysninger-funksjon så de har ikke samme problemet.

https://jira.adeo.no/browse/MELOSYS-5556