### PR TITLE
5882 DAPI La til feilhåndtering i behandlingsmenyen

### DIFF
--- a/src/felleskomponenter/dialogboks/bekreftValg/dialogboksBekreftValg.less
+++ b/src/felleskomponenter/dialogboks/bekreftValg/dialogboksBekreftValg.less
@@ -4,4 +4,8 @@
   .normaltekst {
     margin: 0.5em 0 1.5em;
   }
+
+  .feilmelding {
+    margin-bottom: 0.5rem;
+  }
 }

--- a/src/felleskomponenter/dialogboks/bekreftValg/dialogboksBekreftValg.tsx
+++ b/src/felleskomponenter/dialogboks/bekreftValg/dialogboksBekreftValg.tsx
@@ -12,6 +12,7 @@ import { modalerOperations, modalerSelectors } from "../../../ducks/modaler";
 import Knapperad from "../../knapperad";
 
 import "./dialogboksBekreftValg.css";
+import { useState } from "react";
 
 const { UNNTAK_MEDLEMSKAP } = MKV.Koder.behandlinger.behandlingstema;
 const { EU_EOS, FTRL, TRYGDEAVTALE } = MKV.Koder.sakstyper;
@@ -34,14 +35,15 @@ interface DialogboksBekreftValgProps {
 
 export const DialogboksBekreftValg = ({ ariaHideApp = true }: DialogboksBekreftValgProps) => {
   const dispatch = useDispatch();
+  const [feil, setFeil] = useState(undefined);
 
   const saksnummer = useSelector(fagsakSelectors.SaksnummerSelector);
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
   const sakstype = useSelector(fagsakSelectors.SakstypeKodeSelector);
   const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const bekreftValgType = useSelector(modalerSelectors.BekreftValgTypeSelector);
+
   const skjulModal = () => dispatch(modalerOperations.skjulBekreftValg());
-  const tilForsiden = () => dispatch(navigeringOperations.tilForsiden());
 
   const mapType = () => {
     switch (sakstype) {
@@ -55,29 +57,19 @@ export const DialogboksBekreftValg = ({ ariaHideApp = true }: DialogboksBekreftV
     }
   };
 
-  const avsluttSakSomBortfalt = async () => {
-    await Api.Fagsaker.fagsak.bortfall(saksnummer);
-    skjulModal();
-    tilForsiden();
-  };
+  const håndterKall = (kallPromise: Promise<any>) =>
+    kallPromise
+      .then(() => {
+        skjulModal();
+        dispatch(navigeringOperations.tilForsiden());
+      })
+      .catch((error) => setFeil(error?.body?.message ?? error));
 
-  const ferdigbehandleSak = async () => {
-    await Api.Fagsaker.fagsak.ferdigbehandleSak(saksnummer);
-    skjulModal();
-    tilForsiden();
-  };
-
-  const angiBehandlingsresultattype = async (type: string) => {
-    await Api.Behandlinger.resultat.angiBehandlingsresultattype(behandlingID, { type });
-    skjulModal();
-    tilForsiden();
-  };
-
-  const annullerFagsak = async () => {
-    await Api.Fagsaker.fagsak.annullerFagsak(saksnummer);
-    skjulModal();
-    tilForsiden();
-  };
+  const avsluttSakSomBortfalt = () => håndterKall(Api.Fagsaker.fagsak.bortfall(saksnummer));
+  const ferdigbehandleSak = () => håndterKall(Api.Fagsaker.fagsak.ferdigbehandleSak(saksnummer));
+  const angiBehandlingsresultattype = (type: string) =>
+    håndterKall(Api.Behandlinger.resultat.angiBehandlingsresultattype(behandlingID, { type }));
+  const annullerFagsak = () => håndterKall(Api.Fagsaker.fagsak.annullerFagsak(saksnummer));
 
   const hentBekreftValgDialogDataFraType = () => {
     switch (bekreftValgType) {
@@ -197,9 +189,15 @@ export const DialogboksBekreftValg = ({ ariaHideApp = true }: DialogboksBekreftV
     >
       <Nav.Typo.Systemtittel>{bekreftValgTypeData.tittel}</Nav.Typo.Systemtittel>
       <Nav.Typo.Normaltekst className="normaltekst">{bekreftValgTypeData.tekst}</Nav.Typo.Normaltekst>
+      {feil && (
+        <Nav.Alert variant="error" className="feilmelding">
+          {feil}
+        </Nav.Alert>
+      )}
       <Knapperad
         bekreft={bekreftValgTypeData.handleBekreft}
         bekreftTekst="Bekreft"
+        bekreftRedigerbart={!feil}
         avbryt={skjulModal}
         avbrytTekst="Avbryt"
         redigerbart

--- a/src/services/modules/fagsaker/fagsak.ts
+++ b/src/services/modules/fagsaker/fagsak.ts
@@ -1,6 +1,6 @@
 import { Fagsak } from "../types";
 
-import { getAsJson, postAsJson, putAsText } from "../../utils";
+import { getAsJson, postAsJson, putAsJson } from "../../utils";
 import { API_BASE_URL, FAGSAKER } from "../../api-constants";
 import { FullmektigHistorikk } from "../types/fagsak";
 
@@ -16,6 +16,7 @@ interface SoknadDto {
     flereLandUkjentHvilke: boolean;
   };
 }
+
 export interface OpprettReqDto {
   brukerID?: string;
   virksomhetOrgnr?: string;
@@ -41,11 +42,12 @@ export interface HenleggReqDto {
   begrunnelseKode: string;
   fritekst: string | null;
 }
+
 export const henlegg = (saksnummer: string, body: HenleggReqDto) =>
   postAsJson(`${API_BASE_URL}${FAGSAKER}/${saksnummer}/henlegg`, body);
 
 export const bortfall = (saksnummer: string) =>
-  putAsText(`${API_BASE_URL}${FAGSAKER}/${saksnummer}/henlegg-som-bortfalt`);
+  putAsJson(`${API_BASE_URL}${FAGSAKER}/${saksnummer}/henlegg-som-bortfalt`);
 
 interface Vedlegg {
   journalpostID: string;
@@ -57,6 +59,7 @@ export interface VideresendReqDto {
   fritekst: string | null;
   vedlegg: Vedlegg[];
 }
+
 export const videresend = (saksnummer: string, body: VideresendReqDto) =>
   postAsJson(`${API_BASE_URL}${FAGSAKER}/${saksnummer}/henlegg-videresend`, body);
 
@@ -65,6 +68,7 @@ interface UtpekReqDto {
   fritekstSed: string | null;
   fritekstBrev: string | null;
 }
+
 export const utpek = (saksnummer: string, body: UtpekReqDto) =>
   postAsJson(`${API_BASE_URL}${FAGSAKER}/${saksnummer}/utpek`, body);
 
@@ -80,11 +84,12 @@ export interface EndreSakDto {
 export interface TrygdeavgiftOppsummering {
   harBehandlingMedTrygdeavgift: boolean;
 }
+
 export const endreFagsak = (saksnummer: string, body: EndreSakDto) =>
   postAsJson(`${API_BASE_URL}${FAGSAKER}/${saksnummer}/endre`, body);
 
 export const ferdigbehandleSak = (saksnummer: string) =>
-  putAsText(`${API_BASE_URL}${FAGSAKER}/${saksnummer}/ferdigbehandle`);
+  putAsJson(`${API_BASE_URL}${FAGSAKER}/${saksnummer}/ferdigbehandle`);
 
 export const hentTrygdeavgiftOppsummering = (saksnummer: string): Promise<TrygdeavgiftOppsummering> =>
   getAsJson(`${API_BASE_URL}${FAGSAKER}/${saksnummer}/trygdeavgift/oppsummering`);

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -248,7 +248,6 @@ export const getAsJson = (url, extendResponse = false) => methodToJson("GET", ur
 
 // [post|put]AsJson, data MUST be a valid JSON object, ie. {} or []. Cannot be a empty "" string.
 export const postAsJson = (url, data = {}, extendResponse = false) => methodToJson("POST", url, data, extendResponse);
-// putAsText, data can be empty string.
 export const putAsJson = (url, data, extendResponse = false) => methodToJson("PUT", url, data, extendResponse);
 
 export const postAsJsonReceiveAsPDF = (url, data = {}, extendResponse = false) =>

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -241,37 +241,6 @@ const methodToJson = (method, url, data, extendResponse = false, accept = "appli
   return fetchToJson(url, fetchConfig, extendResponse);
 };
 
-const methodToText = (method, url, data) => {
-  const headers = {
-    Accept: "text/plain",
-    "Accept-Charset": "UTF-8",
-    // 'Cache-control': 'no-store, must-revalidate, no-cache, max-age=0',
-    // Expires: 'Mon, 01 Jan 1990 00:00:00 GMT',
-    // Pragma: 'no-cache',
-    // Origin: window.location.origin, // Set by fetch() automagically
-    // 'Access-Control-Request-Method': method, // Kun ved preflight
-  };
-
-  const fetchConfig = {
-    // body: below, for POST, PUT
-    credentials: "include", // *same-origin, include, omit; NB! MUST use 'include' to pass fetchConfig to fetch(),
-    cache: "no-cache", // *default, no-cache, force-cache, only-if-cached
-    headers: new Headers(headers),
-    method, // *GET, POST, ....
-    mode: "same-origin", // *same-origin, no-cors, cors
-    redirect: "follow", // *manual, follow, error
-    // referrer: // *client, no-referrer
-  };
-
-  const httpVerbsWithBody = ["POST", "PUT"];
-  if (httpVerbsWithBody.includes(method)) {
-    fetchConfig.body = data;
-    fetchConfig.headers.append("Content-Type", "text/plain");
-  }
-
-  return fetchToJson(url, fetchConfig, true);
-};
-
 export const cachedGetAsJson = (url, cacheDurationSec = 60) => cachedFetch(url, cacheDurationSec);
 
 export const deleteAsJson = (url, extendResponse = true) => methodToJson("DELETE", url, extendResponse);

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -280,7 +280,6 @@ export const getAsJson = (url, extendResponse = false) => methodToJson("GET", ur
 // [post|put]AsJson, data MUST be a valid JSON object, ie. {} or []. Cannot be a empty "" string.
 export const postAsJson = (url, data = {}, extendResponse = false) => methodToJson("POST", url, data, extendResponse);
 // putAsText, data can be empty string.
-export const putAsText = (url, data = "") => methodToText("PUT", url, data);
 export const putAsJson = (url, data, extendResponse = false) => methodToJson("PUT", url, data, extendResponse);
 
 export const postAsJsonReceiveAsPDF = (url, data = {}, extendResponse = false) =>


### PR DESCRIPTION
Feilhåndtering i dialogboksBekreftValg. De andre valgene fra avslutt sak i behandlingsmenyen har allerede kontroller pga brev.
Det var noe gammelt/rart med putAsText på to av endepunktene (ExceptionHandler i backend klarte ikke håndtere plain/text og svaret brekker frontend. Endret disse til putAsJson slik de andre bruker, men fant da ut at det krever tilsvarende endringer i api. Gjør dette til en DAPI derfor.

Fjernet metodene som brukte Text istedenfor Json. Skrik ut om dere er uenige.

DAPI: https://github.com/navikt/melosys-api/pull/2351

[MELOSYS-5882](https://jira.adeo.no/browse/MELOSYS-5882)