### PR TITLE
5611 Logikk-feil ved fjerning av toggle

### DIFF
--- a/src/sider/journalforing/komponenter/fagsakVelger.js
+++ b/src/sider/journalforing/komponenter/fagsakVelger.js
@@ -90,21 +90,19 @@ const FagsakVelger = (props) => {
         </div>
       )}
 
-      {!erOpprettNySak && (
-        <>
-          {valgtVisning === EKSISTERENDE && (
-            <Skjema.CustomRadioPanelGruppe
-              feltNavn="saksnummer"
-              radios={radioValg}
-              notify={notifier}
-              begrensVisteRadios
-              onChange={nullstillFormVerdier}
-              className="marginMellomCustomRadioPaneler"
-            />
-          )}
-          {valgtVisning === OPPRETT && <OpprettSak formValues={formValues} feltNavn={feltNavn} />}
-        </>
-      )}
+      <>
+        {valgtVisning === EKSISTERENDE && (
+          <Skjema.CustomRadioPanelGruppe
+            feltNavn="saksnummer"
+            radios={radioValg}
+            notify={notifier}
+            begrensVisteRadios
+            onChange={nullstillFormVerdier}
+            className="marginMellomCustomRadioPaneler"
+          />
+        )}
+        {valgtVisning === OPPRETT && <OpprettSak formValues={formValues} feltNavn={feltNavn} />}
+      </>
     </div>
   );
 };

--- a/src/sider/journalforing/komponenter/fagsakVelger.js
+++ b/src/sider/journalforing/komponenter/fagsakVelger.js
@@ -90,19 +90,17 @@ const FagsakVelger = (props) => {
         </div>
       )}
 
-      <>
-        {valgtVisning === EKSISTERENDE && (
-          <Skjema.CustomRadioPanelGruppe
-            feltNavn="saksnummer"
-            radios={radioValg}
-            notify={notifier}
-            begrensVisteRadios
-            onChange={nullstillFormVerdier}
-            className="marginMellomCustomRadioPaneler"
-          />
-        )}
-        {valgtVisning === OPPRETT && <OpprettSak formValues={formValues} feltNavn={feltNavn} />}
-      </>
+      {valgtVisning === EKSISTERENDE && (
+        <Skjema.CustomRadioPanelGruppe
+          feltNavn="saksnummer"
+          radios={radioValg}
+          notify={notifier}
+          begrensVisteRadios
+          onChange={nullstillFormVerdier}
+          className="marginMellomCustomRadioPaneler"
+        />
+      )}
+      {valgtVisning === OPPRETT && <OpprettSak formValues={formValues} feltNavn={feltNavn} />}
     </div>
   );
 };


### PR DESCRIPTION
Gammel logikk:        
` {(!erOpprettNySak || nyOpprettSakToggleEnabled) && (
`
Den skal altså alltid være synlig siden toggle nå er på.