### PR TITLE
NOJIRA: Ikke kjør CodeQL-workflow ved push til master

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
   schedule:
@@ -37,7 +35,7 @@ jobs:
         node-version: '16.13.2'
         registry-url: https://npm.pkg.github.com/
         scope: '@navikt'
-    
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
Det er ikke noe vits i å kjøre det ved push til master når vi uansett gjør det i pull-requests, samt som vi kjører hver 12. time automatisk.