### PR TITLE
5912 / NOJIRA: Bump kodeverk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@navikt/ds-css": "^4.7.1",
         "@navikt/ds-react": "^4.7.1",
         "@navikt/fnrvalidator": "^1.1.4",
-        "@navikt/melosys-kodeverk": "5.15.213",
+        "@navikt/melosys-kodeverk": "5.15.214",
         "@sentry/integrations": "^7.30.0",
         "@sentry/react": "^7.30.0",
         "@sentry/tracing": "^7.30.0",
@@ -3433,9 +3433,9 @@
       "license": "MIT"
     },
     "node_modules/@navikt/melosys-kodeverk": {
-      "version": "5.15.213",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.213/58d3ddac690b226abb328aafa48ce5e50ff522a7",
-      "integrity": "sha512-B1Ntt0t//cccACf0ZiYeCq9TGpp5VP8vf4xkUVmdbcqPywzdEzVbncQO5jAw4UqvPBOhTT82iHc68i21zG+oGA==",
+      "version": "5.15.214",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.214/34658cbc1bc944f5753d7e93ffed490f2e84e0d2",
+      "integrity": "sha512-AryOt5FDbRElkDbcqCROueLlTNROBG3SNsJh1LeZfQjbOiFvtvDcXwbgNrRrrrQjndeFPnyibAr79OLSD88J3A==",
       "license": "ISC",
       "engines": {
         "node": ">=10.0.0"
@@ -20852,9 +20852,9 @@
       "integrity": "sha512-EZBwlNhp886E57GuknLB6G9Bnv4nl+e5K12B/2BeLpWZENxCmcQ+5oFvIThvEsU+LVOdfJxxGOxSvrwe5ZB3pQ=="
     },
     "@navikt/melosys-kodeverk": {
-      "version": "5.15.213",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.213/58d3ddac690b226abb328aafa48ce5e50ff522a7",
-      "integrity": "sha512-B1Ntt0t//cccACf0ZiYeCq9TGpp5VP8vf4xkUVmdbcqPywzdEzVbncQO5jAw4UqvPBOhTT82iHc68i21zG+oGA=="
+      "version": "5.15.214",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.214/34658cbc1bc944f5753d7e93ffed490f2e84e0d2",
+      "integrity": "sha512-AryOt5FDbRElkDbcqCROueLlTNROBG3SNsJh1LeZfQjbOiFvtvDcXwbgNrRrrrQjndeFPnyibAr79OLSD88J3A=="
     },
     "@navikt/textparser": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@navikt/ds-css": "^4.7.1",
     "@navikt/ds-react": "^4.7.1",
     "@navikt/fnrvalidator": "^1.1.4",
-    "@navikt/melosys-kodeverk": "5.15.213",
+    "@navikt/melosys-kodeverk": "5.15.214",
     "@sentry/integrations": "^7.30.0",
     "@sentry/react": "^7.30.0",
     "@sentry/tracing": "^7.30.0",


### PR DESCRIPTION
Ser ut https://github.com/navikt/melosys-web/pull/2072 har satt feil kodeverkversjon. 