### PR TITLE
5663 TOGGLE: Lagre fritekstfelter ved endring

### DIFF
--- a/src/felleskomponenter/forms/htmlEditor.tsx
+++ b/src/felleskomponenter/forms/htmlEditor.tsx
@@ -12,6 +12,7 @@ type HtmlEditorComponentProps = {
   disabled?: boolean;
   label?: ReactNode;
   feil?: string;
+  onChange?: any;
 };
 
 type InnerHtmlEditorComponentProps = HtmlEditorComponentProps & RegisterHookFormProps;

--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingvedtak/vurderingVedtak.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingvedtak/vurderingVedtak.tsx
@@ -39,14 +39,14 @@ export const VurderingVedtak = ({ aktivtSteg }: Props) => {
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
   const vedtakstype = useSelector(behandlingsresultatSelectors.VedtakstypeSelector);
   const feilmeldinger = useSelector(feiletResponsSelectors.FeilmeldingerSelector);
-  const lagretBegrunnelseFritekst = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector);
-  const lagretInnledningFritekst = useSelector(behandlingsresultatSelectors.InnledningFritekstSelector);
+  const begrunnelseFritekst = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector);
+  const innledningFritekst = useSelector(behandlingsresultatSelectors.InnledningFritekstSelector);
 
   const { control, watch } = useForm({
     mode: "all",
     defaultValues: {
-      begrunnelseFritekst: lagretBegrunnelseFritekst || "",
-      innledningFritekst: lagretInnledningFritekst || "",
+      begrunnelseFritekst: begrunnelseFritekst || "",
+      innledningFritekst: innledningFritekst || "",
     } as FieldValues,
   });
   const formValues = watch();

--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingvedtak/vurderingVedtak.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingvedtak/vurderingVedtak.tsx
@@ -82,15 +82,6 @@ export const VurderingVedtak = ({ aktivtSteg }: Props) => {
 
   const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), []);
 
