### PR TITLE
5693: Fjern orienteringsbrev valg

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak.js
@@ -40,6 +40,7 @@ import {
 
 import "./vurderingArbeidTjenestepersonEllerFlyVedtak.css";
 import { vedtakOperations } from "../../../ducks/vedtak";
+import { fagsakSelectors } from "../../../ducks/fagsaker";
 
 const InformertMyndighetVelger = ({ redigerbart, oppdaterData, slettData, informertMyndighetFakta }) => {
   useEffect(() => {
@@ -94,6 +95,13 @@ const skalSendeSed = (formValues) => {
 
 const skalSendeOrienteringsbrev = (selvstendigArbeid) => selvstendigArbeid?.erSelvstendig !== true;
 
+const skalViseSendOrienteringsbrev = (sakstype, behandlingstema) =>
+  sakstype === MKV.Koder.sakstyper.EU_EOS &&
+  [
+    MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER,
+    MKV.Koder.behandlinger.behandlingstema.ARBEID_TJENESTEPERSON_ELLER_FLY,
+  ].includes(behandlingstema);
+
 export const VurderingArbeidTjenestepersonEllerFlyVedtak = ({
   redigerbart,
   behandlingID,
@@ -107,6 +115,8 @@ export const VurderingArbeidTjenestepersonEllerFlyVedtak = ({
   lagreLovvalgsperioder,
   byggLovvalgsperioder: gjenopprettOpprinneligLovvalgsperiode,
   behandlingstype,
+  behandlingstema,
+  sakstype,
   lovvalgsbestemmelseSomSkalVises,
   lovvalgsbestemmelseSomSkalLagres,
   oppdaterData,
@@ -407,7 +417,7 @@ export const VurderingArbeidTjenestepersonEllerFlyVedtak = ({
           </Nav.Column>
         </Nav.Row>
       )}
-      {redigerbart && (
+      {redigerbart && skalViseSendOrienteringsbrev(sakstype, behandlingstema) && (
         <Skjema.Checkbox feltNavn="kopiTilArbeidsgiver" label="Send orienteringsbrev til arbeidsgiver/virksomhet" />
       )}
       <Nav.Row>
@@ -445,6 +455,8 @@ VurderingArbeidTjenestepersonEllerFlyVedtak.propTypes = {
   byggLovvalgsperioder: PT.func.isRequired,
   lagreLovvalgsperioder: PT.func.isRequired,
   behandlingstype: PT.string.isRequired,
+  behandlingstema: PT.string.isRequired,
+  sakstype: PT.string.isRequired,
   form: PT.string.isRequired,
   handleSubmit: PT.func.isRequired,
   lovvalgsbestemmelseSomSkalVises: PT.string,
@@ -493,6 +505,8 @@ const mapStateToProps = (state, ownProps) => {
     mottatteOpplysningerFom: mottatteOpplysningerSelectors.PeriodeFomSelector(state),
     mottatteOpplysningerTom: mottatteOpplysningerSelectors.PeriodeTomSelector(state),
     behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
+    behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
+    sakstype: fagsakSelectors.SakstypeKodeSelector(state),
     behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
     lovvalgsperiode: lovvalgsperioderSelectors.LovvalgsperiodeSelector(state),
     soknadsperiode: mottatteOpplysningerSelectors.PeriodeSelector(state),

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak.js
@@ -57,6 +57,13 @@ const finnSedMottakerLand = (arbeidsland, bostedsland, lovvalgsperiode) => {
   return arbeidsland[0]?.kode;
 };
 
+const skalViseSendOrienteringsbrev = (sakstype, behandlingstema) =>
+  sakstype === MKV.Koder.sakstyper.EU_EOS &&
+  [
+    MKV.Koder.behandlinger.behandlingstema.UTSENDT_ARBEIDSTAKER,
+    MKV.Koder.behandlinger.behandlingstema.ARBEID_TJENESTEPERSON_ELLER_FLY,
+  ].includes(behandlingstema);
+
 const skalViseMottakerinstitusjoner = (
   sakstype,
   sakstema,
@@ -258,7 +265,7 @@ const VurderingVedtak = ({
             </Nav.Column>
           </Nav.Row>
         )}
-        {redigerbart && (
+        {redigerbart && skalViseSendOrienteringsbrev(sakstype, behandlingstema) && (
           <Skjema.Checkbox feltNavn="kopiTilArbeidsgiver" label="Send orienteringsbrev til arbeidsgiver/virksomhet" />
         )}
         <Nav.Row>

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVirksomhet.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVirksomhet.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import PT from "prop-types";
+import { useDispatch } from "react-redux";
 
 import * as Nav from "../../../navFrontend";
 import * as Mui from "../../../felleskomponenter/ui";
@@ -14,6 +15,7 @@ import * as KV from "../../../kodeverk";
 import { BOOLSK_STRING } from "../../../constants";
 
 import "./vurderingArbeidsgiver.css";
+import { feiletResponsOperations } from "../../../ducks/feiletRespons";
 
 /**
  * Enkeltsjekkboks for ett arbeidsgiver.
@@ -22,6 +24,7 @@ import "./vurderingArbeidsgiver.css";
  */
 const VirksomheterLinje = (props) => {
   const { virksomheten, avklartVirksomhet, redigerbart, oppdaterData, slettData } = props;
+  const dispatch = useDispatch();
 
   useEffect(() => {
     oppdaterData(konverterAvklartfaktaTilStegData(KV.Koder.avklartefaktaKoder.VIRKSOMHET, avklartVirksomhet));
@@ -36,6 +39,7 @@ const VirksomheterLinje = (props) => {
 
   const virksomhetKlikkHandler = () => {
     const verdi = virksomhetErValgt ? BOOLSK_STRING.USANN : BOOLSK_STRING.SANN;
+    dispatch(feiletResponsOperations.resetFeiletRespons());
     oppdaterData(lagAvklartfakta(KV.Koder.avklartefaktaKoder.VIRKSOMHET, virksomheten.virksomhetId, verdi));
   };
 


### PR DESCRIPTION
Fikser kommentar i jirasak: 

- Avhukingen skal kun vises i behandlinger som har følgende behandlingstema:
        UTSENDT_ARBEIDSTAKER
        ARBEID_TJENESTEPERSON_ELLER_FLY
- Feilmeldingen vises fortsatt på vedtakssteget hvis bytte av virksomhet (før valg av mottakerinstitusjon for SED)



ref: https://jira.adeo.no/browse/MELOSYS-5693