### PR TITLE
NOJIRA fikset ulike warnings i consollen

### DIFF
--- a/src/felleskomponenter/forms/datovelger.tsx
+++ b/src/felleskomponenter/forms/datovelger.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode } from "react";
 import { Controller, UseControllerProps } from "react-hook-form";
 
 import * as Utils from "../../utils/dato";
-import * as Nav from "../../navFrontend";
 
 import PlainDatovelger from "../datovelger";
 
@@ -29,7 +28,7 @@ const InnerDatovelgerComponent = React.forwardRef<HTMLSelectElement, InnerDatove
     return (
       <div {...rest}>
         <PlainDatovelger
-          label={label && <Nav.Typo.Element>{label}</Nav.Typo.Element>}
+          label={label && <b>{label}</b>}
           onChange={(nyDato) => onChange(Utils.dateTilNorskString(nyDato))}
           onBlur={rest.onBlur}
           value={Utils.norskStringTilDate(rest.value)}

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVirksomhet.less
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVirksomhet.less
@@ -2,6 +2,7 @@
   .hjelpetekst {
     width: 24px;
     height: 24px;
+    vertical-align: middle;
   }
   .stegvelgertittel {
     margin-bottom: 1.5rem;

--- a/src/sider/journalforing/komponenter/pdfdokument.js
+++ b/src/sider/journalforing/komponenter/pdfdokument.js
@@ -47,7 +47,7 @@ class PDFViser extends Component {
 }
 
 PDFViser.propTypes = {
-  pdfDokument: PT.object.isRequired,
+  pdfDokument: PT.string.isRequired,
   wrapperDivSize: PT.number,
 };
 


### PR DESCRIPTION
[pdfDokument til PDFViser ble endret til string, men propTypes ble ikke oppdatert til å speile dette](https://github.com/navikt/melosys-web/commit/44481107bda57a2f8ce4981770b7483220598505)

[Klagde over div inni p. Siden Nav.Typo.Element bare ble brukt for å få det bold, byttet jeg til < b > tag](https://github.com/navikt/melosys-web/commit/197e0680d5f46c13c14d9847b2b0eb3ea523d8e1)

[Hjelpeteksten var ikke på linje. Dette irriterte meg.](https://github.com/navikt/melosys-web/commit/ce88b11e7507418e4f4ed33a0082132c3959d80c)