### PR TITLE
5285 Endre sakstype tilbakemeldinger test

### DIFF
--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -363,7 +363,18 @@ const soknad = object().when("$behandlingstema", {
     soknadsland: object().shape({
       landkoder: array().when("erUkjenteEllerAlleEosLand", {
         is: (erUkjenteEllerAlleEosLand) => !erUkjenteEllerAlleEosLand,
-        then: array().min(
+        then: array().when("$behandlingstema", {
+          is: MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND,
+          then: array().min(
+            2,
+            lagMelding(
+              KV.Menypunkter.Utenlandsoppdraget.tittel,
+              KV.Menypunkter.Utenlandsoppdraget.undertitler.land,
+              "Det er påkrevd med to eller flere land for behandlingstema ARBEID_FLERE_LAND om ikke ukjenteEllerAlleEosLand er valgt"
+            )
+          ),
+        }),
+        otherwise: array().min(
           1,
           lagMelding(
             KV.Menypunkter.Utenlandsoppdraget.tittel,

--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -370,7 +370,7 @@ const soknad = object().when("$behandlingstema", {
             lagMelding(
               KV.Menypunkter.Utenlandsoppdraget.tittel,
               KV.Menypunkter.Utenlandsoppdraget.undertitler.land,
-              "Det er påkrevd med to eller flere land for behandlingstema ARBEID_FLERE_LAND om ikke ukjenteEllerAlleEosLand er valgt"
+              "Det er påkrevd med to eller flere land for dette behandlingstemaet"
             )
           ),
         }),

--- a/src/ducks/form/soknadSchema.js
+++ b/src/ducks/form/soknadSchema.js
@@ -373,15 +373,15 @@ const soknad = object().when("$behandlingstema", {
               "Det er påkrevd med to eller flere land for dette behandlingstemaet"
             )
           ),
+          otherwise: array().min(
+            1,
+            lagMelding(
+              KV.Menypunkter.Utenlandsoppdraget.tittel,
+              KV.Menypunkter.Utenlandsoppdraget.undertitler.land,
+              "Oppgi minst ett søknadsland"
+            )
+          ),
         }),
-        otherwise: array().min(
-          1,
-          lagMelding(
-            KV.Menypunkter.Utenlandsoppdraget.tittel,
-            KV.Menypunkter.Utenlandsoppdraget.undertitler.land,
-            "Oppgi minst ett søknadsland"
-          )
-        ),
       }),
       erUkjenteEllerAlleEosLand: boolean(),
     }),

--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -199,7 +199,10 @@ function EndreBehandlingModal({
   };
 
   const viserAlert = behandlingEndret || generellFeil?.length > 0;
-  const endringerErBegrenset = erBehandlingstemaMedBegrensetRettigheter(oppsummering.behandlingstema, fagsak.sakstype);
+  const endringerErBegrenset = erBehandlingstemaMedBegrensetRettigheter(
+    oppsummering.behandlingstema?.kode,
+    fagsak.sakstype?.kode
+  );
 
   const nullstillSak = (steg: FeltVerdier): void => {
     switch (steg) {

--- a/src/kodeverk/feilmeldinger.js
+++ b/src/kodeverk/feilmeldinger.js
@@ -13,5 +13,6 @@ export const FANT_INGEN_NAVN_PA_FNR_ELLER_DNR = { melding: "Fant ingen navn på 
 export const SKRIV_INN_GYLDIG_ORGNR = { melding: "Skriv inn gyldig org.nr." };
 export const FANT_INGEN_NAVN_PA_ORGNR = { melding: "Fant ingen navn på dette organisasjonsnummeret" };
 export const VELG_MINST_ETT_LAND = { melding: "Velg minst ett land" };
+export const VELG_MINST_TO_LAND = { melding: "Velg minst to land" };
 
 export const DU_KAN_IKKE_SKRIVE_MER_ENN_500_TEGN = "Du kan ikke skrive mer enn 500 tegn";

--- a/src/sider/journalforing/komponenter/journalforingSchema.js
+++ b/src/sider/journalforing/komponenter/journalforingSchema.js
@@ -13,6 +13,7 @@ const {
   SKRIV_INN_GYLDIG_ORGNR,
   FANT_INGEN_NAVN_PA_ORGNR,
   VELG_MINST_ETT_LAND,
+  VELG_MINST_TO_LAND,
 } = KV.Feilmeldinger;
 const { BRUKER, VIRKSOMHET } = MKV.Koder.aktoersroller;
 
@@ -238,7 +239,11 @@ const journalforing = object().shape({
         ],
         {
           is: kreverLand,
-          then: array().of(string()).min(1, { _error: VELG_MINST_ETT_LAND }),
+          then: array().when("opprettnysak_behandlingstema", {
+            is: MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND,
+            then: array().min(2, { _error: VELG_MINST_TO_LAND }),
+            otherwise: array().min(1, { _error: VELG_MINST_ETT_LAND }),
+          }),
         }
       ),
     otherwise: array()
@@ -254,7 +259,11 @@ const journalforing = object().shape({
         ],
         {
           is: kreverLandDeprecated,
-          then: array().of(string()).min(1, { _error: VELG_MINST_ETT_LAND }),
+          then: array().when("opprettnysak_behandlingstema", {
+            is: MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND,
+            then: array().min(2, { _error: VELG_MINST_TO_LAND }),
+            otherwise: array().min(1, { _error: VELG_MINST_ETT_LAND }),
+          }),
         }
       ),
   }),

--- a/src/sider/opprettnysak/opprettnysakSchema.js
+++ b/src/sider/opprettnysak/opprettnysakSchema.js
@@ -17,6 +17,7 @@ const {
   SKRIV_INN_GYLDIG_ORGNR,
   FANT_INGEN_NAVN_PA_ORGNR,
   VELG_MINST_ETT_LAND,
+  VELG_MINST_TO_LAND,
 } = KV.Feilmeldinger;
 const { BRUKER, VIRKSOMHET } = MKV.Koder.aktoersroller;
 
@@ -38,8 +39,8 @@ const kreverPeriode = (saksnummer, sakstype, sakstema, behandlingstema, behandli
   skalOppretteNySak(saksnummer) && skalViseSoknadsperiodeOgLand(sakstype, sakstema, behandlingstema, behandlingstype);
 
 // Fjernes med toggle melosys.behandle_alle_saker
-const kreverPeriodeDeprecated = (saksnummer, hovedpart, sakstype, behandlingstema) =>
-  skalOppretteNySak(saksnummer) && skalViseSoknadsperiodeOgLandDeprecated(hovedpart, sakstype, behandlingstema);
+const kreverPeriodeDeprecated = (hovedpart, sakstype, behandlingstema) =>
+  skalViseSoknadsperiodeOgLandDeprecated(hovedpart, sakstype, behandlingstema);
 
 const kreverLand = (
   saksnummer,
@@ -53,7 +54,7 @@ const kreverLand = (
   !soknadslandUkjenteEllerAlleEosLand;
 
 // Fjernes med toggle melosys.behandle_alle_saker
-const kreverLandDeprecated = (saksnummer, hovedpart, sakstype, behandlingstema, soknadslandUkjenteEllerAlleEosLand) =>
+const kreverLandDeprecated = (hovedpart, sakstype, behandlingstema, soknadslandUkjenteEllerAlleEosLand) =>
   kreverPeriodeDeprecated(hovedpart, sakstype, behandlingstema) && !soknadslandUkjenteEllerAlleEosLand;
 
 const opprettnysak = object().shape({
@@ -126,7 +127,7 @@ const opprettnysak = object().shape({
         }),
       otherwise: string()
         .nullable()
-        .when(["saksnummer", "hovedpart", "sakstype", "behandlingstema"], {
+        .when(["hovedpart", "sakstype", "behandlingstema"], {
           is: kreverPeriodeDeprecated,
           then: string().required(MAA_FYLLES_UT).erGyldigDato().nullable(),
         }),
@@ -145,40 +146,70 @@ const opprettnysak = object().shape({
         }),
       otherwise: string()
         .nullable()
-        .when(["saksnummer", "hovedpart", "sakstype", "behandlingstema"], {
-          is: (saksnummer, hovedpart, sakstype, behandlingstema) =>
-            skalOppretteNySak(saksnummer) && skalViseSoknadsperiodeOgLandDeprecated(sakstype, behandlingstema),
+        .when(["hovedpart", "sakstype", "behandlingstema"], {
+          is: kreverPeriodeDeprecated,
           then: string().erEtterDatofelt("periodeFraOgMed").erGyldigDato().required(MAA_FYLLES_UT).nullable(),
         }),
     }),
   soknadslandUkjenteEllerAlleEosLand: boolean().nullable(),
-  soknadsland: array().when("$behandleAlleSakerToggleEnabled", {
-    is: true,
-    then: array()
-      .of(string())
-      .ensure()
-      .when(
-        [
-          "saksnummer",
-          "sakstype",
-          "sakstema",
-          "behandlingstema",
-          "behandlingstype",
-          "soknadslandUkjenteEllerAlleEosLand",
-        ],
-        {
-          is: kreverLand,
-          then: array().of(string()).min(1, { _error: VELG_MINST_ETT_LAND }),
-        }
-      ),
-    otherwise: array()
-      .of(string())
-      .ensure()
-      .when(["saksnummer", "hovedpart", "sakstype", "behandlingstema", "soknadslandUkjenteEllerAlleEosLand"], {
-        is: kreverLandDeprecated(),
-        then: array().of(string()).min(1, { _error: VELG_MINST_ETT_LAND }),
-      }),
-  }),
+  soknadsland: array()
+    .when(
+      [
+        "behandleAlleSakerToggleEnabled",
+        "saksnummer",
+        "sakstype",
+        "sakstema",
+        "behandlingstema",
+        "behandlingstype",
+        "soknadslandUkjenteEllerAlleEosLand",
+      ],
+      {
+        is: (
+          behandleAlleSakerToggleEnabled,
+          saksnummer,
+          sakstype,
+          sakstema,
+          behandlingstema,
+          behandlingstype,
+          soknadslandUkjenteEllerAlleEosLand
+        ) =>
+          behandleAlleSakerToggleEnabled &&
+          kreverLand(
+            saksnummer,
+            sakstype,
+            sakstema,
+            behandlingstema,
+            behandlingstype,
+            soknadslandUkjenteEllerAlleEosLand
+          ),
+        then: array().when("behandlingstema", {
+          is: MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND,
+          then: array().min(2, { _error: VELG_MINST_TO_LAND }),
+          otherwise: array().min(1, { _error: VELG_MINST_ETT_LAND }),
+        }),
+      }
+    )
+    .when(
+      [
+        "behandleAlleSakerToggleEnabled",
+        "hovedpart",
+        "sakstype",
+        "behandlingstema",
+        "soknadslandUkjenteEllerAlleEosLand",
+      ],
+      {
+        is: (
+          behandleAlleSakerToggleEnabled,
+          hovedpart,
+          sakstype,
+          behandlingstema,
+          soknadslandUkjenteEllerAlleEosLand
+        ) =>
+          !behandleAlleSakerToggleEnabled &&
+          kreverLandDeprecated(hovedpart, sakstype, behandlingstema, soknadslandUkjenteEllerAlleEosLand),
+        then: array().min(1, { _error: VELG_MINST_ETT_LAND }),
+      }
+    ),
   oppgaveID: string()
     .nullable()
     .when("behandleAlleSakerToggleEnabled", {

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -108,7 +108,7 @@ const VurderingInngang = ({
   const behandleAlleSakerToggle = useFeatureToggle("melosys.behandle_alle_saker");
 
   useEffect(() => {
-    if (initialValues && initialValues.fom && !Utils._isEmpty(initialValues.fom)) {
+    if (!Utils._isEmpty(initialValues.fom) && !Utils._isEmpty(initialValues.arbeidsland)) {
       visMenypanel();
       setInitialFomTomLand({ fom: initialValues.fom, tom: initialValues.tom, arbeidsland: initialValues.arbeidsland });
     }


### PR DESCRIPTION
Se kommentar fra Annettei Jira-saken for beskrivelse av feilene. https://jira.adeo.no/browse/MELOSYS-5285

> 2. Sidemenyen i avtaleland-flyt (+ utenfor avtaleland-flyt når det er på plass) bør bli borte når man endrer sakstype, og periode beholdes.

Løses av https://github.com/navikt/melosys-web/commit/efba218f7b8be7f5a1fb1b4d82903f5a55bb79a5

> 3. Validering på antall land når vi har byttet til behandlingstema ARBEID_FLERE_LAND fra et annet behandlingstema med ett land med sakstype EU/EØS (periode og land beholdes)

Løses av https://github.com/navikt/melosys-web/commit/c5f60ee1569cb79d51d484780d1d216963ce3291

> 5. Det skal ikke være lov å gjøre endring på sakstype/tema når Behandlingstema:

Løses av https://github.com/navikt/melosys-web/commit/68ce386eb0438bcd9bd4878ea83c3164ef82c75c

Velger å ikke skrive TOGGLE på dette, siden deler av den nye ARBEID_FLERE_LAND valideringen også gjelder når toggle er av. 