### PR TITLE
6097 PRODFIX forhåndsvisning av fritekstvedlegg ved utenlandsk mottaker

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
@@ -22,13 +22,15 @@ import { SendBrevFormValues } from "../types";
 import BrevMottakerNorskMyndighet from "./brevMottakerNorskMyndighet";
 import { FeilmeldingProps, Underpunkt } from "../../../../services/modules/dokumenter-v2";
 
-const { BRUKER, ARBEIDSGIVER, VIRKSOMHET, ANNEN_ORGANISASJON, NORSK_MYNDIGHET } = MKV.Koder.mottakerroller;
+const { BRUKER, ARBEIDSGIVER, VIRKSOMHET, ANNEN_ORGANISASJON, NORSK_MYNDIGHET, UTENLANDSK_TRYGDEMYNDIGHET } =
+  MKV.Koder.mottakerroller;
 
 export const erBruker = (rolle: string | undefined) => rolle === BRUKER;
 export const erVirksomhet = (rolle: string | undefined) => rolle === VIRKSOMHET;
 export const erArbeidsgiver = (rolle: string | undefined) => rolle === ARBEIDSGIVER;
 export const erAnnenOrganisasjon = (rolle: string | undefined) => rolle === ANNEN_ORGANISASJON;
 export const erNorskMyndighet = (rolle: string | undefined) => rolle === NORSK_MYNDIGHET;
+export const erUtenlandskMyndighet = (rolle: string | undefined) => rolle === UTENLANDSK_TRYGDEMYNDIGHET;
 
 const mapStateToProps = (state: RootState) => ({
   formValues: getFormValues(KV.Form.SEND_BREV)(state) as SendBrevFormValues,

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -29,7 +29,11 @@ import { formSelectors } from "../../../ducks/form";
 import VedleggVelger from "../../vedleggvelger";
 import VedleggTable from "../../vedleggTable";
 
-import BrevMottaker, { erAnnenOrganisasjon, erNorskMyndighet } from "./brevMottaker/brevMottaker";
+import BrevMottaker, {
+  erAnnenOrganisasjon,
+  erNorskMyndighet,
+  erUtenlandskMyndighet,
+} from "./brevMottaker/brevMottaker";
 import BrevMottakereTabell from "./brevMottaker/brevMottakereTabell";
 import FritekstvedleggSkjema from "./fritekstvedleggSkjema";
 import Brevutkast from "./brevutkast/brevutkast";
@@ -121,6 +125,7 @@ const SendBrev = ({
   const tilgjengeligeBrevtyper =
     tilgjengeligeMaler?.find((mal) => mal?.mottaker.uuid === formValues?.mottaker)?.brevTyper || [];
   const mottakerErNorskMyndighet = erNorskMyndighet(formValues?.valgtMottaker?.rolle);
+  const mottakerErUtenlandskMyndighet = erUtenlandskMyndighet(formValues?.valgtMottaker?.rolle);
   const { accounts } = useMsal();
 
   const hentUtkast = () =>
@@ -312,7 +317,9 @@ const SendBrev = ({
 
   const lagFritekstPdfUrl = async (index: number) => {
     const data = {
-      produserbardokument: MKV.Koder.brev.produserbaredokumenter.GENERELT_FRITEKSTVEDLEGG,
+      produserbardokument: mottakerErUtenlandskMyndighet
+        ? MKV.Koder.brev.produserbaredokumenter.UTENLANDSK_TRYGDEMYNDIGHET_FRITEKSTBREV
+        : MKV.Koder.brev.produserbaredokumenter.GENERELT_FRITEKSTVEDLEGG,
       mottaker: mottakerErNorskMyndighet
         ? MKV.Koder.mottakerroller.NORSK_MYNDIGHET
         : muligeMottakere?.hovedMottaker.rolle || "",


### PR DESCRIPTION
produserbardokument baserer seg på rolle ved forhåndsvisning av fritekstvedlegg

https://jira.adeo.no/browse/MELOSYS-6097