### PR TITLE
6271 Feil i nullstilling ikke yrkesaktiv flyt

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang.tsx
@@ -26,6 +26,7 @@ import vurderingInngangSchema from "./vurderingInngangSchema";
 import "./vurderingInngang.css";
 import { modalerOperations, modalerSelectors } from "../../../../ducks/modaler";
 import { oppsummertfaktaOperations } from "../../../../ducks/oppsummertfakta";
+import { BehandlingUnderOppfriskningSelector } from "../../../../ducks/modaler/selectors";
 
 interface Props {
   bekreft: () => void;
@@ -45,6 +46,7 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
   const søknadsperiode = useSelector(mottatteOpplysningerSelectors.PeriodeSelector);
   const registeropplysningerHentet = useSelector(behandlingerSelectors.SisteOpplysningerHentetDatoSelector);
   const { lagreMottatteOpplysningerOgOppfriskSaksopplysninger } = useContext(FellesHandlersContext) as any;
+  const behandlingUnderOppfriskning = useSelector(BehandlingUnderOppfriskningSelector);
 
   const initialValues = {
     fom: Utils.dato.formatterDatoTilNorsk(søknadsperiode?.fom, false, undefined),
@@ -72,7 +74,7 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
     formValues.land !== initialValues.land ||
     formValues.trygdedekning !== initialValues.trygdedekning;
 
-  const stegErGyldig = formIsValid && !skalHenteRegisteropplysninger;
+  const stegErGyldig = formIsValid && !skalHenteRegisteropplysninger && !behandlingUnderOppfriskning;
 
   useEffect(() => {
     oppdaterStatus(stegErGyldig);

--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -24,6 +24,7 @@ import { fagsakSelectors } from "../../../../ducks/fagsaker";
 import MKV from "../../../../melosyskodeverk";
 import { DialogboksOppfriskSak } from "../../../../felleskomponenter/dialogboks";
 import "./vurderingInngang.css";
+import { BehandlingUnderOppfriskningSelector } from "../../../../ducks/modaler/selectors";
 
 interface Props {
   bekreft: () => void;
@@ -42,6 +43,7 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
   const registeropplysningerHentet = useSelector(behandlingerSelectors.SisteOpplysningerHentetDatoSelector);
   const sakstype = useSelector(fagsakSelectors.SakstypeKodeSelector);
+  const behandlingUnderOppfriskning = useSelector(BehandlingUnderOppfriskningSelector);
   const { lagreMottatteOpplysningerOgOppfriskSaksopplysninger } = useContext(FellesHandlersContext) as any;
 
   const { control, watch, formState, trigger } = useForm({
@@ -65,7 +67,8 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
     sakstype === MKV.Koder.sakstyper.TRYGDEAVTALE &&
     (formValues.land === MKV.Koder.landkoder.FR || formValues.land === MKV.Koder.landkoder.IT);
 
-  const stegErGyldig = formState?.isValid && !skalHenteRegisteropplysninger && !landUtenStøtteValgt;
+  const stegErGyldig =
+    formState?.isValid && !skalHenteRegisteropplysninger && !landUtenStøtteValgt && !behandlingUnderOppfriskning;
 
   useEffect(() => {
     oppdaterStatus(stegErGyldig);


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6271
Fikset bug der bestemmelsessteget ikke ble nullstilt ved endring i inngangssteget. Samme feil som var i unntaksregistreringen der steg 2 ble initialisert før oppfriskning var ferdig.