### PR TITLE
5687 Venter til kall mot backend er feridig før sbh får bekrefte

### DIFF
--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -63,7 +63,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
   };
 
   const debouncedLagreLovvalgsperiode = useCallback(
-    Utils._debounce(async () => dispatch(lovvalgsperioderOperations.lagre()), 1000),
+    Utils._debounce(() => dispatch(lovvalgsperioderOperations.lagre()), 1000),
     []
   );
 

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect } from "react";
 import { KTObject } from "@navikt/melosys-kodeverk";
 import { FieldValues, useForm } from "react-hook-form";
 import { useDispatch, useSelector } from "react-redux";
@@ -40,7 +40,6 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
   const mottatteOpplysningerPeriode = useSelector(mottatteOpplysningerSelectors.PeriodeSelector);
   const lovvalgsperiode = useSelector(lovvalgsperioderSelectors.LovvalgsperiodeSelector);
   const utfallRegistreringUnntak = useSelector(behandlingsresultatSelectors.UtfallRegistreringUnntakSelector);
-  const [lovvalgsperioderLagret, setLovvalgsperioderLagret] = useState(true);
 
   const { control, watch, formState } = useForm({
     resolver: yupResolver(vurdering_unntak_medlemskap),
@@ -64,15 +63,11 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
   };
 
   const debouncedLagreLovvalgsperiode = useCallback(
-    Utils._debounce(async () => {
-      await dispatch(lovvalgsperioderOperations.lagre());
-      setLovvalgsperioderLagret(true);
-    }, 1000),
+    Utils._debounce(async () => dispatch(lovvalgsperioderOperations.lagre()), 1000),
     []
   );
 
   const oppdaterOgLagreLovvalgsperiode = (values: FieldValues) => {
-    setLovvalgsperioderLagret(false);
     const harMedlemskapstypeDelvisUnntatt =
       sakstype === MKV.Koder.sakstyper.TRYGDEAVTALE &&
       [
@@ -130,6 +125,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
   };
 
   const handleBekreft = async () => {
+    await dispatch(lovvalgsperioderOperations.lagre());
     await Api.Saksflyt.Unntaksregistrering.registrerUnntakFraMedlemskap(behandlingID);
     dispatch(navigeringOperations.tilForsiden());
   };
@@ -254,7 +250,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
         tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
         bekreftKnappProps={{
           onClick: handleBekreft,
-          disabled: !formState?.isValid || !lovvalgsperioderLagret || !redigerbart,
+          disabled: !formState?.isValid || !redigerbart,
         }}
         bekreftTekst="Bekreft og avslutt"
       />

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { KTObject } from "@navikt/melosys-kodeverk";
 import { FieldValues, useForm } from "react-hook-form";
 import { useDispatch, useSelector } from "react-redux";
@@ -40,6 +40,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
   const mottatteOpplysningerPeriode = useSelector(mottatteOpplysningerSelectors.PeriodeSelector);
   const lovvalgsperiode = useSelector(lovvalgsperioderSelectors.LovvalgsperiodeSelector);
   const utfallRegistreringUnntak = useSelector(behandlingsresultatSelectors.UtfallRegistreringUnntakSelector);
+  const [lovvalgsperioderLagret, setLovvalgsperioderLagret] = useState(true);
 
   const { control, watch, formState } = useForm({
     resolver: yupResolver(vurdering_unntak_medlemskap),
@@ -63,11 +64,15 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
   };
 
   const debouncedLagreLovvalgsperiode = useCallback(
-    Utils._debounce(() => dispatch(lovvalgsperioderOperations.lagre()), 1000),
+    Utils._debounce(async () => {
+      await dispatch(lovvalgsperioderOperations.lagre());
+      setLovvalgsperioderLagret(true);
+    }, 1000),
     []
   );
 
   const oppdaterOgLagreLovvalgsperiode = (values: FieldValues) => {
+    setLovvalgsperioderLagret(false);
     const harMedlemskapstypeDelvisUnntatt =
       sakstype === MKV.Koder.sakstyper.TRYGDEAVTALE &&
       [
@@ -249,7 +254,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
         tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
         bekreftKnappProps={{
           onClick: handleBekreft,
-          disabled: !formState?.isValid || !redigerbart,
+          disabled: !formState?.isValid || !lovvalgsperioderLagret || !redigerbart,
         }}
         bekreftTekst="Bekreft og avslutt"
       />


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5687

Lovvalgsperiode settes når saksbehandler velger bestemmelse.
Prosessinstans `REGISTRERE_UNNTAK_FRA_MEDLEMSKAP` som kjører etter `Bekreft og avslutt` feiler om ikke lovvalgsperioden er satt. Setter derfor på en begrensning at sbh ikke kan trykke på `Bekreft og avslutt` før kallet til api om å oppdatere/sette lovvalgsperiode er ferdig.
Er usikker på om dette holder eller om det må inn faktisk delay eller noe annet.