### PR TITLE
6217 TOGGLE Bugs med lagring

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngangManglendeInnbetaling/vurderingInngangManglendeInnbetaling.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngangManglendeInnbetaling/vurderingInngangManglendeInnbetaling.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { FieldValues, useForm } from "react-hook-form";
@@ -13,6 +13,7 @@ import { oppsummertfaktaOperations, oppsummertfaktaSelectors } from "../../../..
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 import * as Utils from "../../../../../utils";
 import { inngangSteg, vedtakOpphoerSteg } from "../../initialStegArrayManglendeInnbetaling";
+import { FellesHandlersContext } from "../../../../../contexts";
 
 interface Props {
   bekreft: () => void;
@@ -24,12 +25,7 @@ export const VurderingInngangManglendeInnbetaling = ({ bekreft, aktivtSteg, oppd
   const dispatch = useDispatch();
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
-
-  const initialValues = {
-    fullstendigManglendeInnbetaling: Utils.streng.boolTilUppercaseStreng(
-      useSelector(oppsummertfaktaSelectors.FullstendigManglendeInnbetalingSelector)
-    ),
-  };
+  const { behandlingOppfriskes } = useContext(FellesHandlersContext) as any;
 
   const {
     control,
@@ -38,7 +34,11 @@ export const VurderingInngangManglendeInnbetaling = ({ bekreft, aktivtSteg, oppd
   } = useForm({
     resolver: yupResolver(vurdering_inngang_manglende_innbetaling),
     mode: "all",
-    defaultValues: initialValues as FieldValues,
+    defaultValues: {
+      fullstendigManglendeInnbetaling: Utils.streng.boolTilUppercaseStreng(
+        useSelector(oppsummertfaktaSelectors.FullstendigManglendeInnbetalingSelector)
+      ),
+    } as FieldValues,
   });
   const formValues = watch();
 
@@ -57,6 +57,17 @@ export const VurderingInngangManglendeInnbetaling = ({ bekreft, aktivtSteg, oppd
       );
     }
   }, [formIsValid]);
+
+  useEffect(() => {
+    if (!behandlingOppfriskes && formIsValid) {
+      dispatch(
+        oppsummertfaktaOperations.sendInnbetalingsstatus(
+          behandlingID,
+          Utils.streng.uppercaseStrengTilBool(formValues.fullstendigManglendeInnbetaling)
+        )
+      );
+    }
+  }, [behandlingOppfriskes]);
 
   if (!aktivtSteg) return null;
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -382,8 +382,11 @@ export const VurderingVedtak = ({ tilbake, aktivtSteg }: Props) => {
               control={control}
               className="vedtak_valg_select"
             >
-              <option key={VEDTAK_OPPHOER} value={VEDTAK_OPPHOER} label={VEDTAK_OPPHOER} />
-              <option key={VEDTAK_ENDRET} value={VEDTAK_ENDRET} label={VEDTAK_ENDRET} />
+              {medlemskapsperioder.some((periode) => periode.innvilgelsesResultat === OPPHØRT) ? (
+                <option key={VEDTAK_OPPHOER} value={VEDTAK_OPPHOER} label={VEDTAK_OPPHOER} />
+              ) : (
+                <option key={VEDTAK_ENDRET} value={VEDTAK_ENDRET} label={VEDTAK_ENDRET} />
+              )}
             </Forms.Select>
           </Nav.Column>
         </Nav.Row>

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -37,6 +37,7 @@ import { menypanelOperations, menypanelSelectors } from "../../../../../ducks/me
 
 const { NY_VURDERING, MANGLENDE_INNBETALING_TRYGDEAVGIFT } = MKV.Koder.behandlinger.behandlingstyper;
 const { OPPHØRT } = MKV.Koder.innvilgelsesResultat;
+const { OPPHØRSVEDTAK, FØRSTEGANGSVEDTAK, ENDRINGSVEDTAK } = MKV.Koder.vedtakstyper;
 const { INNVILGELSE_FOLKETRYGDLOVEN, VEDTAK_OPPHOERT_MEDLEMSKAP } = MKV.Koder.brev.produserbaredokumenter;
 const { MEDLEM_I_FOLKETRYGDEN, DELVIS_OPPHØRT } = MKV.Koder.behandlinger.behandlingsresultattyper;
 const VEDTAK_OPPHOER = "Vedtak om opphør av frivillig medlemskap";
@@ -221,8 +222,9 @@ export const VurderingVedtak = ({ tilbake, aktivtSteg }: Props) => {
 
   const getVedtakstype = () => {
     if (lagretVedtakstype) return lagretVedtakstype;
-    if (erNyVurdering || erManglendeInnbetalingTrygdeavgift) return MKV.Koder.vedtakstyper.ENDRINGSVEDTAK;
-    return MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK;
+    if (erManglendeInnbetalingTrygdeavgift) return vedtakOpphøres ? OPPHØRSVEDTAK : ENDRINGSVEDTAK;
+    if (erNyVurdering) return ENDRINGSVEDTAK;
+    return FØRSTEGANGSVEDTAK;
   };
 
   const lagFattVedtakFTRLReqDto = (): Api.Saksflyt.Vedtak.FattVedtakFTRLReqDto => {


### PR DESCRIPTION
Bug 1: Ved oppfriskning fjernes avklarte fakta. Legger derfor på en useEffect i steget for å håndtere dette, istedenfor å endre på den generiske oppfrisk-funksjonen. [9cc284f](https://github.com/navikt/melosys-web/pull/2159/commits/9cc284f13c795b62a8ff3704efadf9a46cba7777)

Bug 2: Manglende innbetaling behandlinger er opphørsvedtak dersom opphørs-brev skal sendes (behandlingsresultat blir DELVIS_OPPHØRT). [7a7b166](https://github.com/navikt/melosys-web/pull/2159/commits/7a7b16669ec161a694408eeb1390478928e2b054) [slack-diskusjon](https://nav-it.slack.com/archives/C05AYQKUC0K/p1705568681295589?thread_ts=1705484368.470009&cid=C05AYQKUC0K)

Bug 3: Vi skal hindre saksbehandlere fra å velge ulogisk brev, så dersom du ikke har perioder med opphør får du heller ikke lov å sende opphørsbrev. Og omvendt for normalt vedtaksbrev. [798504e](https://github.com/navikt/melosys-web/pull/2159/commits/798504e456569618a2e12928182994e1175a57aa) [slack-diskusjon](https://nav-it.slack.com/archives/C05AYQKUC0K/p1705568616727229?thread_ts=1705498550.445329&cid=C05AYQKUC0K)

https://jira.adeo.no/browse/MELOSYS-6217