### PR TITLE
6330 TOGGLE Oppsett Ikke-yrkesaktiv FTRL flyt 

### DIFF
--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -17,7 +17,11 @@ import { medlemskapsperioderOperations } from "../medlemskapsperioder";
 import { erFeatureToggleEnabled } from "../../featuretoggle";
 // noinspection ES6PreferShortImport
 import { harIkkeYrkesaktivFlyt, harUnntaksregistreringFlyt, skalViseIngenFlyt } from "../../url/url";
-import { MELOSYS_FOLKETRYGDEN_MVP, MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING } from "../../featuretoggle/toggleNavn";
+import {
+  MELOSYS_FOLKETRYGDEN_MVP,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
+  MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
+} from "../../featuretoggle/toggleNavn";
 
 const harIngenFlyt = async (sakstype, state) => {
   const sakstema = fagsakSelectors.SakstemaKodeSelector(state);
@@ -25,6 +29,7 @@ const harIngenFlyt = async (sakstype, state) => {
   const behandlingstype = behandlingerSelectors.BehandlingstypeKodeSelector(state);
   const folketrygdenToggleEnabled = erFeatureToggleEnabled(MELOSYS_FOLKETRYGDEN_MVP, state);
   const manglendeInnbetalingToggleEnabled = erFeatureToggleEnabled(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING, state);
+  const ikkeYrkesaktivFtrlToggleEnabled = erFeatureToggleEnabled(MELOSYS_FTRL_IKKE_YRKESAKTIV, state);
 
   return skalViseIngenFlyt(
     sakstype,
@@ -32,7 +37,8 @@ const harIngenFlyt = async (sakstype, state) => {
     behandlingstema,
     behandlingstype,
     folketrygdenToggleEnabled,
-    manglendeInnbetalingToggleEnabled
+    manglendeInnbetalingToggleEnabled,
+    ikkeYrkesaktivFtrlToggleEnabled
   );
 };
 const harUnntaksregistreringEllerIkkeYrkesaktivFlyt = (sakstype, state) => {

--- a/src/featuretoggle/toggleNavn.ts
+++ b/src/featuretoggle/toggleNavn.ts
@@ -2,6 +2,7 @@ const MELOSYS_FOLKETRYGDEN_MVP = "melosys.folketrygden.mvp";
 const MELOSYS_FULLMAKT_TRYGDEAVGIFT = "melosys.fullmakt.trygdeavgift";
 const MELOSYS_FAKTURERINGSKOMPONENTEN_VIS_REFERANSE = "melosys.faktureringskomponent.vis_referanse";
 const MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING = "melosys.saksbehandling.manglende_innbetaling";
+const MELOSYS_FTRL_IKKE_YRKESAKTIV = "melosys.ftrl.ikke_yrkesaktiv";
 const MELOSYS_FTRL_BEGRENSE_PERIODE_VEDTAK = "melosys.ftrl.begrense_periode_vedtak";
 const MELOSYS_FOLKETRYGDEN_2_7 = "melosys.folketrygden.2_7";
 const FEATURE_TOGGLE = "feature-toggle";
@@ -13,6 +14,7 @@ const alleToggleNavn = [
   MELOSYS_FULLMAKT_TRYGDEAVGIFT,
   MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
   MELOSYS_FTRL_BEGRENSE_PERIODE_VEDTAK,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
 ];
 
 export {
@@ -23,5 +25,6 @@ export {
   MELOSYS_FULLMAKT_TRYGDEAVGIFT,
   MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
   MELOSYS_FTRL_BEGRENSE_PERIODE_VEDTAK,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
   alleToggleNavn,
 };

--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
@@ -19,6 +19,7 @@ const {
   BESLUTNING_LOVVALG_NORGE,
   BESLUTNING_LOVVALG_ANNET_LAND,
   YRKESAKTIV,
+  IKKE_YRKESAKTIV,
 } = MKV.Koder.behandlinger.behandlingstema;
 
 const { SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS } = MKV.Koder.mottatteopplysningertyper;
@@ -32,6 +33,7 @@ interface LinkGroupsConfig {
   sakstema: string;
   folketrygdenToggleEnabled: boolean | undefined;
   manglendeInnbetalingToggleEnabled: boolean | undefined;
+  ikkeYrkesaktivFtrlToggleEnabled: boolean | undefined;
 }
 
 class LinkGroupsFactory {
@@ -44,6 +46,7 @@ class LinkGroupsFactory {
     sakstema,
     folketrygdenToggleEnabled,
     manglendeInnbetalingToggleEnabled,
+    ikkeYrkesaktivFtrlToggleEnabled,
   }: LinkGroupsConfig): LinkGroup[] {
     if (
       skalViseIngenFlyt(
@@ -52,7 +55,8 @@ class LinkGroupsFactory {
         behandlingstema,
         behandlingstype,
         folketrygdenToggleEnabled,
-        manglendeInnbetalingToggleEnabled
+        manglendeInnbetalingToggleEnabled,
+        ikkeYrkesaktivFtrlToggleEnabled
       )
     ) {
       const linkBuilder = new LinksBuilder(contentProps).addFullmektig();
@@ -77,7 +81,10 @@ class LinkGroupsFactory {
         .build();
     }
 
-    if (harIkkeYrkesaktivFlyt(sakstype, behandlingstema)) {
+    if (
+      harIkkeYrkesaktivFlyt(sakstype, behandlingstema) ||
+      (ikkeYrkesaktivFtrlToggleEnabled && behandlingstema === IKKE_YRKESAKTIV)
+    ) {
       return new LinkgroupsBuilder()
         .addFraRegister(
           new LinksBuilder(contentProps)

--- a/src/felleskomponenter/menypanel/menypanel.tsx
+++ b/src/felleskomponenter/menypanel/menypanel.tsx
@@ -19,7 +19,11 @@ import { fagsakSelectors } from "../../ducks/fagsaker";
 import OppdaterRegisteropplysninger from "./oppdaterRegisteropplysninger";
 import { LinkGroupsFactory } from "./linkgroups";
 import "./menypanel.css";
-import { MELOSYS_FOLKETRYGDEN_MVP, MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING } from "../../featuretoggle/toggleNavn";
+import {
+  MELOSYS_FOLKETRYGDEN_MVP,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
+  MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
+} from "../../featuretoggle/toggleNavn";
 
 const { SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS } = MKV.Koder.mottatteopplysningertyper;
 
@@ -59,6 +63,7 @@ export const Menypanel = ({
   const [menypanelFeilmelding, setMenypanelFeilmelding] = useState("");
   const folketrygdenToggleEnabled = useFeatureToggle(MELOSYS_FOLKETRYGDEN_MVP);
   const manglendeInnbetalingToggleEnabled = useFeatureToggle(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING);
+  const ikkeYrkesaktivFtrlToggleEnabled = useFeatureToggle(MELOSYS_FTRL_IKKE_YRKESAKTIV);
 
   const visMottatteOpplysningerData = !(
     MKVUtils.erBehandlingAvSed(sakstype, behandlingstema) &&
@@ -84,6 +89,7 @@ export const Menypanel = ({
     sakstema,
     folketrygdenToggleEnabled,
     manglendeInnbetalingToggleEnabled,
+    ikkeYrkesaktivFtrlToggleEnabled,
   });
 
   const linkGroups = linkGroupsWithContent.map((linkGroup, groupIndex) => ({
@@ -120,7 +126,8 @@ export const Menypanel = ({
       behandlingstema,
       behandlingstype,
       folketrygdenToggleEnabled,
-      manglendeInnbetalingToggleEnabled
+      manglendeInnbetalingToggleEnabled,
+      ikkeYrkesaktivFtrlToggleEnabled
     );
 
   if (!visMenypanel) return null;

--- a/src/felleskomponenter/oppgaveliste/behandlingOppgave.jsx
+++ b/src/felleskomponenter/oppgaveliste/behandlingOppgave.jsx
@@ -36,7 +36,13 @@ BehandlingOppgavesLinjeWrapper.propTypes = {
  * for å gi saksbehandler en hent over sakens innhold før hun klikker
  * seg inn på den.
  */
-const BehandlingOppgave = ({ sak, folketrygdenToggleEnabled, manglendeInnbetalingToggleEnabled, landkoder }) => {
+const BehandlingOppgave = ({
+  sak,
+  folketrygdenToggleEnabled,
+  manglendeInnbetalingToggleEnabled,
+  ikkeYrkesaktivFtrlToggleEnabled,
+  landkoder,
+}) => {
   const {
     navn,
     sakstype,
@@ -67,7 +73,8 @@ const BehandlingOppgave = ({ sak, folketrygdenToggleEnabled, manglendeInnbetalin
     behandlingstema.kode,
     behandlingstype.kode,
     folketrygdenToggleEnabled,
-    manglendeInnbetalingToggleEnabled
+    manglendeInnbetalingToggleEnabled,
+    ikkeYrkesaktivFtrlToggleEnabled
   );
   const oppdateringStatus = erUnderOppdatering && "(oppdateres nå)";
 
@@ -162,12 +169,14 @@ BehandlingOppgave.propTypes = {
   folketrygdenToggleEnabled: PT.bool,
   landkoder: PT.arrayOf(MPT.Kodeverk).isRequired,
   manglendeInnbetalingToggleEnabled: PT.bool,
+  ikkeYrkesaktivFtrlToggleEnabled: PT.bool,
 };
 
 BehandlingOppgave.defaultProps = {
   sak: {},
   folketrygdenToggleEnabled: undefined,
   manglendeInnbetalingToggleEnabled: undefined,
+  ikkeYrkesaktivFtrlToggleEnabled: undefined,
 };
 
 export default BehandlingOppgave;

--- a/src/felleskomponenter/oppgaveliste/fagsak.jsx
+++ b/src/felleskomponenter/oppgaveliste/fagsak.jsx
@@ -20,7 +20,13 @@ import "./fagsak.css";
  * for å gi saksbehandler oversikt over sakens innhold før hun klikker
  * seg inn på den.
  */
-const Fagsak = ({ sak, folketrygdenToggleEnabled, manglendeInnbetalingToggleEnabled, landkoder }) => {
+const Fagsak = ({
+  sak,
+  folketrygdenToggleEnabled,
+  manglendeInnbetalingToggleEnabled,
+  ikkeYrkesaktivFtrlToggleEnabled,
+  landkoder,
+}) => {
   const { opprettetDato, sakstype, saksstatus, saksnummer, sakstema, behandlingOversikter } = sak;
 
   const { land } = behandlingOversikter.find((behandlingOversikt) => behandlingOversikt.soknadsperiode != null) ?? {};
@@ -37,7 +43,8 @@ const Fagsak = ({ sak, folketrygdenToggleEnabled, manglendeInnbetalingToggleEnab
       behandling.behandlingstema.kode,
       behandling.behandlingstype.kode,
       folketrygdenToggleEnabled,
-      manglendeInnbetalingToggleEnabled
+      manglendeInnbetalingToggleEnabled,
+      ikkeYrkesaktivFtrlToggleEnabled
     );
 
   const customMargin = { marginLeft: "1em" };
@@ -98,12 +105,14 @@ Fagsak.propTypes = {
   folketrygdenToggleEnabled: PT.bool,
   landkoder: PT.arrayOf(MPT.Kodeverk).isRequired,
   manglendeInnbetalingToggleEnabled: PT.bool,
+  ikkeYrkesaktivFtrlToggleEnabled: PT.bool,
 };
 
 Fagsak.defaultProps = {
   sak: {},
   folketrygdenToggleEnabled: undefined,
   manglendeInnbetalingToggleEnabled: undefined,
+  ikkeYrkesaktivFtrlToggleEnabled: undefined,
 };
 
 export default Fagsak;

--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -25,7 +25,11 @@ import { StandardMeldingOverst } from "../alertmeldinger";
 import { Spinner } from "../spinner";
 
 import "./endreBehandlingModal.css";
-import { MELOSYS_FOLKETRYGDEN_MVP, MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING } from "../../featuretoggle/toggleNavn";
+import {
+  MELOSYS_FOLKETRYGDEN_MVP,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
+  MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
+} from "../../featuretoggle/toggleNavn";
 
 enum FeltVerdier {
   sakstype = "sakstype",
@@ -87,6 +91,7 @@ function EndreBehandlingModal({
   const [muligeBehandlingstyper, setMuligeBehandlingstyper] = useState([]);
   const folketrygdenToggleEnabled = useFeatureToggle(MELOSYS_FOLKETRYGDEN_MVP);
   const manglendeInnbetalingToggleEnabled = useFeatureToggle(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING);
+  const ikkeYrkesaktivFtrlToggleEnabled = useFeatureToggle(MELOSYS_FTRL_IKKE_YRKESAKTIV);
   const typeTemaKanEndres = !anmodningsperioderSendtTilUtlandet;
   const fagsakKanEndres = muligeSakstyper.length !== 0 || muligeSakstemaer.length !== 0;
 
@@ -156,7 +161,8 @@ function EndreBehandlingModal({
         behandlingstema,
         behandlingstype,
         folketrygdenToggleEnabled,
-        manglendeInnbetalingToggleEnabled
+        manglendeInnbetalingToggleEnabled,
+        ikkeYrkesaktivFtrlToggleEnabled
       )
     ) {
       await Api.Trygdeavtale.slettFlyt(behandlingID);
@@ -222,7 +228,8 @@ function EndreBehandlingModal({
           behandlingstema,
           behandlingstype,
           folketrygdenToggleEnabled,
-          manglendeInnbetalingToggleEnabled
+          manglendeInnbetalingToggleEnabled,
+          ikkeYrkesaktivFtrlToggleEnabled
         );
 
         if (nyGenerertLink && nyGenerertLink !== location.pathname + location.search) {

--- a/src/felleskomponenter/oppsummering/oppsummering.tsx
+++ b/src/felleskomponenter/oppsummering/oppsummering.tsx
@@ -25,7 +25,11 @@ import EndreBehandlingModal from "./endreBehandlingModal";
 import "./oppsummering.css";
 import { useAsyncCallbackState } from "../../hooks";
 import { useFeatureToggle } from "../../featuretoggle";
-import { MELOSYS_FOLKETRYGDEN_MVP, MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING } from "../../featuretoggle/toggleNavn";
+import {
+  MELOSYS_FOLKETRYGDEN_MVP,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
+  MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
+} from "../../featuretoggle/toggleNavn";
 
 const { AVSLUTTET, IVERKSETTER_VEDTAK, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Koder.behandlinger.behandlingsstatus;
 const behandlingsStatusMedBegrensetRettigheter = [AVSLUTTET, IVERKSETTER_VEDTAK, MIDLERTIDIG_LOVVALGSBESLUTNING];
@@ -75,6 +79,7 @@ const Oppsummering = ({
   ]);
   const folketrygdenToggleEnabled = useFeatureToggle(MELOSYS_FOLKETRYGDEN_MVP);
   const manglendeInnbetalingToggleEnabled = useFeatureToggle(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING);
+  const ikkeYrkesaktivFtrlToggleEnabled = useFeatureToggle(MELOSYS_FTRL_IKKE_YRKESAKTIV);
   const [skalViseEndreModal, setSkalViseEndreModal] = useState(false);
 
   if (Utils._isEmpty(fagsak) || Utils._isEmpty(oppsummering)) return <div />;
@@ -106,7 +111,8 @@ const Oppsummering = ({
     behandlingstema.kode,
     behandlingstype.kode,
     folketrygdenToggleEnabled,
-    manglendeInnbetalingToggleEnabled
+    manglendeInnbetalingToggleEnabled,
+    ikkeYrkesaktivFtrlToggleEnabled
   );
   const hovedpartErVirksomhet = hovedpartRolle === MKV.Koder.aktoersroller.VIRKSOMHET;
 

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak.jsx
@@ -30,7 +30,11 @@ import Mottakerinstitusjonvelger from "../../../felleskomponenter/mottakerinstit
 import { lagYupToReduxformErrorMapper } from "../../../yup";
 import VurderingArtikkel12VedtakSchema from "./vurderingArtikkel12VedtakSchema";
 import "./vurderingVedtak.css";
-import { MELOSYS_FOLKETRYGDEN_MVP } from "../../../featuretoggle/toggleNavn";
+import {
+  MELOSYS_FOLKETRYGDEN_MVP,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
+  MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
+} from "../../../featuretoggle/toggleNavn";
 import { mottatteOpplysningerSelectors } from "../../../ducks/mottatteOpplysninger";
 import * as Api from "../../../services/api";
 
@@ -72,7 +76,9 @@ const skalViseMottakerinstitusjoner = (
   sakstema,
   behandlingstema,
   behandlingstype,
-  folketrygdenToggleEnabled
+  folketrygdenToggleEnabled,
+  manglendeInnbetalingToggleEnabled,
+  ikkeYrkesaktivFtrlToggleEnabled
 ) => {
   return (
     sakstype === MKV.Koder.sakstyper.EU_EOS &&
@@ -82,7 +88,15 @@ const skalViseMottakerinstitusjoner = (
       MKV.Koder.behandlinger.behandlingstema.ARBEID_FLERE_LAND,
       MKV.Koder.behandlinger.behandlingstema.ARBEID_TJENESTEPERSON_ELLER_FLY,
     ].includes(behandlingstema) &&
-    !skalViseIngenFlyt(sakstype, sakstema, behandlingstema, behandlingstype, folketrygdenToggleEnabled)
+    !skalViseIngenFlyt(
+      sakstype,
+      sakstema,
+      behandlingstema,
+      behandlingstype,
+      folketrygdenToggleEnabled,
+      manglendeInnbetalingToggleEnabled,
+      ikkeYrkesaktivFtrlToggleEnabled
+    )
   );
 };
 
@@ -113,6 +127,8 @@ const VurderingVedtak = ({
   const [vedtakPending, setVedtakPending] = useState(false);
   const [erBucAapen, setErBucAapen] = useState(true);
   const folketrygdenToggleEnabled = useFeatureToggle(MELOSYS_FOLKETRYGDEN_MVP);
+  const manglendeInnbetalingToggleEnabled = useFeatureToggle(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING);
+  const ikkeYrkesaktivFtrlToggleEnabled = useFeatureToggle(MELOSYS_FTRL_IKKE_YRKESAKTIV);
   const dispatch = useDispatch();
   let oppdaterFørKontroll = true;
 
@@ -133,7 +149,9 @@ const VurderingVedtak = ({
     sakstema,
     behandlingstema,
     behandlingstype,
-    folketrygdenToggleEnabled
+    folketrygdenToggleEnabled,
+    manglendeInnbetalingToggleEnabled,
+    ikkeYrkesaktivFtrlToggleEnabled
   );
   const bucType = erArtikkel11_4 ? EKV.Koder.buctyper.legislation.LA_BUC_05 : EKV.Koder.buctyper.legislation.LA_BUC_04;
 

--- a/src/sider/forside/komponenter/mineoppgaver/behandlingOppgaver.tsx
+++ b/src/sider/forside/komponenter/mineoppgaver/behandlingOppgaver.tsx
@@ -11,6 +11,7 @@ import { useFeatureToggle } from "../../../../featuretoggle";
 import "./behandlingsoppgaver.css";
 import {
   MELOSYS_FOLKETRYGDEN_MVP,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
   MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
 } from "../../../../featuretoggle/toggleNavn";
 
@@ -28,6 +29,7 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 export const BehandlingOppgaver = ({ mineSaker, landkoder }: PropsFromRedux) => {
   const folketrygdenToggleEnabled = useFeatureToggle(MELOSYS_FOLKETRYGDEN_MVP);
   const manglendeInnbetalingToggleEnabled = useFeatureToggle(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING);
+  const ikkeYrkesaktivFtrlToggleEnabled = useFeatureToggle(MELOSYS_FTRL_IKKE_YRKESAKTIV);
 
   const { saksbehandling } = mineSaker as any;
 
@@ -42,6 +44,7 @@ export const BehandlingOppgaver = ({ mineSaker, landkoder }: PropsFromRedux) => 
         radioGroupName="behandlingsortering"
         folketrygdenToggleEnabled={folketrygdenToggleEnabled}
         manglendeInnbetalingToggleEnabled={manglendeInnbetalingToggleEnabled}
+        ikkeYrkesaktivFtrlToggleEnabled={ikkeYrkesaktivFtrlToggleEnabled}
         landkoder={landkoder}
       />
     </div>

--- a/src/sider/forside/komponenter/saksplukker/saksplukker.tsx
+++ b/src/sider/forside/komponenter/saksplukker/saksplukker.tsx
@@ -18,6 +18,7 @@ import { useFeatureToggle } from "../../../../featuretoggle";
 import { oppgaverOperations } from "../../../../ducks/oppgaver";
 import {
   MELOSYS_FOLKETRYGDEN_MVP,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
   MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
 } from "../../../../featuretoggle/toggleNavn";
 
@@ -70,6 +71,7 @@ export const Saksplukker = ({
 
   const folketrygdenToggleEnabled = useFeatureToggle(MELOSYS_FOLKETRYGDEN_MVP);
   const manglendeInnbetalingToggleEnabled = useFeatureToggle(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING);
+  const ikkeYrkesaktivFtrlToggleEnabled = useFeatureToggle(MELOSYS_FTRL_IKKE_YRKESAKTIV);
 
   useEffect(() => {
     Api.LovligeKombinasjoner.hentSakstyper().then((lovligeSakstyper) => {
@@ -118,7 +120,8 @@ export const Saksplukker = ({
       behandlingstema,
       behandlingstype,
       folketrygdenToggleEnabled,
-      manglendeInnbetalingToggleEnabled
+      manglendeInnbetalingToggleEnabled,
+      ikkeYrkesaktivFtrlToggleEnabled
     );
 
     history.push(redirectURL);

--- a/src/sider/ftrl/saksbehandling/saksbehandling.tsx
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.tsx
@@ -36,19 +36,25 @@ import { vilkarOperations } from "../../../ducks/vilkar";
 import { menypanelOperations, menypanelSelectors } from "../../../ducks/menypanel";
 import { feiletResponsOperations } from "../../../ducks/feiletRespons";
 
-import { alleSteg } from "./initialStegArray";
+import { alleStegYrkesaktivFlyt } from "./stegLister/stegListeYrkesaktivFlyt";
 import "./saksbehandling.css";
-import { MELOSYS_FOLKETRYGDEN_MVP } from "../../../featuretoggle/toggleNavn";
+import {
+  MELOSYS_FOLKETRYGDEN_MVP,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
+  MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
+} from "../../../featuretoggle/toggleNavn";
 import { kontrollOperations } from "../../../ducks/kontroll";
 import { resetInkluderSiste5Aar } from "../../../ducks/modaler/operations";
 import { setErFullmektigEndret } from "../../../ducks/menypanel/operations";
-import { alleStegManglendeInnbetaling } from "./initialStegArrayManglendeInnbetaling";
+import { alleStegManglendeInnbetalingFlyt } from "./stegLister/stegListeManglendeInnbetalingFlyt";
 import { fakturaserierOperations } from "../../../ducks/fakturaserier";
+import { alleStegIkkeYrkesaktivFlyt } from "./stegLister/stegListeIkkeYrkesaktivFlyt";
 
 const mapStateToProps = (state: RootState) => ({
   arbeidsland: mottatteOpplysningerSelectors.SoknadslandkoderSelector(state),
   hovedpartRolle: fagsakSelectors.HovedpartRolleSelector(state),
   behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
+  behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
   mottatteOpplysninger: mottatteOpplysningerSelectors.MottatteOpplysningerDataSelector(state),
   mottatteOpplysningerPeriodeFom: Utils.dato.formatterDatoTilNorsk(
     mottatteOpplysningerSelectors.PeriodeSelector(state).fom
@@ -147,11 +153,14 @@ const Saksbehandling = ({
   menypanelSynlig,
   samletMedlemskapsperiodeSelector,
   behandlingstype,
+  behandlingstema,
   resetFakturaInformasjon,
 }: Props & PropsFromRedux) => {
   const [behandlingID, setBehandlingID] = useState(-1);
   const [saksopplysningerLastet, setSaksopplysningerLastet] = useState(false);
   const folketrygdenToggle = useFeatureToggle(MELOSYS_FOLKETRYGDEN_MVP);
+  const manglendeInnbetalingToggleEnabled = useFeatureToggle(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING);
+  const ikkeYrkesaktivFtrlToggleEnabled = useFeatureToggle(MELOSYS_FTRL_IKKE_YRKESAKTIV);
 
   const oppdaterBehandlingIDState = () => {
     const behandlingIDFraParam = Utils.queryString.getParam(location, "behandlingID");
@@ -228,10 +237,16 @@ const Saksbehandling = ({
   if (!folketrygdenToggle) return null;
 
   const hentStegArray = () => {
-    if (behandlingstype === MKV.Koder.behandlinger.behandlingstyper.MANGLENDE_INNBETALING_TRYGDEAVGIFT) {
-      return alleStegManglendeInnbetaling;
+    if (ikkeYrkesaktivFtrlToggleEnabled && behandlingstema === MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV) {
+      return alleStegIkkeYrkesaktivFlyt;
     }
-    return alleSteg;
+    if (
+      manglendeInnbetalingToggleEnabled &&
+      behandlingstype === MKV.Koder.behandlinger.behandlingstyper.MANGLENDE_INNBETALING_TRYGDEAVGIFT
+    ) {
+      return alleStegManglendeInnbetalingFlyt;
+    }
+    return alleStegYrkesaktivFlyt;
   };
 
   const erHenlagtSak = fagsakStatusKode === MKV.Koder.saksstatuser.HENLAGT;

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngangManglendeInnbetaling/vurderingInngangManglendeInnbetaling.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngangManglendeInnbetaling/vurderingInngangManglendeInnbetaling.tsx
@@ -12,7 +12,7 @@ import { BOOLSK_STRING } from "../../../../../constants";
 import { oppsummertfaktaOperations, oppsummertfaktaSelectors } from "../../../../../ducks/oppsummertfakta";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 import * as Utils from "../../../../../utils";
-import { inngangSteg, vedtakOpphoerSteg } from "../../initialStegArrayManglendeInnbetaling";
+import { inngangSteg, vedtakOpphoerSteg } from "../../stegLister/stegListeManglendeInnbetalingFlyt";
 import { FellesHandlersContext } from "../../../../../contexts";
 
 interface Props {

--- a/src/sider/ftrl/saksbehandling/stegLister/stegListeIkkeYrkesaktivFlyt.tsx
+++ b/src/sider/ftrl/saksbehandling/stegLister/stegListeIkkeYrkesaktivFlyt.tsx
@@ -1,0 +1,52 @@
+import { FANE_STATUS } from "../../../../felleskomponenter/stegvelger";
+import { VurderingInngang } from "../stegKomponenter/vurderingInngang/vurderingInngang";
+import { VurderingPerioder } from "../stegKomponenter/vurderingPeriode/vurderingPerioder";
+import { VurderingBestemmelse } from "../stegKomponenter/vurderingBestemmelse/vurderingBestemmelse";
+import { VurderingVedtak } from "../stegKomponenter/vurderingVedtak/vurderingVedtak";
+
+const initialInngangSteg = {
+  id: "Inngang",
+  tittel: "Inngang",
+  stegPosisjon: 0,
+  status: FANE_STATUS.UBEHANDLET,
+  aktivtSteg: true,
+  vedtakSteg: false,
+  komponent: VurderingInngang,
+};
+
+const initialBestemmelseSteg = {
+  id: "Bestemmelse",
+  tittel: "Bestemmelse",
+  stegPosisjon: 1,
+  status: FANE_STATUS.UBEHANDLET,
+  aktivtSteg: false,
+  vedtakSteg: false,
+  komponent: VurderingBestemmelse,
+};
+
+const initialPeriodeSteg = {
+  id: "Perioder",
+  tittel: "Perioder",
+  stegPosisjon: 2,
+  status: FANE_STATUS.UBEHANDLET,
+  aktivtSteg: false,
+  vedtakSteg: false,
+  komponent: VurderingPerioder,
+};
+
+const initialVedtakSteg = {
+  id: "Vedtak",
+  tittel: "Vedtak",
+  stegPosisjon: 3,
+  status: FANE_STATUS.UBEHANDLET,
+  aktivtSteg: false,
+  vedtakSteg: true,
+  komponent: VurderingVedtak,
+};
+
+export const alleStegIkkeYrkesaktivFlyt = [
+  initialInngangSteg,
+  initialBestemmelseSteg,
+  initialPeriodeSteg,
+  initialVedtakSteg,
+];

--- a/src/sider/ftrl/saksbehandling/stegLister/stegListeManglendeInnbetalingFlyt.tsx
+++ b/src/sider/ftrl/saksbehandling/stegLister/stegListeManglendeInnbetalingFlyt.tsx
@@ -1,12 +1,12 @@
-import { FANE_STATUS } from "../../../felleskomponenter/stegvelger";
-import { VurderingInngang } from "./stegKomponenter/vurderingInngang/vurderingInngang";
-import { VurderingVirksomhet } from "./stegKomponenter/vurderingVirksomhet/vurderingVirksomhet";
-import { VurderingPerioder } from "./stegKomponenter/vurderingPeriode/vurderingPerioder";
-import { VurderingBestemmelse } from "./stegKomponenter/vurderingBestemmelse/vurderingBestemmelse";
-import { VurderingTrygdeavgift } from "./stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift";
-import { VurderingVedtak } from "./stegKomponenter/vurderingVedtak/vurderingVedtak";
-import { VurderingInngangManglendeInnbetaling } from "./stegKomponenter/vurderingInngangManglendeInnbetaling/vurderingInngangManglendeInnbetaling";
-import { VurderingVedtakOpphoer } from "./stegKomponenter/vurderingVedtakOpphoer/vurderingVedtakOpphoer";
+import { FANE_STATUS } from "../../../../felleskomponenter/stegvelger";
+import { VurderingInngang } from "../stegKomponenter/vurderingInngang/vurderingInngang";
+import { VurderingVirksomhet } from "../stegKomponenter/vurderingVirksomhet/vurderingVirksomhet";
+import { VurderingPerioder } from "../stegKomponenter/vurderingPeriode/vurderingPerioder";
+import { VurderingBestemmelse } from "../stegKomponenter/vurderingBestemmelse/vurderingBestemmelse";
+import { VurderingTrygdeavgift } from "../stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift";
+import { VurderingVedtak } from "../stegKomponenter/vurderingVedtak/vurderingVedtak";
+import { VurderingInngangManglendeInnbetaling } from "../stegKomponenter/vurderingInngangManglendeInnbetaling/vurderingInngangManglendeInnbetaling";
+import { VurderingVedtakOpphoer } from "../stegKomponenter/vurderingVedtakOpphoer/vurderingVedtakOpphoer";
 
 const inngangManglendeInnbetalingSteg = {
   id: "ManglendeInnbetalingInngang",
@@ -99,7 +99,7 @@ export const vedtakOpphoerSteg = {
 
 const stegFullstendigManglendeInnbetaling = [vedtakOpphoerSteg];
 
-export const alleStegManglendeInnbetaling = [
+export const alleStegManglendeInnbetalingFlyt = [
   inngangManglendeInnbetalingSteg,
   ...stegDelvisManglendeInnbetaling,
   ...stegFullstendigManglendeInnbetaling,

--- a/src/sider/ftrl/saksbehandling/stegLister/stegListeYrkesaktivFlyt.tsx
+++ b/src/sider/ftrl/saksbehandling/stegLister/stegListeYrkesaktivFlyt.tsx
@@ -1,10 +1,10 @@
-import { FANE_STATUS } from "../../../felleskomponenter/stegvelger";
-import { VurderingInngang } from "./stegKomponenter/vurderingInngang/vurderingInngang";
-import { VurderingVirksomhet } from "./stegKomponenter/vurderingVirksomhet/vurderingVirksomhet";
-import { VurderingPerioder } from "./stegKomponenter/vurderingPeriode/vurderingPerioder";
-import { VurderingBestemmelse } from "./stegKomponenter/vurderingBestemmelse/vurderingBestemmelse";
-import { VurderingTrygdeavgift } from "./stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift";
-import { VurderingVedtak } from "./stegKomponenter/vurderingVedtak/vurderingVedtak";
+import { FANE_STATUS } from "../../../../felleskomponenter/stegvelger";
+import { VurderingInngang } from "../stegKomponenter/vurderingInngang/vurderingInngang";
+import { VurderingVirksomhet } from "../stegKomponenter/vurderingVirksomhet/vurderingVirksomhet";
+import { VurderingPerioder } from "../stegKomponenter/vurderingPeriode/vurderingPerioder";
+import { VurderingBestemmelse } from "../stegKomponenter/vurderingBestemmelse/vurderingBestemmelse";
+import { VurderingTrygdeavgift } from "../stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift";
+import { VurderingVedtak } from "../stegKomponenter/vurderingVedtak/vurderingVedtak";
 
 const initialInngangSteg = {
   id: "Inngang",
@@ -66,7 +66,7 @@ const initialVedtakSteg = {
   komponent: VurderingVedtak,
 };
 
-export const alleSteg = [
+export const alleStegYrkesaktivFlyt = [
   initialInngangSteg,
   initialVirksomhetSteg,
   initialBestemmelseSteg,

--- a/src/sider/journalforing/komponenter/enkeltSak.jsx
+++ b/src/sider/journalforing/komponenter/enkeltSak.jsx
@@ -18,6 +18,7 @@ import "./enkeltSak.css";
 import { useFeatureToggle } from "../../../featuretoggle";
 import {
   MELOSYS_FOLKETRYGDEN_MVP,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
   MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
 } from "../../../featuretoggle/toggleNavn";
 
@@ -26,6 +27,7 @@ import {
 const EnkeltSak = (props) => {
   const folketrygdenToggleEnabled = useFeatureToggle(MELOSYS_FOLKETRYGDEN_MVP);
   const manglendeInnbetalingToggleEnabled = useFeatureToggle(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING);
+  const ikkeYrkesaktivFtrlToggleEnabled = useFeatureToggle(MELOSYS_FTRL_IKKE_YRKESAKTIV);
 
   const { landkoder } = props;
   const { behandlingOversikter, sakstype, saksnummer, sakstema } = props.sak;
@@ -46,7 +48,8 @@ const EnkeltSak = (props) => {
     behandlingstema.kode,
     behandlingstype.kode,
     folketrygdenToggleEnabled,
-    manglendeInnbetalingToggleEnabled
+    manglendeInnbetalingToggleEnabled,
+    ikkeYrkesaktivFtrlToggleEnabled
   );
 
   const avsluttendePeriode = sakstype.kode === MKV.Koder.sakstyper.FTRL ? medlemskapsperiode : lovvalgsperiode;

--- a/src/sider/journalforing/komponenter/opprettSak.jsx
+++ b/src/sider/journalforing/komponenter/opprettSak.jsx
@@ -42,7 +42,7 @@ export const skalViseSoknadsperiodeOgLand = (sakstype, sakstema, behandlingstema
   behandlingstype &&
   behandlingstema !== MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV &&
   behandlingstema !== MKV.Koder.behandlinger.behandlingstema.A1_ANMODNING_OM_UNNTAK_PAPIR &&
-  !skalViseIngenFlyt(sakstype, sakstema, behandlingstema, behandlingstype);
+  !skalViseIngenFlyt(sakstype, sakstema, behandlingstema, behandlingstype, false, false, false);
 
 export const OpprettSak = (props) => {
   const { settFeltInnhold, formValues, feltNavn } = props;

--- a/src/sider/sok/sok.tsx
+++ b/src/sider/sok/sok.tsx
@@ -13,7 +13,11 @@ import { sokOperations, sokSelectors } from "../../ducks/sok";
 
 import "./sok.css";
 import { useFeatureToggle } from "../../featuretoggle";
-import { MELOSYS_FOLKETRYGDEN_MVP, MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING } from "../../featuretoggle/toggleNavn";
+import {
+  MELOSYS_FOLKETRYGDEN_MVP,
+  MELOSYS_FTRL_IKKE_YRKESAKTIV,
+  MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING,
+} from "../../featuretoggle/toggleNavn";
 
 const mapStateToProps = (state: RootState) => ({
   sokResultat: sokSelectors.FagsakSokSelector(state),
@@ -36,6 +40,7 @@ export type SokProps = PropsFromRedux & {
 export const Sok = ({ sokResultat, children, sok, hentLandkoder, landkoder }: SokProps) => {
   const folketrygdenToggleEnabled = useFeatureToggle(MELOSYS_FOLKETRYGDEN_MVP);
   const manglendeInnbetalingToggleEnabled = useFeatureToggle(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING);
+  const ikkeYrkesaktivFtrlToggleEnabled = useFeatureToggle(MELOSYS_FTRL_IKKE_YRKESAKTIV);
   const sokefrase = sessionStorage.getItem("sokefrase");
 
   useEffect(() => {
@@ -84,6 +89,7 @@ export const Sok = ({ sokResultat, children, sok, hentLandkoder, landkoder }: So
                 radioGroupName="fagsaksortering"
                 folketrygdenToggleEnabled={folketrygdenToggleEnabled}
                 manglendeInnbetalingToggleEnabled={manglendeInnbetalingToggleEnabled}
+                ikkeYrkesaktivFtrlToggleEnabled={ikkeYrkesaktivFtrlToggleEnabled}
                 landkoder={landkoder}
               />
             )}

--- a/src/url/url.test.ts
+++ b/src/url/url.test.ts
@@ -117,7 +117,7 @@ describe("url", () => {
   });
 
   describe("tom flyt", () => {
-    it("Sakstype FTRL med IKKE_YRKESAKTIV får tom flyt med toggle på", () => {
+    it("Sakstype FTRL med IKKE_YRKESAKTIV får tom flyt med ftrl-ikkeYrkesaktiv-toggle av", () => {
       const url = lagUrl(
         "MEL-1",
         1,
@@ -126,13 +126,30 @@ describe("url", () => {
         MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV,
         MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG,
         true,
-        true
+        true,
+        false
       );
 
       expect(url).toContain("/FTRL/behandling/");
     });
 
-    it("IKKE_YRKESAKTIV får ikke tom flyt", () => {
+    it("Sakstype FTRL med IKKE_YRKESAKTIV får ikke tom flyt med ftrl-ikkeYrkesaktiv-toggle på", () => {
+      const url = lagUrl(
+        "MEL-1",
+        1,
+        FTRL,
+        MKV.Koder.sakstemaer.MEDLEMSKAP_LOVVALG,
+        MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV,
+        MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG,
+        true,
+        true,
+        true
+      );
+
+      expect(url).toContain("/FTRL/saksbehandling/");
+    });
+
+    it("Sakstype EU_EØS med IKKE_YRKESAKTIV får ikke tom flyt", () => {
       const url = lagUrl(
         "MEL-1",
         1,
@@ -140,6 +157,7 @@ describe("url", () => {
         MKV.Koder.sakstemaer.MEDLEMSKAP_LOVVALG,
         MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV,
         MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG,
+        true,
         true,
         true
       );
@@ -156,6 +174,7 @@ describe("url", () => {
         MKV.Koder.behandlinger.behandlingstema.TRYGDETID,
         MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG,
         true,
+        true,
         true
       );
 
@@ -171,13 +190,14 @@ describe("url", () => {
         MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV,
         MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG,
         true,
+        true,
         true
       );
 
       expect(url).toContain("/FTRL/saksbehandling/");
     });
 
-    it("YRKESAKTIV for FTRL får tom flyt med toggle av", () => {
+    it("YRKESAKTIV for FTRL får tom flyt med ftrl-toggle av", () => {
       const url = lagUrl(
         "MEL-1",
         1,
@@ -186,6 +206,7 @@ describe("url", () => {
         MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV,
         MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG,
         false,
+        true,
         true
       );
 
@@ -200,6 +221,7 @@ describe("url", () => {
         MKV.Koder.sakstemaer.UNNTAK,
         MKV.Koder.behandlinger.behandlingstema.REGISTRERING_UNNTAK,
         MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG,
+        true,
         true,
         true
       );

--- a/src/url/url.ts
+++ b/src/url/url.ts
@@ -34,6 +34,7 @@ const lagUrlForEuEøsFlyter = (saksnummer: number | string, behandlingID: number
 const lagUrlForFtrlFlyt = (saksnummer: number | string, behandlingID: number, behandlingstemaKode: string) => {
   switch (behandlingstemaKode) {
     case MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV:
+    case MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV:
       return `/${FTRL}/saksbehandling/${saksnummer}/?behandlingID=${behandlingID}`;
     default:
       return flytFinnesIkkeForBehandlingPath;
@@ -83,7 +84,8 @@ export const lagUrl = (
   behandlingstemaKode: string,
   behandlingstypeKode: string,
   folketrygdenToggleEnabled: boolean | undefined,
-  manglendeInnbetalingToggleEnabled: boolean | undefined
+  manglendeInnbetalingToggleEnabled: boolean | undefined,
+  ikkeYrkesaktivFtrlToggleEnabled: boolean | undefined
 ) => {
   if (
     skalViseIngenFlyt(
@@ -92,7 +94,8 @@ export const lagUrl = (
       behandlingstemaKode,
       behandlingstypeKode,
       folketrygdenToggleEnabled,
-      manglendeInnbetalingToggleEnabled
+      manglendeInnbetalingToggleEnabled,
+      ikkeYrkesaktivFtrlToggleEnabled
     )
   ) {
     return lagIngenFlytUrl(sakstypeKode, saksnummer, behandlingID);
@@ -132,7 +135,8 @@ export const skalViseIngenFlyt = (
   behandlingstema: string,
   behandlingstype: string,
   folketrygdenToggleEnabled: boolean = false,
-  manglendeInnbetalingToggleEnabled: boolean = false
+  manglendeInnbetalingToggleEnabled: boolean = false,
+  ikkeYrkesaktivFtrlToggleEnabled: boolean = false
 ) => {
   if (sakstema === MKV.Koder.sakstemaer.TRYGDEAVGIFT) {
     return true;
@@ -151,6 +155,13 @@ export const skalViseIngenFlyt = (
 
   if (harUnntaksregistreringFlyt(sakstype, sakstema, behandlingstema)) return false;
   if (harIkkeYrkesaktivFlyt(sakstype, behandlingstema)) return false;
+
+  if (
+    sakstype === FTRL &&
+    behandlingstema === MKV.Koder.behandlinger.behandlingstema.IKKE_YRKESAKTIV &&
+    ikkeYrkesaktivFtrlToggleEnabled
+  )
+    return false;
 
   if (
     sakstype === TRYGDEAVTALE &&


### PR DESCRIPTION
Legger til toggle
Sender saker med sakstype FTRL og behandlingstema IKKE_YRKESAKTIV til generell ftrl saksbehandling, siden flytene er meget like. 
Legger til stegliste for den nye flyten, og renamer litt på eksisterende kode.
Legger til toggle i all bruk av url-funksjoner som nå har fått ny toggle-parameter

Flyten kommer til å redirecte til ingen-flyt uten api-endring: https://github.com/navikt/melosys-api/pull/2235. Skriver ikke DAPI siden dette kan gå ut i prod uten hverandre (lenge til toggle slåes på og dette blir relevant)

[MELOSYS-6330](https://jira.adeo.no/browse/MELOSYS-6330)