### PR TITLE
6087 5 år grense er for liten

### DIFF
--- a/src/felleskomponenter/datovelger/datovelger.tsx
+++ b/src/felleskomponenter/datovelger/datovelger.tsx
@@ -33,7 +33,7 @@ const Datovelger = ({
 }: DatovelgerProps) => {
   const [erUgyldigDato, setErUgyldigDato] = useState<boolean>(false);
   const { datepickerProps, inputProps } = useDatepicker({
-    fromDate: minDate ?? new Date(moment(moment.now()).subtract(15, "years").toDate()),
+    fromDate: minDate ?? new Date(moment(moment.now()).subtract(25, "years").toDate()),
     toDate: maxDate ?? new Date(moment(moment.now()).add(15, "years").toDate()),
     locale: "nb",
     defaultSelected: value,

--- a/src/felleskomponenter/datovelger/datovelger.tsx
+++ b/src/felleskomponenter/datovelger/datovelger.tsx
@@ -33,8 +33,8 @@ const Datovelger = ({
 }: DatovelgerProps) => {
   const [erUgyldigDato, setErUgyldigDato] = useState<boolean>(false);
   const { datepickerProps, inputProps } = useDatepicker({
-    fromDate: minDate ?? new Date(moment(moment.now()).subtract(5, "years").toDate()),
-    toDate: maxDate ?? new Date(moment(moment.now()).add(5, "years").toDate()),
+    fromDate: minDate ?? new Date(moment(moment.now()).subtract(15, "years").toDate()),
+    toDate: maxDate ?? new Date(moment(moment.now()).add(15, "years").toDate()),
     locale: "nb",
     defaultSelected: value,
     defaultMonth: minDate ?? value,


### PR DESCRIPTION
Hvis man fjerner grensen helt klarer ikke DatePicker å vise måned- og årsvisningen på toppen, siden denne viser årene frem eller tilbake til fromDate/toDate. Setter denne til 15 enn så lenge, mens jeg dobbeltsjekker med fag hva som er et logisk tall her.

https://nav-it.slack.com/archives/C01CFP7SL4Q/p1694761802468189

Etter diskusjon med fag ble det enig om å bruke 25 år tilbake i tid og 15 år fremover. Test skal teste og finne ut om dette er good, hvis ikke kommer saken tilbake.

https://jira.adeo.no/browse/MELOSYS-6087