### PR TITLE
5949 TOGGLE Fjerner trygdeavgiftsperioder når medlemskapsper endres

### DIFF
--- a/src/hooks/useCallbackState.ts
+++ b/src/hooks/useCallbackState.ts
@@ -6,6 +6,9 @@ const dependencyFinnes = (dependency: any) => {
   if (typeof dependency === "number") {
     return dependency !== 0;
   }
+  if (typeof dependency === "boolean") {
+    return true;
+  }
   return !Utils._isEmpty(dependency);
 };
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
@@ -119,7 +119,7 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
     oppdaterStatus(formIsValid);
   }, [formIsValid]);
 
-  const lagreMedlemskapsperiode = (medlemskapsperiode: MedlemskapsperiodeProp, index: number) => {
+  const lagreMedlemskapsperiode = async (medlemskapsperiode: MedlemskapsperiodeProp, index: number) => {
     const periodeRequest = {
       fomDato: Utils.dato.formatterDatoTilISO(medlemskapsperiode.fomDato),
       tomDato: Utils.dato.formatterDatoTilISO(medlemskapsperiode.tomDato),
@@ -127,7 +127,7 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
       innvilgelsesResultat: medlemskapsperiode.innvilgelsesResultat,
     };
 
-    (medlemskapsperiode.ny
+    await (medlemskapsperiode.ny
       ? Api.Medlemskapsperioder.postMedlemskapsperioder(behandlingID, periodeRequest)
       : Api.Medlemskapsperioder.putMedlemskapsperioder(behandlingID, medlemskapsperiode.periodeId, periodeRequest)
     )
@@ -141,11 +141,19 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
 
   const debouncedLagreMedlemskapsperioder = useCallback(
     Utils._debounce(
-      (medlemskapsperioder, isValid, overskrevetIndex) =>
-        isValid &&
-        medlemskapsperioder.forEach((medlemskapsperiode: MedlemskapsperiodeProp, index: number) =>
-          lagreMedlemskapsperiode(medlemskapsperiode, overskrevetIndex !== undefined ? overskrevetIndex : index)
-        ),
+      async (medlemskapsperioder, isValid, overskrevetIndex) => {
+        if (isValid) {
+          // eslint-disable-next-line no-restricted-syntax
+          for (const [index, medlemskapsperiode] of medlemskapsperioder.entries()) {
+            // eslint-disable-next-line no-await-in-loop
+            await lagreMedlemskapsperiode(
+              medlemskapsperiode,
+              overskrevetIndex !== undefined ? overskrevetIndex : index
+            );
+          }
+        }
+      },
+
       500
     ),
     []

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -35,7 +35,7 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const [lagretTrygdeavgift, setTrygdeavgift] = useAsyncCallbackState(
     () => Api.Trygdeavgift.hentBeregnetTrygdeavgift(behandlingID),
     undefined,
-    [behandlingID]
+    [behandlingID, aktivtSteg]
   );
   const [feil, setFeil] = useState<string | undefined>(undefined);
   const {


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5949

Dette løses primært fra backend. Når man kommer inn i trygdeavgifts steget så hentes trygdeavgiftsperioder på nytt. Ved en endring/sletting/opprettelse av medlemskapsperioder så er trygdeavgiftsperioder slettet fra backend