### PR TITLE
PRODFIX Feil i tom flyt pga buggy selector

### DIFF
--- a/src/ducks/mottatteOpplysninger/selectors.js
+++ b/src/ducks/mottatteOpplysninger/selectors.js
@@ -40,9 +40,9 @@ export const ArbeidPaaLandSelector = createSelector(
 );
 
 export const IkkeYrkesaktivSituasjontypeSelector = createSelector(
-  (state) => MottatteOpplysningerSelector(state),
+  (state) => MottatteOpplysningerDataSelector(state),
   (mottatteOpplysningerData) => {
-    return mottatteOpplysningerData.data.ikkeYrkesaktivSituasjontype || null;
+    return mottatteOpplysningerData.ikkeYrkesaktivSituasjontype || null;
   }
 );
 


### PR DESCRIPTION
Bruker MottatteOpplysningerDataSelector for å slippe optional chaining når data er null.