### PR TITLE
6029 Lager likhetsjekk for datoer

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang.tsx
@@ -63,8 +63,8 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
 
   const skalHenteRegisteropplysninger =
     !registeropplysningerHentet ||
-    !Utils.dato.erLikeISODatoer(formValues.fom, initialValues.fom) ||
-    !Utils.dato.erLikeISODatoer(formValues.tom, initialValues.tom) ||
+    !Utils.dato.erLikeDatoer(formValues.fom, initialValues.fom) ||
+    !Utils.dato.erLikeDatoer(formValues.tom, initialValues.tom) ||
     formValues.land !== initialValues.land ||
     formValues.trygdedekning !== initialValues.trygdedekning;
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang.tsx
@@ -63,8 +63,8 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
 
   const skalHenteRegisteropplysninger =
     !registeropplysningerHentet ||
-    formValues.fom !== initialValues.fom ||
-    formValues.tom !== initialValues.tom ||
+    !Utils.dato.erLikeISODatoer(formValues.fom, initialValues.fom) ||
+    !Utils.dato.erLikeISODatoer(formValues.tom, initialValues.tom) ||
     formValues.land !== initialValues.land ||
     formValues.trygdedekning !== initialValues.trygdedekning;
 

--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderinginngang/vurderingInngang.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderinginngang/vurderingInngang.tsx
@@ -57,8 +57,8 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
 
   const skalHenteRegisteropplysninger =
     !registeropplysningerHentet ||
-    formValues?.fom !== periodeFom ||
-    formValues?.tom !== periodeTom ||
+    !Utils.dato.erLikeISODatoer(formValues?.fom, periodeFom) ||
+    !Utils.dato.erLikeISODatoer(formValues?.tom, periodeTom) ||
     formValues?.land !== søknadsland;
 
   const landUtenStøtteValgt =

--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderinginngang/vurderingInngang.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderinginngang/vurderingInngang.tsx
@@ -57,8 +57,8 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
 
   const skalHenteRegisteropplysninger =
     !registeropplysningerHentet ||
