### PR TITLE
5869 DAPI: Gjør "Søknaden er avslått" og "Søknaden er innvilget" tilgjengelig i flere EØS-saker

### DIFF
--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
@@ -296,8 +296,8 @@ describe("AvsluttSak", () => {
       const avsluttSak = shallow(<AvsluttSak {...props} />);
       const handlinger = avsluttSak.find(Handling);
 
-      expect(handlinger).toHaveLength(5);
-      expect(handlinger.at(1).props().tekst).toBe("Vedtaket er omgjort (fvl § 35)");
+      expect(handlinger).toHaveLength(7);
+      expect(handlinger.at(3).props().tekst).toBe("Vedtaket er omgjort (fvl § 35)");
     });
 
     it(`viser ikke 'Vedtaket er omgjort (fvl § 35)' dersom behandlingstype er ${FØRSTEGANG}`, () => {

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
@@ -157,7 +157,15 @@ const AvsluttSak = ({
     if (
       [EU_EOS, TRYGDEAVTALE].includes(sakstype) &&
       [FØRSTEGANG, NY_VURDERING].includes(behandlingstype) &&
-      [YRKESAKTIV, IKKE_YRKESAKTIV, PENSJONIST, ARBEID_KUN_NORGE].includes(behandlingstema)
+      [
+        YRKESAKTIV,
+        IKKE_YRKESAKTIV,
+        PENSJONIST,
+        ARBEID_KUN_NORGE,
+        UTSENDT_ARBEIDSTAKER,
+        UTSENDT_SELVSTENDIG,
+        ARBEID_TJENESTEPERSON_ELLER_FLY,
+      ].includes(behandlingstema)
     ) {
       return true;
     }
@@ -179,6 +187,8 @@ const AvsluttSak = ({
         IKKE_YRKESAKTIV,
         PENSJONIST,
         UNNTAK_MEDLEMSKAP,
+        UTSENDT_ARBEIDSTAKER,
+        UTSENDT_SELVSTENDIG,
       ].includes(behandlingstema)
     );
   };


### PR DESCRIPTION
[MELOSYS-5869](https://jira.adeo.no/browse/MELOSYS-5869)