### PR TITLE
5854 Lovvalgsperiode skal slettes når man bytter vurdering

### DIFF
--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -78,6 +78,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake }: VurderingUnntakM
     setValue("fom", Utils.dato.formatterDatoTilNorsk(mottatteOpplysningerPeriode.fom));
     setValue("tom", Utils.dato.formatterDatoTilNorsk(mottatteOpplysningerPeriode.tom));
     setValue("bestemmelse", "");
+    dispatch(lovvalgsperioderOperations.send(behandlingID, []));
   };
 
   const lagreLovvalgsperiodeOgKontroller = async () => {


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5854

Hvis man nå velger godkjenn eller delvis_godkjenn med bestemmelse så lagres lovvalgsperiode. Denne slettes ikke hvis man bytter til ikke_godkjenn noe som fører til at vi sender lovvalgsperiode til MEDL selv om det ikke skal være det. Endrer til å slette lovvalgsperiode hver gang man bytter vurdering