### PR TITLE
5932 FAG Bugfikser meldt i jirasaken

### DIFF
--- a/src/contexts/fellesHandlers.jsx
+++ b/src/contexts/fellesHandlers.jsx
@@ -46,22 +46,22 @@ const FellesHandlersProviderUnconnected = ({
     await lagreMottatteOpplysninger();
     await oppfriskSaksopplysninger(behandlingID, inkluderSiste5Aar);
     await oppfriskGraphQLSaksopplysninger();
-    await fjernBehandlingOppfriskes();
     await lastInnSaksopplysninger(sakstype, saksnummer, behandlingID);
+    await fjernBehandlingOppfriskes();
   };
 
   const oppfriskOgLastInnSaksopplysninger = async () => {
     await leggTilBehandlingOppfriskes(behandlingID);
     await oppfriskSaksopplysninger(behandlingID);
-    await fjernBehandlingOppfriskes();
     await lastInnSaksopplysninger(sakstype, saksnummer, behandlingID);
+    await fjernBehandlingOppfriskes();
   };
 
   const startOgVisOppfriskModal = async (inkluderSiste5aar) => {
     await leggTilBehandlingOppfriskes(behandlingID);
     visOppfriskDialogHandle(inkluderSiste5aar);
-    await fjernBehandlingOppfriskes();
     await lastInnSaksopplysninger(sakstype, saksnummer, behandlingID);
+    await fjernBehandlingOppfriskes();
   };
 
   const behandlingOppfriskes = behandlingUnderOppfriskning === behandlingID;

--- a/src/sider/unntaksregistrering/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/unntaksregistrering/vurderingInngang/vurderingInngang.tsx
@@ -21,6 +21,7 @@ import vurderingInngangSchema from "./vurderingInngangSchema";
 import "./vurderingInngang.css";
 import { DialogboksOppfriskSak } from "../../../felleskomponenter/dialogboks";
 import { navigeringOperations } from "../../../ducks/navigering";
+import { BehandlingUnderOppfriskningSelector } from "../../../ducks/modaler/selectors";
 
 const { EU_EOS, TRYGDEAVTALE } = MKV.Koder.sakstyper;
 const gyldigeLandkoder = (sakstype: string) =>
@@ -40,6 +41,7 @@ const VurderingInngang = ({ bekreft, oppdaterStatus }: VurderingInngangProps) =>
   const lovvalgsland = useSelector(mottatteOpplysningerSelectors.LovvalgslandSelector);
   const registeropplysningerHentet = useSelector(behandlingerSelectors.SisteOpplysningerHentetDatoSelector);
   const { oppfriskOgLastInnSaksopplysninger } = useContext(FellesHandlersContext) as any;
+  const behandlingUnderOppfriskning = useSelector(BehandlingUnderOppfriskningSelector);
 
   const { control, watch, setValue, formState } = useForm({
     resolver: yupResolver(vurderingInngangSchema),
@@ -64,7 +66,7 @@ const VurderingInngang = ({ bekreft, oppdaterStatus }: VurderingInngangProps) =>
     formValues?.avsenderland !== initialValues?.avsenderland ||
     formValues?.lovvalgsland !== initialValues?.lovvalgsland;
 
-  const stegErGyldig = formState?.isValid && !skalHenteRegisteropplysninger;
+  const stegErGyldig = formState?.isValid && !skalHenteRegisteropplysninger && !behandlingUnderOppfriskning;
 
   useEffect(() => {
     oppdaterStatus(stegErGyldig);

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -64,7 +64,7 @@ const VurderingUnntakMedlemskap = ({ oppdaterStatus, tilbake, aktivtSteg }: Vurd
       fom: Utils.dato.formatterDatoTilNorsk(lovvalgsperiode.fomDato || mottatteOpplysningerPeriode.fom),
       tom: Utils.dato.formatterDatoTilNorsk(lovvalgsperiode.tomDato || mottatteOpplysningerPeriode.tom),
       bestemmelse: lovvalgsperiode.lovvalgsbestemmelse || "",
-      trygdedekning: lovvalgsperiode.trygdedekning,
+      trygdedekning: lovvalgsperiode.trygdeDekning,
     } as FieldValues,
   });
   const formValues = watch();


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5932
Fikset en bug der skjemaverdier persisterte gjennom endring av lovvalgsland steg 1. Oppdaterte status for tidlig etter oppfriskning som medførte at steg 2 brukte gamle data

Fikset en bug der skjemaet ikke "husket" manuelt registrert trygdedekning. Denne oppstod pga case forskjell i lovvalgsperiodedto og opprettlovvalgsperiodedto. trygdeDekning vs trygdedekning