### PR TITLE
5863 Oppdatere registeropplysninger skal ikke fjerne stegvelger

### DIFF
--- a/src/felleskomponenter/enkelStegvelger/enkelStegvelger.tsx
+++ b/src/felleskomponenter/enkelStegvelger/enkelStegvelger.tsx
@@ -55,6 +55,8 @@ export default ({ alleSteg }: EnkelStegvelgerProps) => {
     }
 
     setAktuellesteg(nyeSteg);
+    const normalisertAktivtSteg = Math.min(aktivtStegIndex, nyeSteg.length - 1);
+    setAktivtStegIndex(normalisertAktivtSteg);
   };
 
   const bekreft = () => {


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5863

Når man trykker på oppdater registeropplysninger i enkelflyt blir stegvelger borte hvis aktivIndex > 1, kommer tilbake etter refresh. Index settes nå riktig ved oppdater regopp