### PR TITLE
5192: Legger til Azure spec så vi kan få klient-id i env-filer

### DIFF
--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -31,6 +31,9 @@ spec:
     requests:
       cpu: 100m
       memory: 256Mi
+  azure:
+    application:
+      enabled: true
   vault:
     enabled: true
   {{#if INGRESSES}}


### PR DESCRIPTION
DENNE SKAL IKKE MERGES, MEN BARE DEPLOYES. 
Lager PR for å synliggjøre branchen/deploymenten. 

Branchen inkluderer IKKE Azure endringer, og bruker fortsatt OpenAM. Inneholder _kun_ spec i nais-fil slik at nais oppretter klient i Azure AD.