### PR TITLE
NOJIRA Justerer perioder som viste ---

### DIFF
--- a/src/felleskomponenter/datoOmrade/datoOmrade.jsx
+++ b/src/felleskomponenter/datoOmrade/datoOmrade.jsx
@@ -83,7 +83,7 @@ export const DatoOmradeDescription = ({ periode, label }) =>
     <Fragment>
       <dt>{label}</dt>
       <dd>
-        <EnkeltDato dato={periode.fom} /> - <EnkeltDato dato={periode.tom} />
+        <EnkeltDato dato={periode.fom} defaultValue="" /> - <EnkeltDato dato={periode.tom} defaultValue="" />
       </dd>
     </Fragment>
   ) : null;

--- a/src/felleskomponenter/enkeltDato/enkeltDato.tsx
+++ b/src/felleskomponenter/enkeltDato/enkeltDato.tsx
@@ -3,6 +3,7 @@ import { formatterDatoTilNorsk } from "../../utils/dato";
 interface EnkeltDatoProps {
   dato?: string | null;
   visTidspunkt?: boolean;
+  defaultValue?: string;
 }
 
 /** EnkeltDato gjør det lettere å følge UU der datoer skal benyttes i tillegg til at
@@ -10,10 +11,10 @@ interface EnkeltDatoProps {
  *
  * @param { props }  props object
  */
-function EnkeltDato({ dato = "", visTidspunkt = false }: EnkeltDatoProps) {
+function EnkeltDato({ dato = "", visTidspunkt = false, defaultValue = "-" }: EnkeltDatoProps) {
   const lesbarDato = formatterDatoTilNorsk(dato, visTidspunkt);
 
-  return dato ? <time dateTime={dato}>{lesbarDato}</time> : <>-</>;
+  return dato ? <time dateTime={dato}>{lesbarDato}</time> : <>{defaultValue}</>;
 }
 
 export default EnkeltDato;

--- a/src/felleskomponenter/oppgaveliste/behandling.jsx
+++ b/src/felleskomponenter/oppgaveliste/behandling.jsx
@@ -22,7 +22,9 @@ const BehandlingPanel = ({ behandling, kanVises }) => {
               <dt>{KV.objektTilTerm(behandlingstema, "(ukjent)")}</dt>
               <dt>{KV.objektTilTerm(behandlingstype, "(ukjent)")}</dt>
               <dt>Opprettet:</dt>
-              <dd>{<EnkeltDato dato={opprettetDato} /> || "(ukjent)"}</dd>
+              <dd>
+                <EnkeltDato dato={opprettetDato} defaultValue="(ukjent)" />
+              </dd>
             </dl>
           </Nav.Column>
           <Nav.Column xs="12" md="4">

--- a/src/felleskomponenter/oppgaveliste/behandlingOppgave.jsx
+++ b/src/felleskomponenter/oppgaveliste/behandlingOppgave.jsx
@@ -131,7 +131,9 @@ const BehandlingOppgave = ({ sak, folketrygdenToggleEnabled, landkoder }) => {
                   <Soknadsland land={land} visFulltNavn landkoderKodeverk={landkoder} />
                 </dd>
                 <dt className="infoTerm">Opprettelsesdato:</dt>
-                <dd className="infoDetalj">{<EnkeltDato dato={registrertDato} /> || "(ukjent)"}</dd>
+                <dd className="infoDetalj">
+                  <EnkeltDato dato={registrertDato} defaultValue="(ukjent)" />
+                </dd>
                 <dt className="infoTerm">Sist oppdatert:</dt>
                 <dd className="infoDetalj">{oppdateringStatus || formatterDatoTilNorsk(endretDato)}</dd>
               </dl>

--- a/src/felleskomponenter/oppgaveliste/fagsak.jsx
+++ b/src/felleskomponenter/oppgaveliste/fagsak.jsx
@@ -58,7 +58,9 @@ const Fagsak = ({ sak, landkoder }) => {
               <dt>Saksstatus:</dt>
               <dd>{KV.objektTilTerm(saksstatus, "(ukjent)")}</dd>
               <dt>Sak opprettet:</dt>
-              <dd>{<EnkeltDato dato={opprettetDato} /> || "(ukjent)"}</dd>
+              <dd>
+                <EnkeltDato dato={opprettetDato} defaultValue="(ukjent)" />
+              </dd>
             </dl>
           </Nav.Column>
           <Nav.Column xs="12" md="4">

--- a/src/sider/ftrl/saksbehandling/saksbehandling.tsx
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.tsx
@@ -249,11 +249,7 @@ const Saksbehandling = ({
               </Nav.Column>
               <Nav.Column xs="5">
                 <Oppsummering
-                  arbeidsland={
-                    landkoder && landkoder.filter((landkodeObjekt) => arbeidsland.includes(landkodeObjekt.kode))
-                  }
-                  lovvalgsperiodeFom={mottatteOpplysningerPeriodeFom}
-                  lovvalgsperiodeTom={mottatteOpplysningerPeriodeTom}
+                  arbeidsland={landkoder?.filter((landkodeObjekt) => arbeidsland.includes(landkodeObjekt.kode))}
                   mottatteOpplysningerPeriodeFom={mottatteOpplysningerPeriodeFom}
                   mottatteOpplysningerPeriodeTom={mottatteOpplysningerPeriodeTom}
                 />

--- a/src/sider/journalforing/komponenter/enkeltSak.jsx
+++ b/src/sider/journalforing/komponenter/enkeltSak.jsx
@@ -71,7 +71,7 @@ const EnkeltSak = (props) => {
             term: "Periode:",
             description: periode ? (
               <Fragment>
-                <EnkeltDato dato={periode.fom} /> - <EnkeltDato dato={periode.tom} />
+                <EnkeltDato dato={periode.fom} defaultValue="" /> - <EnkeltDato dato={periode.tom} defaultValue="" />
               </Fragment>
             ) : null,
           },


### PR DESCRIPTION
Default-visningen på EnkeltDato var "-" som skapte rar visning når man hadde periode. Var også flere steder som ikke støttet || "(ukjent)" selv om det ifølge koden så ut som om det skulle det. 
Fant også ut at vi sender inn lovvalgsperiode for FTRL selv om den ikke viser den perioden.