### PR TITLE
6337 DAPI Nytt endepunkt for gyldige innvilgelsesresultat.

### DIFF
--- a/src/ducks/folketrygdenkodeverk/selectors.ts
+++ b/src/ducks/folketrygdenkodeverk/selectors.ts
@@ -12,14 +12,6 @@ export const FolketrygdenkodeverkDataSelector: Selector<RootState, Types.Data> =
   (folketrygdenkodeverk) => (folketrygdenkodeverk.data ? folketrygdenkodeverk.data : {})
 );
 
-export const VilkaarSelector = createSelector(FolketrygdenkodeverkDataSelector, (folketrygdenkodeverk) =>
-  folketrygdenkodeverk.Vilkaar ? folketrygdenkodeverk.Vilkaar : []
-);
-
 export const BegrunnelserSelector = createSelector(FolketrygdenkodeverkDataSelector, (folketrygdenkodeverk) =>
   folketrygdenkodeverk.begrunnelser ? folketrygdenkodeverk.begrunnelser : {}
-);
-
-export const InnvilgelsesResultatSelector = createSelector(FolketrygdenkodeverkDataSelector, (folketrygdenkodeverk) =>
-  folketrygdenkodeverk.InnvilgelsesResultat ? folketrygdenkodeverk.InnvilgelsesResultat : []
 );

--- a/src/services/modules/ftrl/gyldigeInnvilgelsesResultat.ts
+++ b/src/services/modules/ftrl/gyldigeInnvilgelsesResultat.ts
@@ -1,0 +1,5 @@
+import { getAsJson } from "../../utils";
+import { API_BASE_URL, FTRL } from "../../api-constants";
+
+export const hentGyldigeInnvilgelsesresultat = (behandlingstype: string): Promise<string[]> =>
+  getAsJson(`${API_BASE_URL}${FTRL}/innvilgelsesresultat/?behandlingstype=${behandlingstype}`);

--- a/src/services/modules/ftrl/index.ts
+++ b/src/services/modules/ftrl/index.ts
@@ -1,1 +1,2 @@
 export * from "./gyldigeTrygdedekninger";
