### PR TITLE
6156 TOGGLE Schema manglet erNyVurdering i context

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
@@ -97,6 +97,9 @@ export const VurderingVedtak = ({ tilbake, aktivtSteg }: Props) => {
     setValue,
   } = useForm({
     resolver: yupResolver(vurdering_vedtak),
+    context: {
+      erNyVurdering,
+    },
     defaultValues: {
       begrunnelseFritekst: useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) || "",
       innledningFritekst: useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) || "",

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtakSchema.js
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtakSchema.js
@@ -3,9 +3,8 @@
 import { object, string } from "yup";
 import * as KV from "../../../../kodeverk";
 import { FRITEKST_VALG } from "../../../../kodeverk/koder";
-import { MAA_FYLLES_UT } from "../../../../kodeverk/feilmeldinger";
 
-const { DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN } = KV.Feilmeldinger;
+const { DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN, MAA_FYLLES_UT } = KV.Feilmeldinger;
 
 const vurdering_vedtak = object().shape({
   begrunnelseFritekst: string().nullable().max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN),


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6156
Fatt vedtak knapp var ikke grået ut fordi schema manglet variabel erNyVurdering og gjorde derfor aldri den nødvendige valideringen