### PR TITLE
6180 Justerte visning av lovvalgsperiode i avtalelandflyt

### DIFF
--- a/src/sider/trygdeavtale/saksbehandling.jsx
+++ b/src/sider/trygdeavtale/saksbehandling.jsx
@@ -56,6 +56,7 @@ const Saksbehandling = ({
   startOgVisOppfriskModal,
   soknadForm,
   visOppfriskModal,
+  lovvalgsperiodeFom,
   lovvalgsperiodeTom,
   registeropplysningerHentet,
   menypanelSynlig,
@@ -160,8 +161,8 @@ const Saksbehandling = ({
               <Nav.Column xs="5">
                 <Oppsummering
                   arbeidsland={arbeidsland}
-                  lovvalgsperiodeFom={mottatteOpplysningerPeriodeFom}
-                  lovvalgsperiodeTom={lovvalgsperiodeTom || mottatteOpplysningerPeriodeTom}
+                  lovvalgsperiodeFom={lovvalgsperiodeFom}
+                  lovvalgsperiodeTom={lovvalgsperiodeTom}
                   mottatteOpplysningerPeriodeFom={mottatteOpplysningerPeriodeFom}
                   mottatteOpplysningerPeriodeTom={mottatteOpplysningerPeriodeTom}
                 />
@@ -204,6 +205,7 @@ Saksbehandling.propTypes = {
   skjulMenypanel: PT.func.isRequired,
   startOgVisOppfriskModal: PT.func.isRequired,
   visOppfriskModal: PT.func.isRequired,
+  lovvalgsperiodeFom: PT.string.isRequired,
   lovvalgsperiodeTom: PT.string.isRequired,
   registeropplysningerHentet: PT.bool.isRequired,
   menypanelSynlig: PT.bool.isRequired,
@@ -228,6 +230,7 @@ const mapStateToProps = (state) => ({
   fagsakStatusKode: fagsakSelectors.FagsakStatusSelector(state),
   redigerbart: redigerbartSelectors.RedigerbartSelector(state),
   soknadForm: formSelectors.SoknadenFormSelector(state),
+  lovvalgsperiodeFom: Utils.dato.formatterDatoTilNorsk(lovvalgsperioderSelectors.FomDatoSelector(state)),
   lovvalgsperiodeTom: Utils.dato.formatterDatoTilNorsk(lovvalgsperioderSelectors.TomDatoSelector(state)),
   registeropplysningerHentet: behandlingerSelectors.RegisteropplysningerHentetSelector(state),
   menypanelSynlig: menypanelSelectors.MenypanelSynligSelector(state),

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -22,8 +22,10 @@ import vurdering_bestemmelse from "./vurderingBestemmelseSchema";
 import "./vurderingBestemmelse.css";
 import BestemmelseHjelpetekst from "./bestemmelseHjelpetekst/bestemmelseHjelpetekst";
 import { IngenFlytMelding, UnntakHjelpetekst } from "../../../../felleskomponenter/alertmeldinger";
+import { lovvalgsperioderOperations, lovvalgsperioderSelectors } from "../../../../ducks/lovvalgsperioder";
+import { behandlingerSelectors } from "../../../../ducks/behandlinger";
 
-const { NEI_ANMODE_OM_UNNTAK, NEI_AVSLAG, NEI_SENDE_TIL_DEPARTEMENTET } = KV.Koder.AVTALELAND_UTFALL;
+const { NEI_ANMODE_OM_UNNTAK, NEI_AVSLAG, NEI_SENDE_TIL_DEPARTEMENTET, JA_FATTE_VEDTAK } = KV.Koder.AVTALELAND_UTFALL;
 
 const mapStateToProps = (state: RootState, ownProps: Props) => ({
   formIsValid: formSelectors.TrygdeavtaleBestemmelseFormValidSelector(state),
@@ -33,6 +35,8 @@ const mapStateToProps = (state: RootState, ownProps: Props) => ({
     bestemmelse: ownProps.resultat?.bestemmelse,
     tilleggsbestemmelse: Boolean(ownProps.resultat?.tilleggsbestemmelse),
   },
+  lovvalgsperiode: lovvalgsperioderSelectors.LovvalgsperiodeSelector(state),
+  behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
@@ -40,6 +44,8 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>)
     dispatch(change(KV.Form.Trygdeavtale.BESTEMMELSE, field, null));
     dispatch(untouch(KV.Form.Trygdeavtale.BESTEMMELSE, field));
   },
+  slettLovvalgsperiode: (behandlingID: number, lovvalgsperiodeID: number) =>
+    dispatch(lovvalgsperioderOperations.slettLovvalgsperiode(behandlingID, lovvalgsperiodeID)),
 });
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -76,6 +82,9 @@ const VurderingBestemmelse = ({
   steg,
   oppdaterFlyt,
   aktivtSteg,
+  lovvalgsperiode,
+  slettLovvalgsperiode,
+  behandlingID,
 }: PropsFromRedux & Props) => {
   const [updatePending, setUpdatePending] = useState(false);
 
@@ -93,6 +102,9 @@ const VurderingBestemmelse = ({
         },
         () => setUpdatePending(false)
       );
+      if (formValues?.vedtak !== JA_FATTE_VEDTAK) {
+        if (lovvalgsperiode?.periodeID) slettLovvalgsperiode(behandlingID, lovvalgsperiode.periodeID);
+      }
     }
   }, [formValues?.vedtak, formValues?.bestemmelse, formValues?.tilleggsbestemmelse]);
 

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -100,11 +100,13 @@ const VurderingBestemmelse = ({
           bestemmelse: formValues?.bestemmelse,
           tilleggsbestemmelse: formValues.tilleggsbestemmelse ? tilleggsbestemmelseValg?.kode : undefined,
         },
-        () => setUpdatePending(false)
+        () => {
+          setUpdatePending(false);
+          if (formValues?.vedtak && formValues.vedtak !== JA_FATTE_VEDTAK && lovvalgsperiode?.periodeID) {
+            slettLovvalgsperiode(behandlingID, lovvalgsperiode.periodeID);
+          }
+        }
       );
-      if (formValues?.vedtak !== JA_FATTE_VEDTAK) {
-        if (lovvalgsperiode?.periodeID) slettLovvalgsperiode(behandlingID, lovvalgsperiode.periodeID);
-      }
     }
   }, [formValues?.vedtak, formValues?.bestemmelse, formValues?.tilleggsbestemmelse]);
 

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -262,6 +262,8 @@ const VurderingVedtak = ({
     formValues?.nyVurderingBakgrunnFritekst,
   ]);
 
+  // Refresher verdien av lovvalgsperiode i redux da denne lagres gjennom kall fra melosys-trygdeavtale til melosys-api
+  // når vedtakssteget legges til i flyten.
   useEffect(() => {
     hentLovvalgsperiode(behandlingID);
   }, []);

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -262,6 +262,10 @@ const VurderingVedtak = ({
     formValues?.nyVurderingBakgrunnFritekst,
   ]);
 
+  useEffect(() => {
+    hentLovvalgsperiode(behandlingID);
+  }, []);
+
   const handleLagreTomEndring = async () => {
     if (redigerbart && formValues) {
       const isoFom = Utils.dato.formatterDatoTilISO(formValues.lovvalgsperiodeFom);


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6180
Viser nå lovvalgsperiode når vedtakssteget opprettes. Sletter lovvalgsperiode dersom den finnes når vedtaksvalget i vurderingBestemmelse.tsx ikke er JA_FATTE_VEDTAK