### PR TITLE
6082 Aksel-tabell personStatusmodal

### DIFF
--- a/src/felleskomponenter/menypanel/menypanel.less
+++ b/src/felleskomponenter/menypanel/menypanel.less
@@ -21,10 +21,6 @@
       color: @navGra60;
     }
 
-    th {
-      font-weight: 400;
-    }
-
     th,
     td {
       border-style: solid;

--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.less
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.less
@@ -8,32 +8,7 @@
     width: 80%;
   }
 
-  .personstatus-tabell {
-    padding: 1em 0 2em 0.5em;
-
-    &__header {
-      color: @navGra60;
-
-      > * {
-        padding-left: 0;
-      }
-    }
-
-    &__row {
-      border-top: 1px solid @navGra60;
-      padding: 0.3em 0;
-
-      &:last-child {
-        border-bottom: 1px solid @navGra60;
-      }
-
-      > * {
-        padding-left: 0;
-      }
-    }
-  }
-
-  .personstatus-tabell-tom {
-    margin-top: 0.5em;
+  &__historikk {
+    padding-top: 2rem;
   }
 }

--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.tsx
@@ -4,6 +4,7 @@ import { Folkeregisterpersonstatus } from "../../../../../../graphql";
 import { GyldighetshistorikkInfo } from "../../historikk/gyldighetshistorikkInfo";
 import bem from "../../../../../../bemUtils";
 import "./personstatusModal.css";
+import { Table } from "@navikt/ds-react";
 
 interface PersonstatusTabellProps {
   personstatuser: Folkeregisterpersonstatus[];
@@ -18,25 +19,25 @@ export const PersonstatusTabell = ({ personstatuser }: PersonstatusTabellProps) 
     );
   }
 
-  const personstatusTabellCls = bem("personstatus-tabell");
-
   return (
-    <div className={personstatusTabellCls.block}>
-      <Nav.Row className={personstatusTabellCls.element("header")}>
-        <Nav.Column xs="5">Personstatus</Nav.Column>
-        <Nav.Column xs="2">Kilde</Nav.Column>
-        <Nav.Column xs="2">Register</Nav.Column>
-        <Nav.Column xs="3">Gyldighetsdato</Nav.Column>
-      </Nav.Row>
-      {personstatuser.map((status) => (
-        <Nav.Row className={personstatusTabellCls.element("row")} key={Utils._uuid()}>
-          <Nav.Column xs="5">{status.tekst}</Nav.Column>
-          <Nav.Column xs="2">{status.kilde}</Nav.Column>
-          <Nav.Column xs="2">{status.master}</Nav.Column>
-          <Nav.Column xs="3">{Utils.dato.formatterDatoTilNorsk(status.fregGyldighetstidspunkt)}</Nav.Column>
-        </Nav.Row>
-      ))}
-    </div>
+    <Table className="personstatus-tabell">
+      <Table.Header>
+        <Table.HeaderCell>Personstatus</Table.HeaderCell>
+        <Table.HeaderCell>Kilde</Table.HeaderCell>
+        <Table.HeaderCell>Register</Table.HeaderCell>
+        <Table.HeaderCell>Gyldighetsdato</Table.HeaderCell>
+      </Table.Header>
+      <Table.Body>
+        {personstatuser.map((status) => (
+          <Table.Row key={Utils._uuid()}>
+            <Table.DataCell>{status.tekst}</Table.DataCell>
+            <Table.DataCell>{status.kilde}</Table.DataCell>
+            <Table.DataCell>{status.master}</Table.DataCell>
+            <Table.DataCell>{Utils.dato.formatterDatoTilNorsk(status.fregGyldighetstidspunkt)}</Table.DataCell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
   );
 };
 
@@ -69,7 +70,7 @@ const PersonstatusModal = ({
       <Nav.Typo.Innholdstittel>Personstatus</Nav.Typo.Innholdstittel>
       <PersonstatusTabell personstatuser={aktivePersonstatuser} />
 
-      <Nav.Typo.Undertittel>Historikk</Nav.Typo.Undertittel>
+      <Nav.Typo.Undertittel className={personstatusModalCls.element("historikk")}>Historikk</Nav.Typo.Undertittel>
       <GyldighetshistorikkInfo />
       <PersonstatusTabell personstatuser={historiskePersonstatuser} />
     </Nav.Modal>


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6082
Rettet opp i kommentar fra Cathrin
- personOpplysningModal brukte ikke Aksel-tabell (eller vanlig for den saks skyld)
  - Forhåpentligvis er det ikke andre slike "tabeller", for de er vanskelige å finne
- Header i tabellene i sidemeny (personopplysninger) hadde spesiell styling