### PR TITLE
4835 DAPI Refaktor, Tatt vekk unødvendig parameter for henting av mulige etater

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -167,7 +167,6 @@ const SendBrev = ({
 
     if (mottakerErEtat) {
       Api.DokumenterV2.hentMuligeMottakereEtater(behandlingID, {
-        produserbartdokument: formValues?.type || "",
         orgnrEtater: formValues.etater || [],
       })
         .then((response) => setMuligeMottakereEtater(response))

--- a/src/services/modules/dokumenter-v2.ts
+++ b/src/services/modules/dokumenter-v2.ts
@@ -149,7 +149,6 @@ export type HentMuligeMottakereReqDto = {
 };
 
 export type HentMuligeMottakereEtaterReqDto = {
-  produserbartdokument: string;
   orgnrEtater: string[];
 };
 


### PR DESCRIPTION
(Merges ikke før DAPI PR (wip) er klar).
Param tas vekk fordi i denne usecasen er det ingen andre enn etater som skal bruke denne. YAGNI

I backend blir produserbaredokumenter alltid FRITEKSTBREV i denne usecasen :star: 