### PR TITLE
6009 TOGGLE Kjapp fiks med stegErGyldig

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -161,7 +161,7 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
   useEffect(() => {
     if (redigerbart && harHentetGrunnlag) setTrygdeavgift(undefined);
     if (redigerbart && aktivtSteg && !isValidating) {
-      debouncedLagreTrygdeavgiftsgrunnlag(formValues, stegErGyldig);
+      debouncedLagreTrygdeavgiftsgrunnlag(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
     }
   }, [stegErGyldig, isValidating, formValues?.inntektskilder?.length, formValues?.skatteforholdsperioder?.length]);
 


### PR DESCRIPTION
Kan ikke bruke stegErGyldig her siden feil (som er en del av stegErGyldig) kun blir resatt av lagring av trygdeavgift.. som aldri kjører dersom steg er ugyldig, som betyr at man er stuck på steget hvis man en gang fikk en feil fra backend.