-  useEffect(() => {
-    if (
-      formValues.innledningFritekst !== lagretInnledningFritekst ||
-      formValues.begrunnelseFritekst !== lagretBegrunnelseFritekst
-    ) {
-      debouncedOppdaterFritekster(formValues);
-    }
-  }, [formValues?.innledningFritekst, formValues?.begrunnelseFritekst]);
-
   return (
     <div className="vurderingVedtakIkkeYrkesaktiv">
       {sakstype === MKV.Koder.sakstyper.EU_EOS && (
@@ -124,6 +115,7 @@ export const VurderingVedtak = ({ aktivtSteg }: Props) => {
           className="fritekst_editor"
           placeholder="Skriv inn tilleggsinformasjon til innledning..."
           disabled={!redigerbart}
+          onChange={() => debouncedOppdaterFritekster(formValues)}
         />
 
         <Nav.Typo.Element className="fritekst_overskrift" tag="h3">
@@ -139,6 +131,7 @@ export const VurderingVedtak = ({ aktivtSteg }: Props) => {
           className="fritekst_editor"
           placeholder="Skriv inn tilleggsinformasjon til begrunnelse..."
           disabled={!redigerbart}
+          onChange={() => debouncedOppdaterFritekster(formValues)}
         />
       </Nav.Row>
     </div>

--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingvedtak/vurderingVedtak.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingvedtak/vurderingVedtak.tsx
@@ -51,10 +51,10 @@ export const VurderingVedtak = ({ aktivtSteg }: Props) => {
   });
   const formValues = watch();
 
-  const [vedtakPending, setVedtakPending] = useState(false);
+  const [kontrollPending, setKontrollPending] = useState(false);
 
   const kontrollerFerdigbehandling = async () => {
-    setVedtakPending(true);
+    setKontrollPending(true);
     await dispatch(
       kontrollOperations.kontrollerFerdigbehandling({
         behandlingID,
@@ -62,7 +62,7 @@ export const VurderingVedtak = ({ aktivtSteg }: Props) => {
         skalRegisteropplysningerOppdateres: false,
       })
     );
-    setVedtakPending(false);
+    setKontrollPending(false);
   };
 
   useEffect(() => {
@@ -72,7 +72,7 @@ export const VurderingVedtak = ({ aktivtSteg }: Props) => {
   }, [aktivtSteg]);
 
   const oppdaterFritekster = (values: FormValuesProps) => {
-    if (values && redigerbart && !vedtakPending) {
+    if (values && redigerbart && !kontrollPending) {
       Api.Behandlinger.resultat.oppdatererFritekster(behandlingID, {
         innledningFritekst: values.innledningFritekst,
         begrunnelseFritekst: values.begrunnelseFritekst,

--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingvedtak/vurderingVedtak.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingvedtak/vurderingVedtak.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { FieldValues, useForm } from "react-hook-form";
 
@@ -18,9 +18,16 @@ import { feiletResponsSelectors } from "../../../../ducks/feiletRespons";
 
 import { Feilmeldinger } from "../../../../felleskomponenter/feilmeldinger";
 import { INNLEDNING_FRITEKST_HJELPETEKST, BEGRUNNELSE_FRITEKST_HJELPETEKST } from "./tekster";
+import * as Api from "../../../../services/api";
+import * as Utils from "../../../../utils";
 
 interface Props {
   aktivtSteg: boolean;
+}
+
+interface FormValuesProps {
+  innledningFritekst?: string;
+  begrunnelseFritekst?: string;
 }
 
 export const VurderingVedtak = ({ aktivtSteg }: Props) => {
@@ -32,31 +39,57 @@ export const VurderingVedtak = ({ aktivtSteg }: Props) => {
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
   const vedtakstype = useSelector(behandlingsresultatSelectors.VedtakstypeSelector);
   const feilmeldinger = useSelector(feiletResponsSelectors.FeilmeldingerSelector);
-  const begrunnelseFritekst = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector);
-  const innledningFritekst = useSelector(behandlingsresultatSelectors.InnledningFritekstSelector);
+  const lagretBegrunnelseFritekst = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector);
+  const lagretInnledningFritekst = useSelector(behandlingsresultatSelectors.InnledningFritekstSelector);
 
-  const { control } = useForm({
+  const { control, watch } = useForm({
     mode: "all",
     defaultValues: {
-      begrunnelseFritekst: begrunnelseFritekst || "",
-      innledningFritekst: innledningFritekst || "",
+      begrunnelseFritekst: lagretBegrunnelseFritekst || "",
+      innledningFritekst: lagretInnledningFritekst || "",
     } as FieldValues,
   });
+  const formValues = watch();
 
-  const kontrollerFerdigbehandling = () =>
-    dispatch(
+  const [vedtakPending, setVedtakPending] = useState(false);
+
+  const kontrollerFerdigbehandling = async () => {
+    setVedtakPending(true);
+    await dispatch(
       kontrollOperations.kontrollerFerdigbehandling({
         behandlingID,
         vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
         skalRegisteropplysningerOppdateres: false,
       })
     );
+    setVedtakPending(false);
+  };
 
   useEffect(() => {
     if (aktivtSteg) {
       kontrollerFerdigbehandling();
     }
   }, [aktivtSteg]);
+
+  const oppdaterFritekster = (values: FormValuesProps) => {
+    if (values && redigerbart && !vedtakPending) {
+      Api.Behandlinger.resultat.oppdatererFritekster(behandlingID, {
+        innledningFritekst: values.innledningFritekst,
+        begrunnelseFritekst: values.begrunnelseFritekst,
+      });
+    }
+  };
+
+  const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), []);
+
+  useEffect(() => {
+    if (
+      formValues.innledningFritekst !== lagretInnledningFritekst ||
+      formValues.begrunnelseFritekst !== lagretBegrunnelseFritekst
+    ) {
+      debouncedOppdaterFritekster(formValues);
+    }
+  }, [formValues?.innledningFritekst, formValues?.begrunnelseFritekst]);
 
   return (
     <div className="vurderingVedtakIkkeYrkesaktiv">


### PR DESCRIPTION
Lagrer nå fritekstfelter undervveis mens saksbehandler skriver i de.

Ref https://nav-it.slack.com/archives/C05AS8VEPT8/p1686572711769069

https://jira.adeo.no/browse/MELOSYS-5663