### PR TITLE
5684: Fiks validering av felt

### DIFF
--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.less
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.less
@@ -2,6 +2,8 @@
   .undertittel {
     margin-bottom: 1.5rem;
   }
+
+  &__godkjent_advarsel,
   &__info {
     margin-top: 0.5rem;
     margin-bottom: -0.5rem;
@@ -9,16 +11,9 @@
       max-width: none;
     }
   }
+
   &__ikke_godkjent_advarsel {
     margin-top: 1rem;
-    .alertstripe__tekst {
-      max-width: none;
-    }
-  }
-
-  &__godkjent_advarsel {
-    margin-top: 0.5rem;
-    margin-bottom: -0.5rem;
     .alertstripe__tekst {
       max-width: none;
     }

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.less
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.less
@@ -2,7 +2,21 @@
   .undertittel {
     margin-bottom: 1.5rem;
   }
-  &__alertstripe {
+  &__info {
+    margin-top: 0.5rem;
+    margin-bottom: -0.5rem;
+    .alertstripe__tekst {
+      max-width: none;
+    }
+  }
+  &__ikke_godkjent_advarsel {
+    margin-top: 1rem;
+    .alertstripe__tekst {
+      max-width: none;
+    }
+  }
+
+  &__godkjent_advarsel {
     margin-top: 0.5rem;
     margin-bottom: -0.5rem;
     .alertstripe__tekst {

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -129,6 +129,12 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
     dispatch(navigeringOperations.tilForsiden());
   };
 
+  const kanIkkeGodkjenneUnntaksperiodeAdvarsel = (
+    <Nav.AlertStripeAdvarsel className="vurderingUnntakMedlemskap__alertstripe">
+      Du kan ikke godkjenne en unntaksperiode med åpen sluttdato
+    </Nav.AlertStripeAdvarsel>
+  );
+
   return (
     <div className="vurderingUnntakMedlemskap">
       <Nav.Typo.Undertittel className="undertittel">Unntak medlemskap</Nav.Typo.Undertittel>
@@ -180,11 +186,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
               </Forms.Select>
             </Nav.Column>
           </Nav.Row>
-          {Utils._isEmpty(mottatteOpplysningerPeriode.tom) && (
-            <Nav.AlertStripeAdvarsel className="vurderingUnntakMedlemskap__alertstripe">
-              Du kan ikke godkjenne en unntaksperiode med åpen sluttdato
-            </Nav.AlertStripeAdvarsel>
-          )}
+          {Utils._isEmpty(mottatteOpplysningerPeriode.tom) && kanIkkeGodkjenneUnntaksperiodeAdvarsel}
         </>
       )}
 
@@ -231,6 +233,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
             Ved endring av unntaksperiode bør det sendes informasjon til utenlandsk myndighet. Benytt fritekstbrev i
             brevmenyen.
           </Nav.AlertStripeInfo>
+          {Utils._isEmpty(formValues.tom) && kanIkkeGodkjenneUnntaksperiodeAdvarsel}
         </Nav.Fieldset>
       )}
 

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -129,12 +129,6 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
     dispatch(navigeringOperations.tilForsiden());
   };
 
-  const kanIkkeGodkjenneUnntaksperiodeAdvarsel = (
-    <Nav.AlertStripeAdvarsel className="vurderingUnntakMedlemskap__alertstripe">
-      Du kan ikke godkjenne en unntaksperiode med åpen sluttdato
-    </Nav.AlertStripeAdvarsel>
-  );
-
   return (
     <div className="vurderingUnntakMedlemskap">
       <Nav.Typo.Undertittel className="undertittel">Unntak medlemskap</Nav.Typo.Undertittel>
@@ -186,7 +180,11 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
               </Forms.Select>
             </Nav.Column>
           </Nav.Row>
-          {Utils._isEmpty(mottatteOpplysningerPeriode.tom) && kanIkkeGodkjenneUnntaksperiodeAdvarsel}
+          {Utils._isEmpty(mottatteOpplysningerPeriode.tom) && (
+            <Nav.AlertStripeAdvarsel className="vurderingUnntakMedlemskap__godkjent_advarsel">
+              Du kan ikke godkjenne en unntaksperiode med åpen sluttdato
+            </Nav.AlertStripeAdvarsel>
+          )}
         </>
       )}
 
