### PR TITLE
6430 DAPI TOGGLE Feilmelding bestemmelse

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelseNY.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/vurderingBestemmelseNY.tsx
@@ -82,10 +82,18 @@ export const VurderingBestemmelserV2 = ({
     lagredeValgtevirksomheter.includes(virksomhet.orgnr)
   );
   const finnesISelvstendigNaeringsvirksomhetUtland = selvstendigNaeringsvirksomhetUtland.some((virksomhet: any) =>
-    lagredeValgtevirksomheter.includes(virksomhet.orgnr)
+    lagredeValgtevirksomheter.includes(virksomhet.uuid)
   );
 
-  const selvstendigNaeringValgt = finnesISelvstendigNaeringsvirksomhet || finnesISelvstendigNaeringsvirksomhetUtland;
+  const alleSelvstendigeVirksomheter = [...selvstendigNaeringsvirksomhetUtland, ...selvstendigNaeringsvirksomhet];
+
+  const valgteVirksomheterSomIkkeErSelvstendig = lagredeValgtevirksomheter.filter(
+    (orgnr) => !alleSelvstendigeVirksomheter.find((virksomhet) => (virksomhet.uuid ?? virksomhet.orgnr) === orgnr)
+  );
+
+  const selvstendigNaeringValgt =
+    (finnesISelvstendigNaeringsvirksomhet || finnesISelvstendigNaeringsvirksomhetUtland) &&
+    Utils._isEmpty(valgteVirksomheterSomIkkeErSelvstendig);
 
   const ulovligKombinasjonAvSelvstendigNaeringOgVilkår =
     selvstendigNaeringValgt && valgteVilkår.get(MKV.Koder.vilkaar.FTRL_ARBEIDSTAKER);


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6430

En ekstra kriterie fra samtale med Annette:

Avklart med Mina at det ikke skal gis feilmelding på spørsmålet om søker er arbeidstaker om det er valgt flere virksomheter på virksomhetssteget og minst én er en arbeidsgiver (både norsk og utenlandsk).
Nå får jeg feil om jeg både velger en arbeidsgiver i Norge og selvstendig virksomhet i Norge, men da skal jeg altså kunne gå videre. Det har ikke vært presisert tidligere.