### PR TITLE
5645 TOGGLE Småpirk etter test

### DIFF
--- a/src/felleskomponenter/datovelger/datovelger.less
+++ b/src/felleskomponenter/datovelger/datovelger.less
@@ -30,11 +30,10 @@
   }
 
   .datovelger__feilmelding {
-    font-style: italic;
     color: #ba3a26;
     font-family: "Source Sans Pro", Arial, sans-serif;
     font-size: 1rem;
     line-height: 1.375rem;
-    font-weight: 400;
+    font-weight: 600;
   }
 }

--- a/src/felleskomponenter/datovelger/datovelger.test.tsx
+++ b/src/felleskomponenter/datovelger/datovelger.test.tsx
@@ -38,7 +38,6 @@ describe("Datovelger", () => {
       "dd-MM-yyyy",
       "dd-MM-yy",
     ]);
-    expect(input.prop("placeholderText")).toBe("Velg en dato");
     expect(input.prop("disabled")).toBe(false);
     expect(input.prop("onChange")).toBe(props.onChange);
 
@@ -60,7 +59,6 @@ describe("Datovelger", () => {
     const feilmelding = datovelger.find(".datovelger__feilmelding");
 
     expect(input.prop("className")).toContain("datovelger__input_feil");
-    expect(input.prop("placeholderText")).toBe("");
 
     expect(feilmelding).toHaveLength(1);
     expect(feilmelding.children().text()).toBe(feilmeldingTekst);

--- a/src/felleskomponenter/datovelger/datovelger.tsx
+++ b/src/felleskomponenter/datovelger/datovelger.tsx
@@ -81,7 +81,6 @@ const Datovelger = ({
         selected={value}
         locale="nb"
         dateFormat={dateFormat}
-        placeholderText={disabled || feil ? "" : "Velg en dato"}
         disabled={disabled}
         minDate={minDate}
         maxDate={maxDate}

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/periodeElementer.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/periodeElementer.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Control } from "react-hook-form";
 import { KTObject } from "@navikt/melosys-kodeverk";
 import * as Nav from "../../../../../../navFrontend";
+import LabelMedHjelpetekst from "../../../../../../felleskomponenter/labelMedHjelpetekst";
 import { MedlemskapsperiodeProp } from "../vurderingPerioder";
 import { PeriodeElement } from "./periodeElement";
 
@@ -18,7 +19,15 @@ export interface PeriodeElementerProps {
 
 export const PeriodeElementer = (props: PeriodeElementerProps) => {
   return (
-    <Nav.Fieldset legend="Medlemskapsperiode(r)">
+    <Nav.Fieldset
+      legend={
+        <LabelMedHjelpetekst
+          label="Medlemskapsperiode(r)"
+          hjelpetekst="Melosys har foreslått medlemskapsperioder på bakgrunn av periode og dekning det er søkt for, og tidspunktet søknaden ble mottatt. Du har mulighet til å gjøre endringer. Hvis du har mottatt opplysninger om at søknadsperiode eller trygdedekning det er søkt om er endret, må du endre dette i det inngangssteget «Inngang»."
+          hjelpetekstClassName="hjelpetekst"
+        />
+      }
+    >
       <Nav.Row className="labelRad">
         <Nav.Column xs="2">
           <Nav.Typo.Element>Fra og med</Nav.Typo.Element>

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.less
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.less
@@ -5,7 +5,7 @@
   }
   .info_element {
     display: inline-block;
-    padding: 0 0.25rem 0.5rem 0;
+    padding-right: 0.25rem;
   }
   .labelRad {
     margin-bottom: 0.5rem;

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
@@ -19,7 +19,6 @@ import { medlemskapsperioderOperations, medlemskapsperioderSelectors } from "../
 import { folketrygdenkodeverkSelectors } from "../../../../../ducks/folketrygdenkodeverk";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 
-import LabelMedHjelpetekst from "../../../../../felleskomponenter/labelMedHjelpetekst";
 import { useAsyncCallbackState } from "../../../../../hooks";
 
 import { PeriodeElementer } from "./komponenter/periodeElementer";
@@ -184,9 +183,6 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
 
   if (!aktivtSteg || !formValues) return null;
 
-  const hjelpetekst =
-    "Melosys har foreslått medlemskapsperioder på bakgrunn av periode og dekning det er søkt for, og tidspunktet søknaden ble mottatt. Du har mulighet til å gjøre endringer. Hvis du har mottatt opplysninger om at søknadsperiode eller trygdedekning det er søkt om er endret, må du endre dette i det inngangssteget «Inngang».";
-
   const handleEndreTomDato = (tomDato: string, index: number) => {
     if (antallMedlemskapsperioder === 2 && index === 0) {
       setValue(`medlemskapsperioder[1].fomDato`, Utils.dato.plussEnDag(tomDato));
@@ -250,13 +246,7 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
 
   return (
     <div className="vurderingPerioder">
-      <Nav.Typo.Undertittel className="undertittel">
-        <LabelMedHjelpetekst
-          label="Kontroller medlemskapsperioder"
-          hjelpetekst={hjelpetekst}
-          hjelpetekstClassName="hjelpetekst"
-        />
-      </Nav.Typo.Undertittel>
+      <Nav.Typo.Undertittel className="undertittel">Kontroller medlemskapsperioder</Nav.Typo.Undertittel>
 
       <div>
         <Nav.Typo.Element className="info_element">Søknad mottatt: </Nav.Typo.Element>


### PR DESCRIPTION
Datovelger skal ikke ha placeholder. Dette gjelder alle felt i kodebasen. 
Hjelpetekst flyttes noen hakk ned.
Info-elementene skal ikke ha fult så mye luft mellom seg.

https://jira.adeo.no/browse/MELOSYS-5645

TOGGLE siden FTRL

~Venter på to avklaringer fra UX~