### PR TITLE
4813 Disable knapp når mottaker ikke har blitt valgt i Send brev

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -567,7 +567,7 @@ const SendBrev = ({
             Lagre utkast
           </Nav.Knapp>
         )}
-        <Nav.Knapp mini className="brevknapp" onClick={forkastBrev}>
+        <Nav.Knapp mini disabled={!formValues.valgtMottaker} className="brevknapp" onClick={forkastBrev}>
           Forkast brev
         </Nav.Knapp>
       </div>


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-4813

Disabler "Forkast brev"-knapp når man ikke har valgt mottaker. Fikser etter kommentar fra testing.