### PR TITLE
NOJIRA Oppdaterer behandlingsmenyens visningslogikk

### DIFF
--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
@@ -399,6 +399,7 @@ describe("AvsluttSak", () => {
     it(`viser Unntak-handlinger dersom behandlingstema er ${ANMODNING_OM_UNNTAK_HOVEDREGEL} og sakstype er ${TRYGDEAVTALE}`, async () => {
       props.behandlingstema = ANMODNING_OM_UNNTAK_HOVEDREGEL;
       props.sakstype = TRYGDEAVTALE;
+      props.sakstema = UNNTAK;
       renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
 
       const user = userEvent.setup();
@@ -413,6 +414,7 @@ describe("AvsluttSak", () => {
     it(`viser Unntak-handlinger dersom behandlingstema er ${REGISTRERING_UNNTAK} og sakstype er ${TRYGDEAVTALE}`, async () => {
       props.behandlingstema = REGISTRERING_UNNTAK;
       props.sakstype = TRYGDEAVTALE;
+      props.sakstema = UNNTAK;
       renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
 
       const user = userEvent.setup();
@@ -427,6 +429,7 @@ describe("AvsluttSak", () => {
     it(`viser Unntak-handlinger dersom behandlingstema er ${A1_ANMODNING_OM_UNNTAK_PAPIR} og sakstype er ${EU_EOS}`, async () => {
       props.behandlingstema = A1_ANMODNING_OM_UNNTAK_PAPIR;
       props.sakstype = EU_EOS;
+      props.sakstema = UNNTAK;
       renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
 
       const user = userEvent.setup();

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
@@ -23,9 +23,10 @@ const {
   ARBEID_FLERE_LAND,
   A1_ANMODNING_OM_UNNTAK_PAPIR,
 } = MKV.Koder.behandlinger.behandlingstema;
-const { NY_VURDERING, FØRSTEGANG, KLAGE, HENVENDELSE } = MKV.Koder.behandlinger.behandlingstyper;
+const { NY_VURDERING, FØRSTEGANG, KLAGE, HENVENDELSE, MANGLENDE_INNBETALING_TRYGDEAVGIFT } =
+  MKV.Koder.behandlinger.behandlingstyper;
 const { EU_EOS, FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
-const { MEDLEMSKAP_LOVVALG } = MKV.Koder.sakstemaer;
+const { MEDLEMSKAP_LOVVALG, UNNTAK } = MKV.Koder.sakstemaer;
 
 const AvsluttSak = () => {
   const dispatch = useDispatch();
@@ -36,11 +37,6 @@ const AvsluttSak = () => {
   const sakstema = useSelector(fagsakSelectors.SakstemaKodeSelector);
   const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const behandlingstype = useSelector(behandlingerSelectors.BehandlingstypeKodeSelector);
-
-  const behandlingstypeErNyVurdering = behandlingstype === NY_VURDERING;
-  const behandlingstypeErKlage = behandlingstype === KLAGE;
-  const behandlingstemaErUnntak =
-    behandlingstema === ANMODNING_OM_UNNTAK_HOVEDREGEL || behandlingstema === REGISTRERING_UNNTAK;
 
   const skalViseAvslåPgaManglendeOpplysninger = () => {
     if (!redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) return false;
@@ -67,7 +63,7 @@ const AvsluttSak = () => {
     }
     if (sakstype === TRYGDEAVTALE) {
       return (
-        ![HENVENDELSE, KLAGE].includes(behandlingstype) &&
+        [FØRSTEGANG, NY_VURDERING].includes(behandlingstype) &&
         [YRKESAKTIV, IKKE_YRKESAKTIV, PENSJONIST].includes(behandlingstema)
       );
     }
@@ -75,8 +71,109 @@ const AvsluttSak = () => {
     return false;
   };
 
-  const skalViseBehandlingenErHenlagt = () => {
+  const skalViseSøknadKlagenErTrukket = () => {
     if (!redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) return false;
+
+    if (sakstype === EU_EOS) {
+      return (
+        [FØRSTEGANG, NY_VURDERING, MANGLENDE_INNBETALING_TRYGDEAVGIFT].includes(behandlingstype) &&
+        [
+          UTSENDT_ARBEIDSTAKER,
+          UTSENDT_SELVSTENDIG,
+          ARBEID_TJENESTEPERSON_ELLER_FLY,
+          ARBEID_FLERE_LAND,
+          IKKE_YRKESAKTIV,
+          ARBEID_KUN_NORGE,
+          PENSJONIST,
+        ].includes(behandlingstema)
+      );
+    }
+    if (sakstype === FTRL) {
+      return (
+        [FØRSTEGANG, NY_VURDERING, MANGLENDE_INNBETALING_TRYGDEAVGIFT].includes(behandlingstype) &&
+        [YRKESAKTIV, IKKE_YRKESAKTIV, PENSJONIST, UNNTAK_MEDLEMSKAP].includes(behandlingstema)
+      );
+    }
+    if (sakstype === TRYGDEAVTALE) {
+      return (
+        [FØRSTEGANG, NY_VURDERING, MANGLENDE_INNBETALING_TRYGDEAVGIFT].includes(behandlingstype) &&
+        [YRKESAKTIV, IKKE_YRKESAKTIV, PENSJONIST].includes(behandlingstema)
+      );
+    }
+
+    return false;
+  };
+
+  const skalViseBehandlingenErBortfalt = () => redigerbart;
+
+  const skalViseFerdigbehandlet = () => {
+    switch (behandlingstema) {
+      case BESLUTNING_LOVVALG_NORGE:
+      case UTSENDT_ARBEIDSTAKER:
+      case UTSENDT_SELVSTENDIG:
+      case ARBEID_TJENESTEPERSON_ELLER_FLY:
+      case ARBEID_FLERE_LAND:
+        return (
+          redigerbart &&
+          sakstype === EU_EOS &&
+          [NY_VURDERING, HENVENDELSE, MANGLENDE_INNBETALING_TRYGDEAVGIFT].includes(behandlingstema)
+        );
+      default:
+        return redigerbart;
+    }
+  };
+
+  const skalViseKlageHandlinger = redigerbart && behandlingstype === KLAGE;
+
+  const skalViseVedtakOmgjort = () => {
+    if (!redigerbart) return false;
+
+    if (sakstype === EU_EOS) {
+      return (
+        behandlingstype === NY_VURDERING &&
+        [
+          BESLUTNING_LOVVALG_NORGE,
+          UTSENDT_ARBEIDSTAKER,
+          UTSENDT_SELVSTENDIG,
+          ARBEID_TJENESTEPERSON_ELLER_FLY,
+          ARBEID_FLERE_LAND,
+          IKKE_YRKESAKTIV,
+          ARBEID_KUN_NORGE,
+          PENSJONIST,
+          YRKESAKTIV,
+        ].includes(behandlingstema)
+      );
+    }
+    if (sakstype === FTRL) {
+      return behandlingstype === NY_VURDERING;
+    }
+    if (sakstype === TRYGDEAVTALE) {
+      return behandlingstype === NY_VURDERING && [YRKESAKTIV, IKKE_YRKESAKTIV, PENSJONIST].includes(behandlingstema);
+    }
+
+    return false;
+  };
+
+  const skalViseUnntaksHandlinger = () => {
+    if (!redigerbart || sakstema !== UNNTAK) return false;
+
+    if (sakstype === EU_EOS) {
+      return [FØRSTEGANG, NY_VURDERING].includes(behandlingstype) && behandlingstema === A1_ANMODNING_OM_UNNTAK_PAPIR;
+    }
+    if (sakstype === TRYGDEAVTALE) {
+      return (
+        [FØRSTEGANG, NY_VURDERING].includes(behandlingstype) &&
+        [ANMODNING_OM_UNNTAK_HOVEDREGEL, REGISTRERING_UNNTAK].includes(behandlingstema)
+      );
+    }
+
+    return false;
+  };
+
+  const skalViseSøknadenErInnvilget = () => {
+    if (!redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) {
+      return false;
+    }
 
     if (sakstype === EU_EOS) {
       return (
@@ -85,7 +182,6 @@ const AvsluttSak = () => {
           UTSENDT_ARBEIDSTAKER,
           UTSENDT_SELVSTENDIG,
           ARBEID_TJENESTEPERSON_ELLER_FLY,
-          ARBEID_FLERE_LAND,
           IKKE_YRKESAKTIV,
           ARBEID_KUN_NORGE,
           PENSJONIST,
@@ -100,7 +196,7 @@ const AvsluttSak = () => {
     }
     if (sakstype === TRYGDEAVTALE) {
       return (
-        ![HENVENDELSE, KLAGE].includes(behandlingstype) &&
+        [FØRSTEGANG, NY_VURDERING].includes(behandlingstype) &&
         [YRKESAKTIV, IKKE_YRKESAKTIV, PENSJONIST].includes(behandlingstema)
       );
     }
@@ -108,92 +204,18 @@ const AvsluttSak = () => {
     return false;
   };
 
-  const skalViseBehandlingenErBortfalt = () => {
-    return redigerbart;
-  };
-
-  const skalViseFerdigbehandlet = () => {
-    switch (behandlingstema) {
-      case BESLUTNING_LOVVALG_NORGE:
-      case UTSENDT_ARBEIDSTAKER:
-      case UTSENDT_SELVSTENDIG:
-      case ARBEID_TJENESTEPERSON_ELLER_FLY:
-      case ARBEID_FLERE_LAND:
-        return redigerbart && (behandlingstypeErNyVurdering || behandlingstype === HENVENDELSE);
-      default:
-        return redigerbart;
-    }
-  };
-
-  const skalViseKlageHandlinger = redigerbart && behandlingstypeErKlage;
-
-  const skalViseVedtakOmgjort = redigerbart && behandlingstypeErNyVurdering;
-
-  const skalViseUnntaksHandlinger =
-    redigerbart &&
-    ((behandlingstemaErUnntak && sakstype === TRYGDEAVTALE) ||
-      (behandlingstema === A1_ANMODNING_OM_UNNTAK_PAPIR && sakstype === EU_EOS));
-
-  const skalViseSøknadenErInnvilget = () => {
-    if (!redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) {
-      return false;
-    }
-    if (
-      sakstype === FTRL &&
-      [FØRSTEGANG, NY_VURDERING].includes(behandlingstype) &&
-      [YRKESAKTIV, IKKE_YRKESAKTIV, PENSJONIST, UNNTAK_MEDLEMSKAP].includes(behandlingstema)
-    ) {
-      return true;
-    }
-    if (
-      [EU_EOS, TRYGDEAVTALE].includes(sakstype) &&
-      [FØRSTEGANG, NY_VURDERING].includes(behandlingstype) &&
-      [
-        YRKESAKTIV,
-        IKKE_YRKESAKTIV,
-        PENSJONIST,
-        ARBEID_KUN_NORGE,
-        UTSENDT_ARBEIDSTAKER,
-        UTSENDT_SELVSTENDIG,
-        ARBEID_TJENESTEPERSON_ELLER_FLY,
-      ].includes(behandlingstema)
-    ) {
-      return true;
-    }
-
-    return false;
-  };
-
-  const skalViseSøknadenErAvslått = () => {
-    if (!redigerbart || sakstema !== MEDLEMSKAP_LOVVALG) {
-      return false;
-    }
-
-    return (
-      [FØRSTEGANG, NY_VURDERING].includes(behandlingstype) &&
-      [
-        ARBEID_TJENESTEPERSON_ELLER_FLY,
-        ARBEID_KUN_NORGE,
-        YRKESAKTIV,
-        IKKE_YRKESAKTIV,
-        PENSJONIST,
-        UNNTAK_MEDLEMSKAP,
-        UTSENDT_ARBEIDSTAKER,
-        UTSENDT_SELVSTENDIG,
-      ].includes(behandlingstema)
-    );
-  };
+  const skalViseSøknadenErAvslått = () => skalViseSøknadenErInnvilget();
 
   const skalKunneAngiBehandlingsresultat =
     skalViseSøknadenErInnvilget() ||
     skalViseSøknadenErAvslått() ||
     skalViseAvslåPgaManglendeOpplysninger() ||
-    skalViseVedtakOmgjort ||
+    skalViseVedtakOmgjort() ||
     skalViseKlageHandlinger ||
-    skalViseUnntaksHandlinger;
+    skalViseUnntaksHandlinger();
 
   if (
-    !skalViseBehandlingenErHenlagt() &&
+    !skalViseSøknadKlagenErTrukket() &&
     !skalViseBehandlingenErBortfalt() &&
     !skalViseFerdigbehandlet() &&
     !skalKunneAngiBehandlingsresultat
@@ -235,13 +257,13 @@ const AvsluttSak = () => {
               onClick={() => dispatch(modalerOperations.visAvslagSoknad())}
             />
           )}
-          {skalViseVedtakOmgjort && (
+          {skalViseVedtakOmgjort() && (
             <Handling
               tekst="Vedtaket er omgjort (fvl § 35)"
               onClick={() => apneBekreftValgModal(BekreftValgTypes.VEDTAKET_ER_OMGJORT)}
             />
           )}
-          {skalViseUnntaksHandlinger && (
+          {skalViseUnntaksHandlinger() && (
             <>
               <Handling
                 tekst="Perioden er godkjent"
@@ -263,7 +285,7 @@ const AvsluttSak = () => {
       {skalViseFerdigbehandlet() && (
         <Handling tekst="Ferdigbehandlet" onClick={() => apneBekreftValgModal(BekreftValgTypes.FERDIGBEHANDLET)} />
       )}
-      {skalViseBehandlingenErHenlagt() && (
+      {skalViseSøknadKlagenErTrukket() && (
         <Handling tekst="Søknaden/klagen er trukket" onClick={() => dispatch(modalerOperations.visHenlegg())} />
       )}
       {skalViseBehandlingenErBortfalt() && (

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.tsx
@@ -116,7 +116,7 @@ const AvsluttSak = () => {
         return (
           redigerbart &&
           sakstype === EU_EOS &&
-          [NY_VURDERING, HENVENDELSE, MANGLENDE_INNBETALING_TRYGDEAVGIFT].includes(behandlingstema)
+          [NY_VURDERING, HENVENDELSE, MANGLENDE_INNBETALING_TRYGDEAVGIFT].includes(behandlingstype)
         );
       default:
         return redigerbart;


### PR DESCRIPTION
Oppdaterer behandlingsmenyens visningslogikk til å matche oppdatert logikk fra confluence. Ble relevant når MANGLENDE_INBETALING_TRYGDEAVGIFT kom inn i bildet og vi hadde flere != sjekker på behandlingstype.

https://confluence.adeo.no/display/TEESSI/Behandlingsmenyen+i+Melosys