### PR TITLE
5584 Oppdatering av tekst i gosys-oppgave - den nye teksten bør vises først

### DIFF
--- a/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
+++ b/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
@@ -2,7 +2,6 @@ import React from "react";
 import { Link } from "react-router-dom";
 import classNames from "classnames";
 import PT from "prop-types";
-import { v4 as uuidv4 } from "uuid";
 
 import * as MPT from "../../proptypes";
 import * as Nav from "../../navFrontend";
@@ -15,6 +14,7 @@ import { BehandlingsstatusMedSvarfrist } from "../behandlingsstatus";
 import Soknadsland from "../soknadsland";
 
 import { formatterDatoTilNorsk } from "../../utils/dato";
+import * as Utils from "../../utils";
 
 import "./behandlingOppgave.css";
 
@@ -82,13 +82,15 @@ const BehandlingOppgave = ({ sak, folketrygdenToggleEnabled, landkoder }) => {
     return tekst != null && tekst.length > maxLengde ? `${tekst.slice(0, maxLengde)} (...)` : tekst;
   };
 
-  const reverserOgDelOppSisteGosysBeskrivelser = (tekst) => {
-    return tekst != null ? tekst.split("\n").reverse().slice(0, 4) : "";
+  const delOppOgReverserGosysBeskrivelser = (tekst) => {
+    return tekst != null ? tekst.split("\n").reverse() : "";
   };
 
   const stringTilHtmlMedOppdelteLinjer = (tekst) => {
-    const sisteGosysBeskrivelser = reverserOgDelOppSisteGosysBeskrivelser(tekst);
-    return sisteGosysBeskrivelser.map((string) => [string, <br key={uuidv4()} />]);
+    const nyesteNotatIndex = 0;
+    const maxLinjer = 4;
+    const nyesteGosysBeskrivelser = delOppOgReverserGosysBeskrivelser(tekst).slice(nyesteNotatIndex, maxLinjer);
+    return nyesteGosysBeskrivelser.map((string) => [string, <br key={Utils._uuid()} />]);
   };
 
   return (

--- a/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
+++ b/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
@@ -131,7 +131,9 @@ const BehandlingOppgave = ({ sak, folketrygdenToggleEnabled, landkoder }) => {
           </Nav.Column>
 
           <Nav.Column xs="6" md="6" lg="4" className="behandlingOppgave__kolonne__notater">
-            <Nav.Row>{reduserTekstLengde(notat)}</Nav.Row>
+            <Nav.Row>
+              <p>{reduserTekstLengde(notat)}</p>
+            </Nav.Row>
             <Nav.Row>
               <b>Gosys:</b>
               <br />

--- a/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
+++ b/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import classNames from "classnames";
 import PT from "prop-types";
+import { v4 as uuidv4 } from "uuid";
 
 import * as MPT from "../../proptypes";
 import * as Nav from "../../navFrontend";
@@ -81,6 +82,15 @@ const BehandlingOppgave = ({ sak, folketrygdenToggleEnabled, landkoder }) => {
     return tekst != null && tekst.length > maxLengde ? `${tekst.slice(0, maxLengde)} (...)` : tekst;
   };
 
+  const reverserOgDelOppSisteGosysBeskrivelser = (tekst) => {
+    return tekst != null ? tekst.split("\n").reverse().slice(0, 4) : "";
+  };
+
+  const stringTilHtmlMedOppdelteLinjer = (tekst) => {
+    const sisteGosysBeskrivelser = reverserOgDelOppSisteGosysBeskrivelser(tekst);
+    return sisteGosysBeskrivelser.map((string) => [string, <br key={uuidv4()} />]);
+  };
+
   return (
     <BehandlingOppgavesLinjeWrapper link={link} stengt={erUnderOppdatering}>
       <Nav.Panel data-cy-behandlingstema={behandlingstema.kode} className={cl}>
@@ -123,7 +133,7 @@ const BehandlingOppgave = ({ sak, folketrygdenToggleEnabled, landkoder }) => {
             <Nav.Row>
               <b>Gosys:</b>
               <br />
-              {reduserTekstLengde(beskrivelse)}
+              <p>{stringTilHtmlMedOppdelteLinjer(beskrivelse)}</p>
             </Nav.Row>
           </Nav.Column>
         </Nav.Row>

--- a/src/felleskomponenter/oppgaveliste/behandlingOppgave.less
+++ b/src/felleskomponenter/oppgaveliste/behandlingOppgave.less
@@ -6,6 +6,10 @@
   flex: 1;
   padding-right: 3em;
 
+  p {
+    margin: 0;
+  }
+
   .panelheader__tittel {
     margin-top: 0.25em;
   }

--- a/src/felleskomponenter/oppgaveliste/behandlingsOppgave.test.tsx
+++ b/src/felleskomponenter/oppgaveliste/behandlingsOppgave.test.tsx
@@ -6,7 +6,8 @@ import * as Nav from "../../navFrontend";
 
 describe("BehandlingOppgave", () => {
   const sak = {
-    sisteNotat: "aaaaaaaaaaaaaaaaaaaaaaaa aaaaaa aaaaaaaaaaaa AAAAAAAA AAAAAAAAA AAAAAAAAAAAAA",
+    sisteNotat:
+      "dette notatet er mye lenger enn 60 bokstaver som er den nåværende begrensningen vi har for notater i melosys",
     oppgaveBeskrivelse: "linje 1 \nlinje 2 \nlinje 3 \n",
     behandling: {
       behandlingID: "1111",
@@ -42,7 +43,7 @@ describe("BehandlingOppgave", () => {
 
   it("skal vise forkortet notat", () => {
     expect(wrapper.find(".behandlingOppgave__kolonne__notater").find(Nav.Row).at(0).find("p").text()).toEqual(
-      "aaaaaaaaaaaaaaaaaaaaaaaa aaaaaa aaaaaaaaaaaa AAAAAAAA AAAAAA (...)"
+      "dette notatet er mye lenger enn 60 bokstaver som er den nåvæ (...)"
     );
   });
 });

--- a/src/felleskomponenter/oppgaveliste/behandlingsOppgave.test.tsx
+++ b/src/felleskomponenter/oppgaveliste/behandlingsOppgave.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { shallow, ShallowWrapper } from "enzyme";
+import BehandlingOppgave from "./behandlingOppgave";
+import MKV from "../../melosyskodeverk";
+import * as Nav from "../../navFrontend";
+
+describe("BehandlingOppgave", () => {
+  const sak = {
+    sisteNotat: "aaaaaaaaaaaaaaaaaaaaaaaa aaaaaa aaaaaaaaaaaa AAAAAAAA AAAAAAAAA AAAAAAAAAAAAA",
+    oppgaveBeskrivelse: "linje 1 \nlinje 2 \nlinje 3 \n",
+    behandling: {
+      behandlingID: "1111",
+      behandlingstema: {
+        kode: MKV.Koder.behandlinger.behandlingstema.ANMODNING_OM_UNNTAK_HOVEDREGEL,
+      },
+      behandlingstype: {
+        kode: MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG,
+      },
+    },
+    sakstype: {
+      kode: "EU_EOS",
+    },
+    sakstema: {
+      kode: "1111",
+    },
+  };
+  const folketrygdenToggleEnabled = true;
+  const landkoder = [
+    { kode: "kode 1", term: "term 1" },
+    { kode: "kode 2", term: "term 2" },
+  ];
+  const erUnderOppdatering = false;
+  const behandlingstema = {
+    kode: "test_code",
+    term: "ttset",
+  };
+
+  const wrapper: ShallowWrapper = shallow(
+    <BehandlingOppgave sak={sak} folketrygdenToggleEnabled={folketrygdenToggleEnabled} landkoder={landkoder} />
+  );
+
+  it("skal vise reversert rekkefølge og linjedeling", () => {
+    expect(wrapper.find(".behandlingOppgave__kolonne__notater").find(Nav.Row).at(1).find("p").text()).toEqual(
+      "linje 3 linje 2 linje 1 "
+    );
+  });
+
+  it("skal vise forkortet notat", () => {
+    expect(wrapper.find(".behandlingOppgave__kolonne__notater").find(Nav.Row).at(0).find("p").text()).toEqual(
+      "aaaaaaaaaaaaaaaaaaaaaaaa aaaaaa aaaaaaaaaaaa AAAAAAAA AAAAAA (...)"
+    );
+  });
+});

--- a/src/felleskomponenter/oppgaveliste/behandlingsOppgave.test.tsx
+++ b/src/felleskomponenter/oppgaveliste/behandlingsOppgave.test.tsx
@@ -29,11 +29,6 @@ describe("BehandlingOppgave", () => {
     { kode: "kode 1", term: "term 1" },
     { kode: "kode 2", term: "term 2" },
   ];
-  const erUnderOppdatering = false;
-  const behandlingstema = {
-    kode: "test_code",
-    term: "ttset",
-  };
 
   const wrapper: ShallowWrapper = shallow(
     <BehandlingOppgave sak={sak} folketrygdenToggleEnabled={folketrygdenToggleEnabled} landkoder={landkoder} />


### PR DESCRIPTION
Baser beskrivelser fra gosys på antall linjer istedenfor bokstaver.
Reverserer også rekkefølgen siden det er det som er ønskelig for saksbehandler. 
Legger inn formattering for line breaks, slik att det blir rendra korrekt.

Jeg gjør ingen endringer iht akseptansekriteria 1. Siden dette er noe vi ikke har kontroll over.
https://jira.adeo.no/browse/MELOSYS-5584