### PR TITLE
4813: Fikser lagring/henting av kopiTilBruker-sjekkboks

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
@@ -7,6 +7,7 @@ import * as Api from "../../../../services/api";
 import * as KV from "../../../../kodeverk";
 import * as Ikoner from "../../../../resources/images";
 import * as Skjema from "../../../skjema";
+import * as Utils from "../../../../utils";
 
 import { behandlingerSelectors } from "../../../../ducks/behandlinger";
 import { formSelectors } from "../../../../ducks/form";
@@ -70,7 +71,7 @@ const BrevMottakereTabell = ({
   };
 
   const mapKopiMottakere = (muligeBrevMottakere: Api.DokumenterV2.HentMuligeMottakereResDto) => {
-    return formValues?.kopimottaker
+    return formValues?.kopiTilBruker
       ? muligeBrevMottakere.kopiMottakere.map((muligMottaker) => mapRad(muligMottaker))
       : [];
   };
@@ -89,10 +90,10 @@ const BrevMottakereTabell = ({
 
   return (
     <>
-      {muligeMottakere?.kopiMottakere?.length !== 0 && (
+      {!Utils._isEmpty(muligeMottakere?.kopiMottakere) && (
         <Skjema.Checkbox
-          className="kopimottakerSjekkboks"
-          feltNavn="kopimottaker"
+          className="kopiTilBrukerSjekkboks"
+          feltNavn="kopiTilBruker"
           label="Send kopi til bruker/brukers fullmektig"
         />
       )}

--- a/src/felleskomponenter/sideDialog/sendBrev/brevutkast/brevutkast.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevutkast/brevutkast.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { FysiskDokument } from "Domene";
 import * as Api from "../../../../services/api";
 import * as KV from "../../../../kodeverk";
+import * as Utils from "../../../../utils";
 import { SendBrevFormValues } from "../types";
 import { Fritekstvedlegg } from "../sendBrev";
 import LagredeUtkast from "./lagredeUtkast";
@@ -109,6 +110,12 @@ const Brevutkast = ({
     );
   };
 
+  const settKopiTilBruker = (kopiMottakere: Api.DokumenterV2.KopiMottaker[]) => {
+    if (!Utils._isEmpty(kopiMottakere)) {
+      changeField("kopiTilBruker", true);
+    }
+  };
+
   useEffect(() => {
     if (aktivtUtkastTittel && aktivtUtkast && formValues?.valgtBrev?.type) {
       const utkast = aktivtUtkast.brevbestilling;
@@ -121,6 +128,7 @@ const Brevutkast = ({
       settFeltVerdi("STANDARDTEKST_KONTAKTINFORMASJON", utkast.kontaktopplysninger);
       setFritekstvedlegg(utkast.fritekstvedlegg);
       settFeltForSaksvedlegg(utkast.saksvedlegg);
+      settKopiTilBruker(utkast.kopiMottakere);
     }
   }, [formValues?.valgtBrev?.type, aktivtUtkastTittel]);
 

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.less
@@ -80,7 +80,7 @@
     margin-top: 1rem;
   }
 
-  .kopimottakerSjekkboks {
+  .kopiTilBrukerSjekkboks {
     margin-top: 1rem;
     margin-bottom: 0;
   }

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -148,8 +148,7 @@ const SendBrev = ({
     const { rolle, orgnrSettesAvSaksbehandler } = values.valgtMottaker;
     if (erArbeidsgiverEllerVirksomhet(rolle) && !orgnrSettesAvSaksbehandler && !values.arbeidsgiver) return false;
     if (erArbeidsgiverEllerVirksomhet(rolle) && orgnrSettesAvSaksbehandler && !values.organisasjonsnummer) return false;
-    if (erEtat(rolle) && !harValgtEtat()) return false;
-    return true;
+    return !(erEtat(rolle) && !harValgtEtat());
   };
 
   useEffect(() => {
@@ -250,7 +249,7 @@ const SendBrev = ({
   };
 
   const hentKopiMottakere = () => {
-    return formValues.kopimottaker
+    return formValues.kopiTilBruker
       ? muligeMottakere?.kopiMottakere.map(Api.DokumenterV2.konverterMuligMottakerTilKopiMottaker)
       : [];
   };

--- a/src/felleskomponenter/sideDialog/sendBrev/types.ts
+++ b/src/felleskomponenter/sideDialog/sendBrev/types.ts
@@ -12,7 +12,7 @@ export interface SendBrevFormValues {
   felt?: {
     [key: string]: any;
   };
-  kopimottaker?: boolean;
+  kopiTilBruker?: boolean;
   trygdemyndighet?: string;
   aktivtUtkast?: Api.Brevutkast.BrevutkastResDto | null;
 }


### PR DESCRIPTION
Sjekkboksen _Send kopi til bruker/brukers fullmektig_ ble ikke lagret når vi lagret utkast. Det er nå fikset. I tillegg har vi gjort renaming av feltet, fra "kopimottaker" til "kopiTilBruker".

https://jira.adeo.no/browse/MELOSYS-4813