### PR TITLE
5177 Hotfix negativ margin ødelegger stegvelger.

### DIFF
--- a/src/felleskomponenter/alertmeldinger/alertmeldinger.less
+++ b/src/felleskomponenter/alertmeldinger/alertmeldinger.less
@@ -66,5 +66,4 @@
 
 .innsynsmelding {
   margin-bottom: 0.5rem;
-  margin-top: -1rem;
 }

--- a/src/sider/eu_eøs/registrering/registrering.less
+++ b/src/sider/eu_eøs/registrering/registrering.less
@@ -11,6 +11,10 @@
     padding: 0 1em;
   }
 
+  .innsynsmelding {
+    margin-top: -1rem;
+  }
+
   .registrering__fotknapper {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Hotfix for negativ margin som klusser med de nye stegvelger ikonene. La kun på negativ margin i registrering.jsx siden dette er den eneste som er tilpasset negativ margin nå.