### PR TITLE
5892 Skjuler feilmeldinger og bestemmelse-dropdown i visse cases

### DIFF
--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -231,7 +231,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake, aktivtSteg }: Vurd
         />
       </Nav.Fieldset>
 
-      {formValues.utfallRegistreringUnntak === GODKJENT && (
+      {formValues.utfallRegistreringUnntak === GODKJENT && !harErrorFeilmelding() && (
         <Nav.Fieldset legend="">
           <Nav.Row>
             <Nav.Column xs="8">
@@ -301,10 +301,12 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake, aktivtSteg }: Vurd
         exclude={[OVERLAPPENDE_UNNTAK_PERIODER, INGEN_SLUTTDATO]}
       />
 
-      <Alertmeldinger
-        className="vurderingUnntakMedlemskap__alertmeldinger"
-        meldinger={feilmeldingerKunUnntaksperioder(feilmeldinger)}
-      />
+      {![IKKE_GODKJENT, DELVIS_GODKJENT].includes(formValues.utfallRegistreringUnntak) && (
+        <Alertmeldinger
+          className="vurderingUnntakMedlemskap__alertmeldinger"
+          meldinger={feilmeldingerKunUnntaksperioder(feilmeldinger)}
+        />
+      )}
 
       {manglerSluttdato && ![IKKE_GODKJENT, DELVIS_GODKJENT].includes(formValues.utfallRegistreringUnntak) && (
         <Nav.AlertStripeAdvarsel className="vurderingUnntakMedlemskap__ikke_godkjent_advarsel">


### PR DESCRIPTION
https://nav-it.slack.com/archives/C8UV6V830/p1686061928079249
- Dersom man har lagt inn en periode som overlapper medlemskapsperiode, og velger "Godkjenn", skal ikke nedtrekksmeny for bestemmelse dukke opp.
- Når man har lagt inn FOM og TOM dato som overlapper unntaksperiode, og velger "Godkjenn, men endre periode" eller "Ikke godkjenn" så henger den gule varselmeldingen "Det finnes overlappende unntaksperiode i MEDL", selv om det er forventet at den skal forsvinne når man har tatt et valg.