### PR TITLE
5662:DAPI: Gjør behandlingsmeny-handlinger tilgjengelig for A1_ANMODNING_OM_UNNTAK_PAPIR

### DIFF
--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
@@ -14,6 +14,7 @@ const {
   UTSENDT_ARBEIDSTAKER,
   ANMODNING_OM_UNNTAK_HOVEDREGEL,
   REGISTRERING_UNNTAK,
+  A1_ANMODNING_OM_UNNTAK_PAPIR,
 } = MKV.Koder.behandlinger.behandlingstema;
 const { NY_VURDERING, FØRSTEGANG, HENVENDELSE, KLAGE } = MKV.Koder.behandlinger.behandlingstyper;
 const { FTRL, TRYGDEAVTALE, EU_EOS } = MKV.Koder.sakstyper;
@@ -332,6 +333,22 @@ describe("AvsluttSak", () => {
       setupProps(props);
       props.behandlingstema = REGISTRERING_UNNTAK;
       props.sakstype = TRYGDEAVTALE;
+
+      const avsluttSak = shallow(<AvsluttSak {...props} />);
+      const handlinger = avsluttSak.find(Handling);
+
+      expect(handlinger).toHaveLength(5);
+      expect(handlinger.at(0).props().tekst).toBe("Perioden er godkjent");
+      expect(handlinger.at(1).props().tekst).toBe("Perioden er delvis godkjent");
+      expect(handlinger.at(2).props().tekst).toBe("Medlem i folketrygden");
+      expect(handlinger.at(3).props().tekst).toBe("Ferdigbehandlet");
+      expect(handlinger.at(4).props().tekst).toBe("Behandlingen er bortfalt");
+    });
+
+    it(`viser Unntak-handlinger dersom behandlingstema er ${A1_ANMODNING_OM_UNNTAK_PAPIR} og sakstype er ${EU_EOS}`, () => {
+      setupProps(props);
+      props.behandlingstema = A1_ANMODNING_OM_UNNTAK_PAPIR;
+      props.sakstype = EU_EOS;
 
       const avsluttSak = shallow(<AvsluttSak {...props} />);
       const handlinger = avsluttSak.find(Handling);

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
@@ -156,7 +156,8 @@ const AvsluttSak = ({
 
   const skalViseUnntaksHandlinger =
     redigerbart &&
-    ((behandlingstemaErUnntak && sakstype === TRYGDEAVTALE) || behandlingstema === A1_ANMODNING_OM_UNNTAK_PAPIR);
+    ((behandlingstemaErUnntak && sakstype === TRYGDEAVTALE) ||
+      (behandlingstema === A1_ANMODNING_OM_UNNTAK_PAPIR && sakstype === EU_EOS));
 
   const skalViseSøknadenErInnvilget = () => {
     if (!redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) {

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
@@ -17,6 +17,7 @@ const {
   UTSENDT_ARBEIDSTAKER,
   UTSENDT_SELVSTENDIG,
   ARBEID_FLERE_LAND,
+  A1_ANMODNING_OM_UNNTAK_PAPIR,
 } = MKV.Koder.behandlinger.behandlingstema;
 const { NY_VURDERING, FØRSTEGANG, KLAGE, HENVENDELSE } = MKV.Koder.behandlinger.behandlingstyper;
 const { EU_EOS, FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
@@ -153,7 +154,9 @@ const AvsluttSak = ({
 
   const skalViseVedtakOmgjort = redigerbart && behandlingstypeErNyVurdering;
 
-  const skalViseUnntaksHandlinger = redigerbart && behandlingstemaErUnntak && sakstype === TRYGDEAVTALE;
+  const skalViseUnntaksHandlinger =
+    redigerbart &&
+    ((behandlingstemaErUnntak && sakstype === TRYGDEAVTALE) || behandlingstema === A1_ANMODNING_OM_UNNTAK_PAPIR);
 
   const skalViseSøknadenErInnvilget = () => {
     if (!redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) {
@@ -163,14 +166,16 @@ const AvsluttSak = ({
       sakstype === FTRL &&
       [FØRSTEGANG, NY_VURDERING].includes(behandlingstype) &&
       [YRKESAKTIV, IKKE_YRKESAKTIV, PENSJONIST, UNNTAK_MEDLEMSKAP].includes(behandlingstema)
-    )
+    ) {
       return true;
+    }
     if (
       [EU_EOS, TRYGDEAVTALE].includes(sakstype) &&
       [FØRSTEGANG, NY_VURDERING].includes(behandlingstype) &&
       [YRKESAKTIV, IKKE_YRKESAKTIV, PENSJONIST, ARBEID_KUN_NORGE].includes(behandlingstema)
-    )
+    ) {
       return true;
+    }
 
     return false;
   };


### PR DESCRIPTION
NB! Denne er avhengig av https://github.com/navikt/melosys-api/pull/1664.

Gjør handlinger i behandlingsmeny tilgjengelig for A1_ANMODNING_OM_UNNTAK_PAPIR. 

https://jira.adeo.no/browse/MELOSYS-5662

Det er en annen feil som viser feil valg i NY_VURDERING, men den feilen ligger også for sakstype TRYGDEAVTALE. Fiks kommer i egen PR.