### PR TITLE
5794 Viser feilmelding fra beregningsmodul i trygdeavgiftssteg

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -164,7 +164,7 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
 
     if (ingenGjeldendeSats) return feilmelding;
 
-    return error.body?.message || error;
+    return error.body?.feilkoder || error.body?.message || error;
   };
 
   const debouncedLagreTrygdeavgiftsgrunnlag = useCallback(


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-5794
Feilmeldingen som mottas fra beregningsmodul ligger i feilkoder så prioriterer å vise den fremfor message
Response på https://github.com/navikt/melosys-trygdeavgift-beregning/pull/273