### PR TITLE
NOJIRA Fjernet typescript warning for ariaHideApp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,7 @@
         "@types/react-datepicker": "^3.1.8",
         "@types/react-dom": "^16.9.8",
         "@types/react-draft-wysiwyg": "^1.13.0",
+        "@types/react-modal": "^3.13.1",
         "@types/react-redux": "^7.1.9",
         "@types/react-router-dom": "^5.1.5",
         "@types/react-select": "^3.1.2",
@@ -6458,6 +6459,14 @@
       "dev": true,
       "dependencies": {
         "@types/draft-js": "*",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-modal": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.13.1.tgz",
+      "integrity": "sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==",
+      "dependencies": {
         "@types/react": "*"
       }
     },
@@ -37241,6 +37250,14 @@
       "dev": true,
       "requires": {
         "@types/draft-js": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-modal": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.13.1.tgz",
+      "integrity": "sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==",
+      "requires": {
         "@types/react": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "@types/react-datepicker": "^3.1.8",
     "@types/react-dom": "^16.9.8",
     "@types/react-draft-wysiwyg": "^1.13.0",
+    "@types/react-modal": "^3.13.1",
     "@types/react-redux": "^7.1.9",
     "@types/react-router-dom": "^5.1.5",
     "@types/react-select": "^3.1.2",

--- a/src/felleskomponenter/dialogboks/avslagSoknad/dialogboksAvslagSoknad.tsx
+++ b/src/felleskomponenter/dialogboks/avslagSoknad/dialogboksAvslagSoknad.tsx
@@ -102,7 +102,6 @@ export const DialogboksAvslagSoknad = (props: DialogboksAvslagSoknadProps & Prop
       onRequestClose={avbryt}
       closeButton={false}
       shouldCloseOnOverlayClick
-      // @ts-ignore
       ariaHideApp={ariaHideApp}
     >
       <div className="avslagsoknadcontainer">

--- a/src/felleskomponenter/dialogboks/henlegg/dialogboksHenlegg.tsx
+++ b/src/felleskomponenter/dialogboks/henlegg/dialogboksHenlegg.tsx
@@ -138,7 +138,6 @@ export const DialogboksHenleggSak = ({
       onRequestClose={avbryt}
       closeButton={false}
       shouldCloseOnOverlayClick
-      // @ts-ignore
       ariaHideApp={ariaHideApp}
     >
       <div>

--- a/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmer/annenForelderModal/annenForelderModal.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmer/annenForelderModal/annenForelderModal.tsx
@@ -85,7 +85,6 @@ const AnnenForelderModal = ({
       shouldCloseOnOverlayClick
       closeButton
       onRequestClose={onRequestClose}
-      // @ts-ignore
       ariaHideApp={ariaHideApp}
     >
       <Nav.Typo.Innholdstittel className={annenForelderModalClassName.element("tittel")}>

--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.tsx
@@ -65,7 +65,6 @@ const PersonstatusModal = ({
       onRequestClose={lukkModal}
       isOpen={skalViseModal}
       closeButton
-      // @ts-ignore
       ariaHideApp={modalAriaHideApp}
     >
       <Nav.Typo.Innholdstittel>Personstatus</Nav.Typo.Innholdstittel>

--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/sivilstand/sivilstandModal.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/sivilstand/sivilstandModal.tsx
@@ -73,7 +73,6 @@ const SivilstandModal = ({
       onRequestClose={lukkModal}
       isOpen={skalViseModal}
       closeButton
-      // @ts-ignore
       ariaHideApp={modalAriaHideApp}
     >
       <Mui.Undertittel tekst="Sivilstand" />

--- a/src/felleskomponenter/vedleggTable/slettFritekstvedleggModal.tsx
+++ b/src/felleskomponenter/vedleggTable/slettFritekstvedleggModal.tsx
@@ -22,7 +22,6 @@ const SlettFritekstvedleggModal = ({
       isOpen
       shouldCloseOnOverlayClick
       onRequestClose={onRequestClose}
-      // @ts-ignore
       ariaHideApp={ariaHideApp}
     >
       <Nav.Row>

--- a/src/felleskomponenter/vedleggvelger/vedleggVelgerModal.tsx
+++ b/src/felleskomponenter/vedleggvelger/vedleggVelgerModal.tsx
@@ -34,7 +34,6 @@ const VedleggVelgerModal = ({
       shouldCloseOnOverlayClick
       closeButton
       onRequestClose={onRequestClose}
-      // @ts-ignore
       ariaHideApp={ariaHideApp}
     >
       <Nav.Typo.Element>{contentLabel}</Nav.Typo.Element>


### PR DESCRIPTION
Vi har endel @ts-ignore på ariaHideApp-prop-en for modalene våre. Dette for å stoppe en typescript feil som sa den ikke gjenkjente prop-en. Det viste seg å være en manglende type-dependency i bunn. La pakken inn og fjernet alle @ts-ignore.