### PR TITLE
6082 Oppdatert tabell i sivilstandmodal med aksel-tabell…

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personstatus/personstatusModal.tsx
@@ -12,15 +12,11 @@ interface PersonstatusTabellProps {
 
 export const PersonstatusTabell = ({ personstatuser }: PersonstatusTabellProps) => {
   if (personstatuser.length < 1) {
-    return (
-      <Nav.Typo.Normaltekst className="personstatus-tabell-tom">
-        Ingen historikk registrert i folkeregisteret.
-      </Nav.Typo.Normaltekst>
-    );
+    return <Nav.Typo.Normaltekst>Ingen historikk registrert i folkeregisteret.</Nav.Typo.Normaltekst>;
   }
 
   return (
-    <Table className="personstatus-tabell">
+    <Table>
       <Table.Header>
         <Table.HeaderCell>Personstatus</Table.HeaderCell>
         <Table.HeaderCell>Kilde</Table.HeaderCell>

--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/sivilstand/sivilstandModal.less
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/sivilstand/sivilstandModal.less
@@ -8,28 +8,7 @@
     width: 80%;
   }
 
-  .sivilstand-tabell {
-    padding: 1em 0 2em 0.5em;
-
-    &__header {
-      color: @navGra60;
-
-      > * {
-        padding-left: 0;
-      }
-    }
-
-    &__row {
-      border-top: 1px solid @navGra60;
-      padding: 0.3em 0;
-
-      &:last-child {
-        border-bottom: 1px solid @navGra60;
-      }
-
-      > * {
-        padding-left: 0;
-      }
-    }
+  &__historikk {
+    padding-top: 2rem;
   }
 }

--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/sivilstand/sivilstandModal.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/sivilstand/sivilstandModal.tsx
@@ -8,6 +8,7 @@ import { Sivilstand } from "../../../../../../graphql";
 import { GyldighetshistorikkInfo } from "../../historikk/gyldighetshistorikkInfo";
 
 import "./sivilstandModal.css";
+import { Table } from "@navikt/ds-react";
 
 Nav.Modal.setAppElement(document.getElementById("root"));
 
@@ -16,33 +17,33 @@ interface SivilstandTabellProps {
 }
 
 export const SivilstandTabell = ({ sivilstander }: SivilstandTabellProps) => {
-  const sivilstandTabellCls = bem("sivilstand-tabell");
-
   return (
-    <div className={sivilstandTabellCls.block}>
-      <Nav.Row className={sivilstandTabellCls.element("header")}>
-        <Nav.Column xs="2">Sivilstand</Nav.Column>
-        <Nav.Column xs="2">Relasjon til</Nav.Column>
-        <Nav.Column xs="2">Kilde</Nav.Column>
-        <Nav.Column xs="2">Register</Nav.Column>
-        <Nav.Column xs="2">Bekreftelsesdato</Nav.Column>
-        <Nav.Column xs="2">Gyldig f.o.m</Nav.Column>
-      </Nav.Row>
-      {sivilstander.map((sivilstand) => (
-        <Nav.Row className={sivilstandTabellCls.element("row")} key={Utils._uuid()}>
-          <Nav.Column xs="2">{sivilstand.type}</Nav.Column>
-          <Nav.Column xs="2">
-            {sivilstand.relatertVedSivilstand && (
-              <KopierbarTekst hovertekst="Kopier fødselsnummer">{sivilstand.relatertVedSivilstand}</KopierbarTekst>
-            )}
-          </Nav.Column>
-          <Nav.Column xs="2">{sivilstand.kilde}</Nav.Column>
-          <Nav.Column xs="2">{sivilstand.master}</Nav.Column>
-          <Nav.Column xs="2">{Utils.dato.formatterDatoTilNorsk(sivilstand.bekreftelsesdato)}</Nav.Column>
-          <Nav.Column xs="2">{Utils.dato.formatterDatoTilNorsk(sivilstand.gyldigFraOgMed)}</Nav.Column>
-        </Nav.Row>
-      ))}
-    </div>
+    <Table>
+      <Table.Header>
+        <Table.HeaderCell>Sivilstand</Table.HeaderCell>
+        <Table.HeaderCell>Relasjon til</Table.HeaderCell>
+        <Table.HeaderCell>Kilde</Table.HeaderCell>
+        <Table.HeaderCell>Register</Table.HeaderCell>
+        <Table.HeaderCell>Bekreftelsesdato</Table.HeaderCell>
+        <Table.HeaderCell>Gyldig f.o.m</Table.HeaderCell>
+      </Table.Header>
+      <Table.Body>
+        {sivilstander.map((sivilstand) => (
+          <Table.Row key={Utils._uuid()}>
+            <Table.DataCell>{sivilstand.type}</Table.DataCell>
+            <Table.DataCell>
+              {sivilstand.relatertVedSivilstand && (
+                <KopierbarTekst hovertekst="Kopier fødselsnummer">{sivilstand.relatertVedSivilstand}</KopierbarTekst>
+              )}
+            </Table.DataCell>
+            <Table.DataCell>{sivilstand.kilde}</Table.DataCell>
+            <Table.DataCell>{sivilstand.master}</Table.DataCell>
+            <Table.DataCell>{Utils.dato.formatterDatoTilNorsk(sivilstand.bekreftelsesdato)}</Table.DataCell>
+            <Table.DataCell>{Utils.dato.formatterDatoTilNorsk(sivilstand.gyldigFraOgMed)}</Table.DataCell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
   );
 };
 
@@ -76,7 +77,7 @@ const SivilstandModal = ({
       <Mui.Undertittel tekst="Sivilstand" />
       <div className={sivilstandModalCls.element("main-content")}>
         {aktiveSivilstander.length > 0 && <SivilstandTabell sivilstander={aktiveSivilstander} />}
-        <Nav.Typo.Element>Historikk</Nav.Typo.Element>
+        <Nav.Typo.Element className={sivilstandModalCls.element("historikk")}>Historikk</Nav.Typo.Element>
         <GyldighetshistorikkInfo />
         {historiskeSivilstander.length > 0 ? (
           <SivilstandTabell sivilstander={historiskeSivilstander} />


### PR DESCRIPTION
…tilsvarende som i personstatusmodal
https://jira.adeo.no/browse/MELOSYS-6082

(Fjernet også ubrukt styling/classNames i personstatustabell som ble misset forrige runde)

<img width="710" alt="image" src="https://github.com/navikt/melosys-web/assets/56435736/483ca363-87c2-43a8-9d74-2ca3a12ba98a">
