### PR TITLE
5782 Pågående artikkel 16 behandlinger advarsel

### DIFF
--- a/src/felleskomponenter/skjema/input/radio-gruppe.jsx
+++ b/src/felleskomponenter/skjema/input/radio-gruppe.jsx
@@ -32,7 +32,7 @@ RadioGruppeWrappedComponent.propTypes = {
   children: PT.node.isRequired,
   meta: PT.object.isRequired,
   legend: PT.string.isRequired,
-  label: PT.string.isRequired,
+  label: PT.node.isRequired,
   className: PT.string,
 };
 RadioGruppeWrappedComponent.defaultProps = {
@@ -46,7 +46,7 @@ function RadioGruppe({ feltNavn, ...rest }) {
 RadioGruppe.propTypes = {
   feltNavn: PT.string.isRequired,
   legend: PT.string,
-  label: PT.string,
+  label: PT.node,
   children: PT.node,
 };
 

--- a/src/sider/journalforing/komponenter/fagsakVelger.jsx
+++ b/src/sider/journalforing/komponenter/fagsakVelger.jsx
@@ -23,9 +23,9 @@ const OPPRETT = "Opprett ny sak";
 const { JOURNALFORING_VALUES: FormValuesJournalforing, OPPRETT_NY_SAK_VALUES: FormValuesOpprettNySak } = KV.Form;
 
 const FagsakVelger = (props) => {
-  const { fagsakListe, settJournalforingHensikt, landkoder, formValues, erOpprettNySak, nullstillFormVerdier } = props;
+  const { fagsakListe, settJournalforingHensikt, landkoder, formValues, erJournalføring, nullstillFormVerdier } = props;
   const [valgtVisning, setValgtVisning] = useState(EKSISTERENDE);
-  const feltNavn = erOpprettNySak ? FormValuesOpprettNySak : FormValuesJournalforing;
+  const feltNavn = !erJournalføring ? FormValuesOpprettNySak : FormValuesJournalforing;
   const dispatch = useDispatch();
   const ingenSakerFinnes = fagsakListe.length === 0;
 
@@ -44,7 +44,7 @@ const FagsakVelger = (props) => {
   }, [ingenSakerFinnes, valgtVisning]);
 
   const notifier = async (saksnummer) => {
-    if (settJournalforingHensikt && !erOpprettNySak) {
+    if (settJournalforingHensikt && erJournalføring) {
       const hensikt = saksnummer === "-1" ? JOURNALFORING_HENSIKT.OPPRETT : JOURNALFORING_HENSIKT.KNYTT;
       await settJournalforingHensikt(hensikt);
     }
@@ -56,7 +56,7 @@ const FagsakVelger = (props) => {
       {
         value: sak.saksnummer,
         innhold: <EnkeltSak sak={sak} landkoder={landkoder} />,
-        footer: <KnyttTilSak sak={sak} erOpprettNySak={erOpprettNySak} feltNavn={feltNavn} formValues={formValues} />,
+        footer: <KnyttTilSak sak={sak} erJournalføring={erJournalføring} feltNavn={feltNavn} formValues={formValues} />,
       },
     ],
     []
@@ -110,12 +110,11 @@ FagsakVelger.propTypes = {
   settJournalforingHensikt: PT.func,
   landkoder: PT.arrayOf(MPT.Kodeverk).isRequired,
   formValues: PT.object.isRequired,
-  erOpprettNySak: PT.bool,
+  erJournalføring: PT.bool.isRequired,
   nullstillFormVerdier: PT.func,
 };
 
 FagsakVelger.defaultProps = {
-  erOpprettNySak: false,
   nullstillFormVerdier: undefined,
   settJournalforingHensikt: undefined,
 };

--- a/src/sider/journalforing/komponenter/fagsakVelger.jsx
+++ b/src/sider/journalforing/komponenter/fagsakVelger.jsx
@@ -25,7 +25,7 @@ const { JOURNALFORING_VALUES: FormValuesJournalforing, OPPRETT_NY_SAK_VALUES: Fo
 const FagsakVelger = (props) => {
   const { fagsakListe, settJournalforingHensikt, landkoder, formValues, erJournalføring, nullstillFormVerdier } = props;
   const [valgtVisning, setValgtVisning] = useState(EKSISTERENDE);
-  const feltNavn = !erJournalføring ? FormValuesOpprettNySak : FormValuesJournalforing;
+  const feltNavn = erJournalføring ? FormValuesJournalforing : FormValuesOpprettNySak;
   const dispatch = useDispatch();
   const ingenSakerFinnes = fagsakListe.length === 0;
 
@@ -44,7 +44,7 @@ const FagsakVelger = (props) => {
   }, [ingenSakerFinnes, valgtVisning]);
 
   const notifier = async (saksnummer) => {
-    if (settJournalforingHensikt && erJournalføring) {
+    if (erJournalføring && settJournalforingHensikt) {
       const hensikt = saksnummer === "-1" ? JOURNALFORING_HENSIKT.OPPRETT : JOURNALFORING_HENSIKT.KNYTT;
       await settJournalforingHensikt(hensikt);
     }

--- a/src/sider/journalforing/komponenter/journalforingform.jsx
+++ b/src/sider/journalforing/komponenter/journalforingform.jsx
@@ -110,6 +110,7 @@ export const JournalforingForm = ({
           tittel="Knytt til eksisterende sak eller opprett ny sak"
           innhold={
             <FagsakVelger
+              erJournalføring
               fagsakListe={fagsakListe}
               settJournalforingHensikt={settJournalforingHensikt}
               landkoder={landkoder}

--- a/src/sider/journalforing/komponenter/knyttTilSak.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.jsx
@@ -15,7 +15,7 @@ import * as Utils from "../../../utils";
 import "./knyttTilSak.css";
 
 export const KnyttTilSak = (props) => {
-  const { sak, erOpprettNySak, changeField, feltNavn, formValues } = props;
+  const { sak, erJournalføring, changeField, feltNavn, formValues } = props;
   const { behandlingstema, behandlingstype, journalforingGjelder, opprettBehandling } = {
     opprettBehandling: formValues[feltNavn.opprettBehandling],
     behandlingstema: formValues[feltNavn.behandlingstema],
@@ -30,7 +30,7 @@ export const KnyttTilSak = (props) => {
 
   useEffect(() => {
     return () => {
-      if (!erOpprettNySak) changeField(feltNavn.formNavn, "vurderDokument", undefined);
+      if (erJournalføring) changeField(feltNavn.formNavn, "vurderDokument", undefined);
       changeField(feltNavn.formNavn, feltNavn.opprettBehandling, undefined);
       changeField(feltNavn.formNavn, feltNavn.behandlingstema, "");
       changeField(feltNavn.formNavn, feltNavn.behandlingstype, "");
@@ -49,7 +49,7 @@ export const KnyttTilSak = (props) => {
     const kanOppretteAndregangsbehandling =
       sisteBehandlingKanOpprettesAndregangsbehandlingPå && !sakErHenlagtEllerBortfalt;
     changeField(feltNavn.formNavn, feltNavn.opprettBehandling, kanOppretteAndregangsbehandling);
-    if (!erOpprettNySak) {
+    if (erJournalføring) {
       const skalIkkeVurdereDokument = sisteBehandlingKanOpprettesAndregangsbehandlingPå || sakErHenlagtEllerBortfalt;
       changeField(feltNavn.formNavn, "vurderDokument", !skalIkkeVurdereDokument);
     }
@@ -106,7 +106,7 @@ export const KnyttTilSak = (props) => {
   if (sakErHenlagtEllerBortfalt) {
     return (
       <div className="knyttTilSak__behandlingspanel">
-        {erOpprettNySak ? (
+        {!erJournalføring ? (
           <Nav.AlertStripeAdvarsel className="feilmelding_innrykk">
             Du kan ikke opprette en ny behandling på eksisterende sak som er henlagt/bortfalt i Melosys
           </Nav.AlertStripeAdvarsel>
@@ -123,7 +123,7 @@ export const KnyttTilSak = (props) => {
   if (sisteBehandlingKanOpprettesAndregangsbehandlingPå) {
     return (
       <div className="knyttTilSak__panelramme">
-        {!erOpprettNySak && (
+        {erJournalføring && (
           <>
             <Mui.Elementskrift
               tekst="Tidligere behandling er avsluttet. Velg hva du vil gjøre med dokumentet"
@@ -144,7 +144,7 @@ export const KnyttTilSak = (props) => {
         {opprettBehandling && (
           <div className="panelElement">
             <Nav.Typo.Undertittel className="temaTypeOverskrift">
-              {erOpprettNySak
+              {!erJournalføring
                 ? "Tidligere behandling er avsluttet. Velg behandlingstema og -type for den nye behandlingen"
                 : "Velg tema og type for ny behandling"}
             </Nav.Typo.Undertittel>
@@ -171,7 +171,7 @@ export const KnyttTilSak = (props) => {
 
   return (
     <div className="knyttTilSak__behandlingspanel">
-      {erOpprettNySak ? (
+      {!erJournalføring ? (
         <Nav.AlertStripeAdvarsel className="feilmelding_innrykk">
           Du kan ikke opprette en ny behandling på eksisterende sak med en aktiv/pågående behandling
         </Nav.AlertStripeAdvarsel>
@@ -183,13 +183,10 @@ export const KnyttTilSak = (props) => {
 };
 KnyttTilSak.propTypes = {
   sak: MPT.Fagsak.isRequired,
-  erOpprettNySak: PT.bool,
+  erJournalføring: PT.bool.isRequired,
   changeField: PT.func.isRequired,
   feltNavn: PT.object.isRequired,
   formValues: PT.object.isRequired,
-};
-KnyttTilSak.defaultProps = {
-  erOpprettNySak: false,
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/sider/journalforing/komponenter/knyttTilSak.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.jsx
@@ -5,10 +5,8 @@ import PT from "prop-types";
 
 import { MKVUtils } from "../../../melosyskodeverk";
 import * as MPT from "../../../proptypes";
-import * as Ikoner from "../../../resources/images";
 import * as Skjema from "../../../felleskomponenter/skjema";
 import * as Nav from "../../../navFrontend";
-import * as Mui from "../../../felleskomponenter/ui";
 import * as Api from "../../../services/api";
 import * as Utils from "../../../utils";
 
@@ -42,18 +40,30 @@ export const KnyttTilSak = (props) => {
   );
   const sakErHenlagtEllerBortfalt = MKVUtils.erHenlagtEllerHenlagtBortfalt(sak.saksstatus.kode);
 
+  const sisteBehandlingErPågåendeArtikkel16Sak =
+    sisteBehandlingHarSendtAnmodningUnntakTilUtland && !sisteBehandlingErInaktiv;
+
   const sisteBehandlingKanOpprettesAndregangsbehandlingPå =
-    sisteBehandlingErInaktiv || sisteBehandlingHarSendtAnmodningUnntakTilUtland;
+    sisteBehandlingErInaktiv || sisteBehandlingErPågåendeArtikkel16Sak;
 
   useEffect(() => {
-    const kanOppretteAndregangsbehandling =
-      sisteBehandlingKanOpprettesAndregangsbehandlingPå && !sakErHenlagtEllerBortfalt;
-    changeField(feltNavn.formNavn, feltNavn.opprettBehandling, kanOppretteAndregangsbehandling);
+    if (sisteBehandlingErPågåendeArtikkel16Sak && erJournalføring) {
+      changeField(feltNavn.formNavn, feltNavn.opprettBehandling, undefined);
+    } else {
+      const kanOppretteAndregangsbehandling =
+        sisteBehandlingKanOpprettesAndregangsbehandlingPå && !sakErHenlagtEllerBortfalt;
+      changeField(feltNavn.formNavn, feltNavn.opprettBehandling, kanOppretteAndregangsbehandling);
+    }
+
     if (erJournalføring) {
       const skalIkkeVurdereDokument = sisteBehandlingKanOpprettesAndregangsbehandlingPå || sakErHenlagtEllerBortfalt;
       changeField(feltNavn.formNavn, "vurderDokument", !skalIkkeVurdereDokument);
     }
-  }, [sisteBehandlingKanOpprettesAndregangsbehandlingPå, sakErHenlagtEllerBortfalt]);
+  }, [
+    sisteBehandlingKanOpprettesAndregangsbehandlingPå,
+    sakErHenlagtEllerBortfalt,
+    sisteBehandlingErPågåendeArtikkel16Sak,
+  ]);
 
   useEffect(() => {
     const erAnmodningsperiodeSendt = (anmodningsperiode) => anmodningsperiode.sendtUtland;
@@ -123,30 +133,29 @@ export const KnyttTilSak = (props) => {
   if (sisteBehandlingKanOpprettesAndregangsbehandlingPå) {
     return (
       <div className="knyttTilSak__panelramme">
+        {sisteBehandlingErPågåendeArtikkel16Sak ? (
+          <Nav.AlertStripeAdvarsel className="anmodningSvarSendt">
+            Hvis du har mottatt svar på anmodning om unntak skal du <b>ikke</b> opprette en ny behandling.
+          </Nav.AlertStripeAdvarsel>
+        ) : (
+          <Nav.AlertStripeInfo className="tidligereBehandlingAvsluttet">
+            Tidligere behandling er avsluttet.
+          </Nav.AlertStripeInfo>
+        )}
         {erJournalføring && (
-          <>
-            <Mui.Elementskrift
-              tekst="Tidligere behandling er avsluttet. Velg hva du vil gjøre med dokumentet"
-              ikon={Ikoner.InformationCircle}
-              className="elementTittel oversteUndertittel"
-              style={{ "border-bottom": "none" }}
-            />
-            <Skjema.RadioGruppe
-              feltNavn="opprettBehandling"
-              label=""
-              className="panelElement nyBehandling-utenBehandling"
-            >
-              <Skjema.Radio feltNavn={feltNavn.opprettBehandling} value label="Opprett ny behandling" />
-              <Skjema.Radio feltNavn={feltNavn.opprettBehandling} value={false} label="Uten å opprette behandling" />
-            </Skjema.RadioGruppe>
-          </>
+          <Skjema.RadioGruppe
+            feltNavn="opprettBehandling"
+            label={<Nav.Typo.Undertittel>Velg hva du vil gjøre med dokumentet</Nav.Typo.Undertittel>}
+            className="panelElement nyBehandlingEllerUtenBehandling"
+          >
+            <Skjema.Radio feltNavn={feltNavn.opprettBehandling} value label="Opprett ny behandling" />
+            <Skjema.Radio feltNavn={feltNavn.opprettBehandling} value={false} label="Uten å opprette behandling" />
+          </Skjema.RadioGruppe>
         )}
         {opprettBehandling && (
           <div className="panelElement">
             <Nav.Typo.Undertittel className="temaTypeOverskrift">
-              {erJournalføring
-                ? "Velg tema og type for ny behandling"
-                : "Tidligere behandling er avsluttet. Velg behandlingstema og -type for den nye behandlingen"}
+              Velg tema og type for ny behandling
             </Nav.Typo.Undertittel>
             <Skjema.Select
               feltNavn={feltNavn.behandlingstema}

--- a/src/sider/journalforing/komponenter/knyttTilSak.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.jsx
@@ -106,15 +106,15 @@ export const KnyttTilSak = (props) => {
   if (sakErHenlagtEllerBortfalt) {
     return (
       <div className="knyttTilSak__behandlingspanel">
-        {!erJournalføring ? (
-          <Nav.AlertStripeAdvarsel className="feilmelding_innrykk">
-            Du kan ikke opprette en ny behandling på eksisterende sak som er henlagt/bortfalt i Melosys
-          </Nav.AlertStripeAdvarsel>
-        ) : (
+        {erJournalføring ? (
           <Nav.AlertStripeInfo className="feilmelding_innrykk">
             Du kan ikke opprette en ny behandling på en eksisterende sak som er henlagt/bortfalt i Melosys, men du kan
             knytte dokumentet til den avsluttede behandlingen
           </Nav.AlertStripeInfo>
+        ) : (
+          <Nav.AlertStripeAdvarsel className="feilmelding_innrykk">
+            Du kan ikke opprette en ny behandling på eksisterende sak som er henlagt/bortfalt i Melosys
+          </Nav.AlertStripeAdvarsel>
         )}
       </div>
     );
@@ -144,9 +144,9 @@ export const KnyttTilSak = (props) => {
         {opprettBehandling && (
           <div className="panelElement">
             <Nav.Typo.Undertittel className="temaTypeOverskrift">
-              {!erJournalføring
-                ? "Tidligere behandling er avsluttet. Velg behandlingstema og -type for den nye behandlingen"
-                : "Velg tema og type for ny behandling"}
+              {erJournalføring
+                ? "Velg tema og type for ny behandling"
+                : "Tidligere behandling er avsluttet. Velg behandlingstema og -type for den nye behandlingen"}
             </Nav.Typo.Undertittel>
             <Skjema.Select
               feltNavn={feltNavn.behandlingstema}
@@ -171,12 +171,12 @@ export const KnyttTilSak = (props) => {
 
   return (
     <div className="knyttTilSak__behandlingspanel">
-      {!erJournalføring ? (
+      {erJournalføring ? (
+        <Skjema.Checkbox feltNavn="vurderDokument" label={`Oppdater behandlingsstatus til "Vurder dokument"`} />
+      ) : (
         <Nav.AlertStripeAdvarsel className="feilmelding_innrykk">
           Du kan ikke opprette en ny behandling på eksisterende sak med en aktiv/pågående behandling
         </Nav.AlertStripeAdvarsel>
-      ) : (
-        <Skjema.Checkbox feltNavn="vurderDokument" label={`Oppdater behandlingsstatus til "Vurder dokument"`} />
       )}
     </div>
   );

--- a/src/sider/journalforing/komponenter/knyttTilSak.less
+++ b/src/sider/journalforing/komponenter/knyttTilSak.less
@@ -25,8 +25,13 @@
     border: 1px solid #979797;
     padding: 0.5em;
 
-    .nyBehandling-utenBehandling {
+    .nyBehandlingEllerUtenBehandling {
       margin-top: 1rem;
+    }
+
+    .anmodningSvarSendt,
+    .tidligereBehandlingAvsluttet {
+      margin-bottom: 1rem;
     }
 
     .panelElement {

--- a/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
@@ -1,10 +1,16 @@
-import * as Skjema from "../../../felleskomponenter/skjema";
 import { JOURNALFORING_VALUES } from "../../../kodeverk/form";
-
 import MKV from "../../../melosyskodeverk";
-
 import { KnyttTilSak } from "./knyttTilSak";
+import { renderWithProviders } from "~/ducks/test-utils/renderWithProviders";
+import { screen, within } from "@testing-library/react";
+import { reduxForm } from "redux-form";
 
+vi.mock("../../../services/modules/anmodningsperioder", () => ({
+  hent: () => Promise.resolve([]),
+}));
+vi.mock("../../../services/modules/lovligekombinasjoner", () => ({
+  hentBehandlingstemaer: () => Promise.resolve([]),
+}));
 describe("KnyttTilSak", () => {
   let props = null;
 
@@ -24,6 +30,7 @@ describe("KnyttTilSak", () => {
           {
             behandlingsstatus: { kode: MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET },
             behandlingstype: { kode: MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG },
+            behandlingstema: { kode: MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV },
           },
         ],
       },
@@ -40,21 +47,24 @@ describe("KnyttTilSak", () => {
       behandlingstema: "",
       behandlingstype: "",
       changeField: vi.fn(),
+      erJournalføring: true,
     };
   });
+
+  const WrappedKnyttTilSak = reduxForm({ form: "test" })(KnyttTilSak);
 
   it(`Vis komponent for knytte til eksisterende sak komponent og knapper for å opprette ny behandling dersom siste behandling er inaktiv`, () => {
     props.sak.behandlingOversikter[0].behandlingsstatus = { kode: MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET };
 
-    const knyttTilSak = shallow(<KnyttTilSak {...props} />);
-    const knyttTilEksisterendeSakKomponent = knyttTilSak.find(".knyttTilSak__panelramme");
+    renderWithProviders(<WrappedKnyttTilSak {...props} />);
 
-    expect(knyttTilEksisterendeSakKomponent).toHaveLength(1);
-
-    const radios = knyttTilEksisterendeSakKomponent.find(Skjema.Radio);
-
-    expect(radios).toHaveLength(2);
-    expect(radios.first().props().label).toBe("Opprett ny behandling");
+    expect(
+      screen.getByText("Tidligere behandling er avsluttet. Velg hva du vil gjøre med dokumentet")
+    ).toBeInTheDocument();
+    const radiogruppe = screen.getByRole("group");
+    expect(radiogruppe).toBeInTheDocument();
+    expect(within(radiogruppe).queryAllByRole("radio")).toHaveLength(2);
+    expect(within(radiogruppe).getByLabelText("Opprett ny behandling")).toBeInTheDocument();
   });
 
   it(`Ikke vis knytt til eksisterende sak komponent dersom siste behandling er aktiv`, () => {
@@ -62,60 +72,48 @@ describe("KnyttTilSak", () => {
       kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
     };
 
-    const knyttTilSak = shallow(<KnyttTilSak {...props} />);
-    const knyttTilEksisterendeSakKomponent = knyttTilSak.find(".knyttTilSak__panelramme");
+    renderWithProviders(<WrappedKnyttTilSak {...props} />);
 
-    expect(knyttTilEksisterendeSakKomponent).toHaveLength(0);
+    expect(screen.queryByText("Tidligere behandling er avsluttet. Velg hva du vil gjøre med dokumentet")).toBeNull();
+    expect(screen.queryByRole("group")).toBeNull();
   });
 
   it(`Ikke vis knytt til eksisterende sak komponent dersom status er henlagt`, () => {
     props.sak.saksstatus.kode = MKV.Koder.saksstatuser.HENLAGT;
+    props.erJournalføring = false;
 
-    const knyttTilSak = shallow(<KnyttTilSak {...props} />);
-    const knyttTilEksisterendeSakKomponent = knyttTilSak.find(".knyttTilSak__panelramme");
+    renderWithProviders(<WrappedKnyttTilSak {...props} />);
 
-    expect(knyttTilEksisterendeSakKomponent).toHaveLength(0);
+    expect(screen.queryByText("Tidligere behandling er avsluttet. Velg hva du vil gjøre med dokumentet")).toBeNull();
+    expect(screen.queryByRole("group")).toBeNull();
+    const henlagtTekst = "Du kan ikke opprette en ny behandling på eksisterende sak som er henlagt/bortfalt i Melosys";
+    expect(screen.getByText(henlagtTekst)).toBeInTheDocument();
   });
 
-  it(`Vis journalfør uten videre behandling dersom saktype er EØS`, () => {
+  it(`Vis vurder dokument dersom man er i journalføring-kontekst`, () => {
     props.sak.behandlingOversikter[0].behandlingsstatus = {
       kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
     };
-    props.sak.sakstype.kode = MKV.Koder.sakstyper.EU_EOS;
+    props.erJournalføring = true;
 
-    const knyttTilSak = shallow(<KnyttTilSak {...props} />);
+    renderWithProviders(<WrappedKnyttTilSak {...props} />);
 
-    const checkbox = knyttTilSak.find(Skjema.Checkbox);
-
-    expect(checkbox).toHaveLength(1);
-    expect(checkbox.first().props().label).toBe(`Oppdater behandlingsstatus til "Vurder dokument"`);
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    expect(screen.getByText(`Oppdater behandlingsstatus til "Vurder dokument"`)).toBeInTheDocument();
   });
 
-  it(`Vis journalfør uten videre behandling dersom saktype er FTRL`, () => {
+  it(`Ikke vis vurder dokument dersom man er i opprett ny sak/behandling-kontekst`, () => {
     props.sak.behandlingOversikter[0].behandlingsstatus = {
       kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
     };
-    props.sak.sakstype.kode = MKV.Koder.sakstyper.FTRL;
+    props.erJournalføring = false;
 
-    const knyttTilSak = shallow(<KnyttTilSak {...props} />);
+    renderWithProviders(<WrappedKnyttTilSak {...props} />);
 
-    const checkbox = knyttTilSak.find(Skjema.Checkbox);
-
-    expect(checkbox).toHaveLength(1);
-    expect(checkbox.first().props().label).toBe(`Oppdater behandlingsstatus til "Vurder dokument"`);
-  });
-
-  it(`Vis journalfør uten videre behandling dersom saktype er TRYGDEAVTALE`, () => {
-    props.sak.behandlingOversikter[0].behandlingsstatus = {
-      kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
-    };
-    props.sak.sakstype.kode = MKV.Koder.sakstyper.TRYGDEAVTALE;
-
-    const knyttTilSak = shallow(<KnyttTilSak {...props} />);
-
-    const checkbox = knyttTilSak.find(Skjema.Checkbox);
-
-    expect(checkbox).toHaveLength(1);
-    expect(checkbox.first().props().label).toBe(`Oppdater behandlingsstatus til "Vurder dokument"`);
+    expect(screen.queryByRole("checkbox")).toBeNull();
+    expect(screen.queryByText(`Oppdater behandlingsstatus til "Vurder dokument"`)).toBeNull();
+    expect(
+      screen.getByText("Du kan ikke opprette en ny behandling på eksisterende sak med en aktiv/pågående behandling")
+    ).toBeInTheDocument();
   });
 });

--- a/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
@@ -1,12 +1,17 @@
 import { JOURNALFORING_VALUES } from "../../../kodeverk/form";
 import MKV from "../../../melosyskodeverk";
 import { KnyttTilSak } from "./knyttTilSak";
-import { renderWithProviders } from "~/ducks/test-utils/renderWithProviders";
-import { screen, within } from "@testing-library/react";
+import { renderWithProviders } from "../../../ducks/test-utils/renderWithProviders";
+import { screen, waitFor, within } from "@testing-library/react";
 import { reduxForm } from "redux-form";
 
+const mocks = vi.hoisted(() => {
+  return {
+    hent: vi.fn(),
+  };
+});
 vi.mock("../../../services/modules/anmodningsperioder", () => ({
-  hent: () => Promise.resolve([]),
+  hent: () => Promise.resolve(mocks.hent()),
 }));
 vi.mock("../../../services/modules/lovligekombinasjoner", () => ({
   hentBehandlingstemaer: () => Promise.resolve([]),
@@ -49,6 +54,7 @@ describe("KnyttTilSak", () => {
       changeField: vi.fn(),
       erJournalføring: true,
     };
+    mocks.hent.mockReset();
   });
 
   const WrappedKnyttTilSak = reduxForm({ form: "test" })(KnyttTilSak);
@@ -58,9 +64,8 @@ describe("KnyttTilSak", () => {
 
     renderWithProviders(<WrappedKnyttTilSak {...props} />);
 
-    expect(
-      screen.getByText("Tidligere behandling er avsluttet. Velg hva du vil gjøre med dokumentet")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Tidligere behandling er avsluttet.")).toBeInTheDocument();
+    expect(screen.getByText("Velg hva du vil gjøre med dokumentet")).toBeInTheDocument();
     const radiogruppe = screen.getByRole("group");
     expect(radiogruppe).toBeInTheDocument();
     expect(within(radiogruppe).queryAllByRole("radio")).toHaveLength(2);
@@ -74,7 +79,7 @@ describe("KnyttTilSak", () => {
 
     renderWithProviders(<WrappedKnyttTilSak {...props} />);
 
-    expect(screen.queryByText("Tidligere behandling er avsluttet. Velg hva du vil gjøre med dokumentet")).toBeNull();
+    expect(screen.queryByText("Velg hva du vil gjøre med dokumentet")).toBeNull();
     expect(screen.queryByRole("group")).toBeNull();
   });
 
@@ -84,10 +89,9 @@ describe("KnyttTilSak", () => {
 
     renderWithProviders(<WrappedKnyttTilSak {...props} />);
 
-    expect(screen.queryByText("Tidligere behandling er avsluttet. Velg hva du vil gjøre med dokumentet")).toBeNull();
+    expect(screen.queryByText("Velg hva du vil gjøre med dokumentet")).toBeNull();
     expect(screen.queryByRole("group")).toBeNull();
-    const henlagtTekst = "Du kan ikke opprette en ny behandling på eksisterende sak som er henlagt/bortfalt i Melosys";
-    expect(screen.getByText(henlagtTekst)).toBeInTheDocument();
+    expect(screen.getByText(/Du kan ikke opprette en ny behandling/i)).toBeInTheDocument();
   });
 
   it(`Vis vurder dokument dersom man er i journalføring-kontekst`, () => {
@@ -112,8 +116,29 @@ describe("KnyttTilSak", () => {
 
     expect(screen.queryByRole("checkbox")).toBeNull();
     expect(screen.queryByText(`Oppdater behandlingsstatus til "Vurder dokument"`)).toBeNull();
-    expect(
-      screen.getByText("Du kan ikke opprette en ny behandling på eksisterende sak med en aktiv/pågående behandling")
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Du kan ikke opprette en ny behandling/i)).toBeInTheDocument();
+  });
+
+  it(`Vis varselmelding om anmodning om unntak dersom siste behandling er pågående artikkel 16 sak`, async () => {
+    mocks.hent.mockReturnValueOnce({ anmodningsperioder: [{ sendtUtland: true }] });
+    props.sak.behandlingOversikter[0].behandlingsstatus = {
+      kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
+    };
+
+    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+
+    await waitFor(() => expect(mocks.hent).toHaveBeenCalledOnce());
+    expect(screen.getByText(/Hvis du har mottatt svar på anmodning om unntak skal du/i)).toBeInTheDocument();
+  });
+
+  it(`Ikke vis varselmelding om anmodning om unntak dersom siste behandling er avsluttet artikkel 16 sak`, async () => {
+    mocks.hent.mockReturnValueOnce({ anmodningsperioder: [{ sendtUtland: true }] });
+    props.sak.behandlingOversikter[0].behandlingsstatus = { kode: MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET };
+
+    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+
+    await waitFor(() => expect(mocks.hent).toHaveBeenCalledOnce());
+    expect(screen.queryByText(/Hvis du har mottatt svar på anmodning om unntak skal du/i)).toBeNull();
+    expect(screen.getByText("Tidligere behandling er avsluttet.")).toBeInTheDocument();
   });
 });

--- a/src/sider/opprettnysak/opprettnysak.tsx
+++ b/src/sider/opprettnysak/opprettnysak.tsx
@@ -327,7 +327,7 @@ const OpprettNySak = ({
                   />
                   <div className="innrykk">
                     <FagsakVelger
-                      erOpprettNySak
+                      erJournalføring={false}
                       fagsakListe={fagsakListe}
                       landkoder={landkoderListe}
                       nullstillFormVerdier={nullstillFormVerdier}


### PR DESCRIPTION
Skille ut "Tidligere behandling er avsluttet." i egen alertmelding
Dro labelen "Velg hva du vil gjøre med dokumentetn" inn i RadioGruppe sin label for å matche skissene.
Endret senere melding som repeterte "Tidligere behandling er avsluttet" til å bare spørre om tema og type for behandling.
opprettBehandling skal ikke være default huket av dersom siste behandling er pågående artikkel 16 sak og man journalfører.

https://jira.adeo.no/browse/MELOSYS-5782

Skissene (her er det avklaringen om at "Tidligere behandling er avsluttet" skulle dras ut i egen infoboks): https://www.figma.com/file/xYpUVr1mz7gQKIzULO46I4/Journalf%C3%B8ringer?node-id=2702-21281&t=6AkfU2TIKo7zf0jv-0