### PR TITLE
5374 Endre avkrysning i journalføring som styrer ingenVurdering-feltet

### DIFF
--- a/src/kodeverk/form.ts
+++ b/src/kodeverk/form.ts
@@ -18,9 +18,9 @@ export enum JOURNALFORING_VALUES {
   soknadslandUkjenteEllerAlleEosLand = "journalforingSoknadslandUkjenteEllerAlleEosLand",
   periodeFraOgMed = "journalforingPeriodeFraOgMed",
   periodeTilOgMed = "journalforingPeriodeTilOgMed",
+  opprettBehandling = "opprettBehandling",
   saksnummer = "saksnummer",
   formNavn = "journalforing",
-  kanOppretteAndregangsbehandling = "kanOppretteAndregangsbehandling",
 }
 
 export const SOKNAD = "soknad";
@@ -121,9 +121,9 @@ export enum OPPRETT_NY_SAK_VALUES {
   periodeFraOgMed = "periodeFraOgMed",
   periodeTilOgMed = "periodeTilOgMed",
   saksnummer = "saksnummer",
+  opprettBehandling = "opprettBehandling",
   hovedpart = "hovedpart",
   formNavn = "opprett_ny_sak",
-  kanOppretteAndregangsbehandling = "kanOppretteAndregangsbehandling",
 }
 export const VURDERING_VIDERESEND = "vurdering_videresend";
 export const VURDER_UTPEKING = "vurder_utpeking";

--- a/src/sider/journalforing/journalforing.js
+++ b/src/sider/journalforing/journalforing.js
@@ -126,8 +126,11 @@ class Journalforing extends Component {
       avsenderType: this.mapAvsenderType(avsenderType),
     };
 
