### PR TITLE
NOJIRA Stegikon for ubehandlet vedtak utgår for steglinjen

### DIFF
--- a/src/felleskomponenter/stegLinje/stegIkon.jsx
+++ b/src/felleskomponenter/stegLinje/stegIkon.jsx
@@ -8,18 +8,15 @@ import * as Ikoner from "../../resources/images";
 import "./stegIkon.css";
 
 const ikonVelger = (status, vedtakSteg, aktivtSteg) => {
-  if (aktivtSteg) {
-    if (vedtakSteg) {
-      return Ikoner.VedtakGodkjentAktiv;
-    }
-    return status === FANE_STATUS.UBEHANDLET ? Ikoner.UbehandletAktiv : Ikoner.FerdigAktiv;
-  }
-
   if (vedtakSteg) {
-    return status === FANE_STATUS.UBEHANDLET ? Ikoner.VedtakUbehandlet : Ikoner.VedtakGodkjentIkkeAktiv;
+    return aktivtSteg ? Ikoner.VedtakGodkjentAktiv : Ikoner.VedtakGodkjentIkkeAktiv;
   }
 
-  return status === FANE_STATUS.UBEHANDLET ? Ikoner.Ubehandlet : Ikoner.Ferdig;
+  if (aktivtSteg) {
+    return status === FANE_STATUS.UBEHANDLET ? Ikoner.UbehandletAktiv : Ikoner.FerdigAktiv;
+  } else {
+    return status === FANE_STATUS.UBEHANDLET ? Ikoner.Ubehandlet : Ikoner.Ferdig;
+  }
 };
 
 const StegIkon = (props) => {

--- a/src/felleskomponenter/stegLinje/stegIkon.jsx
+++ b/src/felleskomponenter/stegLinje/stegIkon.jsx
@@ -14,9 +14,9 @@ const ikonVelger = (status, vedtakSteg, aktivtSteg) => {
 
   if (aktivtSteg) {
     return status === FANE_STATUS.UBEHANDLET ? Ikoner.UbehandletAktiv : Ikoner.FerdigAktiv;
-  } else {
-    return status === FANE_STATUS.UBEHANDLET ? Ikoner.Ubehandlet : Ikoner.Ferdig;
   }
+
+  return status === FANE_STATUS.UBEHANDLET ? Ikoner.Ubehandlet : Ikoner.Ferdig;
 };
 
 const StegIkon = (props) => {


### PR DESCRIPTION
Etter diskusjon med UX ble det bestemt at stegikonet til vedtaksteg kun skal være avhengig av om det er aktivtSteg eller ikke, siden implementering av status på vedtak-steg ikke er gjort på de aller fleste flyter. Det ble derfor meget misvisende bl.a. ved innsynsmodus der det så ut som vedtaksteget var ubehandlet frem til steget ble aktivt/trykket på.