+export * from "./gyldigeInnvilgelsesResultat";

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/komponenter/vilkaarOgBegrunnelser.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/komponenter/vilkaarOgBegrunnelser.tsx
@@ -25,7 +25,6 @@ interface VilkaarOgBegrunnelserProps {
   vilkårOgBegrunnelser: Api.MedlemAvFolketrygden.Bestemmelser.VilkårOgBegrunnelser;
   alleValgteVilkår: Map<string, string>;
   alleValgteBegrunnelser: Map<string, Begrunnelse>;
-  vilkårKodeverk: KTObject[];
   begrunnelseKodeverk: {
     [key: string]: KTObject[];
   };
@@ -39,7 +38,6 @@ export const VilkaarOgBegrunnelser = ({
   vilkårOgBegrunnelser: { vilkår, muligeBegrunnelser },
   alleValgteVilkår,
   alleValgteBegrunnelser,
-  vilkårKodeverk,
   begrunnelseKodeverk,
   handleEndreVilkår,
   handleEndreBegrunnelseKode,
@@ -59,7 +57,7 @@ export const VilkaarOgBegrunnelser = ({
       <Nav.Fieldset
         legend={
           <LabelMedHjelpetekst
-            label={KV.finnTermFraListe(vilkårKodeverk, vilkår)}
+            label={KV.finnTermFraListe(MKV.KTObjects.vilkaar, vilkår)}
             hjelpetekst={hjelpetekstForVilkaar}
           />
         }

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelse.tsx
@@ -54,7 +54,6 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
   const lagretBestemmelse = useSelector(medlemskapsperioderSelectors.BestemmelseSelector);
   const lagredeVilkår = useSelector(vilkarSelectors.VilkarSelector);
-  const vilkårKodeverk = useSelector(folketrygdenkodeverkSelectors.VilkaarSelector);
   const begrunnelseKodeverk = useSelector(folketrygdenkodeverkSelectors.BegrunnelserSelector);
   const trygdedekning = useSelector(mottatteOpplysningerSelectors.TrygdedekningSelector);
 
@@ -296,7 +295,6 @@ export const VurderingBestemmelse = ({ bekreft, tilbake, aktivtSteg, oppdaterSta
             vilkårOgBegrunnelser={vilkårOgBegrunnelser}
             alleValgteVilkår={valgteVilkår}
             alleValgteBegrunnelser={valgteBegrunnelser}
-            vilkårKodeverk={vilkårKodeverk}
             begrunnelseKodeverk={begrunnelseKodeverk}
             handleEndreVilkår={handleEndreVilkår}
             handleEndreBegrunnelseKode={handleEndreBegrunnelseKode}

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/medlemskapsperioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/medlemskapsperioder.tsx
@@ -1,5 +1,4 @@
 import { Control, FieldArrayWithId } from "react-hook-form";
-import { KTObject } from "@navikt/melosys-kodeverk";
 import * as Forms from "../../../../../../felleskomponenter/forms";
 import * as Ikoner from "../../../../../../resources/images";
 import * as Nav from "../../../../../../navFrontend";
@@ -17,7 +16,7 @@ const { PLIKTIG } = MKV.Koder.medlemskapstyper;
 export interface PeriodeElementerProps {
   redigerbart: boolean;
   trygdedekninger: string[];
-  innvilgelsesResultater: KTObject[];
+  innvilgelsesResultater: string[];
   control: Control;
   fields: FieldArrayWithId<FieldArrayProps, "medlemskapsperioder">[];
   handleSlett: (index: number) => void;
@@ -96,9 +95,9 @@ export const Medlemskapsperioder = ({
                   emptyFieldDisabled={!!field.innvilgelsesResultat}
                   onChange={(value) => handleChange([{ ...field, innvilgelsesResultat: value }], formIsValid, index)}
                 >
-                  {innvilgelsesResultater.map((item: KTObject) => (
-                    <option key={item.kode} value={item.kode}>
-                      {item.term}
+                  {innvilgelsesResultater.map((resultat) => (
+                    <option key={resultat} value={resultat}>
+                      {KV.kodeTilTerm(resultat, MKV.KTObjects.innvilgelsesResultat)}
                     </option>
                   ))}
                 </Forms.Select>

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
@@ -16,7 +16,6 @@ import {
   medlemskapsperioderSelectors,
   medlemskapsperioderTypes,
 } from "../../../../../ducks/medlemskapsperioder";
-import { folketrygdenkodeverkSelectors } from "../../../../../ducks/folketrygdenkodeverk";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 
 import { Medlemskapsperioder } from "./komponenter/medlemskapsperioder";
@@ -69,6 +68,7 @@ const mapInitialMedlemskapsperioder = (
 export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus }: VurderingPerioderProps) => {
   const dispatch = useDispatch();
   const [lovligeDekninger, setLovligeDekninger] = useState<string[]>([]);
+  const [lovligeInnvilgelsesresultat, setLovligeInnvilgelsesresultat] = useState<string[]>([]);
 
   const begrensePeriodeVedtakToggleEnabled = useFeatureToggle(MELOSYS_FTRL_BEGRENSE_PERIODE_VEDTAK);
   const manglendeInnbetalingToggleEnabled = useFeatureToggle(MELOSYS_SAKSBEHANDLING_MANGLENDE_INNBETALING);
@@ -76,7 +76,6 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
   const lagredeMedlemskapsperioder = useSelector(medlemskapsperioderSelectors.AlleMedlemskapsperioderSelector);
   const behandlingstype = useSelector(behandlingerSelectors.BehandlingstypeKodeSelector);
-  const innvilgelsesResultater = useSelector(folketrygdenkodeverkSelectors.InnvilgelsesResultatSelector);
   const soknadsperiode = useSelector(mottatteOpplysningerSelectors.PeriodeSelector);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
   const lagretBestemmelse = useSelector(medlemskapsperioderSelectors.BestemmelseSelector);
@@ -106,12 +105,6 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
     name: "medlemskapsperioder",
   });
   const formValues = watch();
-
-  const gyldigeInnvilgelsesResultat = innvilgelsesResultater.filter(
-    (kt) =>
-      kt.kode !== OPPHØRT ||
-      (manglendeInnbetalingToggleEnabled && behandlingstype === MANGLENDE_INNBETALING_TRYGDEAVGIFT)
-  );
 
   const aktivFeilmeldingType = finnAktivFeilmelding(
     formValues?.medlemskapsperioder,
@@ -143,6 +136,7 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
 
   useEffect(() => {
     Api.LovligeKombinasjoner.hentTrygdedekninger(lagretBestemmelse).then(setLovligeDekninger);
+    Api.Ftrl.hentGyldigeInnvilgelsesresultat(behandlingstype).then(setLovligeInnvilgelsesresultat);
   }, [lagretBestemmelse]);
 
   const lagreMedlemskapsperiode = async (medlemskapsperiode: MedlemskapsperiodeProp, index: number) => {
@@ -248,7 +242,7 @@ export const VurderingPerioder = ({ bekreft, tilbake, aktivtSteg, oppdaterStatus
 
       <Medlemskapsperioder
         trygdedekninger={lovligeDekninger}
-        innvilgelsesResultater={gyldigeInnvilgelsesResultat}
+        innvilgelsesResultater={lovligeInnvilgelsesresultat}
         control={control}
         fields={fields}
         handleSlett={handleSlett}


### PR DESCRIPTION
Nytt endepunkt for gyldige innvilgelsesresultat.
Flytter også vilkår bort siden vi bare kan bruke MKV til å hente disse. Den er kun brukt til å finne term, ikke til noe visningslogikk.

[MELOSYS-6337](https://jira.adeo.no/browse/MELOSYS-6337)

DAPI: https://github.com/navikt/melosys-api/pull/2244