### PR TITLE
5730 TOGGLE logikk i periode steget

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/feilmeldinger.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/feilmeldinger.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import MKV from "../../../../../../melosyskodeverk";
+import * as Nav from "../../../../../../navFrontend";
+import * as Utils from "../../../../../../utils";
+import { MedlemskapsperiodeProp, sorterPerioder } from "../vurderingPerioder";
+
+const { AVSLAATT, INNVILGET } = MKV.Koder.innvilgelsesResultat;
+
+const IkkeStottetIMelosys = (
+  <Nav.AlertStripeInfo className="infomelding">
+    Søknaden kan foreløpig ikke behandles i Melosys. Avslutt saken som bortfalt.
+  </Nav.AlertStripeInfo>
+);
+
+const IngenMedlemskapsperioder = (
+  <Nav.AlertStripeAdvarsel className="infomelding">
+    Du må legge inn minst én periode før du kan fortsette.
+  </Nav.AlertStripeAdvarsel>
+);
+
+const OppholdIPeriodene = (
+  <Nav.AlertStripeAdvarsel className="infomelding">Det er opphold mellom innvilgede perioder.</Nav.AlertStripeAdvarsel>
+);
+
+const OverlappendePerioder = (
+  <Nav.AlertStripeAdvarsel className="infomelding">Innvilgede perioder overlapper.</Nav.AlertStripeAdvarsel>
+);
+
+const IngenSluttdato = (
+  <Nav.AlertStripeInfo className="infomelding">
+    Du må oppgi sluttdato for å kunne angi resultat. Dette blir sluttdatoen på vedtaket.
+  </Nav.AlertStripeInfo>
+);
+
+const erIkkeStøtteIMelosys = (medlemskapsperioder: MedlemskapsperiodeProp[], mottaksdato: string | undefined) => {
+  const erPeriodeTidligereEnnMottaksdato = (periode: MedlemskapsperiodeProp) =>
+    Utils.dato.erGyldigPeriode(periode.fomDato, Utils.dato.formatterDatoTilNorsk(mottaksdato)) &&
+    Utils.dato.erGyldigPeriode(periode.tomDato, Utils.dato.formatterDatoTilNorsk(mottaksdato));
+
+  return (
+    medlemskapsperioder.every((periode) => periode.innvilgelsesResultat === AVSLAATT) ||
+    medlemskapsperioder.some(
+      (periode) => !erPeriodeTidligereEnnMottaksdato(periode) && periode.innvilgelsesResultat === AVSLAATT
+    )
+  );
+};
+
+const perioderErLike = (periode1: MedlemskapsperiodeProp, periode2: MedlemskapsperiodeProp) =>
+  periode1.fomDato === periode2.fomDato && periode1.tomDato === periode2.tomDato;
+
+const finnesOverlappendePerioder = (medlemskapsperioder: MedlemskapsperiodeProp[]) => {
+  const sortertePerioder = medlemskapsperioder.sort(sorterPerioder);
+
+  if (!sortertePerioder?.length || sortertePerioder.length < 2) return false;
+
+  for (let i = 0; i < sortertePerioder.length - 1; i += 1) {
+    const periode = sortertePerioder[i];
+    const nestePeriode = sortertePerioder[i + 1];
+
+    if (Utils.dato.perioderOverlapper(periode.fomDato, periode.tomDato, nestePeriode.fomDato, nestePeriode.tomDato)) {
+      const innvilgelsesResultater = [periode.innvilgelsesResultat, nestePeriode.innvilgelsesResultat];
+      const énAvslåttÉnInnvilget =
+        innvilgelsesResultater.includes(AVSLAATT) && innvilgelsesResultater.includes(INNVILGET);
+      return !(énAvslåttÉnInnvilget && perioderErLike(periode, nestePeriode));
+    }
+  }
+  return false;
+};
+
+const finnesOppholdIInnvilgedePerioder = (medlemskapsperioder: MedlemskapsperiodeProp[]) => {
+  const innvilgedePerioder = medlemskapsperioder
+    ?.filter((periode) => periode.innvilgelsesResultat === INNVILGET)
+    .sort(sorterPerioder);
+
+  if (!innvilgedePerioder?.length || innvilgedePerioder.length < 2) return false;
+
+  for (let i = 0; i < innvilgedePerioder.length - 1; i += 1) {
+    const periode = innvilgedePerioder[i];
+    const nestePeriode = innvilgedePerioder[i + 1];
+
+    const nestePeriodeErPåfølgende = nestePeriode.fomDato === Utils.dato.plussEnDag(periode.tomDato);
+    if (!(nestePeriodeErPåfølgende || perioderErLike(periode, nestePeriode))) {
+      return true;
+    }
+  }
+  return false;
+};
+
+enum TypeFeilmelding {
+  INGEN_MEDLEMSKAPSPERIODER = "INGEN_MEDLEMSKAPSPERIODER",
+  IKKE_STØTTET_I_MELOSYS = "IKKE_STØTTET_I_MELOSYS",
+  INGEN_SLUTTDATO = "INGEN_SLUTTDATO",
+  OVERLAPPENDE_PERIODER = "OVERLAPPENDE_PERIODER",
+  OPPHOLD_I_PERIODENE = "OPPHOLD_I_PERIODENE",
+}
+
+export function finnAktivFeilmelding(
+  medlemskapsperioder: MedlemskapsperiodeProp[],
+  mottaksdato?: string
+): string | undefined {
+  const ingenMedlemskapsperioder = medlemskapsperioder?.length === undefined || medlemskapsperioder?.length === 0;
+  if (ingenMedlemskapsperioder) {
+    return TypeFeilmelding.INGEN_MEDLEMSKAPSPERIODER;
+  }
+
+  if (erIkkeStøtteIMelosys(medlemskapsperioder, mottaksdato)) {
+    return TypeFeilmelding.IKKE_STØTTET_I_MELOSYS;
+  }
+
+  const manglerSluttdato = Utils._isEmpty(medlemskapsperioder[medlemskapsperioder.length - 1].tomDato);
+  if (manglerSluttdato) {
+    return TypeFeilmelding.INGEN_SLUTTDATO;
+  }
+
+  if (finnesOverlappendePerioder(medlemskapsperioder)) {
+    return TypeFeilmelding.OVERLAPPENDE_PERIODER;
+  }
+
+  if (finnesOppholdIInnvilgedePerioder(medlemskapsperioder)) {
+    return TypeFeilmelding.OPPHOLD_I_PERIODENE;
+  }
+
+  return undefined;
+}
+
+export const Feilmelding = ({ type }: { type?: string }) => {
+  switch (type) {
+    case TypeFeilmelding.INGEN_MEDLEMSKAPSPERIODER:
+      return IngenMedlemskapsperioder;
+    case TypeFeilmelding.IKKE_STØTTET_I_MELOSYS:
+      return IkkeStottetIMelosys;
+    case TypeFeilmelding.INGEN_SLUTTDATO:
+      return IngenSluttdato;
+    case TypeFeilmelding.OVERLAPPENDE_PERIODER:
+      return OverlappendePerioder;
+    case TypeFeilmelding.OPPHOLD_I_PERIODENE:
+      return OppholdIPeriodene;
+    default:
+      return null;
+  }
+};

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/periodeElement.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/periodeElement.tsx
@@ -20,28 +20,17 @@ export const PeriodeElement = ({
   medlemskapsperioder,
   control,
   handleSlett,
-  erPeriodeFoerSoknadMottatDato,
-  handleEndreTomDato,
 }: PeriodeElementProps) => {
-  const skalDelvisInnvilgetVises =
-    erPeriodeFoerSoknadMottatDato(medlemskapsperioder[index]) &&
-    medlemskapsperioder[index].trygdedekning === MKV.Koder.trygdedekninger.PENSJONSDEL;
-
-  const kanSlettePeriode = redigerbart && index === medlemskapsperioder.length - 1 && medlemskapsperioder.length !== 1;
+  const kanSlettePeriode = redigerbart && medlemskapsperioder.length !== 1;
 
   return (
     <>
       <Nav.Row>
         <Nav.Column xs="2">
-          <Forms.Datovelger control={control} name={`medlemskapsperioder[${index}].fomDato`} disabled />
+          <Forms.Datovelger control={control} name={`medlemskapsperioder[${index}].fomDato`} disabled={!redigerbart} />
         </Nav.Column>
         <Nav.Column xs="2">
-          <Forms.Datovelger
-            control={control}
-            name={`medlemskapsperioder[${index}].tomDato`}
-            disabled={!redigerbart}
-            onChange={(dato) => handleEndreTomDato(dato, index)}
-          />
+          <Forms.Datovelger control={control} name={`medlemskapsperioder[${index}].tomDato`} disabled={!redigerbart} />
         </Nav.Column>
         <Nav.Column xs="4">
           <Forms.Select
@@ -65,9 +54,7 @@ export const PeriodeElement = ({
             emptyFieldDisabled={!!medlemskapsperioder[index].innvilgelsesResultat}
           >
             {innvilgelsesResultater
-              .filter((item: KTObject) =>
-                skalDelvisInnvilgetVises ? true : item.kode !== MKV.Koder.innvilgelsesResultat.DELVIS_INNVILGET
-              )
+              .filter((item: KTObject) => item.kode !== MKV.Koder.innvilgelsesResultat.DELVIS_INNVILGET)
               .map((item: KTObject) => (
                 <option key={item.kode} value={item.kode}>
                   {item.term}

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/periodeElementer.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/periodeElementer.tsx
@@ -12,8 +12,6 @@ export interface PeriodeElementerProps {
   control: Control;
   medlemskapsperioder: MedlemskapsperiodeProp[];
   handleSlett: (index: number) => void;
-  erPeriodeFoerSoknadMottatDato: (medlemskapsperiode: MedlemskapsperiodeProp) => boolean;
-  handleEndreTomDato: (tomDato: string, index: number) => void;
 }
 
 export const PeriodeElementer = (props: PeriodeElementerProps) => {

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
@@ -23,10 +23,13 @@ import LabelMedHjelpetekst from "../../../../../felleskomponenter/labelMedHjelpe
 import { useAsyncCallbackState } from "../../../../../hooks";
 
 import { PeriodeElementer } from "./komponenter/periodeElementer";
+import { Feilmelding, finnAktivFeilmelding } from "./komponenter/feilmeldinger";
 import vurderingPerioderSchema from "./vurderingPerioderSchema";
 import "./vurderingPerioder.css";
 
 export type MedlemskapsperiodeProp = Medlemskapsperiode & { ny: boolean; feil: string | undefined };
+
+export const sorterPerioder = (a: Medlemskapsperiode, b: Medlemskapsperiode) => a.fomDato.localeCompare(b.fomDato);
 
 const mapTilMedlemskapsperiodeProps = (medlemskapsperiode: Medlemskapsperiode): MedlemskapsperiodeProp => ({
   ...medlemskapsperiode,
@@ -39,9 +42,7 @@ const mapTilMedlemskapsperiodeProps = (medlemskapsperiode: Medlemskapsperiode): 
 const mapInitialMedlemskapsperioder = (
   medlemskapsperioder: Medlemskapsperiode[] | undefined
 ): MedlemskapsperiodeProp[] =>
-  medlemskapsperioder
-    ? [...medlemskapsperioder].sort((a, b) => a.fomDato.localeCompare(b.fomDato)).map(mapTilMedlemskapsperiodeProps)
-    : [];
+  medlemskapsperioder ? [...medlemskapsperioder].sort(sorterPerioder).map(mapTilMedlemskapsperiodeProps) : [];
 
 const komponentState = (state: RootState) => ({
   valgtTrygdedekning: mottatteOpplysningerSelectors.TrygdedekningSelector(state),
@@ -84,10 +85,7 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
   } = useForm({
     resolver: yupResolver(vurderingPerioderSchema),
     mode: "all",
-    context: {
-      soknadsperiode,
-      mottaksdato,
-    },
+    context: { soknadsperiode },
     values: {
       medlemskapsperioder: mapInitialMedlemskapsperioder(medlemskapsperioder),
     } as FieldValues,
@@ -106,10 +104,6 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
   const antallMedlemskapsperioder = formValues.medlemskapsperioder?.length;
 
   const ingenMedlemskapsperioder = antallMedlemskapsperioder === undefined || antallMedlemskapsperioder === 0;
-
-  const erPeriodeFørMottaksdato = (medlemskapsperiode: MedlemskapsperiodeProp) =>
-    Utils.dato.erGyldigPeriode(medlemskapsperiode.fomDato, Utils.dato.formatterDatoTilNorsk(mottaksdato)) &&
-    Utils.dato.erGyldigPeriode(medlemskapsperiode.tomDato, Utils.dato.formatterDatoTilNorsk(mottaksdato));
 
   const oppdaterMedlemskapsperiode = (
     oppdatertMedlemskapsperiode: OppdaterMedlemskapsperiode,
@@ -158,40 +152,10 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
   };
   const debouncedLagreMedlemskapsperioder = useCallback(Utils._debounce(lagreMedlemskapsperioder, 1000), []);
 
-  const erKombinasjonGyldig = (medlemskapsperiode: MedlemskapsperiodeProp) => {
-    if (erPeriodeFørMottaksdato(medlemskapsperiode)) {
-      return (
-        medlemskapsperiode.innvilgelsesResultat !== MKV.Koder.innvilgelsesResultat.DELVIS_INNVILGET ||
-        medlemskapsperiode.trygdedekning === MKV.Koder.trygdedekninger.PENSJONSDEL
-      );
-    }
-    return medlemskapsperiode.innvilgelsesResultat !== MKV.Koder.innvilgelsesResultat.DELVIS_INNVILGET;
-  };
-
-  const finnesUgyldigKombinasjon = formValues?.medlemskapsperioder?.some(
-    (medlemskapsperiode: MedlemskapsperiodeProp) => !erKombinasjonGyldig(medlemskapsperiode)
-  );
-
-  useEffect(() => {
-    if (finnesUgyldigKombinasjon) {
-      formValues?.medlemskapsperioder?.forEach((medlemskapsperiode: MedlemskapsperiodeProp, index: number) => {
-        if (!erKombinasjonGyldig(medlemskapsperiode)) {
-          setValue(`medlemskapsperioder[${index}].innvilgelsesResultat`, "");
-        }
-      });
-    }
-  }, [finnesUgyldigKombinasjon]);
-
   if (!aktivtSteg || !formValues) return null;
 
   const hjelpetekst =
     "Melosys har foreslått medlemskapsperioder på bakgrunn av periode og dekning det er søkt for, og tidspunktet søknaden ble mottatt. Du har mulighet til å gjøre endringer. Hvis du har mottatt opplysninger om at søknadsperiode eller trygdedekning det er søkt om er endret, må du endre dette i det inngangssteget «Inngang».";
-
-  const handleEndreTomDato = (tomDato: string, index: number) => {
-    if (antallMedlemskapsperioder === 2 && index === 0) {
-      setValue(`medlemskapsperioder[1].fomDato`, Utils.dato.plussEnDag(tomDato));
-    }
-  };
 
   const handleSlett = (index: number) => {
     if (!formValues?.medlemskapsperioder) return;
@@ -213,15 +177,9 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
   const handleLeggTil = () => {
     if (!antallMedlemskapsperioder) return;
 
-    const nyPeriodeFomDato =
-      antallMedlemskapsperioder > 0
-        ? Utils.dato.plussEnDag(formValues.medlemskapsperioder[antallMedlemskapsperioder - 1].tomDato)
-        : Utils.dato.formatterDatoTilNorsk(soknadsperiode.fom);
-
     const nyMedlemskapsperiode = {
       id: Utils._uuid(),
       ny: true,
-      fomDato: nyPeriodeFomDato,
     };
     setValue(`medlemskapsperioder[${antallMedlemskapsperioder}]`, nyMedlemskapsperiode);
   };
@@ -233,20 +191,15 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
 
   const visLeggTilNyPeriode =
     !ingenMedlemskapsperioder &&
-    !formValues.medlemskapsperioder.some((periode: MedlemskapsperiodeProp) => Utils._isEmpty(periode.tomDato));
+    !formValues.medlemskapsperioder.some(
+      (periode: MedlemskapsperiodeProp) =>
+        Utils._isEmpty(periode.fomDato) ||
+        Utils._isEmpty(periode.tomDato) ||
+        Utils._isEmpty(periode.trygdedekning) ||
+        Utils._isEmpty(periode.innvilgelsesResultat)
+    );
 
-  const visIkkeStottetIMelosys =
-    !ingenMedlemskapsperioder &&
-    (formValues.medlemskapsperioder.every(
-      (periode: MedlemskapsperiodeProp) => periode.innvilgelsesResultat === MKV.Koder.innvilgelsesResultat.AVSLAATT
-    ) ||
-      formValues.medlemskapsperioder.some(
-        (periode: MedlemskapsperiodeProp) =>
-          !erPeriodeFørMottaksdato(periode) && periode.innvilgelsesResultat === MKV.Koder.innvilgelsesResultat.AVSLAATT
-      ));
-
-  const ingenSluttdato =
-    !ingenMedlemskapsperioder && Utils._isEmpty(formValues.medlemskapsperioder[antallMedlemskapsperioder - 1].tomDato);
+  const aktivFeilmeldingType = finnAktivFeilmelding(formValues?.medlemskapsperioder, mottaksdato);
 
   return (
     <div className="vurderingPerioder">
@@ -278,8 +231,6 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
         medlemskapsperioder={formValues.medlemskapsperioder}
         handleSlett={handleSlett}
         redigerbart={redigerbart}
-        erPeriodeFoerSoknadMottatDato={erPeriodeFørMottaksdato}
-        handleEndreTomDato={handleEndreTomDato}
       />
 
       {visLeggTilNyPeriode && (
@@ -290,26 +241,13 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
         </div>
       )}
 
-      {visIkkeStottetIMelosys && (
-        <Nav.AlertStripeInfo className="infomelding">
-          Søknaden kan foreløpig ikke behandles i Melosys. Avslutt saken som bortfalt.
-        </Nav.AlertStripeInfo>
-      )}
-
-      {ingenMedlemskapsperioder && (
-        <Nav.AlertStripeAdvarsel className="infomelding">
-          Du må legge inn minst én periode før du kan fortsette.
-        </Nav.AlertStripeAdvarsel>
-      )}
-
-      {ingenSluttdato && (
-        <Nav.AlertStripeInfo className="infomelding">
-          Du må oppgi sluttdato for å kunne angi resultat. Dette blir sluttdatoen på vedtaket.
-        </Nav.AlertStripeInfo>
-      )}
+      <Feilmelding type={aktivFeilmeldingType} />
 
       <Mui.StegKnapper
-        bekreftKnappProps={{ onClick: handleBekreft, disabled: !redigerbart || !formIsValid }}
+        bekreftKnappProps={{
+          onClick: handleBekreft,
+          disabled: !redigerbart || !formIsValid || !!aktivFeilmeldingType,
+        }}
         tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
       />
     </div>

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioderSchema.js
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioderSchema.js
@@ -1,5 +1,4 @@
-import { object, string, array } from "yup";
-import MKV from "../../../../../melosyskodeverk";
+import { array, object, string } from "yup";
 import * as KV from "../../../../../kodeverk";
 import * as Utils from "../../../../../utils";
 
@@ -7,29 +6,7 @@ const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 const INNGILGELSESRESULTAT_FELT_KREVES = { melding: "Du må velge innvilgelsesresultat" };
 const TRYGDEDEKNING_FELT_KREVES = { melding: "Du må velge trygdedekning" };
 
-const erPeriodeTidligereEnnMottattDato = (medlemskapsperiode, mottaksdato) => {
-  return (
-    Utils.dato.erGyldigPeriode(medlemskapsperiode.fomDato, Utils.dato.formatterDatoTilNorsk(mottaksdato)) &&
-    Utils.dato.erGyldigPeriode(medlemskapsperiode.tomDato, Utils.dato.formatterDatoTilNorsk(mottaksdato))
-  );
-};
-
-const ugyldigeInnvilgelsesResultater = (medlemskapsperioder, mottaksdato) => {
-  if (!medlemskapsperioder) return false;
-  return (
-    medlemskapsperioder.every(
-      (medlemskapsperiode) => medlemskapsperiode.innvilgelsesResultat === MKV.Koder.innvilgelsesResultat.AVSLAATT
-    ) ||
-    medlemskapsperioder.find(
-      (medlemskapsperiode) =>
-        !erPeriodeTidligereEnnMottattDato(medlemskapsperiode, mottaksdato) &&
-        medlemskapsperiode.innvilgelsesResultat === MKV.Koder.innvilgelsesResultat.AVSLAATT
-    )
-  );
-};
-
-const erFeilAktivPaaPerioder = (medlemskapsperioder) =>
-  medlemskapsperioder && medlemskapsperioder.some((medlemskapsperiode) => !!medlemskapsperiode.feil);
+const erFeilPaaPerioder = (medlemskapsperioder) => medlemskapsperioder?.some((periode) => !!periode.feil);
 
 const erPeriodeSisteMedlemskapsperiode = (id, formValues) => {
   const medlemskapsperioder = formValues?.medlemskapsperioder || [];
@@ -64,7 +41,6 @@ const vurdering_perioder = object().shape({
     .of(
       object().shape({
         id: string().required(),
-        arbeidsland: string(),
         fomDato: string().erGyldigDato().erInnenforSoknadsperioden().required(MAA_FYLLES_UT),
         tomDato: string()
           .erGyldigDato()
@@ -72,19 +48,13 @@ const vurdering_perioder = object().shape({
           .test(utenforSøknadsperioden)
           .test(åpenTomNårIkkeSistePeriodeTest)
           .required(MAA_FYLLES_UT),
-        bestemmelse: string(),
         innvilgelsesResultat: string().required(INNGILGELSESRESULTAT_FELT_KREVES),
         trygdedekning: string().required(TRYGDEDEKNING_FELT_KREVES),
-        medlemskapstype: string(),
       })
     )
     .min(1),
-  ikkeStottetIMelosys: string().when(["medlemskapsperioder", "$mottaksdato"], {
-    is: ugyldigeInnvilgelsesResultater,
-    then: string().required(),
-  }),
-  feilAktivPaaPerioder: string().when("medlemskapsperioder", {
-    is: erFeilAktivPaaPerioder,
+  feilPaaPerioder: string().when("medlemskapsperioder", {
+    is: erFeilPaaPerioder,
     then: string().required(),
   }),
 });

--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -1,5 +1,6 @@
 import moment from "moment";
 import momentTZ from "moment-timezone";
+import { areIntervalsOverlapping } from "date-fns";
 
 /**
  * Saksbehandlere har forskjellig måte å taste inn datoer på. Denne funksjonen forsøker å
@@ -178,6 +179,20 @@ function dateTilIsoString(dato) {
   return `${dato.getFullYear()}-${maned}-${dag}`;
 }
 
+function perioderOverlapper(periode1Fom, periode1Tom, periode2Fom, periode2Tom) {
+  const intervalLeft = {
+    start: norskStringTilDate(periode1Fom),
+    end: norskStringTilDate(periode1Tom),
+  };
+  const intervalRight = {
+    start: norskStringTilDate(periode2Fom),
+    end: norskStringTilDate(periode2Tom),
+  };
+  if (!intervalLeft || !intervalRight) return false;
+
+  return areIntervalsOverlapping(intervalLeft, intervalRight, { inclusive: true });
+}
+
 export {
   vaskInputDato,
   normaliserInputDato,
@@ -196,5 +211,6 @@ export {
   isoStringTilDate,
   dateTilNorskString,
   dateTilIsoString,
+  perioderOverlapper,
   MAX_AR_FREM_I_TID,
 };


### PR DESCRIPTION
- Fjerner mulighet til å velge DELVIS_INNVILGET.
- Fjerner disablet fom-felt og fjerner automatisk oppdatering av dette feltet ved tom-endring på tidligere periode.
- Lagt periodeOverlapper-funksjon i dato.js
- React Hook Form validator til Yup støtter ikke feilmeldinger som ikke matcher formnames, og bruker ikke mere tid på å lage customValidator. Flytter heller feilmeldinger og deres alertstriper ut i egen fil som styrer både visning og hvilke feil som finnes.

https://jira.adeo.no/browse/MELOSYS-5730

Funksjonelt [DAPI](https://github.com/navikt/melosys-api/pull/1749), men kan fint gå ut uten at det skaper issues. 