### PR TITLE
5508 TOGGLE DAPI Logikk i hvilken periode som vises i journalføringen: lovvalgsperiode/soknadsperiode

### DIFF
--- a/src/felleskomponenter/oppgaveliste/fagsak.js
+++ b/src/felleskomponenter/oppgaveliste/fagsak.js
@@ -26,7 +26,8 @@ const Fagsak = ({ sak, visSakstema, landkoder }) => {
   const folketrygdenToggle = useFeatureToggle("melosys.folketrygden.mvp");
   const { opprettetDato, sakstype, saksstatus, saksnummer, sakstema, behandlingOversikter } = sak;
 
-  const { periode, land } = behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.periode != null) ?? {};
+  const { lovvalgsperiode, soknadsperiode, land } =
+    behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.lovvalgsperiode != null) ?? {};
   const tittel = visSakstema
     ? `${KV.objektTilTerm(sakstype)} - ${KV.objektTilTerm(sakstema)}`
     : `${KV.objektTilTerm(sakstype)}`;
@@ -66,7 +67,7 @@ const Fagsak = ({ sak, visSakstema, landkoder }) => {
             <dl className="fagsak__meta">
               <DatoOmradeDescription
                 label={behandleAlleSakerToggle === "enabled" ? "Lovvalgsperiode: " : "Periode: "}
-                periode={periode}
+                periode={behandleAlleSakerToggle === "enabled" ? lovvalgsperiode : soknadsperiode}
               />
               <dt>Land:</dt>
               <dd>

--- a/src/proptypes/behandlingOversikt.js
+++ b/src/proptypes/behandlingOversikt.js
@@ -11,7 +11,8 @@ const BehandligOversiktPropType = PT.shape({
     erUkjenteEllerAlleEosLand: PT.bool,
   }),
   opprettetDato: PT.string,
-  periode: Periode,
+  soknadsperiode: Periode,
+  lovvalgsperiode: Periode,
 });
 const BehandligOversikterPropType = PT.arrayOf(BehandligOversiktPropType);
 export { BehandligOversiktPropType as BehandligOversikt, BehandligOversikterPropType as BehandligOversikter };

--- a/src/sider/journalforing/komponenter/enkeltSak.js
+++ b/src/sider/journalforing/komponenter/enkeltSak.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from "react";
 import PT from "prop-types";
 
+import { MKVUtils } from "../../../melosyskodeverk";
 import * as KV from "../../../kodeverk";
 import * as MPT from "../../../proptypes";
 import * as Skjema from "../../../felleskomponenter/skjema";
@@ -19,12 +20,14 @@ import { useFeatureToggle } from "../../../featuretoggle";
 /** Den enkelte sak-elementet som brukes i iterasjon i listen
  */
 const EnkeltSak = (props) => {
+  const folketrygdenToggleEnabled = useFeatureToggle("melosys.folketrygden.mvp") === "enabled";
   const { behandleAlleSakerToggleEnabled, landkoder } = props;
   const { opprettetDato, behandlingOversikter, sakstype, saksstatus, saksnummer, sakstema } = props.sak;
 
-  const { land, behandlingstype, periode, behandlingsstatus, behandlingstema, svarFrist, behandlingID } =
+  const { behandlingstype, soknadsperiode, behandlingsstatus, behandlingstema, svarFrist, behandlingID } =
     behandlingOversikter[0];
-  const folketrygdenToggleEnabled = useFeatureToggle("melosys.folketrygden.mvp") === "enabled";
+  const { lovvalgsperiode, land } =
+    behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.lovvalgsperiode != null) ?? {};
 
   const link = behandleAlleSakerToggleEnabled
     ? lagUrl(
@@ -39,6 +42,9 @@ const EnkeltSak = (props) => {
     : lagUrlFraBehandlingstema(saksnummer, behandlingID, behandlingstema.kode);
 
   if (behandleAlleSakerToggleEnabled) {
+    const periode = MKVUtils.erAvsluttetEllerMidlertidigBeslutning(behandlingsstatus?.kode)
+      ? lovvalgsperiode
+      : soknadsperiode;
     return (
       <div className="enkeltSak">
         <Skjema.CustomRadioPanelElement
@@ -59,7 +65,7 @@ const EnkeltSak = (props) => {
             { description: KV.objektTilTerm(behandlingstema) },
             { description: <div className="behandlingstype">{KV.objektTilTerm(behandlingstype)}</div> },
             {
-              term: "Søknadsperiode:",
+              term: "Periode:",
               description: periode ? (
                 <Fragment>
                   <EnkeltDato dato={periode.fom} /> - <EnkeltDato dato={periode.tom} />
@@ -90,9 +96,9 @@ const EnkeltSak = (props) => {
         { term: "Behandlingstype:", description: KV.objektTilTerm(behandlingstype) },
         {
           term: "Søknadsperiode:",
-          description: periode ? (
+          description: soknadsperiode ? (
             <Fragment>
-              <EnkeltDato dato={periode.fom} /> - <EnkeltDato dato={periode.tom} />
+              <EnkeltDato dato={soknadsperiode.fom} /> - <EnkeltDato dato={soknadsperiode.tom} />
             </Fragment>
           ) : null,
         },


### PR DESCRIPTION
- Deler periode opp i soknadsperiode og lovvalgsperiode.
- Oppgavelisten skal fortsatt vise lovvalgsperioden, men journalforing skal bytte på å vise soknadsperiode og lovvalgsperiode basert på behandlingsstatusen.
- Lovvalgsperiode og land hentes fra den siste behandlingen som har vedtak/lovvalgsperiode. Dette tilsvarende logikk som allerede finnes i oppgavelisten.

https://jira.adeo.no/browse/MELOSYS-5508
API-endring som denne er avhengig av: https://github.com/navikt/melosys-api/pull/1559