### PR TITLE
5588 Legger til ny-vurdering melding i. eøs-flytene

### DIFF
--- a/src/felleskomponenter/alertmeldinger/index.ts
+++ b/src/felleskomponenter/alertmeldinger/index.ts
@@ -4,6 +4,7 @@ import {
   IngenFlytMelding,
   VirksomhetMelding,
   Innsynsmelding,
+  NyVurderingMelding,
 } from "./alertmeldinger";
 import UnntakHjelpetekst from "./unntakHjelpetekst";
 import StatsborgerskapFeil from "./statsborgerskapFeil";
@@ -16,4 +17,5 @@ export {
   UnntakHjelpetekst,
   Innsynsmelding,
   StatsborgerskapFeil,
+  NyVurderingMelding,
 };

--- a/src/felleskomponenter/enkelStegvelger/enkelStegvelger.tsx
+++ b/src/felleskomponenter/enkelStegvelger/enkelStegvelger.tsx
@@ -2,13 +2,12 @@ import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import * as Utils from "../../utils";
 import { redigerbartSelectors } from "../../ducks/redigerbart";
-import { Innsynsmelding } from "../alertmeldinger";
+import { Innsynsmelding, NyVurderingMelding } from "../alertmeldinger";
 import StegLinje from "../stegLinje/stegLinje";
 import StegFane from "../stegFane";
 import { FANE_STATUS } from "../stegvelger";
 import MKV from "../../melosyskodeverk";
 import { behandlingerSelectors } from "../../ducks/behandlinger";
-import { NyVurderingMelding } from "../alertmeldinger/alertmeldinger";
 import { Feilmeldinger } from "../feilmeldinger";
 
 interface AktueltSteg {

--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -36,7 +36,7 @@ import { kontrollOperations, kontrollSelectors } from "../../ducks/kontroll";
 
 import MottatteOpplysningerFeilmeldinger from "../mottatteOpplysningerFeilmeldinger";
 import { Feilmeldinger } from "../feilmeldinger";
-import { Innsynsmelding } from "../alertmeldinger";
+import { Innsynsmelding, NyVurderingMelding } from "../alertmeldinger";
 import { AvklartefaktaStore, EnkelDataStore, StegStoreTyper, VilkaarStore } from "./StegState";
 import "./stegvelger.css";
 
@@ -510,22 +510,29 @@ class Stegvelger extends Component {
     return this.state.aktuelleSteg[stegNummer]?.vedtakSteg;
   }
 
+  erInngangsteg(stegNummer) {
+    return this.state.aktuelleSteg[stegNummer]?.stegPosisjon === 0;
+  }
+
   kontrollerFerdigbehandling = (data) => {
     return this.props.kontrollerFerdigbehandling(data);
   };
 
   render() {
+    const { visMottatteOpplysningerFeilmeldinger, aktivtStegNummer, aktuelleSteg } = this.state;
+    const { redigerbart, oppsummering } = this.props;
     const visFeilmeldinger =
-      this.erVedtakSteg(this.state.aktivtStegNummer) ||
-      this.state.aktuelleSteg[this.state.aktivtStegNummer]?.id === STEG.ARTIKKEL_16_ANMODNING;
-    const { visMottatteOpplysningerFeilmeldinger } = this.state;
+      this.erVedtakSteg(aktivtStegNummer) || aktuelleSteg[aktivtStegNummer]?.id === STEG.ARTIKKEL_16_ANMODNING;
+    const inngangStegErAktivt = this.erInngangsteg(aktivtStegNummer);
+    const erNyVurdering = oppsummering.behandlingstype?.kode === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING;
 
     return (
       <div className="stegvelger panelSeksjon">
-        <StegLinje steg={this.state.aktuelleSteg} stegKlikk={this.validerSoknadOgGaTilSteg} />
-        {!this.props.redigerbart && <Innsynsmelding />}
+        <StegLinje steg={aktuelleSteg} stegKlikk={this.validerSoknadOgGaTilSteg} />
+        {!redigerbart && <Innsynsmelding />}
         {visFeilmeldinger && <Feilmeldinger />}
-        {this.state.aktuelleSteg.map((item) => (
+        {erNyVurdering && redigerbart && inngangStegErAktivt && <NyVurderingMelding />}
+        {aktuelleSteg.map((item) => (
           <StegFane id={item.id} key={item.id} faneData={item} />
         ))}
         {visMottatteOpplysningerFeilmeldinger && <MottatteOpplysningerFeilmeldinger />}

--- a/src/sider/trygdeavtale/stegvelger.tsx
+++ b/src/sider/trygdeavtale/stegvelger.tsx
@@ -14,7 +14,7 @@ import StegLinje from "../../felleskomponenter/stegLinje";
 import StegFane from "../../felleskomponenter/stegFane";
 import { FANE_STATUS } from "../../felleskomponenter/stegvelger";
 import MottatteOpplysningerFeilmeldinger from "../../felleskomponenter/mottatteOpplysningerFeilmeldinger";
-import { Innsynsmelding } from "../../felleskomponenter/alertmeldinger";
+import { Innsynsmelding, NyVurderingMelding } from "../../felleskomponenter/alertmeldinger";
 import { Feilmeldinger } from "../../felleskomponenter/feilmeldinger";
 
 import { mottatteOpplysningerSelectors } from "../../ducks/mottatteOpplysninger";
@@ -25,7 +25,6 @@ import { formSelectors } from "../../ducks/form";
 import { redigerbartSelectors } from "../../ducks/redigerbart";
 
 import "./stegvelger.css";
-import { NyVurderingMelding } from "../../felleskomponenter/alertmeldinger/alertmeldinger";
 import { modalerSelectors } from "../../ducks/modaler";
 
 export enum StegStatus {


### PR DESCRIPTION
Legger til ny-vurdering melding i felleskomponenter/stegvelger (eøs-flytene).
Denne har samme visningslogikk som de andre stegvelgerne. 
Litt justeringer på imports.

https://jira.adeo.no/browse/MELOSYS-5588