### PR TITLE
4813 Endrer ikon som viser mottaksretning

### DIFF
--- a/src/felleskomponenter/sideDialog/sideDialogDokumenter.less
+++ b/src/felleskomponenter/sideDialog/sideDialogDokumenter.less
@@ -32,4 +32,21 @@
       border-bottom: 1px solid @gray;
     }
   }
+
+  .mottaksretning {
+    border: 1px solid #979797;
+    border-radius: 4px;
+    text-align: center;
+    width: 3rem;
+
+    &__inn {
+      background: #d8f9ff;
+    }
+    &__ut {
+      background: #ffffff;
+    }
+    &__notat {
+      background: #e6e6e6;
+    }
+  }
 }

--- a/src/felleskomponenter/sideDialog/sideDialogDokumenter.tsx
+++ b/src/felleskomponenter/sideDialog/sideDialogDokumenter.tsx
@@ -28,11 +28,13 @@ const MottaksretningIkon = ({ mottaksretning }: MottaksretningIkonProps) => {
 
   switch (kode) {
     case MKV.Koder.mottaksretning.INN:
-      return <Ikoner.InnBrev />;
+      return <div className="mottaksretning mottaksretning__inn">inn</div>;
     case MKV.Koder.mottaksretning.UT:
-      return <Ikoner.Svar />;
+      return <div className="mottaksretning mottaksretning__ut">ut</div>;
+    case MKV.Koder.mottaksretning.NOTAT:
+      return <div className="mottaksretning mottaksretning__notat">notat</div>;
     default:
-      return <Ikoner.Svar />;
+      return <div className="mottaksretning">ukjent</div>;
   }
 };
 


### PR DESCRIPTION
Ikke togglet. Endrer ikonet i dokument-fanen. Løser punkt 4 i jira-saken.

https://jira.adeo.no/browse/MELOSYS-4813