-    if (hensikt === JOURNALFORING_HENSIKT.KNYTT || hensikt === JOURNALFORING_HENSIKT.ANDREGANGSBEHANDLE) {
-      return this.dataSpesifiktTilKnyttEllerAndregangs(journalPostData);
+    if (hensikt === JOURNALFORING_HENSIKT.KNYTT) {
+      return this.dataSpesifiktTilKnytt(journalPostData);
+    }
+    if (hensikt === JOURNALFORING_HENSIKT.ANDREGANGSBEHANDLE) {
+      return this.dataSpesifiktTilAndregangs(journalPostData);
     }
     if (hensikt === JOURNALFORING_HENSIKT.OPPRETT) {
       return this.dataSpesifiktTilOpprett(journalPostData);
@@ -140,8 +143,19 @@ class Journalforing extends Component {
     MKV.Koder.avsendertyper.ORGANISASJON,
   ];
 
-  dataSpesifiktTilKnyttEllerAndregangs = (fellesData) => {
-    const { behandlingstema, behandlingstype, saksnummer, ingenVurdering } = this.props.journalforingSkjemaVerdier;
+  dataSpesifiktTilKnytt = (fellesData) => {
+    const { saksnummer, vurderDokument } = this.props.journalforingSkjemaVerdier;
+
+    return {
+      ...fellesData,
+      ikkeSendForvaltingsmelding: null,
+      saksnummer,
+      ingenVurdering: !vurderDokument,
+    };
+  };
+
+  dataSpesifiktTilAndregangs = (fellesData) => {
+    const { behandlingstema, behandlingstype, saksnummer } = this.props.journalforingSkjemaVerdier;
 
     return {
       ...fellesData,
@@ -149,7 +163,6 @@ class Journalforing extends Component {
       behandlingstemaKode: behandlingstema,
       behandlingstypeKode: behandlingstype,
       saksnummer,
-      ingenVurdering,
     };
   };
 
@@ -324,7 +337,6 @@ class Journalforing extends Component {
     const { settFeltInnhold } = this.props;
     settFeltInnhold("behandlingstype", null);
     settFeltInnhold("behandlingstema", null);
-    settFeltInnhold("ingenVurdering", false);
   };
 
   velgDokumentID = () => {

--- a/src/sider/journalforing/komponenter/journalforingform.js
+++ b/src/sider/journalforing/komponenter/journalforingform.js
@@ -160,7 +160,6 @@ const mapStateToProps = (state) => ({
     },
     journalforingSoknadsland: [],
     journalforingSoknadslandUkjenteEllerAlleEosLand: false,
-    ingenVurdering: false,
     ikkeSendForvaltingsmelding: false,
     skalTilordnes: false,
     submittable: false,

--- a/src/sider/journalforing/komponenter/knyttTilSak.js
+++ b/src/sider/journalforing/komponenter/knyttTilSak.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { change } from "redux-form";
 import PT from "prop-types";
 
-import MKV, { MKVUtils } from "../../../melosyskodeverk";
+import { MKVUtils } from "../../../melosyskodeverk";
 import * as MPT from "../../../proptypes";
 import * as Ikoner from "../../../resources/images";
 import * as Skjema from "../../../felleskomponenter/skjema";
@@ -17,7 +17,7 @@ import "./knyttTilSak.css";
 export const KnyttTilSak = (props) => {
   const { sak, erOpprettNySak, changeField, feltNavn, formValues } = props;
   const { behandlingstema, behandlingstype, journalforingGjelder, opprettBehandling } = {
-    opprettBehandling: formValues.opprettBehandling,
+    opprettBehandling: formValues[feltNavn.opprettBehandling],
     behandlingstema: formValues[feltNavn.behandlingstema],
     behandlingstype: formValues[feltNavn.behandlingstype],
     journalforingGjelder: formValues[feltNavn.hovedpart],
@@ -30,7 +30,8 @@ export const KnyttTilSak = (props) => {
 
   useEffect(() => {
     return () => {
-      changeField(feltNavn.formNavn, "opprettBehandling", undefined);
+      if (!erOpprettNySak) changeField(feltNavn.formNavn, "vurderDokument", undefined);
+      changeField(feltNavn.formNavn, feltNavn.opprettBehandling, undefined);
       changeField(feltNavn.formNavn, feltNavn.behandlingstema, "");
       changeField(feltNavn.formNavn, feltNavn.behandlingstype, "");
     };
@@ -41,12 +42,18 @@ export const KnyttTilSak = (props) => {
   );
   const sakErHenlagtEllerBortfalt = MKVUtils.erHenlagtEllerHenlagtBortfalt(sak.saksstatus.kode);
 
-  const visKnyttTilEksisterende =
-    (sisteBehandlingErInaktiv || sisteBehandlingHarSendtAnmodningUnntakTilUtland) && !sakErHenlagtEllerBortfalt;
+  const sisteBehandlingKanOpprettesAndregangsbehandlingPå =
+    sisteBehandlingErInaktiv || sisteBehandlingHarSendtAnmodningUnntakTilUtland;
 
   useEffect(() => {
-    changeField(feltNavn.formNavn, "opprettBehandling", visKnyttTilEksisterende);
-  }, [visKnyttTilEksisterende]);
+    const kanOppretteAndregangsbehandling =
+      sisteBehandlingKanOpprettesAndregangsbehandlingPå && !sakErHenlagtEllerBortfalt;
+    changeField(feltNavn.formNavn, feltNavn.opprettBehandling, kanOppretteAndregangsbehandling);
+    if (!erOpprettNySak) {
+      const skalIkkeVurdereDokument = sisteBehandlingKanOpprettesAndregangsbehandlingPå || sakErHenlagtEllerBortfalt;
+      changeField(feltNavn.formNavn, "vurderDokument", !skalIkkeVurdereDokument);
+    }
+  }, [sisteBehandlingKanOpprettesAndregangsbehandlingPå, sakErHenlagtEllerBortfalt]);
 
   useEffect(() => {
     const erAnmodningsperiodeSendt = (anmodningsperiode) => anmodningsperiode.sendtUtland;
@@ -96,11 +103,24 @@ export const KnyttTilSak = (props) => {
     }
   }, [opprettBehandling, behandlingstema, behandlingstype, sisteBehandling?.behandlingstema?.kode]);
 
-  useEffect(() => {
-    changeField(feltNavn.formNavn, feltNavn.kanOppretteAndregangsbehandling, visKnyttTilEksisterende);
-  }, [visKnyttTilEksisterende]);
+  if (sakErHenlagtEllerBortfalt) {
+    return (
+      <div className="knyttTilSak__behandlingspanel">
+        {erOpprettNySak ? (
+          <Nav.AlertStripeAdvarsel className="feilmelding_innrykk">
+            Du kan ikke opprette en ny behandling på eksisterende sak som er henlagt/bortfalt i Melosys
+          </Nav.AlertStripeAdvarsel>
+        ) : (
+          <Nav.AlertStripeInfo className="feilmelding_innrykk">
+            Du kan ikke opprette en ny behandling på en eksisterende sak som er henlagt/bortfalt i Melosys, men du kan
+            knytte dokumentet til den avsluttede behandlingen
+          </Nav.AlertStripeInfo>
+        )}
+      </div>
+    );
+  }
 
-  if (visKnyttTilEksisterende) {
+  if (sisteBehandlingKanOpprettesAndregangsbehandlingPå) {
     return (
       <div className="knyttTilSak__panelramme">
         {!erOpprettNySak && (
@@ -116,8 +136,8 @@ export const KnyttTilSak = (props) => {
               label=""
               className="panelElement nyBehandling-utenBehandling"
             >
-              <Skjema.Radio feltNavn="opprettBehandling" value label="Opprett ny behandling" />
-              <Skjema.Radio feltNavn="opprettBehandling" value={false} label="Uten å opprette behandling" />
+              <Skjema.Radio feltNavn={feltNavn.opprettBehandling} value label="Opprett ny behandling" />
+              <Skjema.Radio feltNavn={feltNavn.opprettBehandling} value={false} label="Uten å opprette behandling" />
             </Skjema.RadioGruppe>
           </>
         )}
@@ -149,36 +169,14 @@ export const KnyttTilSak = (props) => {
     );
   }
 
-  const visUtenVidereBehandling = sakstype.kode === MKV.Koder.sakstyper.EU_EOS && !sakErHenlagtEllerBortfalt;
-
-  const kanIkkeOppretteAndregangGrunn = sakErHenlagtEllerBortfalt
-    ? "Du kan ikke opprette en ny behandling på eksisterende sak som er henlagt/bortfalt i Melosys"
-    : "Du kan ikke opprette en ny behandling på eksisterende sak med en aktiv/pågående behandling";
-
   return (
     <div className="knyttTilSak__behandlingspanel">
       {erOpprettNySak ? (
-        <div className="innrykk">
-          <Nav.AlertStripeAdvarsel>{kanIkkeOppretteAndregangGrunn}</Nav.AlertStripeAdvarsel>
-        </div>
+        <Nav.AlertStripeAdvarsel className="feilmelding_innrykk">
+          Du kan ikke opprette en ny behandling på eksisterende sak med en aktiv/pågående behandling
+        </Nav.AlertStripeAdvarsel>
       ) : (
-        <>
-          {sakErHenlagtEllerBortfalt && (
-            <div className="innrykk">
-              <Nav.AlertStripeInfo>
-                Du kan ikke opprette en ny behandling på en sak som er henlagt/bortfalt i Melosys, men du kan knytte
-                dokumentet til den avsluttede behandlingen
-              </Nav.AlertStripeInfo>
-            </div>
-          )}
-          {visUtenVidereBehandling && (
-            <Skjema.Checkbox
-              className="knyttTilSak"
-              feltNavn="ingenVurdering"
-              label="Journalfør uten videre behandling"
-            />
-          )}
-        </>
+        <Skjema.Checkbox feltNavn="vurderDokument" label={`Oppdater behandlingsstatus til "Vurder dokument"`} />
       )}
     </div>
   );

--- a/src/sider/journalforing/komponenter/knyttTilSak.less
+++ b/src/sider/journalforing/komponenter/knyttTilSak.less
@@ -15,8 +15,9 @@
       margin: 0.5rem 0 0.5rem 2em;
     }
 
-    .innrykk {
-      margin-left: 2em;
+    .feilmelding_innrykk {
+      margin-left: 0.5rem;
+      margin-right: 0.5rem;
     }
   }
   &__panelramme {

--- a/src/sider/journalforing/komponenter/knyttTilSak.test.js
+++ b/src/sider/journalforing/komponenter/knyttTilSak.test.js
@@ -90,10 +90,10 @@ describe("KnyttTilSak", () => {
     const checkbox = knyttTilSak.find(Skjema.Checkbox);
 
     expect(checkbox).toHaveLength(1);
-    expect(checkbox.first().props().label).toBe("Journalfør uten videre behandling");
+    expect(checkbox.first().props().label).toBe(`Oppdater behandlingsstatus til "Vurder dokument"`);
   });
 
-  it(`Ikke vis journalfør uten videre behandling dersom saktype er FTRL`, () => {
+  it(`Vis journalfør uten videre behandling dersom saktype er FTRL`, () => {
     props.sak.behandlingOversikter[0].behandlingsstatus = {
       kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
     };
@@ -103,10 +103,11 @@ describe("KnyttTilSak", () => {
 
     const checkbox = knyttTilSak.find(Skjema.Checkbox);
 
-    expect(checkbox).toHaveLength(0);
+    expect(checkbox).toHaveLength(1);
+    expect(checkbox.first().props().label).toBe(`Oppdater behandlingsstatus til "Vurder dokument"`);
   });
 
-  it(`Ikke vis journalfør uten videre behandling dersom saktype er TRYGDEAVTALE`, () => {
+  it(`Vis journalfør uten videre behandling dersom saktype er TRYGDEAVTALE`, () => {
     props.sak.behandlingOversikter[0].behandlingsstatus = {
       kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
     };
@@ -116,6 +117,7 @@ describe("KnyttTilSak", () => {
 
     const checkbox = knyttTilSak.find(Skjema.Checkbox);
 
-    expect(checkbox).toHaveLength(0);
+    expect(checkbox).toHaveLength(1);
+    expect(checkbox.first().props().label).toBe(`Oppdater behandlingsstatus til "Vurder dokument"`);
   });
 });

--- a/src/sider/opprettnysak/opprettnysakSchema.js
+++ b/src/sider/opprettnysak/opprettnysakSchema.js
@@ -143,7 +143,7 @@ const opprettnysak = object().shape({
         Boolean(oppretterOppgave) && behandlingsaarsakType === MKV.Koder.behandlinger.behandlingsaarsaktyper.FRITEKST,
       then: string().max(25, MAX_25_TEGN).required(VELG_BEHANDLINGSAARSAK).nullable(),
     }),
-  kanOppretteAndregangsbehandling: boolean()
+  opprettBehandling: boolean()
     .nullable()
     .when("saksnummer", {
       is: (saksnummer) => !skalOppretteNySak(saksnummer) && !Utils._isEmpty(saksnummer),


### PR DESCRIPTION
- Snudd om på feltet som styrte `ingenVurdering` slik at dette er det omvendte av `vurderDokument`. Det har også fått ny tekst som følge.
- Feltet `kanOppretteAndregangsbehandling` er ikke lengre nødvendig, bruker feltet opprettBehandling istedenfor. 
- Samler initialiseringen av `opprettBehandling` og `vurderDokument`. 
- Delte visningen i `knyttTilSak.js` opp i 3: 
    - sak er henlagt, 
    - behandling er avsluttet (eller sendt anmodning), 
    - behandling er aktiv. 
- Delte opp dataSpesifikt-funksjonen til `KNYTT` og `ANDREGANGSBEHANDLING` siden det er ulik data som trengs. 
- Fikser tester. Checkboks skal nå vises for alle sakstyper.

https://jira.adeo.no/browse/MELOSYS-5374