### PR TITLE
6330 Bugs inngang steget ikke-yrkesaktiv

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.less
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.less
@@ -28,6 +28,10 @@
     margin-bottom: 2rem;
   }
 
+  .trygdedekning {
+    min-width: 18rem !important;
+  }
+
   .land_wrapper {
     margin-left: 1rem !important;
     min-width: 14rem !important;

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.less
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.less
@@ -52,7 +52,7 @@
   }
 
   .alert {
-    margin-bottom: 0.5rem;
+    margin-bottom: 1rem;
   }
   .hjelpetekst {
     width: 20px;

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -232,7 +232,7 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
             </Nav.Column>
           )}
 
-          <Nav.Column>
+          <Nav.Column className="trygdedekning">
             <Forms.Select
               name="trygdedekning"
               control={control}

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -139,9 +139,9 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
 
   if (!aktivtSteg) return null;
 
-  const valgtLandHarTrygdeavtaleMedNorgeEllerErEøsLand = formValues.land
-    ? MKV.Kodekombinasjoner.unikeAvtalelandKoder.includes(formValues.land)
-    : false;
+  const valgtLandHarTrygdeavtaleMedNorgeEllerErEøsLand = [...formValues.land, formValues.arbeidsland].some(
+    (land) => land && MKV.Kodekombinasjoner.unikeAvtalelandKoder.includes(land)
+  );
   const flereLandUkjentHvilkeErUSANN = formValues.flereLandUkjentHvilke === BOOLSK_STRING.USANN;
   const erNyVurdering = behandlingstype === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING;
   const nyVurderingPeriodetekst =
@@ -250,6 +250,12 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
         </Nav.Row>
       </div>
 
+      {valgtLandHarTrygdeavtaleMedNorgeEllerErEøsLand && (
+        <Nav.AlertStripeAdvarsel className="alert">
+          Ett eller flere av landene du har valgt er EØS- eller avtaleland
+        </Nav.AlertStripeAdvarsel>
+      )}
+
       <Nav.Row>
         <Forms.Checkbox
           className="inkluderSiste5Aar"
@@ -260,16 +266,6 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
           disabled={!redigerbart}
         />
       </Nav.Row>
-      {valgtLandHarTrygdeavtaleMedNorgeEllerErEøsLand && (
-        <Nav.Row>
-          <Nav.Column xs="4" />
-          <Nav.Column xs="3">
-            <Nav.AlertStripeAdvarsel>
-              Landet er et EØS-land og/eller et land Norge har trygdeavtale med
-            </Nav.AlertStripeAdvarsel>
-          </Nav.Column>
-        </Nav.Row>
-      )}
 
       <Mui.StegKnapper
         bekreftKnappProps={{

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -61,7 +61,9 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
     tom: Utils.dato.formatterDatoTilNorsk(søknadsperiode?.tom, false, undefined),
     arbeidsland: søknadsland.landkoder.toString(),
     land: søknadsland.landkoder || [],
-    flereLandUkjentHvilke: Utils.streng.boolTilUppercaseStreng(søknadsland.erUkjenteEllerAlleEosLand ?? false),
+    flereLandUkjentHvilke: registeropplysningerHentet
+      ? Utils.streng.boolTilUppercaseStreng(søknadsland.erUkjenteEllerAlleEosLand)
+      : null,
     trygdedekning: useSelector(mottatteOpplysningerSelectors.TrygdedekningSelector) ?? "",
     inkluderSiste5Aar: useSelector(modalerSelectors.InkluderSiste5AarSelector),
   };


### PR DESCRIPTION
Når man først går inn på steget skal man ikke ha fylt ut flereLandUkjentHvilke enda. Legger derfor med sjekk på registeropplysningerHentet siden disse hentes samtidig som man lagrer mottatteopplysnigner.

Fikser også brukket logikk for andre-avtaler-feilmeldingen og flyttet den etter avklaring med UX.

Justerte min-width-en til trygdedekning

[MELOSYS-6330](https://jira.adeo.no/browse/MELOSYS-6330)