### PR TITLE
5874: Endre fra default http versjon i proxy 1.0 -> 1.1

### DIFF
--- a/nais/proxy.nginx
+++ b/nais/proxy.nginx
@@ -2,6 +2,7 @@ server {
   root /usr/share/nginx/html;
   listen       3000;
   include /etc/nginx/mime.types;
+  proxy_http_version 1.1;
 
   location /api/ {
     proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
Det at vi endret fra [dev.intern.nav.no](http://dev.intern.nav.no/) til [intern.dev.nav.no](http://intern.dev.nav.no/) gjorde at vi gikk over til en annen lastbalanser internt i Nais-plattformen. 
Jeg regner med at lastbalanseren krever minimum HTTP-versjon 1.1. Tydeligvis er ikke dette default på nginx.

https://jira.adeo.no/browse/MELOSYS-5874