### PR TITLE
NOJIRA spinner cursor når forhåndsvisning av brev holder på

### DIFF
--- a/src/felleskomponenter/dokumentliste/dokumentliste.less
+++ b/src/felleskomponenter/dokumentliste/dokumentliste.less
@@ -4,6 +4,10 @@
 .dokumentliste {
   margin: 1em 0;
 
+  .pending {
+    cursor: wait;
+  }
+
   .varsel {
     margin: 1em 0;
   }

--- a/src/felleskomponenter/dokumentliste/dokumentliste.tsx
+++ b/src/felleskomponenter/dokumentliste/dokumentliste.tsx
@@ -20,6 +20,7 @@ import {
 
 const Dokumentliste = ({ behandlingID, dokumenter, validateOnClick }: DokumentlisteType) => {
   const [feilmelding, setFeilmelding] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
 
   const klikk = async (
     dokument: BrevDokumentMetadataType | SedDokumentMetadataType,
@@ -32,6 +33,7 @@ const Dokumentliste = ({ behandlingID, dokumenter, validateOnClick }: Dokumentli
       if (!validert) return;
     }
 
+    setPending(true);
     let fileURL;
     try {
       if (isSed(dokument)) {
@@ -66,6 +68,7 @@ const Dokumentliste = ({ behandlingID, dokumenter, validateOnClick }: Dokumentli
       await apnePdfINyFane(fileURL);
       setFeilmelding(null);
     }
+    setPending(false);
   };
 
   const tittel = (dokumentnavn: string) => `${dokumentnavn} (åpnes i ny fane)`;
@@ -73,7 +76,7 @@ const Dokumentliste = ({ behandlingID, dokumenter, validateOnClick }: Dokumentli
   const mapBrev = (dokument: BrevDokumentMetadataType) => (
     <Table.Row key={Utils._uuid()}>
       <Table.DataCell>
-        <Nav.Lenker href="#" onClick={(event) => klikk(dokument, event)}>
+        <Nav.Lenker href="#" onClick={(event) => klikk(dokument, event)} className={pending ? "pending" : ""}>
           {tittel(
             dokument.dokumentNavn ??
               KV.kodeTilTerm(dokument.dokumentData?.produserbardokument, MKV.KTObjects.brev.produserbaredokumenter)
@@ -87,7 +90,7 @@ const Dokumentliste = ({ behandlingID, dokumenter, validateOnClick }: Dokumentli
   const mapSED = (dokument: SedDokumentMetadataType) => (
     <Table.Row key={Utils._uuid()}>
       <Table.DataCell>
-        <Nav.Lenker href="#" onClick={(event) => klikk(dokument, event)}>
+        <Nav.Lenker href="#" onClick={(event) => klikk(dokument, event)} className={pending ? "pending" : ""}>
           {tittel(dokument.dokumentNavn || `SED ${dokument.sedType}`)}
         </Nav.Lenker>
       </Table.DataCell>
@@ -102,7 +105,7 @@ const Dokumentliste = ({ behandlingID, dokumenter, validateOnClick }: Dokumentli
   };
 
   return (
-    <div>
+    <div className="dokumentliste">
       <Table size="small">
         <Table.Header>
           <Table.Row>

--- a/src/felleskomponenter/sideDialog/sideDialog.tsx
+++ b/src/felleskomponenter/sideDialog/sideDialog.tsx
@@ -130,7 +130,7 @@ const SideDialog = ({
             </Tabs.List>
           </nav>
           {tabs.map((tab) => (
-            <Tabs.Panel value={tab.navn}>
+            <Tabs.Panel key={Utils._uuid()} value={tab.navn}>
               <FaneViser
                 navn={tab.navn}
                 saksnummer={saksnummer}


### PR DESCRIPTION
Prøver meg på forbedring av brukervennlighet når brev tar så lang tid at man føler man må trykke to ganger for å forhåndsvise brev. Under lokal testing ser det ut som om noen kall til forhåndsvisning bare går ekstremt sakte, men at den dukker opp etterhvert. 

Det er tillatt å trykke to ganger, selv om den viser spinner-cursor.

Thoughts?