### PR TITLE
6260 Fjerner lovvalgsperiode ved endring av soknadsland til et land uten flyt

### DIFF
--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -92,6 +92,7 @@ export const lastInnSaksopplysninger = (sakstype, saksnummer, behandlingID) => a
     dispatch(behandlingerOperations.hentBehandling(behandlingID)),
     dispatch(behandlingsresultatOperations.hent(behandlingID)),
     dispatch(mottatteOpplysningerOperations.hent(behandlingID)),
+    dispatch(lovvalgsperioderOperations.hent(behandlingID)),
     dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer)),
   ]);
 };

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -63,7 +63,6 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>)
     dispatch(mottatteOpplysningerOperations.oppdaterSoeknadsland(landkoder, false)),
   lagreMottatteOpplysninger: () => dispatch(mottatteOpplysningerOperations.lagre()),
   tilForsiden: () => dispatch(navigeringOperations.tilForsiden()),
-  hentLovvalgsperiode: (behandlingID: number) => dispatch(lovvalgsperioderOperations.hent(behandlingID)),
   slettLovvalgsperiode: (behandlingID: number, lovvalgsperiodeID: number) =>
     dispatch(lovvalgsperioderOperations.slettLovvalgsperiode(behandlingID, lovvalgsperiodeID)),
 });
@@ -109,11 +108,9 @@ const VurderingInngang = ({
   aktivtSteg,
   registeropplysningerHentet,
   tilForsiden,
-  hentLovvalgsperiode,
   behandlingID,
   slettLovvalgsperiode,
   lovvalgsperiode,
-  behandlingUnderOppfriskning,
 }: PropsFromRedux & Props) => {
   const { oppfriskOgLastInnSaksopplysninger } = useContext(FellesHandlersContext) as any;
   const [initialFomTomLand, setInitialFomTomLand] = useState<{ fom?: string; tom?: string; arbeidsland?: string }>({});
@@ -166,12 +163,6 @@ const VurderingInngang = ({
       slettLovvalgsperiode(behandlingID, lovvalgsperiode.periodeID);
     }
   }, [landUtenStøtteValgt]);
-
-  useEffect(() => {
-    if (!behandlingUnderOppfriskning && lovvalgsperiode?.periodeID) {
-      hentLovvalgsperiode(behandlingID);
-    }
-  }, [behandlingUnderOppfriskning]);
 
   const innhentRegisteropplysninger = () => {
     setInitialFomTomLand({ fom: formValues.fom, tom: formValues.tom, arbeidsland: formValues.arbeidsland });

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -30,7 +30,6 @@ import { DialogboksOppfriskSak } from "../../../../felleskomponenter/dialogboks"
 import { FellesHandlersContext } from "../../../../contexts";
 import { navigeringOperations } from "../../../../ducks/navigering";
 import { lovvalgsperioderOperations, lovvalgsperioderSelectors } from "../../../../ducks/lovvalgsperioder";
-import { modalerSelectors } from "../../../../ducks/modaler";
 
 interface Periode {
   fom?: string | null;
@@ -53,7 +52,6 @@ const mapStateToProps = (state: RootState) => ({
   registeropplysningerHentet: behandlingerSelectors.SisteOpplysningerHentetDatoSelector(state),
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
   lovvalgsperiode: lovvalgsperioderSelectors.LovvalgsperiodeSelector(state),
-  behandlingUnderOppfriskning: modalerSelectors.BehandlingUnderOppfriskningSelector(state),
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -29,6 +29,8 @@ import { behandlingerSelectors } from "../../../../ducks/behandlinger";
 import { DialogboksOppfriskSak } from "../../../../felleskomponenter/dialogboks";
 import { FellesHandlersContext } from "../../../../contexts";
 import { navigeringOperations } from "../../../../ducks/navigering";
+import { lovvalgsperioderOperations, lovvalgsperioderSelectors } from "../../../../ducks/lovvalgsperioder";
+import { modalerSelectors } from "../../../../ducks/modaler";
 
 interface Periode {
   fom?: string | null;
@@ -49,6 +51,9 @@ const mapStateToProps = (state: RootState) => ({
   ),
   formIsValid: formSelectors.TrygdeavtaleInngangFormValidSelector(state),
   registeropplysningerHentet: behandlingerSelectors.SisteOpplysningerHentetDatoSelector(state),
+  behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
+  lovvalgsperiode: lovvalgsperioderSelectors.LovvalgsperiodeSelector(state),
+  behandlingUnderOppfriskning: modalerSelectors.BehandlingUnderOppfriskningSelector(state),
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>) => ({
@@ -58,6 +63,9 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>)
     dispatch(mottatteOpplysningerOperations.oppdaterSoeknadsland(landkoder, false)),
   lagreMottatteOpplysninger: () => dispatch(mottatteOpplysningerOperations.lagre()),
   tilForsiden: () => dispatch(navigeringOperations.tilForsiden()),
+  hentLovvalgsperiode: (behandlingID: number) => dispatch(lovvalgsperioderOperations.hent(behandlingID)),
+  slettLovvalgsperiode: (behandlingID: number, lovvalgsperiodeID: number) =>
+    dispatch(lovvalgsperioderOperations.slettLovvalgsperiode(behandlingID, lovvalgsperiodeID)),
 });
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -101,6 +109,11 @@ const VurderingInngang = ({
   aktivtSteg,
   registeropplysningerHentet,
   tilForsiden,
+  hentLovvalgsperiode,
+  behandlingID,
+  slettLovvalgsperiode,
+  lovvalgsperiode,
+  behandlingUnderOppfriskning,
 }: PropsFromRedux & Props) => {
   const { oppfriskOgLastInnSaksopplysninger } = useContext(FellesHandlersContext) as any;
   const [initialFomTomLand, setInitialFomTomLand] = useState<{ fom?: string; tom?: string; arbeidsland?: string }>({});
@@ -135,7 +148,6 @@ const VurderingInngang = ({
         tom: Utils.dato.formatterDatoTilISO(formValues.tom, false, undefined),
       });
       oppdaterSoeknadsland(formValues?.arbeidsland ? [formValues.arbeidsland] : []);
-
       debouncedLagremottatteOpplysningerOgOppdaterFlyt();
     }
   }, [formValues?.fom, formValues?.tom, formValues?.arbeidsland, formIsValid]);
@@ -148,6 +160,18 @@ const VurderingInngang = ({
       oppdaterFlyt(resultat);
     }
   }, [formValues?.arbeidsland]);
+
+  useEffect(() => {
+    if (landUtenStøtteValgt && lovvalgsperiode?.periodeID) {
+      slettLovvalgsperiode(behandlingID, lovvalgsperiode.periodeID);
+    }
+  }, [landUtenStøtteValgt]);
+
+  useEffect(() => {
+    if (!behandlingUnderOppfriskning && lovvalgsperiode?.periodeID) {
+      hentLovvalgsperiode(behandlingID);
+    }
+  }, [behandlingUnderOppfriskning]);
 
   const innhentRegisteropplysninger = () => {
     setInitialFomTomLand({ fom: formValues.fom, tom: formValues.tom, arbeidsland: formValues.arbeidsland });

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.less
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.less
@@ -80,6 +80,6 @@
   }
 
   &__alertstripe {
-    margin: -1rem auto;
+    margin-top: 1rem;
   }
 }


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6260
Henter også lovvalgsperiode etter oppfriskning for land med flyt. Denne er alltid(?) slettet etter oppfriskning så fetchen skjer for å ha oppdatert verdi i redux.

Justerte margin på varselboks i vedtakssteget