### PR TITLE
5580 bug forsvunnet feilmelding

### DIFF
--- a/src/sider/journalforing/komponenter/knyttTilSak.js
+++ b/src/sider/journalforing/komponenter/knyttTilSak.js
@@ -57,7 +57,7 @@ export const KnyttTilSak = (props) => {
   }, [sisteBehandling]);
 
   useEffect(() => {
-    if (sakstema.kode && sakstype.kode) {
+    if (sakstype.kode && sakstema.kode) {
       Api.LovligeKombinasjoner.hentBehandlingstemaer(
         journalforingGjelder,
         sakstype.kode,
@@ -67,10 +67,10 @@ export const KnyttTilSak = (props) => {
         setMuligeBehandlingstemaer(alleMuligeBehandlingstemaer);
       });
     }
-  }, [journalforingGjelder, sakstema.kode, sakstype.kode]);
+  }, [journalforingGjelder, sakstype.kode, sakstema.kode, sisteBehandling?.behandlingstema?.kode]);
 
   useEffect(() => {
-    if (sakstema.kode && sakstype.kode && behandlingstema) {
+    if (sakstype.kode && sakstema.kode && behandlingstema) {
       Api.LovligeKombinasjoner.hentBehandlingstyper(
         journalforingGjelder,
         sakstype.kode,
@@ -82,7 +82,7 @@ export const KnyttTilSak = (props) => {
         setMuligeBehandlingstyper(alleMuligeBehandlingstyper);
       });
     }
-  }, [journalforingGjelder, sakstema.kode, sakstype.kode, behandlingstema]);
+  }, [journalforingGjelder, sakstype.kode, sakstema.kode, behandlingstema, sisteBehandling?.behandlingID]);
 
   useEffect(() => {
     if (opprettBehandling && Utils._isEmpty(behandlingstema)) {
@@ -94,7 +94,7 @@ export const KnyttTilSak = (props) => {
     if (!opprettBehandling && !Utils._isEmpty(behandlingstype)) {
       changeField(feltNavn.formNavn, feltNavn.behandlingstype, "");
     }
-  }, [opprettBehandling, behandlingstema, behandlingstype]);
+  }, [opprettBehandling, behandlingstema, behandlingstype, sisteBehandling?.behandlingstema?.kode]);
 
   useEffect(() => {
     changeField(feltNavn.formNavn, feltNavn.kanOppretteAndregangsbehandling, visKnyttTilEksisterende);

--- a/src/sider/journalforing/komponenter/knyttTilSak.js
+++ b/src/sider/journalforing/komponenter/knyttTilSak.js
@@ -150,31 +150,35 @@ export const KnyttTilSak = (props) => {
   }
 
   const visUtenVidereBehandling = sakstype.kode === MKV.Koder.sakstyper.EU_EOS && !sakErHenlagtEllerBortfalt;
-  const skalViseUtenVidereBehandling = !erOpprettNySak && !sakErHenlagtEllerBortfalt && visUtenVidereBehandling;
-  const skalViseSakErHenlagtEllerBortfalt = !erOpprettNySak && sakErHenlagtEllerBortfalt;
-  const skalViseErOpprettNySak = erOpprettNySak;
+
+  const kanIkkeOppretteAndregangGrunn = sakErHenlagtEllerBortfalt
+    ? "Du kan ikke opprette en ny behandling på eksisterende sak som er henlagt/bortfalt i Melosys"
+    : "Du kan ikke opprette en ny behandling på eksisterende sak med en aktiv/pågående behandling";
 
   return (
     <div className="knyttTilSak__behandlingspanel">
-      {skalViseErOpprettNySak && (
+      {erOpprettNySak ? (
         <div className="innrykk">
-          <Nav.AlertStripeAdvarsel>
-            Du kan ikke opprette en ny behandling på eksisterende sak som er henlagt/bortfalt i Melosys
-          </Nav.AlertStripeAdvarsel>
+          <Nav.AlertStripeAdvarsel>{kanIkkeOppretteAndregangGrunn}</Nav.AlertStripeAdvarsel>
         </div>
-      )}
-
-      {skalViseSakErHenlagtEllerBortfalt && (
-        <div className="innrykk">
-          <Nav.AlertStripeInfo>
-            Du kan ikke opprette en ny behandling på en sak som er henlagt/bortfalt i Melosys, men du kan knytte
-            dokumentet til den avsluttede behandlingen
-          </Nav.AlertStripeInfo>
-        </div>
-      )}
-
-      {skalViseUtenVidereBehandling && (
-        <Skjema.Checkbox className="knyttTilSak" feltNavn="ingenVurdering" label="Journalfør uten videre behandling" />
+      ) : (
+        <>
+          {sakErHenlagtEllerBortfalt && (
+            <div className="innrykk">
+              <Nav.AlertStripeInfo>
+                Du kan ikke opprette en ny behandling på en sak som er henlagt/bortfalt i Melosys, men du kan knytte
+                dokumentet til den avsluttede behandlingen
+              </Nav.AlertStripeInfo>
+            </div>
+          )}
+          {visUtenVidereBehandling && (
+            <Skjema.Checkbox
+              className="knyttTilSak"
+              feltNavn="ingenVurdering"
+              label="Journalfør uten videre behandling"
+            />
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
Opprett ny sak hadde bare én feilmelding, istedenfor at denne baserte seg på grunnen til at man ikke kunne knytte til sak. La tilbake denne koden. 

Tok samtidig en liten opprydding i dependencies og rekkefølge i useEffectene.