@@ -229,11 +227,15 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
               </Forms.Select>
             </Nav.Column>
           </Nav.Row>
-          <Nav.AlertStripeInfo className="vurderingUnntakMedlemskap__alertstripe">
+          <Nav.AlertStripeInfo className="vurderingUnntakMedlemskap__info">
             Ved endring av unntaksperiode bør det sendes informasjon til utenlandsk myndighet. Benytt fritekstbrev i
             brevmenyen.
           </Nav.AlertStripeInfo>
-          {Utils._isEmpty(formValues.tom) && kanIkkeGodkjenneUnntaksperiodeAdvarsel}
+          {Utils._isEmpty(formValues.tom) && (
+            <Nav.AlertStripeAdvarsel className="vurderingUnntakMedlemskap__ikke_godkjent_advarsel">
+              Du kan ikke godkjenne en unntaksperiode med åpen sluttdato
+            </Nav.AlertStripeAdvarsel>
+          )}
         </Nav.Fieldset>
       )}
 

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskapSchema.js
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskapSchema.js
@@ -17,12 +17,12 @@ const erIkkeInnvilgetMedÅpenSluttDatoGodkjentUtfall = {
 
 const vurdering_unntak_medlemskap = object().shape({
   utfallRegistreringUnntak: string().test(erIkkeInnvilgetMedÅpenSluttDatoGodkjentUtfall).required(MAA_FYLLES_UT),
-  fom: string().when("$utfallRegistreringUnntak", {
-    is: MKV.Koder.innvilgelsesResultat.DELVIS_GODKJENT,
+  fom: string().when("utfallRegistreringUnntak", {
+    is: MKV.Koder.utfallregistreringunntak.DELVIS_GODKJENT,
     then: string().erGyldigDato().required(MAA_FYLLES_UT),
   }),
   tom: string().when("utfallRegistreringUnntak", {
-    is: (utfall) => utfall === MKV.Koder.utfallregistreringunntak.DELVIS_GODKJENT,
+    is: MKV.Koder.utfallregistreringunntak.DELVIS_GODKJENT,
     then: string().erGyldigDato().erEtterDatofelt("fom", TIDLIGERE_ENN_FOM).required(MAA_FYLLES_UT),
   }),
   bestemmelse: string().when("utfallRegistreringUnntak", {

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskapSchema.js
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskapSchema.js
@@ -5,8 +5,8 @@ import MKV from "../../../melosyskodeverk";
 
 const { MAA_FYLLES_UT, TIDLIGERE_ENN_FOM } = KV.Feilmeldinger;
 
-const erIkkeInnvilgetMedÅpenSluttDato = {
-  name: "Ikke godkjenn åpen sluttdato",
+const erIkkeInnvilgetMedÅpenSluttDatoGodkjentUtfall = {
+  name: "Ikke godkjenn åpen sluttdato for GODKJENT utfall",
   message: { feilmelding: "Du kan ikke godkjenne en periode med åpen sluttdato" },
   test() {
     const resultat = this.parent.utfallRegistreringUnntak;
@@ -15,16 +15,28 @@ const erIkkeInnvilgetMedÅpenSluttDato = {
   },
 };
 
+const erIkkeInnvilgetMedÅpenSluttDatoDelvisGodkjentUtfall = {
+  name: "Ikke godkjenn åpen sluttdato for DELVIS_GODKJENT utfall",
+  message: { feilmelding: "Du kan ikke godkjenne en periode med åpen sluttdato" },
+  test() {
+    const resultat = this.parent.utfallRegistreringUnntak;
+    const sluttdato = this.parent.tom;
+    return !(resultat === MKV.Koder.utfallregistreringunntak.DELVIS_GODKJENT && Utils._isEmpty(sluttdato));
+  },
+};
+
 const vurdering_unntak_medlemskap = object().shape({
-  utfallRegistreringUnntak: string().test(erIkkeInnvilgetMedÅpenSluttDato).required(MAA_FYLLES_UT),
+  utfallRegistreringUnntak: string().test(erIkkeInnvilgetMedÅpenSluttDatoGodkjentUtfall).required(MAA_FYLLES_UT),
   fom: string().when("utfallRegistreringUnntak", {
     is: MKV.Koder.innvilgelsesResultat.DELVIS_GODKJENT,
     then: string().erGyldigDato().required(MAA_FYLLES_UT),
   }),
-  tom: string().when("utfallRegistreringUnntak", {
-    is: MKV.Koder.innvilgelsesResultat.DELVIS_GODKJENT,
-    then: string().erGyldigDato().erEtterDatofelt("fom", TIDLIGERE_ENN_FOM).required(MAA_FYLLES_UT),
-  }),
+  tom: string()
+    .when("utfallRegistreringUnntak", {
+      is: MKV.Koder.innvilgelsesResultat.DELVIS_GODKJENT,
+      then: string().erGyldigDato().erEtterDatofelt("fom", TIDLIGERE_ENN_FOM).required(MAA_FYLLES_UT),
+    })
+    .test(erIkkeInnvilgetMedÅpenSluttDatoDelvisGodkjentUtfall),
   bestemmelse: string().when("utfallRegistreringUnntak", {
     is: (vurdering) =>
       vurdering === MKV.Koder.utfallregistreringunntak.GODKJENT ||

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskapSchema.js
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskapSchema.js
@@ -15,32 +15,20 @@ const erIkkeInnvilgetMedÅpenSluttDatoGodkjentUtfall = {
   },
 };
 
-const erIkkeInnvilgetMedÅpenSluttDatoDelvisGodkjentUtfall = {
-  name: "Ikke godkjenn åpen sluttdato for DELVIS_GODKJENT utfall",
-  message: { feilmelding: "Du kan ikke godkjenne en periode med åpen sluttdato" },
-  test() {
-    const resultat = this.parent.utfallRegistreringUnntak;
-    const sluttdato = this.parent.tom;
-    return !(resultat === MKV.Koder.utfallregistreringunntak.DELVIS_GODKJENT && Utils._isEmpty(sluttdato));
-  },
-};
-
 const vurdering_unntak_medlemskap = object().shape({
   utfallRegistreringUnntak: string().test(erIkkeInnvilgetMedÅpenSluttDatoGodkjentUtfall).required(MAA_FYLLES_UT),
-  fom: string().when("utfallRegistreringUnntak", {
+  fom: string().when("$utfallRegistreringUnntak", {
     is: MKV.Koder.innvilgelsesResultat.DELVIS_GODKJENT,
     then: string().erGyldigDato().required(MAA_FYLLES_UT),
   }),
-  tom: string()
-    .when("utfallRegistreringUnntak", {
-      is: MKV.Koder.innvilgelsesResultat.DELVIS_GODKJENT,
-      then: string().erGyldigDato().erEtterDatofelt("fom", TIDLIGERE_ENN_FOM).required(MAA_FYLLES_UT),
-    })
-    .test(erIkkeInnvilgetMedÅpenSluttDatoDelvisGodkjentUtfall),
+  tom: string().when("utfallRegistreringUnntak", {
+    is: (utfall) => utfall === MKV.Koder.utfallregistreringunntak.DELVIS_GODKJENT,
+    then: string().erGyldigDato().erEtterDatofelt("fom", TIDLIGERE_ENN_FOM).required(MAA_FYLLES_UT),
+  }),
   bestemmelse: string().when("utfallRegistreringUnntak", {
-    is: (vurdering) =>
-      vurdering === MKV.Koder.utfallregistreringunntak.GODKJENT ||
-      vurdering === MKV.Koder.utfallregistreringunntak.DELVIS_GODKJENT,
+    is: (utfall) =>
+      utfall === MKV.Koder.utfallregistreringunntak.GODKJENT ||
+      utfall === MKV.Koder.utfallregistreringunntak.DELVIS_GODKJENT,
     then: string().required(MAA_FYLLES_UT),
   }),
 });


### PR DESCRIPTION
Validering av periode-feltene fungerte ikke slik det skulle.
Følgende feil er fikset:
- Validering av tilOgMed-dato (ikke tomt)
- Validering av tilOgMed-dato (ikke før fraOgMed dato)
- Validering av fraOgMed-dato
- Det er lagt til logikk for DELVIS_GODKJENT; hvis man mangler å fylle ut tilOgMedDato, vil man få feilmelding
- 
https://jira.adeo.no/browse/MELOSYS-5684