### PR TITLE
MELOSYS-5954 Justerte logikk for visning av varsel og feilmeldinger i…

### DIFF
--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.less
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.less
@@ -1,5 +1,6 @@
 .vurderingUnntakMedlemskap {
-  .fieldset {
+  .formLabel {
+    font-size: 1.125rem;
     margin-bottom: 0.5rem;
   }
 

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -186,7 +186,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake, aktivtSteg }: Vurd
 
   const utfallErGODKJENT = formValues?.utfallRegistreringUnntak === GODKJENT;
   const utfallErDelvisGodkjent = formValues?.utfallRegistreringUnntak === DELVIS_GODKJENT;
-  const utfallRegistrert = formValues?.utfallRegistreringUnntak;
+  const utfallValgt = formValues?.utfallRegistreringUnntak;
 
   return (
     <div className="vurderingUnntakMedlemskap">
@@ -300,7 +300,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake, aktivtSteg }: Vurd
         />
       )}
 
-      {!harSluttdato && !utfallRegistrert && (
+      {!harSluttdato && !utfallValgt && (
         <Nav.AlertStripeAdvarsel className="vurderingUnntakMedlemskap__ikke_godkjent_advarsel">
           Du kan ikke godkjenne en unntaksperiode med åpen sluttdato
         </Nav.AlertStripeAdvarsel>

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -182,65 +182,68 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake, aktivtSteg }: Vurd
     !Utils._isEmpty(feilmeldinger) ||
     !Utils._isEmpty(kontrollfeil?.filter((value) => value.kode !== OVERLAPPENDE_UNNTAK_PERIODER));
 
-  const manglerSluttdato = Utils._isEmpty(formValues.tom);
+  const harSluttdato = !Utils._isEmpty(formValues.tom);
 
   const utfallErGODKJENT = formValues?.utfallRegistreringUnntak === GODKJENT;
+  const utfallErDelvisGodkjent = formValues?.utfallRegistreringUnntak === DELVIS_GODKJENT;
+  const utfallRegistrert = formValues?.utfallRegistreringUnntak;
 
   return (
     <div className="vurderingUnntakMedlemskap">
       <Nav.Typo.Innholdstittel className="stegvelgertittel">Unntak medlemskap</Nav.Typo.Innholdstittel>
-      <Nav.Fieldset legend="Vurder unntaksperiode">
-        <Forms.Radio
-          name="utfallRegistreringUnntak"
-          control={control}
-          label="Godkjenn"
-          value={GODKJENT}
-          onChange={lagreUtfallRegistreringUnntak}
-          disabled={!redigerbart || manglerSluttdato}
-        />
-        <Forms.Radio
-          name="utfallRegistreringUnntak"
-          control={control}
-          label="Godkjenn, men endre periode"
-          value={DELVIS_GODKJENT}
-          onChange={lagreUtfallRegistreringUnntak}
-          disabled={!redigerbart}
-        />
-        <Forms.Radio
-          name="utfallRegistreringUnntak"
-          control={control}
-          label="Ikke godkjenn"
-          value={IKKE_GODKJENT}
-          onChange={lagreUtfallRegistreringUnntak}
-          disabled={!redigerbart}
-        />
-      </Nav.Fieldset>
+      <Nav.Row>
+        <Nav.Column xs="8">
+          <Nav.Typo.Normaltekst className="formLabel">Vurder unntaksperiode</Nav.Typo.Normaltekst>
+          <Forms.Radio
+            name="utfallRegistreringUnntak"
+            control={control}
+            label="Godkjenn"
+            value={GODKJENT}
+            onChange={lagreUtfallRegistreringUnntak}
+            disabled={!redigerbart || !harSluttdato}
+          />
+          <Forms.Radio
+            name="utfallRegistreringUnntak"
+            control={control}
+            label="Godkjenn, men endre periode"
+            value={DELVIS_GODKJENT}
+            onChange={lagreUtfallRegistreringUnntak}
+            disabled={!redigerbart}
+          />
+          <Forms.Radio
+            name="utfallRegistreringUnntak"
+            control={control}
+            label="Ikke godkjenn"
+            value={IKKE_GODKJENT}
+            onChange={lagreUtfallRegistreringUnntak}
+            disabled={!redigerbart}
+          />
+        </Nav.Column>
+      </Nav.Row>
 
       {utfallErGODKJENT && !harErrorFeilmelding && (
-        <Nav.Fieldset legend="">
-          <Nav.Row>
-            <Nav.Column xs="8">
-              <Forms.Select
-                name="bestemmelse"
-                control={control}
-                label="Bestemmelse"
-                emptyFieldDisabled={!!formValues.bestemmelse}
-                disabled={!redigerbart}
-                onChange={lagreBestemmelse}
-              >
-                {bestemmelser?.map((item: KTObject) => (
-                  <option key={item.kode} value={item.kode}>
-                    {item.term}
-                  </option>
-                ))}
-              </Forms.Select>
-            </Nav.Column>
-          </Nav.Row>
-        </Nav.Fieldset>
+        <Nav.Row>
+          <Nav.Column xs="8">
+            <Forms.Select
+              name="bestemmelse"
+              control={control}
+              label="Bestemmelse"
+              emptyFieldDisabled={!!formValues.bestemmelse}
+              disabled={!redigerbart}
+              onChange={lagreBestemmelse}
+            >
+              {bestemmelser?.map((item: KTObject) => (
+                <option key={item.kode} value={item.kode}>
+                  {item.term}
+                </option>
+              ))}
+            </Forms.Select>
+          </Nav.Column>
+        </Nav.Row>
       )}
 
       {formValues.utfallRegistreringUnntak === DELVIS_GODKJENT && (
-        <Nav.Fieldset legend="Lovvalgsperiode">
+        <>
           <Nav.Row>
             <Nav.Column xs="2">
               <Forms.Datovelger
@@ -261,24 +264,28 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake, aktivtSteg }: Vurd
                 onChange={lagreTom}
               />
             </Nav.Column>
-            <Nav.Column xs="8">
-              <Forms.Select
-                name="bestemmelse"
-                control={control}
-                label="Bestemmelse"
-                emptyFieldDisabled={!!formValues.bestemmelse}
-                disabled={!redigerbart}
-                onChange={lagreBestemmelse}
-              >
-                {bestemmelser?.map((item: KTObject) => (
-                  <option key={item.kode} value={item.kode}>
-                    {item.term}
-                  </option>
-                ))}
-              </Forms.Select>
-            </Nav.Column>
           </Nav.Row>
-        </Nav.Fieldset>
+          {harSluttdato && !harErrorFeilmelding && (
+            <Nav.Row>
+              <Nav.Column xs="8">
+                <Forms.Select
+                  name="bestemmelse"
+                  control={control}
+                  label="Bestemmelse"
+                  emptyFieldDisabled={!!formValues.bestemmelse}
+                  disabled={!redigerbart}
+                  onChange={lagreBestemmelse}
+                >
+                  {bestemmelser?.map((item: KTObject) => (
+                    <option key={item.kode} value={item.kode}>
+                      {item.term}
+                    </option>
+                  ))}
+                </Forms.Select>
+              </Nav.Column>
+            </Nav.Row>
+          )}
+        </>
       )}
 
       <Feilmeldinger
@@ -286,20 +293,20 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake, aktivtSteg }: Vurd
         exclude={[OVERLAPPENDE_UNNTAK_PERIODER, INGEN_SLUTTDATO]}
       />
 
-      {utfallErGODKJENT && (
+      {(utfallErGODKJENT || utfallErDelvisGodkjent) && !harErrorFeilmelding && (
         <Alertmeldinger
           className="vurderingUnntakMedlemskap__alertmeldinger"
           meldinger={kontrollFeilOverlappendeUnntakperiode}
         />
       )}
 
-      {manglerSluttdato && utfallErGODKJENT && (
+      {!harSluttdato && !utfallRegistrert && (
         <Nav.AlertStripeAdvarsel className="vurderingUnntakMedlemskap__ikke_godkjent_advarsel">
           Du kan ikke godkjenne en unntaksperiode med åpen sluttdato
         </Nav.AlertStripeAdvarsel>
       )}
 
-      {[DELVIS_GODKJENT, IKKE_GODKJENT].includes(formValues.utfallRegistreringUnntak) && (
+      {[DELVIS_GODKJENT, IKKE_GODKJENT].includes(formValues.utfallRegistreringUnntak) && !harErrorFeilmelding && (
         <Nav.AlertStripeInfo className="vurderingUnntakMedlemskap__alertstripe">
           Ved endring/ikke godkjenning av unntaksperiode bør det sendes informasjon til utenlandsk trygdemyndighet.
         </Nav.AlertStripeInfo>


### PR DESCRIPTION
… vurderingUnntakMedlemskap.tsx.

Fjernet bruk av fieldsets, hensikten med taggen er å gruppere logisk tilknyttede skjemaelementer. Eks. et registreringsskjema for en nettside gir det mening å gruppere skjemaelementene tilknyttet adressen til en bruker under et fieldset, personopplysninger under et annet fieldset osv. 
Viser ikke varsel eller infobokser ved errors. Gir lite mening å informere saksbehandler om at utenlandsk trygdemyndighet burde informeres ved endring av periode dersom behandlingen har kontrollfeil som gjør det umulig å gå videre i behandlingen. 
Viser ikke bestemmelsesvalg før sluttdato er registrert.