### PR TITLE
6502 TOGGLE DAPI FTRL_2_9_TREDJE_LEDD_YRKESSKADE er en gyldig kode

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -96,7 +96,13 @@ export const VurderingInngang = ({ bekreft, aktivtSteg, oppdaterStatus }: Props)
     formValues.trygdedekning !== initialValues.trygdedekning;
 
   useEffect(() => {
-    Api.Ftrl.hentGyldigeTrygdedekninger(behandlingstema).then(setGyldigeTrygdedekninger);
+    Api.Ftrl.hentGyldigeTrygdedekninger(behandlingstema).then((trygdedekninger) =>
+      setGyldigeTrygdedekninger(
+        trygdedekninger.filter(
+          (trygdedekning) => trygdedekning !== MKV.Koder.trygdedekninger.FTRL_2_9_TREDJE_LEDD_YRKESSKADE
+        )
+      )
+    );
   }, []);
 
   const stegErGyldig = formIsValid && !skalHenteRegisteropplysninger && !behandlingUnderOppfriskning;


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6502
FTRL_2_9_TREDJE_LEDD_YRKESSKADE er en gyldig kode men skal ikke være tilgjengelig i inngangssteget. Så må filtrere bort nå som den mottas fra api: https://github.com/navikt/melosys-api/pull/2350