### PR TITLE
5683: Send forvaltningsmelding og postnummer fix

### DIFF
--- a/src/sider/journalforing/komponenter/journalforingform.jsx
+++ b/src/sider/journalforing/komponenter/journalforingform.jsx
@@ -63,6 +63,7 @@ export const JournalforingForm = ({
   }, [visForvaltningsmelding]);
 
   useEffect(() => {
+    if (!visForvaltningsmelding) return;
     if ((brukerID || representantID) && avsenderType) {
       const gyldigBrukerFnrEllerDnr = Utils.person.erGyldigFnrEllerDnr(brukerID);
       const gyldigFullmektigFnrEllerDnr = Utils.person.erGyldigFnrEllerDnr(representantID);
@@ -90,10 +91,13 @@ export const JournalforingForm = ({
         brukerID: brukerIDPerson,
         orgnr,
       })
-        .then((harAdresse) => setHarRegistrertAdresse(harAdresse))
+        .then((harAdresse) => {
+          setHarRegistrertAdresse(harAdresse);
+          settFeltInnhold("ikkeSendForvaltingsmelding", !harAdresse);
+        })
         .catch(() => setHarRegistrertAdresse(false));
     }
-  }, [brukerID, avsenderType, representantID, representantRepresenterer]);
+  }, [brukerID, avsenderType, representantID, representantRepresenterer, visForvaltningsmelding]);
 
   return (
     <form onSubmit={handleSubmit} className="journalforingform">

--- a/src/sider/journalforing/komponenter/sendForvaltningsMelding.tsx
+++ b/src/sider/journalforing/komponenter/sendForvaltningsMelding.tsx
@@ -9,7 +9,7 @@ import "./sendForvaltningsMelding.css";
 
 interface SendForvaltningsMeldingProps {
   avsenderType: string;
-  settFeltInnhold: (felt: string, value: string) => void;
+  settFeltInnhold: (felt: string, value: string | boolean) => void;
   harRegistrertAdresse?: boolean;
   representantRepresenterer?: string;
 }
@@ -43,12 +43,12 @@ const SendForvaltningsMelding = ({
           disabled={!harRegistrertAdresse}
           feltNavn="ikkeSendForvaltingsmelding"
           label="Ja, melding skal sendes automatisk"
-          value
+          value={false}
         />
         <Skjema.Radio
           feltNavn="ikkeSendForvaltingsmelding"
           label="Nei, jeg vil sende melding senere eller behandle saken innen kort tid"
-          value={false}
+          value
         />
         {avsenderErFullmelktig && (
           <Fragment>


### PR DESCRIPTION
Forvaltningsmelding ble ikke sendt pga. jeg så feil på ikkeSendForvaltingsmelding. Når den sendes som false fra frontend, betyr det at den blir tolket som "sendForvaltningsmelding" - i api. 

Retter på dette og postnummer sjekk.

https://jira.adeo.no/browse/MELOSYS-5683