### PR TITLE
5830 Sett maks tekst til 3000

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -116,10 +116,10 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
           return harVilkår && valgtBegrunnelseForVilkår;
         }
 
-        const maksLengdeTillatt = 3000;
         const pTagsLengde = 7;
+        const maksLengdeTillatt = 3000 + pTagsLengde;
         const begrunnelseFritekstErForLang =
-          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) >= maksLengdeTillatt + pTagsLengde;
+          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) >= maksLengdeTillatt;
 
         return (
           harVilkår &&

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -116,9 +116,10 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
           return harVilkår && valgtBegrunnelseForVilkår;
         }
 
-        const maksLengdeTillatt = 4000;
+        const maksLengdeTillatt = 3000;
+        const pTagsLengde = 7;
         const begrunnelseFritekstErForLang =
-          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) > maksLengdeTillatt;
+          (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) >= maksLengdeTillatt + pTagsLengde;
 
         return (
           harVilkår &&


### PR DESCRIPTION
Ref: https://jira.adeo.no/browse/MELOSYS-5830

Det var ønsket å redusere til 3000 (+ padding i koden) etter jeg snakket med tester (trygg og enkel måte å sikre at vi ikke lagrer (uforutsigbar) tegn over 4000)