### PR TITLE
4615: Legger til innstilling om ingen lagring i Cache Control

### DIFF
--- a/nais/proxy.nginx
+++ b/nais/proxy.nginx
@@ -47,6 +47,9 @@ server {
   }
 
   location /melosys/ {
+    add_header Cache-Control 'no-store';
+    add_header Cache-Control 'no-cache';
+    expires 0;
     try_files $uri /index.html;
   }
 


### PR DESCRIPTION
Sjekk logger: https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2023-01-10T06:57:42.636Z',to:'2023-01-10T12:58:11.517Z'))&_a=(columns:!(level,message,envclass,application,pod),filters:!(),index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:kuery,query:'application:melosys%20%20and%20envclass:p%20and%20level:%22Error%22'),sort:!(!('@timestamp',desc)))
Dette er bare en teori, så jeg setter ikke [tasken](https://jira.adeo.no/browse/MELOSYS-4615) inn i QA/test. 

Jeg mistenker at nettleseren cacher index.html, slik at når vi prodsetter, så prøver nettleseren å laste inn chunk-filer som ikke eksisterer. 

Setter cache control på index.html, slik at nettleseren ikke cacher det.
