### PR TITLE
5755 Ikke vis beregnet verdi mens grunnlag er ugyldig.

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -181,7 +181,9 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
         </Nav.Knapp>
       )}
 
-      {trygdeavgiftErIkkeTom && <TrygdeavgiftsperioderTabell perioder={lagretTrygdeavgift?.trygdeavgiftsperioder!!} />}
+      {trygdeavgiftErIkkeTom && formIsValid && (
+        <TrygdeavgiftsperioderTabell perioder={lagretTrygdeavgift?.trygdeavgiftsperioder!!} />
+      )}
 
       {feil && <Nav.AlertStripeFeil className="infomelding">{feil}</Nav.AlertStripeFeil>}
 


### PR DESCRIPTION
Ikke vis tabell mens form er ugyldig. Dette kan skje etter man endrer grunnlaget, men før det blir gyldig og lagres i databasen.

[MELOSYS-5755](https://jira.adeo.no/browse/MELOSYS-5755)