### PR TITLE
5576: ux bugs endre behandling

### DIFF
--- a/src/felleskomponenter/datovelger/datovelger.tsx
+++ b/src/felleskomponenter/datovelger/datovelger.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode, FocusEventHandler } from "react";
 import DatePicker, { registerLocale } from "react-datepicker";
 import { nb } from "date-fns/locale";
 import classNames from "classnames";
+import * as Popper from "popper.js";
+
 import "react-datepicker/dist/react-datepicker.css";
 import "./datovelger.css";
 
@@ -18,6 +20,7 @@ interface DatovelgerProps {
   bredde?: string;
   minDate?: Date;
   maxDate?: Date;
+  calendarPlacement?: Popper.Placement;
   onBlur?: FocusEventHandler;
   onCalendarClose?: () => void;
 }
@@ -31,6 +34,7 @@ const Datovelger = ({
   bredde = "fullbredde",
   minDate,
   maxDate,
+  calendarPlacement,
   onBlur,
   onCalendarClose,
 }: DatovelgerProps) => {
@@ -81,6 +85,7 @@ const Datovelger = ({
         disabled={disabled}
         minDate={minDate}
         maxDate={maxDate}
+        popperPlacement={calendarPlacement}
       />
       {feil && (
         <div role="alert" aria-live="assertive" className="datovelger__feilmelding">

--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.less
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.less
@@ -3,6 +3,14 @@
     margin-top: 18px;
     margin-left: 52px;
     margin-right: 52px;
+
+    .skjemaelement {
+      width: 29em;
+    }
+
+    .feilmeldingliste {
+      margin: 0;
+    }
   }
 
   .infomelding {

--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -72,7 +72,6 @@ function EndreBehandlingModal({
   anmodningsperioderSendtTilUtlandet,
 }: EndreBehandlingModalProps) {
   const [generellFeil, setGenerellFeil] = useState("");
-  const [forsøktLagre, setForsøktLagre] = useState(false);
   const [behandlingEndret, setBehandlingEndret] = useState(false);
   const [sakstype, setSakstype] = useState(fagsak.sakstype?.kode);
   const [sakstema, setSakstema] = useState(fagsak.sakstema?.kode);
@@ -81,6 +80,7 @@ function EndreBehandlingModal({
   const [mottaksdato, setMottaksdato] = useState(Datoutils.isoStringTilDate(mottattDato));
   const [behandlingsstatus, setBehandlingsstatus] = useState(oppsummering.behandlingsstatus?.kode);
   const [skalViseSpinner, setSkalViseSpinner] = useState(false);
+  const [skalViseFeilmeldinger, setSkalViseFeilmeldinger] = useState(false);
   const [muligeSakstyper, setMuligeSakstyper] = useState([]);
   const [muligeSakstemaer, setMuligeSakstemaer] = useState([]);
   const [muligeBehandlingstemaer, setMuligeBehandlingstemaer] = useState([]);
@@ -131,6 +131,7 @@ function EndreBehandlingModal({
       hentMuligeBehandlingsstatuser(behandlingID);
       setGenerellFeil("");
       setBehandlingEndret(false);
+      setSkalViseFeilmeldinger(false);
       setSakstype(fagsak.sakstype?.kode);
       setSakstema(fagsak.sakstema?.kode);
       setBehandlingstema(oppsummering.behandlingstema?.kode);
@@ -155,11 +156,11 @@ function EndreBehandlingModal({
 
   const harMottaksdatoEndretSeg = () => Datoutils.isoStringTilDate(mottattDato)?.getTime() !== mottaksdato?.getTime();
 
-  const sakstypeFeilmelding = forsøktLagre && !sakstype ? "Du må velge sakstype" : null;
-  const sakstemaFeilmelding = forsøktLagre && !sakstema ? "Du må velge sakstema" : null;
-  const behandlingstemaFeilmelding = forsøktLagre && !behandlingstema ? "Du må velge behandlingstema" : null;
-  const behandlingstypeFeilmelding = forsøktLagre && !behandlingstype ? "Du må velge behandlingstype" : null;
-  const behandlingsstatusFeilmelding = forsøktLagre && !behandlingsstatus ? "Du må velge behandlingsstatus" : null;
+  const sakstypeFeilmelding = !sakstype ? "Du må velge sakstype" : null;
+  const sakstemaFeilmelding = !sakstema ? "Du må velge sakstema" : null;
+  const behandlingstemaFeilmelding = !behandlingstema ? "Du må velge behandlingstema" : null;
+  const behandlingstypeFeilmelding = !behandlingstype ? "Du må velge behandlingstype" : null;
+  const behandlingsstatusFeilmelding = !behandlingsstatus ? "Du må velge behandlingsstatus" : null;
   const alleFeilmeldinger = [
     sakstypeFeilmelding,
     sakstemaFeilmelding,
@@ -169,8 +170,8 @@ function EndreBehandlingModal({
   ].filter((feilmelding) => feilmelding !== null);
 
   const endreBehandlingHandle = () => {
-    setForsøktLagre(true);
-    if (!(sakstype && sakstema && behandlingstema && behandlingstype && behandlingsstatus)) {
+    if (alleFeilmeldinger.length > 0) {
+      setSkalViseFeilmeldinger(true);
       return;
     }
 
@@ -259,7 +260,7 @@ function EndreBehandlingModal({
               value={sakstype}
               koder={fagsakKanEndres ? muligeSakstyper : [fagsak.sakstype]}
               redigerbart={!endringerErBegrenset && typeTemaKanEndres && fagsakKanEndres}
-              feil={sakstypeFeilmelding}
+              feil={skalViseFeilmeldinger ? sakstypeFeilmelding : null}
               disableForsteValg
             />
             <Mui.KodeTermSelect
@@ -271,7 +272,7 @@ function EndreBehandlingModal({
               value={sakstema}
               koder={fagsakKanEndres ? muligeSakstemaer : [fagsak.sakstema]}
               redigerbart={!endringerErBegrenset && typeTemaKanEndres && fagsakKanEndres}
-              feil={sakstemaFeilmelding}
+              feil={skalViseFeilmeldinger ? sakstemaFeilmelding : null}
               disableForsteValg
             />
             <Mui.KodeTermSelect
@@ -283,7 +284,7 @@ function EndreBehandlingModal({
               value={behandlingstema}
               koder={muligeBehandlingstemaer}
               redigerbart={!endringerErBegrenset && typeTemaKanEndres}
-              feil={behandlingstemaFeilmelding}
+              feil={skalViseFeilmeldinger ? behandlingstemaFeilmelding : null}
               disableForsteValg
             />
             <Mui.KodeTermSelect
@@ -292,7 +293,7 @@ function EndreBehandlingModal({
               value={behandlingstype}
               koder={muligeBehandlingstyper}
               redigerbart={!endringerErBegrenset && typeTemaKanEndres}
-              feil={behandlingstypeFeilmelding}
+              feil={skalViseFeilmeldinger ? behandlingstypeFeilmelding : null}
               disableForsteValg
             />
             <Datovelger onChange={setMottaksdato} label="Mottaksdato" value={mottaksdato} calendarPlacement="top" />
@@ -301,11 +302,11 @@ function EndreBehandlingModal({
               label="Behandlingsstatus"
               value={behandlingsstatus}
               koder={muligeVerdierPlussGjeldende(oppsummering.behandlingsstatus, muligeBehandlingsstatuser)}
-              feil={behandlingsstatusFeilmelding}
+              feil={skalViseFeilmeldinger ? behandlingsstatusFeilmelding : null}
               disableForsteValg
             />
 
-            {alleFeilmeldinger.length > 0 && (
+            {skalViseFeilmeldinger && (
               <AlertStripeFeil>
                 <Nav.Typo.Normaltekst>Følgende feil ble funnet</Nav.Typo.Normaltekst>
                 <ul className="feilmeldingliste">

--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -6,6 +6,7 @@ import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { KTObject } from "@navikt/melosys-kodeverk";
+import { AlertStripeFeil } from "nav-frontend-alertstriper";
 
 import MKV, { MKVUtils } from "../../melosyskodeverk";
 import * as Mui from "../ui";
@@ -17,13 +18,13 @@ import * as Datoutils from "../../utils/dato";
 import { behandlingsstatusOperations, behandlingsstatusSelectors } from "../../ducks/behandlingsstatus";
 import { behandlingerSelectors } from "../../ducks/behandlinger";
 import { navigeringOperations } from "../../ducks/navigering";
-
 import { anmodningsperioderSelectors } from "../../ducks/anmodningsperioder";
 import { useFeatureToggle } from "../../featuretoggle";
 import Datovelger from "../datovelger";
 import Knapperad from "../knapperad";
 import { StandardMeldingOverst } from "../alertmeldinger";
 import { Spinner } from "../spinner";
+
 import "./endreBehandlingModal.css";
 
 enum FeltVerdier {
@@ -71,6 +72,7 @@ function EndreBehandlingModal({
   anmodningsperioderSendtTilUtlandet,
 }: EndreBehandlingModalProps) {
   const [generellFeil, setGenerellFeil] = useState("");
+  const [forsøktLagre, setForsøktLagre] = useState(false);
   const [behandlingEndret, setBehandlingEndret] = useState(false);
   const [sakstype, setSakstype] = useState(fagsak.sakstype?.kode);
   const [sakstema, setSakstema] = useState(fagsak.sakstema?.kode);
@@ -153,7 +155,25 @@ function EndreBehandlingModal({
 
   const harMottaksdatoEndretSeg = () => Datoutils.isoStringTilDate(mottattDato)?.getTime() !== mottaksdato?.getTime();
 
+  const sakstypeFeilmelding = forsøktLagre && !sakstype ? "Du må velge sakstype" : null;
+  const sakstemaFeilmelding = forsøktLagre && !sakstema ? "Du må velge sakstema" : null;
+  const behandlingstemaFeilmelding = forsøktLagre && !behandlingstema ? "Du må velge behandlingstema" : null;
+  const behandlingstypeFeilmelding = forsøktLagre && !behandlingstype ? "Du må velge behandlingstype" : null;
+  const behandlingsstatusFeilmelding = forsøktLagre && !behandlingsstatus ? "Du må velge behandlingsstatus" : null;
+  const alleFeilmeldinger = [
+    sakstypeFeilmelding,
+    sakstemaFeilmelding,
+    behandlingstemaFeilmelding,
+    behandlingstypeFeilmelding,
+    behandlingsstatusFeilmelding,
+  ].filter((feilmelding) => feilmelding !== null);
+
   const endreBehandlingHandle = () => {
+    setForsøktLagre(true);
+    if (!(sakstype && sakstema && behandlingstema && behandlingstype && behandlingsstatus)) {
+      return;
+    }
+
     setSkalViseSpinner(true);
     const {
       saksnummer,
@@ -238,8 +258,9 @@ function EndreBehandlingModal({
               label="Sakstype"
               value={sakstype}
               koder={fagsakKanEndres ? muligeSakstyper : [fagsak.sakstype]}
-              disableForsteValg
               redigerbart={!endringerErBegrenset && typeTemaKanEndres && fagsakKanEndres}
+              feil={sakstypeFeilmelding}
+              disableForsteValg
             />
             <Mui.KodeTermSelect
               onChange={(e) => {
@@ -249,8 +270,9 @@ function EndreBehandlingModal({
               label="Sakstema"
               value={sakstema}
               koder={fagsakKanEndres ? muligeSakstemaer : [fagsak.sakstema]}
-              disableForsteValg
               redigerbart={!endringerErBegrenset && typeTemaKanEndres && fagsakKanEndres}
+              feil={sakstemaFeilmelding}
+              disableForsteValg
             />
             <Mui.KodeTermSelect
               onChange={(e) => {
@@ -260,16 +282,18 @@ function EndreBehandlingModal({
               label="Behandlingstema"
               value={behandlingstema}
               koder={muligeBehandlingstemaer}
-              disableForsteValg
               redigerbart={!endringerErBegrenset && typeTemaKanEndres}
+              feil={behandlingstemaFeilmelding}
+              disableForsteValg
             />
             <Mui.KodeTermSelect
               onChange={(e) => setBehandlingstype(e.target.value)}
               label="Behandlingstype"
               value={behandlingstype}
               koder={muligeBehandlingstyper}
-              disableForsteValg
               redigerbart={!endringerErBegrenset && typeTemaKanEndres}
+              feil={behandlingstypeFeilmelding}
+              disableForsteValg
             />
             <Datovelger onChange={setMottaksdato} label="Mottaksdato" value={mottaksdato} />
             <Mui.KodeTermSelect
@@ -277,9 +301,22 @@ function EndreBehandlingModal({
               label="Behandlingsstatus"
               value={behandlingsstatus}
               koder={muligeVerdierPlussGjeldende(oppsummering.behandlingsstatus, muligeBehandlingsstatuser)}
+              feil={behandlingsstatusFeilmelding}
               disableForsteValg
             />
           </div>
+
+          {alleFeilmeldinger.length > 0 && (
+            <AlertStripeFeil>
+              <Nav.Typo.Normaltekst>Følgende feil ble funnet</Nav.Typo.Normaltekst>
+              <ul>
+                {alleFeilmeldinger.map((feilmelding) => (
+                  <li key={feilmelding}>{feilmelding}</li>
+                ))}
+              </ul>
+            </AlertStripeFeil>
+          )}
+
           <Knapperad
             avbryt={lukkModal}
             avbrytTekst="Avbryt"

--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -6,7 +6,6 @@ import { ThunkDispatch } from "redux-thunk";
 import { Action } from "redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { KTObject } from "@navikt/melosys-kodeverk";
-import { AlertStripeFeil } from "nav-frontend-alertstriper";
 
 import MKV, { MKVUtils } from "../../melosyskodeverk";
 import * as Mui from "../ui";
@@ -307,14 +306,14 @@ function EndreBehandlingModal({
             />
 
             {skalViseFeilmeldinger && (
-              <AlertStripeFeil>
+              <Nav.AlertStripeFeil>
                 <Nav.Typo.Normaltekst>Følgende feil ble funnet</Nav.Typo.Normaltekst>
                 <ul className="feilmeldingliste">
                   {alleFeilmeldinger.map((feilmelding) => (
                     <li key={feilmelding}>{feilmelding}</li>
                   ))}
                 </ul>
-              </AlertStripeFeil>
+              </Nav.AlertStripeFeil>
             )}
           </div>
 

--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -304,18 +304,18 @@ function EndreBehandlingModal({
               feil={behandlingsstatusFeilmelding}
               disableForsteValg
             />
-          </div>
 
-          {alleFeilmeldinger.length > 0 && (
-            <AlertStripeFeil>
-              <Nav.Typo.Normaltekst>Følgende feil ble funnet</Nav.Typo.Normaltekst>
-              <ul>
-                {alleFeilmeldinger.map((feilmelding) => (
-                  <li key={feilmelding}>{feilmelding}</li>
-                ))}
-              </ul>
-            </AlertStripeFeil>
-          )}
+            {alleFeilmeldinger.length > 0 && (
+              <AlertStripeFeil>
+                <Nav.Typo.Normaltekst>Følgende feil ble funnet</Nav.Typo.Normaltekst>
+                <ul className="feilmeldingliste">
+                  {alleFeilmeldinger.map((feilmelding) => (
+                    <li key={feilmelding}>{feilmelding}</li>
+                  ))}
+                </ul>
+              </AlertStripeFeil>
+            )}
+          </div>
 
           <Knapperad
             avbryt={lukkModal}

--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -295,7 +295,7 @@ function EndreBehandlingModal({
               feil={behandlingstypeFeilmelding}
               disableForsteValg
             />
-            <Datovelger onChange={setMottaksdato} label="Mottaksdato" value={mottaksdato} />
+            <Datovelger onChange={setMottaksdato} label="Mottaksdato" value={mottaksdato} calendarPlacement="top" />
             <Mui.KodeTermSelect
               onChange={(e) => setBehandlingsstatus(e.target.value)}
               label="Behandlingsstatus"


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5576
Flere mindre design endringer:
- Viser feilmelding på tomme inputfelt om en forsøker å endre til dem
- Viser tilsvarende feilmeldinger i en alertboks
- Støtte for å spesifisere posisjon til kalenderpopupen og flyttet til over mottaksdato
- Hardkodet bredde på inputfeltene slik at modalen ikke "hopper" i størrelse