### PR TITLE
5830 Slå av knapp hvis fritekst overstiger 4000

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/komponenter/vilkaarOgBegrunnelser.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/komponenter/vilkaarOgBegrunnelser.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, Fragment, useCallback } from "react";
+import React, { ChangeEventHandler, Fragment } from "react";
 import { KTObject } from "@navikt/melosys-kodeverk";
 
 import MKV from "../../../../../../melosyskodeverk";
@@ -47,14 +47,6 @@ export const VilkaarOgBegrunnelser = ({
   const hjelpetekstForVilkaar = hjelpetekster.get(vilkår);
   const valgtVilkår = alleValgteVilkår.get(`${vilkår}`);
   const valgtBegrunnelseForVilkår = alleValgteBegrunnelser.get(`${vilkår}_begrunnelser`);
-
-  const debouncedHandleEndreBegrunnelseFritekst = useCallback(
-    Utils._debounce(
-      (vilkår_begrunnelser, fritekst) => handleEndreBegrunnelseFritekst(vilkår_begrunnelser, fritekst),
-      750
-    ),
-    []
-  );
 
   const visBegrunnelseFritekst = KV.termFraNestedKTObject(
     begrunnelseKodeverk,
@@ -135,9 +127,7 @@ export const VilkaarOgBegrunnelser = ({
               <Nav.Column xs="12">
                 <HtmlEditor
                   value={valgtBegrunnelseForVilkår?.begrunnelseFritekst || ""}
-                  onChange={(fritekst: string) =>
-                    debouncedHandleEndreBegrunnelseFritekst(`${vilkår}_begrunnelser`, fritekst)
-                  }
+                  onChange={(fritekst: string) => handleEndreBegrunnelseFritekst(`${vilkår}_begrunnelser`, fritekst)}
                   placeholder="Vennligst spesifiser..."
                   spellCheck
                   readOnly={!redigerbart}

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -117,14 +117,13 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
         }
 
         const maksLengdeTillatt = 4000;
-        const begrunnelseFritekstErIkkeForLang = !(
-          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) > maksLengdeTillatt
-        );
+        const begrunnelseFritekstErForLang =
+          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) > maksLengdeTillatt;
 
         return (
           harVilkår &&
           harStrengInnhold(valgtBegrunnelseForVilkår?.begrunnelseFritekst ?? "") &&
-          begrunnelseFritekstErIkkeForLang
+          !begrunnelseFritekstErForLang
         );
       }
     );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -117,13 +117,14 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
         }
 
         const maksLengdeTillatt = 4000;
-        const erBegrunnelseFritekstErForLang =
-          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) > maksLengdeTillatt;
+        const begrunnelseFritekstErIkkeForLang = !(
+          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) > maksLengdeTillatt
+        );
 
         return (
           harVilkår &&
           harStrengInnhold(valgtBegrunnelseForVilkår?.begrunnelseFritekst ?? "") &&
-          !erBegrunnelseFritekstErForLang
+          begrunnelseFritekstErIkkeForLang
         );
       }
     );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -116,14 +116,14 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
           return harVilkår && valgtBegrunnelseForVilkår;
         }
 
-        const maksLengdeTillattDB = 4000;
-        const begrunnelseFritekstErForLang =
-          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) > maksLengdeTillattDB;
+        const maksLengdeTillatt = 4000;
+        const erBegrunnelseFritekstErForLang =
+          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) > maksLengdeTillatt;
 
         return (
           harVilkår &&
           harStrengInnhold(valgtBegrunnelseForVilkår?.begrunnelseFritekst ?? "") &&
-          !begrunnelseFritekstErForLang
+          !erBegrunnelseFritekstErForLang
         );
       }
     );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -116,7 +116,15 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
           return harVilkår && valgtBegrunnelseForVilkår;
         }
 
-        return harVilkår && harStrengInnhold(valgtBegrunnelseForVilkår?.begrunnelseFritekst ?? "");
+        const maksLengdeTillattDB = 4000;
+        const begrunnelseFritekstErForLang =
+          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) > maksLengdeTillattDB;
+
+        return (
+          harVilkår &&
+          harStrengInnhold(valgtBegrunnelseForVilkår?.begrunnelseFritekst ?? "") &&
+          !begrunnelseFritekstErForLang
+        );
       }
     );
 


### PR DESCRIPTION
Ref: https://jira.adeo.no/browse/MELOSYS-5830

- Har lagt til validering for å sikre at brukeren ikke kan trykke knappen hvis tekstinnhold (ink p-tags) overstiger 4000 i lengde