### PR TITLE
5839: Sender kun en overgangsregel hvis artikkel 87

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingUtpekt.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingUtpekt.js
@@ -102,10 +102,6 @@ export const VurderingUtpekt = ({
       ? lovvalgsbestemmelserStottetAvBrevVedNorgeUtpekt
       : MKV.Kodekombinasjoner.alleLovvalg;
 
-  useEffect(() => {
-    console.log({ lovvalgsbe: formValues.lovvalgsbestemmelse });
-  }, [formValues.lovvalgsbestemmelse]);
-
   return (
     <form onSubmit={handleSubmit}>
       <Nav.Typo.Innholdstittel className="stegvelgertittel">Vurder lovvalgsbeslutningen (A003)</Nav.Typo.Innholdstittel>
@@ -146,14 +142,16 @@ export const VurderingUtpekt = ({
         <Nav.Row className="rad">
           <Nav.Column xs="5">
             <Nav.Typo.Element>Overgangsregler gjelder:</Nav.Typo.Element>
-            <Skjema.ListeVelger
-              feltNavn="overgangsregelbestemmelser"
-              label="Legg til ny overgangsregelbestemmelse:"
-              placeholder="(Velg bestemmelse)"
-              muligeValg={MKV.KTObjects.lovvalgsbestemmelser.overgangsregelbestemmelser}
-              disabled={!redigerbart}
-              gruppe
-            />
+            <Nav.Fieldset>
+              <Skjema.ListeVelger
+                feltNavn="overgangsregelbestemmelser"
+                label="Legg til ny overgangsregelbestemmelse:"
+                placeholder="(Velg bestemmelse)"
+                muligeValg={MKV.KTObjects.lovvalgsbestemmelser.overgangsregelbestemmelser}
+                disabled={!redigerbart}
+                gruppe
+              />
+            </Nav.Fieldset>
           </Nav.Column>
         </Nav.Row>
       )}

--- a/src/sider/eu_eøs/stegKomponenter/vurderingUtpekt.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingUtpekt.js
@@ -102,6 +102,10 @@ export const VurderingUtpekt = ({
       ? lovvalgsbestemmelserStottetAvBrevVedNorgeUtpekt
       : MKV.Kodekombinasjoner.alleLovvalg;
 
+  useEffect(() => {
+    console.log({ lovvalgsbe: formValues.lovvalgsbestemmelse });
+  }, [formValues.lovvalgsbestemmelse]);
+
   return (
     <form onSubmit={handleSubmit}>
       <Nav.Typo.Innholdstittel className="stegvelgertittel">Vurder lovvalgsbeslutningen (A003)</Nav.Typo.Innholdstittel>

--- a/src/sider/eu_eøs/stegKomponenter/vurderingUtpektSchema.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingUtpektSchema.js
@@ -1,9 +1,10 @@
-import { string, object } from "yup";
+import { string, object, array } from "yup";
 import * as KV from "../../../kodeverk";
 import MKV from "../../../melosyskodeverk";
 
 const { MAA_FYLLES_UT } = KV.Feilmeldinger;
-const VELG_MOTTAKERINSTITUSJON = { melding: "Velg mottakerinstitusjon" };
+const VELG_OVERGANGSREGEL_MINST_1 = "Du må velge en overgangsregel";
+const VELG_OVERGANGSREGEL_MAKS_1 = "Du kan kun velge en overgangsregel";
 
 const harOvergangsregler = (lovvalgsbestemmelse) => {
   const grunnlag87 = [
@@ -17,9 +18,9 @@ const harOvergangsregler = (lovvalgsbestemmelse) => {
 const vurder_utpeking = object().shape({
   fom: string().erGyldigDato().required(MAA_FYLLES_UT),
   tom: string().erGyldigDato().erEtterDatofelt("fom").required(MAA_FYLLES_UT),
-  overgangsregelbestemmelser: string().when("lovvalgsbestemmelse", {
+  overgangsregelbestemmelser: array().when("lovvalgsbestemmelse", {
     is: (lovvalgsbestemmelse) => harOvergangsregler(lovvalgsbestemmelse),
-    then: string().required(VELG_MOTTAKERINSTITUSJON).min(1).max(1),
+    then: array().min(1, { _error: VELG_OVERGANGSREGEL_MINST_1 }).max(1, { _error: VELG_OVERGANGSREGEL_MAKS_1 }),
   }),
 });
 

--- a/src/sider/eu_eøs/stegKomponenter/vurderingUtpektSchema.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingUtpektSchema.js
@@ -1,11 +1,26 @@
 import { string, object } from "yup";
 import * as KV from "../../../kodeverk";
+import MKV from "../../../melosyskodeverk";
 
 const { MAA_FYLLES_UT } = KV.Feilmeldinger;
+const VELG_MOTTAKERINSTITUSJON = { melding: "Velg mottakerinstitusjon" };
+
+const harOvergangsregler = (lovvalgsbestemmelse) => {
+  const grunnlag87 = [
+    MKV.Koder.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004.FO_883_2004_ART87_8,
+    MKV.Koder.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004.FO_883_2004_ART87A,
+  ];
+
+  return grunnlag87.includes(lovvalgsbestemmelse);
+};
 
 const vurder_utpeking = object().shape({
   fom: string().erGyldigDato().required(MAA_FYLLES_UT),
   tom: string().erGyldigDato().erEtterDatofelt("fom").required(MAA_FYLLES_UT),
+  overgangsregelbestemmelser: string().when("lovvalgsbestemmelse", {
+    is: (lovvalgsbestemmelse) => harOvergangsregler(lovvalgsbestemmelse),
+    then: string().required(VELG_MOTTAKERINSTITUSJON).min(1).max(1),
+  }),
 });
 
 export default vurder_utpeking;


### PR DESCRIPTION
For å hindre at prosessen feiler, setter vi grunnlaget som skal til MEDL
til å være overgangsregelen dersom grunnlaget er artikkel 87. Frontend
skal kun sende med seg en overgangsregel. Har pratet med Jonas om
hvordan man vet hvilke overgangsregel som skal brukes, kommet frem til
at det kun er ett som skal sendes fra frontend.

ref: https://jira.adeo.no/browse/MELOSYS-5839