### PR TITLE
5508 Endrer logikk på hvor vi henter søknadsperiode og land fra

### DIFF
--- a/src/felleskomponenter/oppgaveliste/fagsak.js
+++ b/src/felleskomponenter/oppgaveliste/fagsak.js
@@ -26,7 +26,9 @@ const Fagsak = ({ sak, visSakstema, landkoder }) => {
   const folketrygdenToggle = useFeatureToggle("melosys.folketrygden.mvp");
   const { opprettetDato, sakstype, saksstatus, saksnummer, sakstema, behandlingOversikter } = sak;
 
-  const { lovvalgsperiode, soknadsperiode, land } =
+  const { soknadsperiode, land } =
+    behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.soknadsperiode != null) ?? {};
+  const { lovvalgsperiode } =
     behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.lovvalgsperiode != null) ?? {};
   const tittel = visSakstema
     ? `${KV.objektTilTerm(sakstype)} - ${KV.objektTilTerm(sakstema)}`

--- a/src/sider/journalforing/komponenter/enkeltSak.js
+++ b/src/sider/journalforing/komponenter/enkeltSak.js
@@ -24,9 +24,10 @@ const EnkeltSak = (props) => {
   const { behandleAlleSakerToggleEnabled, landkoder } = props;
   const { opprettetDato, behandlingOversikter, sakstype, saksstatus, saksnummer, sakstema } = props.sak;
 
-  const { behandlingstype, soknadsperiode, behandlingsstatus, behandlingstema, svarFrist, behandlingID } =
-    behandlingOversikter[0];
-  const { lovvalgsperiode, land } =
+  const { behandlingstype, behandlingsstatus, behandlingstema, svarFrist, behandlingID } = behandlingOversikter[0];
+  const { soknadsperiode, land } =
+    behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.soknadsperiode != null) ?? {};
+  const { lovvalgsperiode } =
     behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.lovvalgsperiode != null) ?? {};
 
   const link = behandleAlleSakerToggleEnabled


### PR DESCRIPTION
Vi må endre logikk på hvor vi henter søknadsperiode og land fra.  Disse er ikke garantert skal hentes fra siste behandling med lovvalgsperiode.

Legger derfor til logikk der vi henter disse fra siste behandling der søknadsperiode ikke er null.

Ref siste kommentar på https://jira.adeo.no/browse/MELOSYS-5508