### PR TITLE
5711 Viser full tekstblokk fra Gosys i oppgaven

### DIFF
--- a/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
+++ b/src/felleskomponenter/oppgaveliste/behandlingOppgave.js
@@ -77,9 +77,31 @@ const BehandlingOppgave = ({ sak, folketrygdenToggleEnabled, ikkeYrkesaktivFlytT
     behandlingOppgave__stengt: erUnderOppdatering,
   });
 
-  const reduserTekstLengde = (tekst) => {
-    const maxLengde = 60;
-    return tekst != null && tekst.length > maxLengde ? `${tekst.slice(0, maxLengde)} (...)` : tekst;
+  const hentForsteGosysTekstblokk = (tekst) => {
+    if (!tekst || !tekst.includes("\n")) {
+      return tekst;
+    }
+
+    let forsteBlokk = tekst;
+    const start = tekst.indexOf("---");
+    if (start >= 0 && !tekst.startsWith("---")) {
+      forsteBlokk = tekst.substring(0, start).trim();
+    }
+
+    if (start >= 0) {
+      const andreDelimeter = tekst.indexOf("---", start + 1);
+      const siste = tekst.indexOf("---", andreDelimeter + 1);
+      if (siste >= 0) {
+        forsteBlokk = tekst.substring(start, siste).trim();
+      }
+    }
+
+    return <span>{forsteBlokk}</span>;
+  };
+
+  const reduserTekstLinjer = (tekst) => {
+    const lines = tekst.split("\n");
+    return lines.slice(0, 3).join("\n");
   };
 
   return (
@@ -120,11 +142,13 @@ const BehandlingOppgave = ({ sak, folketrygdenToggleEnabled, ikkeYrkesaktivFlytT
           </Nav.Column>
 
           <Nav.Column xs="6" md="6" lg="4" className="behandlingOppgave__kolonne__notater">
-            <Nav.Row>{reduserTekstLengde(notat)}</Nav.Row>
+            <span>
+              <b>Behandlingsnotat:</b> {reduserTekstLinjer(notat)}
+            </span>
             <Nav.Row>
-              <b>Gosys:</b>
+              <b>Gosys beskrivelseshistorikk:</b>
               <br />
-              {reduserTekstLengde(beskrivelse)}
+              {hentForsteGosysTekstblokk(beskrivelse)}
             </Nav.Row>
           </Nav.Column>
         </Nav.Row>

--- a/src/felleskomponenter/sideDialog/sideDialog.tsx
+++ b/src/felleskomponenter/sideDialog/sideDialog.tsx
@@ -157,7 +157,7 @@ const SideDialog = ({
 
 export const defaultFaner: Fane[] = [
   { navn: "dokumenter", tittel: "Dokumenter" },
-  { navn: "notat", tittel: "Notat" },
+  { navn: "notat", tittel: "Behandlingsnotat" },
   { navn: "brevbestilling", tittel: "Send brev" },
   { navn: "sedbestilling", tittel: "Opprett ny BUC" },
   { navn: "besvarsed", tittel: "SED-utveksling" },
@@ -165,7 +165,7 @@ export const defaultFaner: Fane[] = [
 
 export const fanerUtenBucOgSed: Fane[] = [
   { navn: "dokumenter", tittel: "Dokumenter" },
-  { navn: "notat", tittel: "Notat" },
+  { navn: "notat", tittel: "Behandlingsnotat" },
   { navn: "brevbestilling", tittel: "Send brev" },
 ];
 


### PR DESCRIPTION
Etter testing ble følgende bestemt:
* Viser nå full tekst fra Gosys, men splitter opp slik Gosys/Melosys nå splitter. Splitter altså på ---tekst---, ettersom det er da nytt innslag i feltet. Skal bare vise første innslag.
* Notat skal nå hete Behandlingsnotat
* Legger også til tekst som viser at det er en Melosys notat i oppgaven.


https://jira.adeo.no/browse/MELOSYS-5711

Andre fiks fra test: https://github.com/navikt/melosys-api/pull/1675