### PR TITLE
NOJIRA Fjerne overflødige kall til kontrollerFerdigbehandle

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { getFormValues, isValid, reduxForm } from "redux-form";
 import PT from "prop-types";
@@ -266,24 +266,26 @@ export const VurderingArbeidTjenestepersonEllerFlyVedtak = ({
     };
   };
 
-  useEffect(() => {
-    async function kontroller() {
-      if (redigerbart && mottatteOpplysningerStatus === "OK" && aktivtSteg) {
-        setVedtakPending(true);
-        await kontrollerFerdigbehandling({
-          behandlingID,
-          vedtakstype: formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-          behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
-          kontrollerSomSkalIgnoreres: formValues.kopiTilArbeidsgiver
-            ? []
-            : [MKV.Koder.begrunnelser.kontroll_begrunnelser.OPPHØRT_ARBEIDSGIVER],
-          skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-        });
-        setOppdaterFoerKontroll(false);
-        setVedtakPending(false);
-      }
+  async function kontroller(data) {
+    if (redigerbart && data.mottatteOpplysningerStatus === "OK" && data.aktivtSteg) {
+      setVedtakPending(true);
+      await kontrollerFerdigbehandling({
+        behandlingID,
+        vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
+        behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
+        kontrollerSomSkalIgnoreres: data.formValues.kopiTilArbeidsgiver
+          ? []
+          : [MKV.Koder.begrunnelser.kontroll_begrunnelser.OPPHØRT_ARBEIDSGIVER],
+        skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
+      });
+      setOppdaterFoerKontroll(false);
+      setVedtakPending(false);
     }
-    kontroller();
+  }
+  const debouncedKontrollerBehandling = useCallback(Utils._debounce(kontroller, 250), [kontrollerFerdigbehandling]);
+
+  useEffect(() => {
+    debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus, formValues });
   }, [aktivtSteg, formIsValid, formValues?.kopiTilArbeidsgiver, mottatteOpplysningerStatus]);
 
   const onSubmit = async (values, dispatch, props) => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
@@ -135,7 +135,7 @@ export const VurderingArbeidTjenestepersonEllerFlyVedtak = ({
   selvstendigArbeid,
 }) => {
   const [vedtakPending, setVedtakPending] = useState(false);
-  const [oppdaterFoerKontroll, setOppdaterFoerKontroll] = useState(true);
+  const [oppdaterFørKontroll, setOppdaterFørKontroll] = useState(true);
 
   useEffect(() => {
     if (lovvalgsbestemmelseSomSkalLagres) {
@@ -269,16 +269,17 @@ export const VurderingArbeidTjenestepersonEllerFlyVedtak = ({
   async function kontroller(data) {
     if (redigerbart && data.mottatteOpplysningerStatus === "OK" && data.aktivtSteg) {
       setVedtakPending(true);
-      await kontrollerFerdigbehandling({
+      const request = {
         behandlingID,
         vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
         behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
         kontrollerSomSkalIgnoreres: data.formValues.kopiTilArbeidsgiver
           ? []
           : [MKV.Koder.begrunnelser.kontroll_begrunnelser.OPPHØRT_ARBEIDSGIVER],
-        skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-      });
-      setOppdaterFoerKontroll(false);
+        skalRegisteropplysningerOppdateres: oppdaterFørKontroll,
+      };
+      setOppdaterFørKontroll(false);
+      await kontrollerFerdigbehandling(request);
       setVedtakPending(false);
     }
   }

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak.jsx
@@ -53,7 +53,7 @@ export const VurderingArtikkel13_x_vedtak = ({
   mottatteOpplysningerStatus,
 }) => {
   const [vedtakPending, setVedtakPending] = useState(false);
-  const [oppdaterFoerKontroll, setOppdaterFoerKontroll] = useState(true);
+  const [oppdaterFørKontroll, setOppdaterFørKontroll] = useState(true);
 
   const erNyVurdering = behandlingstype === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING;
 
@@ -63,13 +63,14 @@ export const VurderingArtikkel13_x_vedtak = ({
   const kontrollerBehandling = async (data) => {
     if (redigerbart && data.mottatteOpplysningerStatus === "OK" && data.aktivtSteg && data.formIsValid) {
       setVedtakPending(true);
-      await kontrollerFerdigbehandling({
+      const request = {
         behandlingID,
         vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
         behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FORELOEPIG_FASTSATT_LOVVALGSLAND,
-        skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-      });
-      setOppdaterFoerKontroll(false);
+        skalRegisteropplysningerOppdateres: oppdaterFørKontroll,
+      };
+      setOppdaterFørKontroll(false);
+      await kontrollerFerdigbehandling(request);
       setVedtakPending(false);
     }
   };
@@ -91,7 +92,7 @@ export const VurderingArtikkel13_x_vedtak = ({
     if (isoTomDato) {
       oppdaterLovvalgsperiode(lovvalgsperiode.fomDato, isoTomDato);
     }
-    debouncedKontrollerBehandling({ aktivtSteg, formIsValid, formValues });
+    debouncedKontrollerBehandling({ aktivtSteg, formIsValid, formValues, mottatteOpplysningerStatus });
   }, [formValues?.tomDato]);
 
   const gjenopprettOpprinneligLovvalgsperiode = () => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak.jsx
@@ -370,7 +370,7 @@ export const VurderingArtikkel16Vedtak = ({
   mottatteOpplysningerStatus,
 }) => {
   const [vedtakPending, setVedtakPending] = useState(false);
-  const [oppdaterFoerKontroll, setOppdaterFoerKontroll] = useState(true);
+  const [oppdaterFørKontroll, setOppdaterFørKontroll] = useState(true);
 
   useEffect(() => {
     /**
@@ -421,13 +421,14 @@ export const VurderingArtikkel16Vedtak = ({
   async function kontroller(data) {
     if (redigerbart && data.mottatteOpplysningerStatus === "OK" && data.aktivtSteg && data.formIsValid) {
       setVedtakPending(true);
-      await kontrollerFerdigbehandling({
+      const request = {
         behandlingID,
         vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
         behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
-        skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-      });
-      setOppdaterFoerKontroll(false);
+        skalRegisteropplysningerOppdateres: oppdaterFørKontroll,
+      };
+      setOppdaterFørKontroll(false);
+      await kontrollerFerdigbehandling(request);
       setVedtakPending(false);
     }
   }

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak.jsx
@@ -418,22 +418,23 @@ export const VurderingArtikkel16Vedtak = ({
     };
   };
 
-  useEffect(() => {
-    async function kontroller() {
-      if (redigerbart && mottatteOpplysningerStatus === "OK" && aktivtSteg && formIsValid) {
-        setVedtakPending(true);
-        await kontrollerFerdigbehandling({
-          behandlingID,
-          vedtakstype: formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-          behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
-          skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-        });
-        setOppdaterFoerKontroll(false);
-        setVedtakPending(false);
-      }
+  async function kontroller(data) {
+    if (redigerbart && data.mottatteOpplysningerStatus === "OK" && data.aktivtSteg && data.formIsValid) {
+      setVedtakPending(true);
+      await kontrollerFerdigbehandling({
+        behandlingID,
+        vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
+        behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
+        skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
+      });
+      setOppdaterFoerKontroll(false);
+      setVedtakPending(false);
     }
+  }
+  const debouncedKontrollerBehandling = useCallback(Utils._debounce(kontroller, 250), [kontrollerFerdigbehandling]);
 
-    kontroller();
+  useEffect(() => {
+    debouncedKontrollerBehandling({ aktivtSteg, formValues, mottatteOpplysningerStatus, formIsValid });
   }, [aktivtSteg, formIsValid, mottatteOpplysningerStatus]);
 
   const vedKlikk = async () => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak.jsx
@@ -111,7 +111,7 @@ const VurderingVedtak = ({
   mottatteOpplysningerStatus,
 }) => {
   const [vedtakPending, setVedtakPending] = useState(false);
-  const [oppdaterFoerKontroll, setOppdaterFoerKontroll] = useState(true);
+  const [oppdaterFørKontroll, setOppdaterFørKontroll] = useState(true);
   const [erBucAapen, setErBucAapen] = useState(true);
   const folketrygdenToggleEnabled = useFeatureToggle(MELOSYS_FOLKETRYGDEN_MVP);
   const dispatch = useDispatch();
@@ -169,16 +169,17 @@ const VurderingVedtak = ({
   async function kontroller(data) {
     if (redigerbart && data.mottatteOpplysningerStatus === "OK" && data.aktivtSteg) {
       setVedtakPending(true);
-      await kontrollerFerdigbehandling({
+      const request = {
         behandlingID,
         vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
         behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
         kontrollerSomSkalIgnoreres: data.formValues.kopiTilArbeidsgiver
           ? []
           : [MKV.Koder.begrunnelser.kontroll_begrunnelser.OPPHØRT_ARBEIDSGIVER],
-        skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-      });
-      setOppdaterFoerKontroll(false);
+        skalRegisteropplysningerOppdateres: oppdaterFørKontroll,
+      };
+      setOppdaterFørKontroll(false);
+      await kontrollerFerdigbehandling(request);
       setVedtakPending(false);
     }
   }

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { connect, useDispatch } from "react-redux";
 import { getFormValues, isValid, reduxForm } from "redux-form";
 import PT from "prop-types";
@@ -158,8 +158,6 @@ const VurderingVedtak = ({
     };
   };
 
-  const { kopiTilArbeidsgiver, vedtakstype } = formValues;
-
   useEffect(() => {
     if (behandlingstema === MKV.Koder.behandlinger.behandlingstema.BESLUTNING_LOVVALG_NORGE) {
       Api.Kontroll.erBucAapen(behandlingID).then((res) => {
@@ -168,26 +166,27 @@ const VurderingVedtak = ({
     }
   }, []);
 
-  useEffect(() => {
-    async function kontroller() {
-      if (redigerbart && mottatteOpplysningerStatus === "OK" && aktivtSteg) {
-        setVedtakPending(true);
-        await kontrollerFerdigbehandling({
-          behandlingID,
-          vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-          behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
-          kontrollerSomSkalIgnoreres: kopiTilArbeidsgiver
-            ? []
-            : [MKV.Koder.begrunnelser.kontroll_begrunnelser.OPPHØRT_ARBEIDSGIVER],
-          skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-        });
-        setOppdaterFoerKontroll(false);
-        setVedtakPending(false);
-      }
+  async function kontroller(data) {
+    if (redigerbart && data.mottatteOpplysningerStatus === "OK" && data.aktivtSteg) {
+      setVedtakPending(true);
+      await kontrollerFerdigbehandling({
+        behandlingID,
+        vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
+        behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
+        kontrollerSomSkalIgnoreres: data.formValues.kopiTilArbeidsgiver
+          ? []
+          : [MKV.Koder.begrunnelser.kontroll_begrunnelser.OPPHØRT_ARBEIDSGIVER],
+        skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
+      });
+      setOppdaterFoerKontroll(false);
+      setVedtakPending(false);
     }
+  }
+  const debouncedKontrollerBehandling = useCallback(Utils._debounce(kontroller, 250), [kontrollerFerdigbehandling]);
 
-    kontroller();
-  }, [redigerbart, formIsValid, aktivtSteg, kopiTilArbeidsgiver, mottatteOpplysningerStatus]);
+  useEffect(() => {
+    debouncedKontrollerBehandling({ aktivtSteg, formValues, mottatteOpplysningerStatus });
+  }, [redigerbart, formIsValid, aktivtSteg, formValues?.kopiTilArbeidsgiver, mottatteOpplysningerStatus]);
 
   const onSubmit = async () => {
     if (!validerForm()) return;

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
@@ -262,26 +262,23 @@ export const VurderingVedtak = ({ tilbake, aktivtSteg }: Props) => {
     };
   };
 
-  const lagKontrollerFerdigbehandlingDto = () => {
-    return {
-      behandlingID,
-      vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-      behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.MEDLEM_I_FOLKETRYGDEN,
-      skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-    };
-  };
+  async function kontroller(data: any) {
+    if (data.aktivtSteg && redigerbart && data.mottatteOpplysningerStatus === "OK") {
+      setVedtakPending(true);
+      await kontrollerFerdigbehandling({
+        behandlingID,
+        vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
+        behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.MEDLEM_I_FOLKETRYGDEN,
+        skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
+      });
+      setOppdaterFoerKontroll(false);
+      setVedtakPending(false);
+    }
+  }
+  const debouncedKontrollerBehandling = useCallback(Utils._debounce(kontroller, 250), [kontrollerFerdigbehandling]);
 
   useEffect(() => {
-    async function kontroller() {
-      if (aktivtSteg && redigerbart && mottatteOpplysningerStatus === "OK") {
-        setVedtakPending(true);
-        await kontrollerFerdigbehandling(lagKontrollerFerdigbehandlingDto());
-        setOppdaterFoerKontroll(false);
-        setVedtakPending(false);
-      }
-    }
-
-    kontroller();
+    debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus, formValues });
   }, [aktivtSteg, redigerbart, mottatteOpplysningerStatus]);
 
   const onSubmit = async () => {

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak.tsx
@@ -113,7 +113,7 @@ export const VurderingVedtak = ({ tilbake, aktivtSteg }: Props) => {
   const [muligeMottakere, setMuligeMottakere] = useState(Api.DokumenterV2.tomHentMuligeMottakereResDto());
   const [trygdeavgiftMottaker, setTrygdeavgiftMottaker] = useState<KTObject | undefined>(undefined);
   const [fakturamottaker, setFakturamottaker] = useState<string | undefined>(undefined);
-  const [oppdaterFoerKontroll, setOppdaterFoerKontroll] = useState(true);
+  const [oppdaterFørKontroll, setOppdaterFørKontroll] = useState(true);
   const [vedtakPending, setVedtakPending] = useState(false);
   const stegErGyldig = redigerbart && formIsValid && Utils._isEmpty(feilmeldinger) && Utils._isEmpty(kontrollfeil);
 
@@ -265,13 +265,14 @@ export const VurderingVedtak = ({ tilbake, aktivtSteg }: Props) => {
   async function kontroller(data: any) {
     if (data.aktivtSteg && redigerbart && data.mottatteOpplysningerStatus === "OK") {
       setVedtakPending(true);
-      await kontrollerFerdigbehandling({
+      const request = {
         behandlingID,
         vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
         behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.MEDLEM_I_FOLKETRYGDEN,
-        skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-      });
-      setOppdaterFoerKontroll(false);
+        skalRegisteropplysningerOppdateres: oppdaterFørKontroll,
+      };
+      setOppdaterFørKontroll(false);
+      await kontrollerFerdigbehandling(request);
       setVedtakPending(false);
     }
   }

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -150,7 +150,7 @@ const VurderingVedtak = ({
   const [muligeMottakere, setMuligeMottakere] = useState(Api.DokumenterV2.tomHentMuligeMottakereResDto());
   const [visTomEndringFelt, setVisTomEndringFelt] = useState(false);
   const [vedtakPending, setVedtakPending] = useState(false);
-  const [oppdaterFoerKontroll, setOppdaterFoerKontroll] = useState(true);
+  const [oppdaterFørKontroll, setOppdaterFørKontroll] = useState(true);
   const [harOppfrisketLovvalgsperiode, setHarOppfrisketLovvalgsperiode] = useState(false);
   const isMounted = Hooks.useIsMounted();
   const dispatch = useDispatch();
@@ -194,17 +194,16 @@ const VurderingVedtak = ({
   async function kontroller(data: any) {
     if (data.mottatteOpplysningerStatus === "OK" && data.aktivtSteg && redigerbart) {
       setVedtakPending(true);
-      await dispatch(
-        kontrollerFerdigbehandling({
-          behandlingID,
-          vedtakstype: erNyVurdering
-            ? MKV.Koder.vedtakstyper.ENDRINGSVEDTAK
-            : vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-          behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
-          skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-        })
-      );
-      setOppdaterFoerKontroll(false);
+      const request = {
+        behandlingID,
+        vedtakstype: erNyVurdering
+          ? MKV.Koder.vedtakstyper.ENDRINGSVEDTAK
+          : vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
+        behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
+        skalRegisteropplysningerOppdateres: oppdaterFørKontroll,
+      };
+      setOppdaterFørKontroll(false);
+      await dispatch(kontrollerFerdigbehandling(request));
       setVedtakPending(false);
     }
   }

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -191,26 +191,27 @@ const VurderingVedtak = ({
     nyVurderingBakgrunn: getNyVurderingBakgrunn(),
   });
 
-  useEffect(() => {
-    async function kontroller() {
-      if (mottatteOpplysningerStatus === "OK" && aktivtSteg && redigerbart) {
-        setVedtakPending(true);
-        await dispatch(
-          kontrollerFerdigbehandling({
-            behandlingID,
-            vedtakstype: erNyVurdering
-              ? MKV.Koder.vedtakstyper.ENDRINGSVEDTAK
-              : vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
-            behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
-            skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
-          })
-        );
-        setOppdaterFoerKontroll(false);
-        setVedtakPending(false);
-      }
+  async function kontroller(data: any) {
+    if (data.mottatteOpplysningerStatus === "OK" && data.aktivtSteg && redigerbart) {
+      setVedtakPending(true);
+      await dispatch(
+        kontrollerFerdigbehandling({
+          behandlingID,
+          vedtakstype: erNyVurdering
+            ? MKV.Koder.vedtakstyper.ENDRINGSVEDTAK
+            : vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
+          behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
+          skalRegisteropplysningerOppdateres: oppdaterFoerKontroll,
+        })
+      );
+      setOppdaterFoerKontroll(false);
+      setVedtakPending(false);
     }
+  }
+  const debouncedKontrollerBehandling = useCallback(Utils._debounce(kontroller, 250), [kontrollerFerdigbehandling]);
 
-    kontroller();
+  useEffect(() => {
+    debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus });
   }, [aktivtSteg, resultat.lovvalgsperiodeTom, mottatteOpplysningerStatus]);
 
   const hentProduserbartDokument = (): string => {


### PR DESCRIPTION
> API kall feilet: Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1; statement executed: delete from saksopplysning_kilde where id=?; nested exception is org.hibernate.StaleStateException: Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1; statement executed: delete from saksopplysning_kilde where id=?

Denne kommer av at frontend kaller kontrollerFerdigbehandling med oppfriskning av saksopplysninger to ganger, og disse krasjer ofte inn i hverandre. Fikser multiple kall til backend rett etter hverandre med en debounce, og setter staten som styrer om vi skal oppfriske saksopplysninger med en gang uten å måtte vente på svar fra backend først. 