### PR TITLE
NO_JIRA TOGGLE Endrer tekst på avklartefakta tittel

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/komponenter/typer.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingBestemmelse/komponenter/typer.tsx
@@ -11,7 +11,7 @@ export const FaktaTypeOverskrifter: Record<string, FaktaType> = {
     kodeverk: "ikkeyrkesaktivrelasjontype",
   },
   IKKE_YRKESAKTIV_FTRL_2_1_OPPHOLD: {
-    tittel: "Angi brukers opphold",
+    tittel: "Angi brukers situasjon",
     kodeverk: "ikkeyrkesaktivoppholdtype",
   },
   ARBEIDSSITUASJON: {


### PR DESCRIPTION
I kodeverk har den en type selv, men tittelen skal være annerledes:

https://confluence.adeo.no/display/TEESSI/Spesifikke+kodeverk+FTRL#SpesifikkekodeverkFTRL-IkkeYrkesaktivOppholdType

Margareth: jeg oppdaget ved en tilfeldighet en liten feil på bestemmelsesteget på i FTRL ikke-yrkesaktiv flyt som jeg tror kommer av endring i forbindelse med endringer på bestemmelsesteget i FTRL yrkesaktiv flyten
I begge flytene skal det stå "Angi brukers situasjon", men nå står det "Angi brukers opphold"