### PR TITLE
5730 TOGGLE periode steget bugs

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/felles/flytFinnesIkke.less
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/felles/flytFinnesIkke.less
@@ -1,0 +1,3 @@
+.flytFinnesIkke {
+  margin-top: 1.5rem;
+}

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/felles/flytFinnesIkke.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/felles/flytFinnesIkke.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import * as Nav from "../../../../../../navFrontend";
+import * as Nav from "../../../../../navFrontend";
+import "./flytFinnesIkke.css";
 
 export const FlytFinnesIkke = () => (
   <div className="flytFinnesIkke">
@@ -9,6 +10,6 @@ export const FlytFinnesIkke = () => (
         <li>du kan bruke &quot;Send brev&quot;-fanen for å sende brev og vedtak</li>
         <li>du kan avslutte saken og angi behandlingsresultatet i behandlingsmenyen</li>
       </ul>
-    </Nav.AlertStripeAdvarsel>{" "}
+    </Nav.AlertStripeAdvarsel>
   </div>
 );

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/komponenter/vilkaarOgBegrunnelser.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/komponenter/vilkaarOgBegrunnelser.tsx
@@ -10,8 +10,8 @@ import * as Utils from "../../../../../../utils";
 import LabelMedHjelpetekst from "../../../../../../felleskomponenter/labelMedHjelpetekst";
 import HtmlEditor from "../../../../../../felleskomponenter/htmlEditor";
 import { BOOLSK_STRING } from "../../../../../../constants";
+import { FlytFinnesIkke } from "../../felles/flytFinnesIkke";
 import { Begrunnelse } from "../vurderingBestemmelse";
-import { FlytFinnesIkke } from "./flytFinnesIkke";
 
 const { SANN, USANN } = BOOLSK_STRING;
 const hjelpetekster = new Map([

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.less
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.less
@@ -4,9 +4,6 @@
       margin-bottom: 0;
     }
   }
-  .flytFinnesIkke {
-    margin-top: 1.5rem;
-  }
   .radio {
     .skjema__legend {
       margin-bottom: 0.5rem;

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -17,10 +17,10 @@ import { redigerbartSelectors } from "../../../../../ducks/redigerbart";
 
 import { BOOLSK_STRING } from "../../../../../constants";
 import { useAsyncCallbackState } from "../../../../../hooks";
+
 import { VilkaarOgBegrunnelser } from "./komponenter/vilkaarOgBegrunnelser";
 import { FlytFinnesIkke } from "./komponenter/flytFinnesIkke";
 import "./vurderingBestemmelse.css";
-import { harStrengInnhold } from "../../../../../utils/streng";
 
 const { SANN, USANN } = BOOLSK_STRING;
 export interface Begrunnelse {
@@ -102,28 +102,28 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
     const alleVilkårHarSvarJaOgValgtBegrunnelse = valgtBestemmelseMedVilkårOgBegrunnelser?.vilkårOgBegrunnelser.every(
       (element) => {
         const harVilkår = valgteVilkår.get(element.vilkår) === SANN;
+
+        if (Utils._isEmpty(element.muligeBegrunnelser)) {
+          return harVilkår;
+        }
+
         const valgtBegrunnelseForVilkår = valgteBegrunnelser.get(`${element.vilkår}_begrunnelser`);
         const begrunnelseInneholderFritekst = KV.termFraNestedKTObject(
           begrunnelseKodeverk,
           valgtBegrunnelseForVilkår?.begrunnelseKode
         )?.includes("(fritekst)");
 
-        if (Utils._isEmpty(element.muligeBegrunnelser)) {
-          return harVilkår;
-        }
-
         if (!begrunnelseInneholderFritekst) {
           return harVilkår && valgtBegrunnelseForVilkår;
         }
 
-        const pTagsLengde = 7;
-        const maksLengdeTillatt = 3000 + pTagsLengde;
+        const maksLengdeTillatt = 3000;
         const begrunnelseFritekstErForLang =
           (valgtBegrunnelseForVilkår?.begrunnelseFritekst?.length ?? 0) >= maksLengdeTillatt;
 
         return (
           harVilkår &&
-          harStrengInnhold(valgtBegrunnelseForVilkår?.begrunnelseFritekst ?? "") &&
+          Utils.streng.harStrengInnhold(valgtBegrunnelseForVilkår?.begrunnelseFritekst) &&
           !begrunnelseFritekstErForLang
         );
       }

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -18,8 +18,8 @@ import { redigerbartSelectors } from "../../../../../ducks/redigerbart";
 import { BOOLSK_STRING } from "../../../../../constants";
 import { useAsyncCallbackState } from "../../../../../hooks";
 
+import { FlytFinnesIkke } from "../felles/flytFinnesIkke";
 import { VilkaarOgBegrunnelser } from "./komponenter/vilkaarOgBegrunnelser";
-import { FlytFinnesIkke } from "./komponenter/flytFinnesIkke";
 import "./vurderingBestemmelse.css";
 
 const { SANN, USANN } = BOOLSK_STRING;

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/feilmeldinger.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/feilmeldinger.tsx
@@ -17,8 +17,14 @@ const OppholdIPeriodene = (
   <Nav.AlertStripeAdvarsel className="infomelding">Det er opphold mellom innvilgede perioder.</Nav.AlertStripeAdvarsel>
 );
 
-const OverlappendePerioder = (
+const OverlappIInnvilgedePerioder = (
   <Nav.AlertStripeAdvarsel className="infomelding">Innvilgede perioder overlapper.</Nav.AlertStripeAdvarsel>
+);
+
+const OverlappMenIkkeLikPeriode = (
+  <Nav.AlertStripeAdvarsel className="infomelding">
+    Innvilget og avslått periode som overlapper må ha lik periode.
+  </Nav.AlertStripeAdvarsel>
 );
 
 const IngenSluttdato = (
@@ -33,7 +39,27 @@ const erIkkeStøttetIMelosys = (medlemskapsperioder: MedlemskapsperiodeProp[]) =
 const perioderErLike = (periode1: MedlemskapsperiodeProp, periode2: MedlemskapsperiodeProp) =>
   periode1.fomDato === periode2.fomDato && periode1.tomDato === periode2.tomDato;
 
-const finnesOverlappendePerioder = (medlemskapsperioder: MedlemskapsperiodeProp[]) => {
+const finnesOverlappIInnvilgedePerioder = (medlemskapsperioder: MedlemskapsperiodeProp[]) => {
+  const innvilgedePerioder = [...medlemskapsperioder]
+    ?.filter((periode) => periode.innvilgelsesResultat === INNVILGET)
+    .sort(sorterPerioder);
+
+  if (!innvilgedePerioder?.length || innvilgedePerioder.length < 2) return false;
+
+  for (let i = 0; i < innvilgedePerioder.length - 1; i += 1) {
+    const periode = innvilgedePerioder[i];
+    const nestePeriode = innvilgedePerioder[i + 1];
+
+    if (Utils.dato.perioderOverlapper(periode.fomDato, periode.tomDato, nestePeriode.fomDato, nestePeriode.tomDato)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const finnesInnvilgetOgAvslåttPeriodeSomOverlapperMenIkkeHarLikPeriode = (
+  medlemskapsperioder: MedlemskapsperiodeProp[]
+) => {
   const sortertePerioder = [...medlemskapsperioder].sort(sorterPerioder);
 
   if (!sortertePerioder?.length || sortertePerioder.length < 2) return false;
@@ -42,11 +68,18 @@ const finnesOverlappendePerioder = (medlemskapsperioder: MedlemskapsperiodeProp[
     const periode = sortertePerioder[i];
     const nestePeriode = sortertePerioder[i + 1];
 
-    if (Utils.dato.perioderOverlapper(periode.fomDato, periode.tomDato, nestePeriode.fomDato, nestePeriode.tomDato)) {
-      const innvilgelsesResultater = [periode.innvilgelsesResultat, nestePeriode.innvilgelsesResultat];
-      const énAvslåttÉnInnvilget =
-        innvilgelsesResultater.includes(AVSLAATT) && innvilgelsesResultater.includes(INNVILGET);
-      return !(énAvslåttÉnInnvilget && perioderErLike(periode, nestePeriode));
+    const periodeneOverlapper = Utils.dato.perioderOverlapper(
+      periode.fomDato,
+      periode.tomDato,
+      nestePeriode.fomDato,
+      nestePeriode.tomDato
+    );
+    const innvilgelsesResultater = [periode.innvilgelsesResultat, nestePeriode.innvilgelsesResultat];
+    const énAvslåttÉnInnvilget =
+      innvilgelsesResultater.includes(AVSLAATT) && innvilgelsesResultater.includes(INNVILGET);
+
+    if (periodeneOverlapper && énAvslåttÉnInnvilget && !perioderErLike(periode, nestePeriode)) {
+      return true;
     }
   }
   return false;
@@ -75,7 +108,8 @@ enum TypeFeilmelding {
   INGEN_MEDLEMSKAPSPERIODER = "INGEN_MEDLEMSKAPSPERIODER",
   IKKE_STØTTET_I_MELOSYS = "IKKE_STØTTET_I_MELOSYS",
   INGEN_SLUTTDATO = "INGEN_SLUTTDATO",
-  OVERLAPPENDE_PERIODER = "OVERLAPPENDE_PERIODER",
+  OVERLAPP_I_INNVILGEDE_PERIODER = "OVERLAPP_I_INNVILGEDE_PERIODER",
+  OVERLAPP_MEN_FORSKJELLIG_PERIODE = "OVERLAPP_MEN_FORSKJELLIG_PERIODE",
   OPPHOLD_I_PERIODENE = "OPPHOLD_I_PERIODENE",
 }
 
@@ -94,8 +128,12 @@ export function finnAktivFeilmelding(medlemskapsperioder: MedlemskapsperiodeProp
     return TypeFeilmelding.INGEN_SLUTTDATO;
   }
 
-  if (finnesOverlappendePerioder(medlemskapsperioder)) {
-    return TypeFeilmelding.OVERLAPPENDE_PERIODER;
+  if (finnesOverlappIInnvilgedePerioder(medlemskapsperioder)) {
+    return TypeFeilmelding.OVERLAPP_I_INNVILGEDE_PERIODER;
+  }
+
+  if (finnesInnvilgetOgAvslåttPeriodeSomOverlapperMenIkkeHarLikPeriode(medlemskapsperioder)) {
+    return TypeFeilmelding.OVERLAPP_MEN_FORSKJELLIG_PERIODE;
   }
 
   if (finnesOppholdIInnvilgedePerioder(medlemskapsperioder)) {
@@ -113,8 +151,10 @@ export const Feilmelding = ({ type }: { type?: string }) => {
       return <FlytFinnesIkke />;
     case TypeFeilmelding.INGEN_SLUTTDATO:
       return IngenSluttdato;
-    case TypeFeilmelding.OVERLAPPENDE_PERIODER:
-      return OverlappendePerioder;
+    case TypeFeilmelding.OVERLAPP_I_INNVILGEDE_PERIODER:
+      return OverlappIInnvilgedePerioder;
+    case TypeFeilmelding.OVERLAPP_MEN_FORSKJELLIG_PERIODE:
+      return OverlappMenIkkeLikPeriode;
     case TypeFeilmelding.OPPHOLD_I_PERIODENE:
       return OppholdIPeriodene;
     default:

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/feilmeldinger.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/feilmeldinger.tsx
@@ -2,15 +2,10 @@ import React from "react";
 import MKV from "../../../../../../melosyskodeverk";
 import * as Nav from "../../../../../../navFrontend";
 import * as Utils from "../../../../../../utils";
+import { FlytFinnesIkke } from "../../felles/flytFinnesIkke";
 import { MedlemskapsperiodeProp, sorterPerioder } from "../vurderingPerioder";
 
 const { AVSLAATT, INNVILGET } = MKV.Koder.innvilgelsesResultat;
-
-const IkkeStottetIMelosys = (
-  <Nav.AlertStripeInfo className="infomelding">
-    Søknaden kan foreløpig ikke behandles i Melosys. Avslutt saken som bortfalt.
-  </Nav.AlertStripeInfo>
-);
 
 const IngenMedlemskapsperioder = (
   <Nav.AlertStripeAdvarsel className="infomelding">
@@ -115,7 +110,7 @@ export const Feilmelding = ({ type }: { type?: string }) => {
     case TypeFeilmelding.INGEN_MEDLEMSKAPSPERIODER:
       return IngenMedlemskapsperioder;
     case TypeFeilmelding.IKKE_STØTTET_I_MELOSYS:
-      return IkkeStottetIMelosys;
+      return <FlytFinnesIkke />;
     case TypeFeilmelding.INGEN_SLUTTDATO:
       return IngenSluttdato;
     case TypeFeilmelding.OVERLAPPENDE_PERIODER:

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/feilmeldinger.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/feilmeldinger.tsx
@@ -32,24 +32,14 @@ const IngenSluttdato = (
   </Nav.AlertStripeInfo>
 );
 
-const erIkkeStøtteIMelosys = (medlemskapsperioder: MedlemskapsperiodeProp[], mottaksdato: string | undefined) => {
-  const erPeriodeTidligereEnnMottaksdato = (periode: MedlemskapsperiodeProp) =>
-    Utils.dato.erGyldigPeriode(periode.fomDato, Utils.dato.formatterDatoTilNorsk(mottaksdato)) &&
-    Utils.dato.erGyldigPeriode(periode.tomDato, Utils.dato.formatterDatoTilNorsk(mottaksdato));
-
-  return (
-    medlemskapsperioder.every((periode) => periode.innvilgelsesResultat === AVSLAATT) ||
-    medlemskapsperioder.some(
-      (periode) => !erPeriodeTidligereEnnMottaksdato(periode) && periode.innvilgelsesResultat === AVSLAATT
-    )
-  );
-};
+const erIkkeStøttetIMelosys = (medlemskapsperioder: MedlemskapsperiodeProp[]) =>
+  medlemskapsperioder.every((periode) => periode.innvilgelsesResultat === AVSLAATT);
 
 const perioderErLike = (periode1: MedlemskapsperiodeProp, periode2: MedlemskapsperiodeProp) =>
   periode1.fomDato === periode2.fomDato && periode1.tomDato === periode2.tomDato;
 
 const finnesOverlappendePerioder = (medlemskapsperioder: MedlemskapsperiodeProp[]) => {
-  const sortertePerioder = medlemskapsperioder.sort(sorterPerioder);
+  const sortertePerioder = [...medlemskapsperioder].sort(sorterPerioder);
 
   if (!sortertePerioder?.length || sortertePerioder.length < 2) return false;
 
@@ -68,7 +58,7 @@ const finnesOverlappendePerioder = (medlemskapsperioder: MedlemskapsperiodeProp[
 };
 
 const finnesOppholdIInnvilgedePerioder = (medlemskapsperioder: MedlemskapsperiodeProp[]) => {
-  const innvilgedePerioder = medlemskapsperioder
+  const innvilgedePerioder = [...medlemskapsperioder]
     ?.filter((periode) => periode.innvilgelsesResultat === INNVILGET)
     .sort(sorterPerioder);
 
@@ -94,16 +84,13 @@ enum TypeFeilmelding {
   OPPHOLD_I_PERIODENE = "OPPHOLD_I_PERIODENE",
 }
 
-export function finnAktivFeilmelding(
-  medlemskapsperioder: MedlemskapsperiodeProp[],
-  mottaksdato?: string
-): string | undefined {
+export function finnAktivFeilmelding(medlemskapsperioder: MedlemskapsperiodeProp[]): string | undefined {
   const ingenMedlemskapsperioder = medlemskapsperioder?.length === undefined || medlemskapsperioder?.length === 0;
   if (ingenMedlemskapsperioder) {
     return TypeFeilmelding.INGEN_MEDLEMSKAPSPERIODER;
   }
 
-  if (erIkkeStøtteIMelosys(medlemskapsperioder, mottaksdato)) {
+  if (erIkkeStøttetIMelosys(medlemskapsperioder)) {
     return TypeFeilmelding.IKKE_STØTTET_I_MELOSYS;
   }
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
@@ -195,7 +195,7 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
         Utils._isEmpty(periode.innvilgelsesResultat)
     );
 
-  const aktivFeilmeldingType = finnAktivFeilmelding(formValues?.medlemskapsperioder, mottaksdato);
+  const aktivFeilmeldingType = finnAktivFeilmelding(formValues?.medlemskapsperioder);
 
   return (
     <div className="vurderingPerioder">

--- a/src/utils/streng.ts
+++ b/src/utils/streng.ts
@@ -96,7 +96,7 @@ export function separerListeMedBindestrek(liste: string[] | string): string {
   }, "");
 }
 
-export function harStrengInnhold(streng?: string): boolean {
+export function harStrengInnhold(streng?: string | null): boolean {
   // htmlEditor har defaultverdi <p></p> når feltet er tomt.
   return !!streng && streng.replace("<p></p>", "").trim() !== "";
 }


### PR DESCRIPTION
- Periodene drev å justerte rekkefølgen siden funksjonene som sjekket feil sorterte direkte på listen og muterte derfor denne direkte. Fjernet dette og sorterer heller en kopi av listen. 
- Man skal vise den samme feilmeldingen i bestemmelse- og periode-steget når vi ikke støtter videre behandling i stegvelgere. Flytter denne derfor ut av bestemmelse og inn i /felles
- Justert logikk på når behandling ikke kan behandles i melosys. Dette skal ikke være avhengig av mottaksdato lengre.
- Litt småtteri på valideringen i bestemmelse-steget, bare byttet litt rekkefølge.

TOGGLE siden FTRL-flyten er togglet

https://jira.adeo.no/browse/MELOSYS-5730