-    !Utils.dato.erLikeISODatoer(formValues?.fom, periodeFom) ||
-    !Utils.dato.erLikeISODatoer(formValues?.tom, periodeTom) ||
+    !Utils.dato.erLikeDatoer(formValues?.fom, periodeFom) ||
+    !Utils.dato.erLikeDatoer(formValues?.tom, periodeTom) ||
     formValues?.land !== søknadsland;
 
   const landUtenStøtteValgt =

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -109,8 +109,8 @@ const VurderingInngang = ({
 
   const skalHenteRegisteropplysninger =
     !registeropplysningerHentet ||
-    formValues?.fom !== initialFomTomLand?.fom ||
-    formValues?.tom !== initialFomTomLand?.tom ||
+    !Utils.dato.erLikeISODatoer(formValues?.fom, initialFomTomLand?.fom) ||
+    !Utils.dato.erLikeISODatoer(formValues?.tom, initialFomTomLand?.tom) ||
     formValues?.arbeidsland !== initialFomTomLand?.arbeidsland;
 
   useEffect(() => {

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -109,8 +109,8 @@ const VurderingInngang = ({
 
   const skalHenteRegisteropplysninger =
     !registeropplysningerHentet ||
-    !Utils.dato.erLikeISODatoer(formValues?.fom, initialFomTomLand?.fom) ||
-    !Utils.dato.erLikeISODatoer(formValues?.tom, initialFomTomLand?.tom) ||
+    !Utils.dato.erLikeDatoer(formValues?.fom, initialFomTomLand?.fom) ||
+    !Utils.dato.erLikeDatoer(formValues?.tom, initialFomTomLand?.tom) ||
     formValues?.arbeidsland !== initialFomTomLand?.arbeidsland;
 
   useEffect(() => {

--- a/src/sider/unntaksregistrering/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/unntaksregistrering/vurderingInngang/vurderingInngang.tsx
@@ -59,8 +59,8 @@ const VurderingInngang = ({ bekreft, oppdaterStatus }: VurderingInngangProps) =>
 
   const skalHenteRegisteropplysninger =
     !registeropplysningerHentet ||
-    formValues?.fom !== initialValues?.fom ||
-    formValues?.tom !== initialValues?.tom ||
+    !Utils.dato.erLikeISODatoer(formValues?.fom, initialValues?.fom) ||
+    !Utils.dato.erLikeISODatoer(formValues?.tom, initialValues?.tom) ||
     formValues?.avsenderland !== initialValues?.avsenderland ||
     formValues?.lovvalgsland !== initialValues?.lovvalgsland;
 

--- a/src/sider/unntaksregistrering/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/unntaksregistrering/vurderingInngang/vurderingInngang.tsx
@@ -59,8 +59,8 @@ const VurderingInngang = ({ bekreft, oppdaterStatus }: VurderingInngangProps) =>
 
   const skalHenteRegisteropplysninger =
     !registeropplysningerHentet ||
-    !Utils.dato.erLikeISODatoer(formValues?.fom, initialValues?.fom) ||
-    !Utils.dato.erLikeISODatoer(formValues?.tom, initialValues?.tom) ||
+    !Utils.dato.erLikeDatoer(formValues?.fom, initialValues?.fom) ||
+    !Utils.dato.erLikeDatoer(formValues?.tom, initialValues?.tom) ||
     formValues?.avsenderland !== initialValues?.avsenderland ||
     formValues?.lovvalgsland !== initialValues?.lovvalgsland;
 

--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -145,6 +145,10 @@ function erLike(datoEn, datoTo) {
   return moment(datoEn).isSame(datoTo);
 }
 
+function erLikeISODatoer(datoEn, datoTo) {
+  return erLike(formatterDatoTilISO(datoEn, false, datoEn), formatterDatoTilISO(datoTo, false, datoTo));
+}
+
 function plussEnDag(dato) {
   return moment(dato, "DD.MM.YYYY").add(1, "days").format("DD.MM.YYYY");
 }
@@ -219,6 +223,7 @@ export {
   erGyldigPeriode,
   erIPeriode,
   erLike,
+  erLikeISODatoer,
   plussEnDag,
   norskStringTilDate,
   isoStringTilDate,

--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -145,7 +145,7 @@ function erLike(datoEn, datoTo) {
   return moment(datoEn).isSame(datoTo);
 }
 
-function erLikeISODatoer(datoEn, datoTo) {
+function erLikeDatoer(datoEn, datoTo) {
   return erLike(formatterDatoTilISO(datoEn, false, datoEn), formatterDatoTilISO(datoTo, false, datoTo));
 }
 
@@ -223,7 +223,7 @@ export {
   erGyldigPeriode,
   erIPeriode,
   erLike,
-  erLikeISODatoer,
+  erLikeDatoer,
   plussEnDag,
   norskStringTilDate,
   isoStringTilDate,

--- a/src/utils/dato.test.js
+++ b/src/utils/dato.test.js
@@ -11,6 +11,7 @@ import {
   beregnAlder,
   erGyldigPeriode,
   erLike,
+  erLikeISODatoer,
   plussEnDag,
 } from "./dato";
 
@@ -283,6 +284,18 @@ describe("dato.js:", () => {
         { fom: "2019-04-23T10:02:52.031Z", tom: "2019-04-23T10:02:52.031Z", forventetResultat: true },
         { fom: "2019-04-23T10:02:52.031Z", tom: "2019-04-23T10:02:59.031Z", forventetResultat: false },
       ].forEach((periode) => expect(erLike(periode.fom, periode.tom)).toBe(periode.forventetResultat));
+    });
+  });
+
+  describe("erLikeISODatoer", () => {
+    it("returnerer forventet resultat", () => {
+      [
+        { fom: "2022-01-23", tom: "23.01.2022", forventetResultat: true },
+        { fom: "2022-01-23", tom: "2022-02-23", forventetResultat: false },
+        { fom: "2022-01-23", tom: "23012022", forventetResultat: true },
+        { fom: "23.01.2022", tom: "23012022", forventetResultat: true },
+        { fom: "2022-01-23", tom: "23.01.2022", forventetResultat: true },
+      ].forEach((periode) => expect(erLikeISODatoer(periode.fom, periode.tom)).toBe(periode.forventetResultat));
     });
   });
 

--- a/src/utils/dato.test.js
+++ b/src/utils/dato.test.js
@@ -11,7 +11,7 @@ import {
   beregnAlder,
   erGyldigPeriode,
   erLike,
-  erLikeISODatoer,
+  erLikeDatoer,
   plussEnDag,
 } from "./dato";
 
@@ -287,7 +287,7 @@ describe("dato.js:", () => {
     });
   });
 
-  describe("erLikeISODatoer", () => {
+  describe("erLikeDatoer", () => {
     it("returnerer forventet resultat", () => {
       [
         { fom: "2022-01-23", tom: "23.01.2022", forventetResultat: true },
@@ -295,7 +295,7 @@ describe("dato.js:", () => {
         { fom: "2022-01-23", tom: "23012022", forventetResultat: true },
         { fom: "23.01.2022", tom: "23012022", forventetResultat: true },
         { fom: "2022-01-23", tom: "23.01.2022", forventetResultat: true },
-      ].forEach((periode) => expect(erLikeISODatoer(periode.fom, periode.tom)).toBe(periode.forventetResultat));
+      ].forEach((periode) => expect(erLikeDatoer(periode.fom, periode.tom)).toBe(periode.forventetResultat));
     });
   });
 


### PR DESCRIPTION
Skapte bug når saksbehandler skrev inn dato: 05072022 og dette ikke lengre er likt 05.07.2022. Dette er fortsatt et gyldig format vi støtter, så lager likhets-sjekk som skal være litt mere robust.

[MELOSYS-6029](https://jira.adeo.no/browse/MELOSYS-6029)