### PR TITLE
5700 DAPI DDOKGEN Aktoersroller -> mottakerroller for forhåndsvisning

### DIFF
--- a/src/felleskomponenter/dialogboks/avslagSoknad/dialogboksAvslagSoknad.tsx
+++ b/src/felleskomponenter/dialogboks/avslagSoknad/dialogboksAvslagSoknad.tsx
@@ -79,7 +79,7 @@ export const DialogboksAvslagSoknad = (props: DialogboksAvslagSoknadProps & Prop
       data: {
         begrunnelseKode: MKV.Koder.begrunnelser.folketrygdloven.avslag.MANGLENDE_OPPLYSNINGER,
         fritekst: brevFritekst,
-        mottaker: MKV.Koder.aktoersroller.BRUKER,
+        mottaker: MKV.Koder.mottakerroller.BRUKER,
       },
     },
   ];

--- a/src/felleskomponenter/dialogboks/henlegg/dialogboksHenlegg.tsx
+++ b/src/felleskomponenter/dialogboks/henlegg/dialogboksHenlegg.tsx
@@ -116,7 +116,7 @@ export const DialogboksHenleggSak = ({
     ? {
         begrunnelseKode,
         fritekst,
-        mottaker: MKV.Koder.aktoersroller.BRUKER,
+        mottaker: MKV.Koder.mottakerroller.BRUKER,
       }
     : {};
 

--- a/src/felleskomponenter/pdfLenkeListe/pdfLenkeListe.test.js
+++ b/src/felleskomponenter/pdfLenkeListe/pdfLenkeListe.test.js
@@ -23,7 +23,7 @@ describe("PdfLenkeListe", () => {
           data: {
             begrunnelseKode: MKV.Koder.begrunnelser.folketrygdloven.avslag.MANGLENDE_OPPLYSNINGER,
             fritekst: null,
-            mottaker: MKV.Koder.aktoersroller.BRUKER,
+            mottaker: MKV.Koder.mottakerroller.BRUKER,
           },
         },
         {

--- a/src/sider/eu_eøs/saksbehandling/stegMap/vedtak.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/vedtak.js
@@ -31,7 +31,7 @@ class Vedtak extends Steg {
           navn: "Forhåndsvis vedtaksbrev og A1",
           type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV,
           data: {
-            mottaker: MKV.Koder.aktoersroller.BRUKER,
+            mottaker: MKV.Koder.mottakerroller.BRUKER,
             fritekst: formValues.vedtaksbrevFritekst,
           },
         },
@@ -50,7 +50,7 @@ class Vedtak extends Steg {
           navn: "Orienteringsbrev til arbeidsgiver",
           type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_ARBEIDSGIVER,
           data: {
-            mottaker: MKV.Koder.aktoersroller.ARBEIDSGIVER,
+            mottaker: MKV.Koder.mottakerroller.ARBEIDSGIVER,
           },
         });
       }

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak.js
@@ -166,7 +166,7 @@ export const VurderingArbeidTjenestepersonEllerFlyVedtak = ({
       navn: "Forhåndsvis vedtaksbrev og A1",
       type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV,
       data: {
-        mottaker: MKV.Koder.aktoersroller.BRUKER,
+        mottaker: MKV.Koder.mottakerroller.BRUKER,
         fritekst: formValues.vedtaksbrevFritekst,
       },
     },

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13UtpekLand.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13UtpekLand.js
@@ -114,7 +114,7 @@ export const VurderingArtikkel13UtpekLand = ({
       data: {
         begrunnelseKode: null,
         fritekst: formValues.fritekstOrienteringsbrev,
-        mottaker: MKV.Koder.aktoersroller.BRUKER,
+        mottaker: MKV.Koder.mottakerroller.BRUKER,
       },
     },
     {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.js
@@ -111,7 +111,7 @@ export const VurderingArtikkel13_x_vedtak = ({
       navn: "Forhåndsvis vedtaksbrev og A1",
       type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV_FLERE_LAND,
       data: {
-        mottaker: MKV.Koder.aktoersroller.BRUKER,
+        mottaker: MKV.Koder.mottakerroller.BRUKER,
         fritekst: formValues.vedtaksbrevFritekst,
       },
     },

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning.js
@@ -330,7 +330,7 @@ class VurderingArtikkel16Anmodning extends Component {
             navn: "Forhåndsvis orienteringsbrev til bruker",
             type: MKV.Koder.brev.produserbaredokumenter.ORIENTERING_ANMODNING_UNNTAK,
             data: {
-              mottaker: MKV.Koder.aktoersroller.BRUKER,
+              mottaker: MKV.Koder.mottakerroller.BRUKER,
             },
           },
           {
@@ -347,14 +347,14 @@ class VurderingArtikkel16Anmodning extends Component {
             navn: "Forhåndsvis orienteringsbrev til bruker",
             type: MKV.Koder.brev.produserbaredokumenter.ORIENTERING_ANMODNING_UNNTAK,
             data: {
-              mottaker: MKV.Koder.aktoersroller.BRUKER,
+              mottaker: MKV.Koder.mottakerroller.BRUKER,
             },
           },
           {
             navn: "Forhåndsvis anmodning til utenlandsk myndighet",
             type: MKV.Koder.brev.produserbaredokumenter.ANMODNING_UNNTAK,
             data: {
-              mottaker: MKV.Koder.aktoersroller.TRYGDEMYNDIGHET,
+              mottaker: MKV.Koder.mottakerroller.UTENLANDSK_TRYGDEMYNDIGHET,
               ytterligereInformasjon: this.props.formValues.fritekstSed,
             },
           },

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak.js
@@ -88,7 +88,7 @@ export const Innvilgelse = ({
       type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV,
       data: {
         fritekst: vedtaksbrevFritekst,
-        mottaker: MKV.Koder.aktoersroller.BRUKER,
+        mottaker: MKV.Koder.mottakerroller.BRUKER,
       },
     },
   ];
@@ -98,7 +98,7 @@ export const Innvilgelse = ({
       navn: "Brev til arbeidsgiver",
       type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_ARBEIDSGIVER,
       data: {
-        mottaker: MKV.Koder.aktoersroller.ARBEIDSGIVER,
+        mottaker: MKV.Koder.mottakerroller.ARBEIDSGIVER,
       },
     });
   }
@@ -180,7 +180,7 @@ export const DelvisInnvilgelse = ({
       type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV,
       data: {
         fritekst: vedtaksbrevFritekst,
-        mottaker: MKV.Koder.aktoersroller.BRUKER,
+        mottaker: MKV.Koder.mottakerroller.BRUKER,
       },
     },
   ];
@@ -190,7 +190,7 @@ export const DelvisInnvilgelse = ({
       navn: "Brev til arbeidsgiver",
       type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_ARBEIDSGIVER,
       data: {
-        mottaker: MKV.Koder.aktoersroller.ARBEIDSGIVER,
+        mottaker: MKV.Koder.mottakerroller.ARBEIDSGIVER,
       },
     });
   }
@@ -272,7 +272,7 @@ export const Avslag = ({
       type: MKV.Koder.brev.produserbaredokumenter.AVSLAG_YRKESAKTIV,
       data: {
         fritekst: vedtaksbrevFritekst,
-        mottaker: MKV.Koder.aktoersroller.BRUKER,
+        mottaker: MKV.Koder.mottakerroller.BRUKER,
       },
     },
   ];
@@ -282,7 +282,7 @@ export const Avslag = ({
       navn: "Brev til arbeidsgiver",
       type: MKV.Koder.brev.produserbaredokumenter.AVSLAG_ARBEIDSGIVER,
       data: {
-        mottaker: MKV.Koder.aktoersroller.ARBEIDSGIVER,
+        mottaker: MKV.Koder.mottakerroller.ARBEIDSGIVER,
       },
     });
   }

--- a/src/sider/eu_eøs/stegKomponenter/vurderingAvslag12_x_og_16.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingAvslag12_x_og_16.js
@@ -46,7 +46,7 @@ const VurderingAvslag12_x_og_16 = ({
       navn: "Forhåndsvis vedtaksbrev",
       type: MKV.Koder.brev.produserbaredokumenter.AVSLAG_YRKESAKTIV,
       data: {
-        mottaker: MKV.Koder.aktoersroller.BRUKER,
+        mottaker: MKV.Koder.mottakerroller.BRUKER,
         fritekst: formValues.vedtaksbrevFritekst,
       },
     },
@@ -57,7 +57,7 @@ const VurderingAvslag12_x_og_16 = ({
       navn: "Orientering til arbeidsgiver om avslag",
       type: MKV.Koder.brev.produserbaredokumenter.AVSLAG_ARBEIDSGIVER,
       data: {
-        mottaker: MKV.Koder.aktoersroller.ARBEIDSGIVER,
+        mottaker: MKV.Koder.mottakerroller.ARBEIDSGIVER,
       },
     });
   }

--- a/src/sider/eu_eøs/stegKomponenter/vurderingEndrePeriode.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingEndrePeriode.js
@@ -206,7 +206,7 @@ export class VurderingEndrePeriode extends React.Component {
         navn: "Forhåndsvis vedtaksbrev og A1",
         type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV,
         data: {
-          mottaker: MKV.Koder.aktoersroller.BRUKER,
+          mottaker: MKV.Koder.mottakerroller.BRUKER,
           fritekst: null,
           begrunnelseKode: begrunnelse,
         },

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVideresend.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVideresend.js
@@ -41,7 +41,7 @@ export const VurderingVideresend = ({
       navn: "Forhåndsvis orienteringsbrev",
       type: MKV.Koder.brev.produserbaredokumenter.ORIENTERING_VIDERESENDT_SOEKNAD,
       data: {
-        mottaker: MKV.Koder.aktoersroller.BRUKER,
+        mottaker: MKV.Koder.mottakerroller.BRUKER,
         fritekst: formValues.orienteringsbrevFritekst,
       },
     },

--- a/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
+++ b/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
@@ -21,7 +21,7 @@ class GodkjennUtpekingNorge extends Steg {
           navn: "Forhåndsvis vedtaksbrev og A1",
           type: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV_FLERE_LAND,
           data: {
-            mottaker: MKV.Koder.aktoersroller.BRUKER,
+            mottaker: MKV.Koder.mottakerroller.BRUKER,
             fritekst: formValues.vedtaksbrevFritekst,
           },
         },


### PR DESCRIPTION
Endrer fra aktoersroller til mottakerroller ved visning av utkast. Det er egentlig bare feil i vurderingArtikkel16Anmodning.js der vi brukte "TRYGDEAVTALE" istedenfor "UTENLANDSK_TRYGDEAVTALE", men greit å være konsekvente.


https://jira.adeo.no/browse/MELOSYS-5700