### PR TITLE
5469 DAPI vise medlemskapsperiode

### DIFF
--- a/src/felleskomponenter/oppgaveliste/fagsak.jsx
+++ b/src/felleskomponenter/oppgaveliste/fagsak.jsx
@@ -1,5 +1,6 @@
 import PT from "prop-types";
 
+import MKV from "../../melosyskodeverk";
 import * as MPT from "../../proptypes";
 import * as Nav from "../../navFrontend";
 import * as KV from "../../kodeverk";
@@ -28,6 +29,8 @@ const Fagsak = ({ sak, landkoder }) => {
   const { land } = behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.soknadsperiode != null) ?? {};
   const { lovvalgsperiode } =
     behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.lovvalgsperiode != null) ?? {};
+  const { medlemskapsperiode } =
+    behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.medlemskapsperiode != null) ?? {};
   const link = (behandling) =>
     Routing.lagUrl(
       saksnummer,
@@ -60,7 +63,11 @@ const Fagsak = ({ sak, landkoder }) => {
           </Nav.Column>
           <Nav.Column xs="12" md="4">
             <dl className="fagsak__meta">
-              <DatoOmradeDescription label="Lovvalgsperiode: " periode={lovvalgsperiode} />
+              {sakstype?.kode === MKV.Koder.sakstyper.FTRL ? (
+                <DatoOmradeDescription label="Medlemskapsperiode: " periode={medlemskapsperiode} />
+              ) : (
+                <DatoOmradeDescription label="Lovvalgsperiode: " periode={lovvalgsperiode} />
+              )}
               <dt>Land:</dt>
               <dd>
                 <Soknadsland land={land} visFulltNavn landkoderKodeverk={landkoder} />

--- a/src/proptypes/behandlingOversikt.js
+++ b/src/proptypes/behandlingOversikt.js
@@ -13,6 +13,7 @@ const BehandligOversiktPropType = PT.shape({
   opprettetDato: PT.string,
   soknadsperiode: Periode,
   lovvalgsperiode: Periode,
+  medlemskapsperiode: Periode,
 });
 const BehandligOversikterPropType = PT.arrayOf(BehandligOversiktPropType);
 export { BehandligOversiktPropType as BehandligOversikt, BehandligOversikterPropType as BehandligOversikter };

--- a/src/services/modules/types/fagsak.ts
+++ b/src/services/modules/types/fagsak.ts
@@ -25,7 +25,8 @@ export type FagsakOppsummering = {
     behandlingsstatus: KTObject;
     behandlingstype: KTObject;
     behandlingstema: KTObject;
-    periode: Periode;
+    lovvalgsperiode?: Periode;
+    medlemskapsperioder?: Periode;
     land: Soeknadsland;
     opprettetDato: string;
     behandlingsresultattype: KTObject;

--- a/src/sider/journalforing/komponenter/enkeltSak.jsx
+++ b/src/sider/journalforing/komponenter/enkeltSak.jsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import PT from "prop-types";
 
-import { MKVUtils } from "../../../melosyskodeverk";
+import MKV, { MKVUtils } from "../../../melosyskodeverk";
 import * as KV from "../../../kodeverk";
 import * as MPT from "../../../proptypes";
 import * as Skjema from "../../../felleskomponenter/skjema";
@@ -31,6 +31,8 @@ const EnkeltSak = (props) => {
     behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.soknadsperiode != null) ?? {};
   const { lovvalgsperiode } =
     behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.lovvalgsperiode != null) ?? {};
+  const { medlemskapsperiode } =
+    behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.medlemskapsperiode != null) ?? {};
 
   const link = lagUrl(
     saksnummer,
@@ -42,8 +44,9 @@ const EnkeltSak = (props) => {
     folketrygdenToggleEnabled
   );
 
+  const avsluttendePeriode = sakstype.kode === MKV.Koder.sakstyper.FTRL ? medlemskapsperiode : lovvalgsperiode;
   const periode = MKVUtils.erAvsluttetEllerMidlertidigBeslutning(behandlingsstatus?.kode)
-    ? lovvalgsperiode
+    ? avsluttendePeriode
     : soknadsperiode;
   return (
     <div className="enkeltSak">


### PR DESCRIPTION
Viser medlemskapsperiode på saksoversikten, samt bruker denne perioden under Eksisterende Sak på Journalføringsbildet. 

https://jira.adeo.no/browse/MELOSYS-5469

Denne er avhengig av melosys-api (https://github.com/navikt/melosys-api/pull/1956)

Ikke togglet da jeg har tatt beskrivelsen i jira bokstavlig angående sakstype. Da kommer FTRL + tom fly til å få "medlemskapsperiode: --" i prod. Men tenker dette er like bra som "lovvalgsperiode: --" som er der nå.