### PR TITLE
6368: La avsluttede behandlingers vilkår være gyldige 

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -27,7 +27,6 @@ import {
 import { mottatteOpplysningerSelectors } from "../../../../../ducks/mottatteOpplysninger";
 import { useFeatureToggle } from "../../../../../featuretoggle";
 import { MELOSYS_FOLKETRYGDEN_2_7 } from "../../../../../featuretoggle/toggleNavn";
-import { erAvsluttetEllerMidlertidigBeslutning } from "../../../../../melosyskodeverk/utils";
 
 const { SANN, USANN } = BOOLSK_STRING;
 export const kodeInkludererFritekst = (nestedKtObject: { [key: string]: KTObject[] }, kode?: string) =>
@@ -74,7 +73,9 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
 
   const bestemmelseIkkeStøttetValgt = ikkeStøttedeBestemmelser?.some((bestemmelse) => bestemmelse === valgtBestemmelse);
 
-  const stegErGyldig = (formIsValid || erAvsluttetEllerMidlertidigBeslutning(behandlingstatus)) && !harSkjeddEndringer;
+  const behandlingErAvsluttetMedLagretBestemmelse =
+    Boolean(lagretBestemmelse) && behandlingstatus === MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET;
+  const stegErGyldig = (formIsValid || behandlingErAvsluttetMedLagretBestemmelse) && !harSkjeddEndringer;
 
   const initialiserSteg = async () => {
     await Api.MedlemAvFolketrygden.Bestemmelser.hentMuligeBestemmelser(behandlingstema).then((response) => {
@@ -151,6 +152,14 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
     const vilkårSomSkalVises: Api.MedlemAvFolketrygden.Bestemmelser.VilkårOgBegrunnelser[] = [];
 
     valgtBestemmelsesVilkårOgBegrunnelser?.forEach((vilkårOgBegrunnelser) => {
+      if (behandlingErAvsluttetMedLagretBestemmelse) {
+        // Filtrer bort vilkår som ikke var med behandlingen på avslutningstidspunktet
+        if (valgteVilkår.get(vilkårOgBegrunnelser.vilkår) === SANN) {
+          vilkårSomSkalVises.push(vilkårOgBegrunnelser);
+        }
+        return;
+      }
+
       if (Utils._isEmpty(vilkårSomSkalVises)) {
         vilkårSomSkalVises.push(vilkårOgBegrunnelser);
         return;

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -27,7 +27,6 @@ import {
 import { mottatteOpplysningerSelectors } from "../../../../../ducks/mottatteOpplysninger";
 import { useFeatureToggle } from "../../../../../featuretoggle";
 import { MELOSYS_FOLKETRYGDEN_2_7 } from "../../../../../featuretoggle/toggleNavn";
-import { behandlingsresultatSelectors } from "../../../../../ducks/behandlingsresultat";
 import { erAvsluttetEllerMidlertidigBeslutning } from "../../../../../melosyskodeverk/utils";
 
 const { SANN, USANN } = BOOLSK_STRING;

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -27,6 +27,8 @@ import {
 import { mottatteOpplysningerSelectors } from "../../../../../ducks/mottatteOpplysninger";
 import { useFeatureToggle } from "../../../../../featuretoggle";
 import { MELOSYS_FOLKETRYGDEN_2_7 } from "../../../../../featuretoggle/toggleNavn";
+import { behandlingsresultatSelectors } from "../../../../../ducks/behandlingsresultat";
+import { erAvsluttetEllerMidlertidigBeslutning } from "../../../../../melosyskodeverk/utils";
 
 const { SANN, USANN } = BOOLSK_STRING;
 export const kodeInkludererFritekst = (nestedKtObject: { [key: string]: KTObject[] }, kode?: string) =>
@@ -49,6 +51,7 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
   const folketrygden2_7ToggleEnabled = useFeatureToggle(MELOSYS_FOLKETRYGDEN_2_7);
 
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
+  const behandlingstatus = useSelector(behandlingerSelectors.BehandlingsstatusKodeSelector);
   const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
   const lagretBestemmelse = useSelector(medlemskapsperioderSelectors.BestemmelseSelector);
@@ -71,7 +74,8 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
     folketrygden2_7ToggleEnabled && Boolean(valgtBestemmelse) && !lovligeBestemmelser.includes(valgtBestemmelse);
 
   const bestemmelseIkkeStøttetValgt = ikkeStøttedeBestemmelser?.some((bestemmelse) => bestemmelse === valgtBestemmelse);
-  const stegErGyldig = formIsValid && !harSkjeddEndringer;
+
+  const stegErGyldig = (formIsValid || erAvsluttetEllerMidlertidigBeslutning(behandlingstatus)) && !harSkjeddEndringer;
 
   const initialiserSteg = async () => {
     await Api.MedlemAvFolketrygden.Bestemmelser.hentMuligeBestemmelser(behandlingstema).then((response) => {


### PR DESCRIPTION
...selv om de mangler vilkår

Nå som det er nye vilkår på samme bestemmelse, så blir steget ugyldig for gamle behandlinger.