### PR TITLE
5533: Ikke bygg nytt image hvis det allerede eksisterer

### DIFF
--- a/.github/workflows/deploy-manuelt.yml
+++ b/.github/workflows/deploy-manuelt.yml
@@ -38,6 +38,7 @@ jobs:
   build:
     name: Build
     needs: check_docker_image_exists
+    if: needs.check_docker_image_exists.outputs.exists != 'true'
     runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5533

Nå som vi kan deploye samme image overalt, bør vi legge tilbake sjekken om eksisterende image i deploy-manuelt