### PR TITLE
5833 Fikset en bug ved innlasting av utkast

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -211,7 +211,7 @@ const SendBrev = ({
   ]);
 
   useEffect(() => {
-    if (tilgjengeligeBrevtyper?.length > 1) {
+    if (tilgjengeligeBrevtyper?.length > 1 && formValues?.type) {
       changeField("type", undefined);
     }
   }, [formValues?.valgtMottaker]);


### PR DESCRIPTION
Feilen forårsakes av useEffect kollisjoner. Effect i brevUtkast (nr 1) som setter brevtype kjøres før effect i sendBrev (nr 2) som nullstiller brevtype, men denne kjøres igjen før changeField resolver med oppdateringen fra 1. Siden vi nå har to changeField kall mot samme form felt velges den nyeste verdien. Dette resulterer i at neste useEffect i sendBrev som oppdaterer feltet valgtBrev ikke kjøres da formValues.type er uendret.