### PR TITLE
NOIJIRA TOGGLE Må sette defaultverdi siden denne ikke finnes i aktiv flyt

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtakOpphoer/vurderingVedtakOpphoer.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtakOpphoer/vurderingVedtakOpphoer.tsx
@@ -79,7 +79,7 @@ export const VurderingVedtakOpphoer = ({ tilbake, aktivtSteg }: Props) => {
     return {
       behandlingsresultatTypeKode: MKV.Koder.behandlinger.behandlingsresultattyper.OPPHØRT,
       begrunnelseFritekst: formValues?.begrunnelseFritekst || null,
-      vedtakstype,
+      vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
       kopiMottakere: muligeMottakere.kopiMottakere.map(Api.DokumenterV2.konverterMuligMottakerTilKopiMottaker),
     };
   };


### PR DESCRIPTION
Må sette defaultverdi på vedtakstype siden denne ikke finnes i aktiv flyt. Skal skrives over når/hvis endringsvedtak kommer (ref: https://nav-it.slack.com/archives/C05AYQKUC0K/p1702884337807179), men enn så lenge forhindrer dette testing.