### PR TITLE
NOJIRA Siden hopper til topp ved trykk på lenker

### DIFF
--- a/src/felleskomponenter/dokumentliste/dokumentliste.tsx
+++ b/src/felleskomponenter/dokumentliste/dokumentliste.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { MouseEvent, useState } from "react";
 
 import * as Nav from "../../navFrontend";
 import { dokumenterOperations } from "../../ducks/dokumenter";
@@ -21,7 +21,11 @@ import {
 const Dokumentliste = ({ behandlingID, dokumenter, validateOnClick }: DokumentlisteType) => {
   const [feilmelding, setFeilmelding] = useState<string | null>(null);
 
-  const klikk = async (dokument: BrevDokumentMetadataType | SedDokumentMetadataType) => {
+  const klikk = async (
+    dokument: BrevDokumentMetadataType | SedDokumentMetadataType,
+    event: MouseEvent<HTMLAnchorElement>
+  ) => {
+    event.preventDefault();
     if (validateOnClick) {
       // Avbryt forespørsel hvis validator er oppgitt og returnerer false
       const validert = await validateOnClick();
@@ -69,7 +73,7 @@ const Dokumentliste = ({ behandlingID, dokumenter, validateOnClick }: Dokumentli
   const mapBrev = (dokument: BrevDokumentMetadataType) => (
     <Table.Row key={Utils._uuid()}>
       <Table.DataCell>
-        <Nav.Lenker href="#" onClick={() => klikk(dokument)}>
+        <Nav.Lenker href="#" onClick={(event) => klikk(dokument, event)}>
           {tittel(
             dokument.dokumentNavn ||
               KV.kodeTilTerm(dokument.dokumentData?.produserbardokument, MKV.KTObjects.brev.produserbaredokumenter)
@@ -83,7 +87,7 @@ const Dokumentliste = ({ behandlingID, dokumenter, validateOnClick }: Dokumentli
   const mapSED = (dokument: SedDokumentMetadataType) => (
     <Table.Row key={Utils._uuid()}>
       <Table.DataCell>
-        <Nav.Lenker href="#" onClick={() => klikk(dokument)}>
+        <Nav.Lenker href="#" onClick={(event) => klikk(dokument, event)}>
           {tittel(dokument.dokumentNavn || `SED ${dokument.sedType}`)}
         </Nav.Lenker>
       </Table.DataCell>

--- a/src/felleskomponenter/pdfLink/pdfLink.tsx
+++ b/src/felleskomponenter/pdfLink/pdfLink.tsx
@@ -12,7 +12,14 @@ interface PdfLinkProps {
 }
 
 const PdfLink = ({ journalpostID, dokumentID, tittel }: PdfLinkProps) => (
-  <Nav.Lenker href="#" onClick={() => apnePdfINyFane(lagPdfUrl(journalpostID, dokumentID))}>
+  <Nav.Lenker
+    href="#"
+    onClick={(event) => {
+      event.preventDefault();
+      console.log("hei");
+      apnePdfINyFane(lagPdfUrl(journalpostID, dokumentID));
+    }}
+  >
     {`${tittel} (åpnes i ny fane)`}
   </Nav.Lenker>
 );

--- a/src/felleskomponenter/pdfLink/pdfLink.tsx
+++ b/src/felleskomponenter/pdfLink/pdfLink.tsx
@@ -16,7 +16,6 @@ const PdfLink = ({ journalpostID, dokumentID, tittel }: PdfLinkProps) => (
     href="#"
     onClick={(event) => {
       event.preventDefault();
-      console.log("hei");
       apnePdfINyFane(lagPdfUrl(journalpostID, dokumentID));
     }}
   >

--- a/src/felleskomponenter/saksoversiktLenke/saksoversiktLenke.tsx
+++ b/src/felleskomponenter/saksoversiktLenke/saksoversiktLenke.tsx
@@ -1,3 +1,4 @@
+import { MouseEvent } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { RootState } from "AppTypes";
 
@@ -27,7 +28,8 @@ const SaksoversiktLenke = ({ behandlingID, saksnummer, hovedpartRolle }: PropsFr
   const hovedpartErVirksomhet = hovedpartRolle === MKV.Koder.aktoersroller.VIRKSOMHET;
   const personopplysninger = useHentPersonopplysninger(behandlingID, hovedpartErVirksomhet);
 
-  const hentSaksoversikt = async () => {
+  const hentSaksoversikt = async (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
     if (hovedpartErVirksomhet) {
       const org = await Api.Fagsaker.aktoer
         .hent(saksnummer, MKV.Koder.aktoersroller.VIRKSOMHET)
@@ -52,7 +54,7 @@ const SaksoversiktLenke = ({ behandlingID, saksnummer, hovedpartRolle }: PropsFr
     <div className="saksoversiktLenke">
       <Nav.Panel>
         Vis saksoversikt:
-        <Nav.Lenker href="#" onClick={() => hentSaksoversikt()}>
+        <Nav.Lenker href="#" onClick={hentSaksoversikt}>
           <Ikon.ExternalLink className="ikon" />
           Åpnes i nytt vindu
         </Nav.Lenker>

--- a/src/felleskomponenter/vedleggTable/fritekstvedleggRow.tsx
+++ b/src/felleskomponenter/vedleggTable/fritekstvedleggRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, MouseEvent } from "react";
 
 import * as Nav from "../../navFrontend";
 import * as Mui from "../ui";
@@ -27,7 +27,8 @@ const FritekstvedleggRow = ({
 }: FritekstvedleggRowProps) => {
   const [visBekreftelseModal, setVisBekreftelseModal] = useState<boolean>(false);
 
-  const aapnePdf = async () => {
+  const aapnePdf = async (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
     const url = lagFritekstPdfUrl ? await lagFritekstPdfUrl(index) : null;
     if (url) {
       apnePdfINyFane(url);


### PR DESCRIPTION
Når man trykker på ulike lenker hopper man til toppen av siden man er på, selv om lenkene i seg selv åpnes i ny side. Dette er irriterende når man er langt ned på siden og må scrolle tilbake til der man var.


Kommentar: https://nav-it.slack.com/archives/C01CFP7SL4Q/p1704881485126109
Svar: https://nav-it.slack.com/archives/C01CFP7SL4Q/p1704883895846369