### PR TITLE
6014 TOGGLE Manglende await skapte bug i stegvelger

### DIFF
--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderinginngang/vurderingInngang.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderinginngang/vurderingInngang.tsx
@@ -98,8 +98,8 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
     }
   };
 
-  const bekreftOgInnhentRegisteropplysninger = () => {
-    innhentRegisteropplysninger();
+  const bekreftOgInnhentRegisteropplysninger = async () => {
+    await innhentRegisteropplysninger();
     bekreft();
   };
 


### PR DESCRIPTION
Vi bruker spinneren til å sjekke om steg er gyldig, men når vi ikke awaiter, så bekrefter vi mens spinneren fortsatt spinner.  

https://jira.adeo.no/browse/MELOSYS-6019