### PR TITLE
NOJIRA: Bruk ubuntu-latest-8-cores i deploy-q2

### DIFF
--- a/.github/workflows/deploy-q2.yaml
+++ b/.github/workflows/deploy-q2.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build, deploy to q2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v3


### PR DESCRIPTION
hadde glemt at deploy-q2 også bygger. Fortsettelse av https://github.com/navikt/melosys-web/pull/1914 