### PR TITLE
NOJIRA Dobbel innlastning og feil setting av behandlingsOppfriskes

### DIFF
--- a/src/contexts/fellesHandlers.jsx
+++ b/src/contexts/fellesHandlers.jsx
@@ -60,8 +60,6 @@ const FellesHandlersProviderUnconnected = ({
   const startOgVisOppfriskModal = async (inkluderSiste5aar) => {
     await leggTilBehandlingOppfriskes(behandlingID);
     visOppfriskDialogHandle(inkluderSiste5aar);
-    await lastInnSaksopplysninger(sakstype, saksnummer, behandlingID);
-    await fjernBehandlingOppfriskes();
   };
 
   const behandlingOppfriskes = behandlingUnderOppfriskning === behandlingID;


### PR DESCRIPTION
startOgVisOppfriskModal kaller visOppfriskDialogHandle som gjør at dialogboksmodalen vises. Denne modalen oppfrisker saksopplysnigner med lagreMottatteOpplysningerOgOppfriskSaksopplysninger (lengre opp i fellesHandlers.jsx) som etterpå laster inn de oppfriskede saksopplysningene. Fjerner derfor lasting av saksopplysnigner fra startOgVisOppfriskModal da det er unødvendig og heller gikk i bena på oppfriskningen og andre oppdateringer. 
Fjerning av behandlingOppfriskes venter ikke på nevnt oppfriskning av saksopplysninger og gjør bare vondt værre. Denne fjernes uansett i lagreMottatteOpplysningerOgOppfriskSaksopplysninger, så sletter den fra denne funksjonen også.