### PR TITLE
5874: Revert endring av ingress

### DIFF
--- a/nais/vars-q1.json
+++ b/nais/vars-q1.json
@@ -3,7 +3,7 @@
   "APP_URL_TRYGDEAVTALE": "http://melosys-trygdeavtale-q1.teammelosys",
   "APP_URL_FAKTURERINGSKOMPONENTEN": "https://faktureringskomponenten-q1.intern.dev.nav.no",
   "APP_URL_MELOSYS": "http://melosys-q1.teammelosys",
-  "INGRESSES": ["https://melosys-q1.intern.dev.nav.no"],
+  "INGRESSES": ["https://melosys-q1.dev.intern.nav.no"],
   "GROUP_MELOSYS_INNLOGGING": "52981246-8032-40f0-863a-2bd2844f2d57",
   "REPLY_URL": "http://localhost:3000",
   "APP_NAME_API": "melosys-q1",

--- a/nais/vars-q1.json
+++ b/nais/vars-q1.json
@@ -1,9 +1,9 @@
 {
   "APP_NAME": "melosys-web-q1",
   "APP_URL_TRYGDEAVTALE": "http://melosys-trygdeavtale-q1.teammelosys",
-  "APP_URL_FAKTURERINGSKOMPONENTEN": "https://faktureringskomponenten-q1.dev.intern.nav.no",
+  "APP_URL_FAKTURERINGSKOMPONENTEN": "https://faktureringskomponenten-q1.intern.dev.nav.no",
   "APP_URL_MELOSYS": "http://melosys-q1.teammelosys",
-  "INGRESSES": ["https://melosys-q1.dev.intern.nav.no"],
+  "INGRESSES": ["https://melosys-q1.intern.dev.nav.no"],
   "GROUP_MELOSYS_INNLOGGING": "52981246-8032-40f0-863a-2bd2844f2d57",
   "REPLY_URL": "http://localhost:3000",
   "APP_NAME_API": "melosys-q1",

--- a/nais/vars-q2.json
+++ b/nais/vars-q2.json
@@ -1,9 +1,9 @@
 {
   "APP_NAME": "melosys-web",
   "APP_URL_TRYGDEAVTALE": "http://melosys-trygdeavtale.teammelosys",
-  "APP_URL_FAKTURERINGSKOMPONENTEN": "https://faktureringskomponenten-q2.dev.intern.nav.no",
+  "APP_URL_FAKTURERINGSKOMPONENTEN": "https://faktureringskomponenten-q2.intern.dev.nav.no",
   "APP_URL_MELOSYS": "http://melosys.teammelosys",
-  "INGRESSES": ["https://melosys.dev.intern.nav.no", "https://melosys-q2.dev.intern.nav.no"],
+  "INGRESSES": ["https://melosys.intern.dev.nav.no", "https://melosys-q2.intern.dev.nav.no"],
   "GROUP_MELOSYS_INNLOGGING": "52981246-8032-40f0-863a-2bd2844f2d57",
   "REPLY_URL": "http://localhost:3000",
   "APP_NAME_API": "melosys",

--- a/nais/vars-q2.json
+++ b/nais/vars-q2.json
@@ -3,7 +3,7 @@
   "APP_URL_TRYGDEAVTALE": "http://melosys-trygdeavtale.teammelosys",
   "APP_URL_FAKTURERINGSKOMPONENTEN": "https://faktureringskomponenten-q2.intern.dev.nav.no",
   "APP_URL_MELOSYS": "http://melosys.teammelosys",
-  "INGRESSES": ["https://melosys.intern.dev.nav.no", "https://melosys-q2.intern.dev.nav.no"],
+  "INGRESSES": ["https://melosys.dev.intern.nav.no", "https://melosys-q2.dev.intern.nav.no"],
   "GROUP_MELOSYS_INNLOGGING": "52981246-8032-40f0-863a-2bd2844f2d57",
   "REPLY_URL": "http://localhost:3000",
   "APP_NAME_API": "melosys",


### PR DESCRIPTION
Reverter endring av ingress fordi dev-fss støtter ikke intern.dev.nav.no. 

Se også https://github.com/navikt/melosys-web/pull/1851