### PR TITLE
6029 "Invalid date" ble sendt til backend og skapte litt issues.

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.jsx
@@ -87,8 +87,9 @@ export const VurderingArtikkel13_x_vedtak = ({
   };
 
   useEffect(() => {
-    if (!Utils._isEmpty(formValues?.tomDato)) {
-      oppdaterLovvalgsperiode(lovvalgsperiode.fomDato, Utils.dato.formatterDatoTilISO(formValues.tomDato));
+    const isoTomDato = Utils.dato.formatterDatoTilISO(formValues.tomDato, false, null);
+    if (isoTomDato) {
+      oppdaterLovvalgsperiode(lovvalgsperiode.fomDato, isoTomDato);
     }
     debouncedKontrollerBehandling({ aktivtSteg, formIsValid, formValues });
   }, [formValues?.tomDato]);


### PR DESCRIPTION
Justerer til å kun oppdatere Lovvalgsperiode dersom det er gyldig dato. Det gir ikke mening å oppdatere lovvalgsperode før dette uansett.

https://jira.adeo.no/browse/MELOSYS-6029