### PR TITLE
NOJIRA Støttet ikke tom tomDato i likhetssjekk

### DIFF
--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -146,6 +146,7 @@ function erLike(datoEn, datoTo) {
 }
 
 function erLikeDatoer(datoEn, datoTo) {
+  if (datoEn === datoTo) return true;
   return erLike(formatterDatoTilISO(datoEn, false, datoEn), formatterDatoTilISO(datoTo, false, datoTo));
 }
 

--- a/src/utils/dato.test.js
+++ b/src/utils/dato.test.js
@@ -379,6 +379,9 @@ describe("dato.js:", () => {
         { fom: "2022-01-23", tom: "23012022", forventetResultat: true },
         { fom: "23.01.2022", tom: "23012022", forventetResultat: true },
         { fom: "2022-01-23", tom: "23.01.2022", forventetResultat: true },
+        { fom: "2022-01-23", tom: undefined, forventetResultat: false },
+        { fom: undefined, tom: "23.01.2022", forventetResultat: false },
+        { fom: undefined, tom: undefined, forventetResultat: true },
       ].forEach((periode) => expect(erLikeDatoer(periode.fom, periode.tom)).toBe(periode.forventetResultat));
     });
   });


### PR DESCRIPTION
erLikeDatoer fungerte ikke når dato er undefined/null.

Siden to undefined datoer er like justerer jeg logikken før man går til moment. Dersom datoene oppriktig er like, ser jeg ikke poenget med å formatere dem på lik måte for så å sjekke.