### PR TITLE
6014 Bug i omdirigering til tom flyt 

### DIFF
--- a/src/ducks/mottatteOpplysninger/operations.js
+++ b/src/ducks/mottatteOpplysninger/operations.js
@@ -28,7 +28,7 @@ export function hent(behandlingID) {
 
     if (
       dispatchedMottatteOpplysningerAction.type === Types.FEILET &&
-      erFeatureToggleEnabled(MELOSYS_REGISTRERING_UNNTAK_FRA_MEDLEMSKAP, getState)
+      erFeatureToggleEnabled(MELOSYS_REGISTRERING_UNNTAK_FRA_MEDLEMSKAP, getState())
     ) {
       await dispatch(navigeringOperations.tilTomFlyt());
       return dispatchedMottatteOpplysningerAction;


### PR DESCRIPTION
getState er en funksjon, så den må kalles med () om du vil hente state

https://jira.adeo.no/browse/MELOSYS-6014