### PR TITLE
6252 Hindre bug med flyt i EØS etter oppfriskning av saksopplysninger

### DIFF
--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -421,6 +421,7 @@ class Stegvelger extends Component {
       soknadsperiode: props.soknadsperiode,
       harFeilmeldinger: !Utils._isEmpty(props.feilmeldinger) || !Utils._isEmpty(props.kontrollfeil),
       konvensjonStorbritanniaToggleEnabled: props.konvensjonStorbritanniaToggleEnabled,
+      behandlingOppfriskes: props.behandlingOppfriskes,
     };
 
     const stegMotor = new StegMotor(propsLight, props.stegMap, props.forsteSteg);
@@ -639,12 +640,14 @@ Stegvelger.propTypes = {
     })
   ),
   konvensjonStorbritanniaToggleEnabled: PT.bool.isRequired,
+  behandlingOppfriskes: PT.bool,
 };
 
 Stegvelger.defaultProps = {
   arbeidsgivereIPerioden: [],
   avklartefakta: [],
   bostedsland: null,
+  behandlingOppfriskes: false,
   bestemmelser: [],
   oppsummering: {},
   valgteVirksomheter: [],

--- a/src/sider/eu_eøs/saksbehandling/komponenter/saksopplysninger/saksopplysninger.jsx
+++ b/src/sider/eu_eøs/saksbehandling/komponenter/saksopplysninger/saksopplysninger.jsx
@@ -37,6 +37,7 @@ const hentForsteSteg = (behandlingstype) => {
 
 const Saksopplysninger = ({
   behandlingstype,
+  behandlingOppfriskes,
   redigerbart,
   behandlingID,
   soknadForm,
@@ -79,6 +80,7 @@ const Saksopplysninger = ({
         {visStegVelger && (
           <Stegvelger
             behandlingID={behandlingID}
+            behandlingOppfriskes={behandlingOppfriskes}
             lagreVilkarHandler={lagreVilkarHandler}
             lagreAvklartefaktaHandler={lagreAvklartefaktaHandler}
             lagreLovvalgsperioderHandler={lagreLovvalgsperioderHandler}
@@ -122,6 +124,7 @@ Saksopplysninger.propTypes = {
   tilForsiden: PT.func.isRequired,
   startOgVisOppfriskModal: PT.func.isRequired,
   anmodningsperioderErSendtUtlandet: PT.bool.isRequired,
+  behandlingOppfriskes: PT.bool,
 };
 
 Saksopplysninger.defaultProps = {
@@ -130,6 +133,7 @@ Saksopplysninger.defaultProps = {
   vurdering: {},
   syncErrors: {},
   inngangForm: {},
+  behandlingOppfriskes: false,
 };
 
 const mapStateToProps = (state) => ({

--- a/src/sider/eu_eøs/saksbehandling/saksbehandling.jsx
+++ b/src/sider/eu_eøs/saksbehandling/saksbehandling.jsx
@@ -164,6 +164,7 @@ class Saksbehandling extends Component {
       mottatteOpplysningerPeriodeTom,
       tilForsiden,
       startOgVisOppfriskModal,
+      behandlingOppfriskes,
     } = this.props;
     const { behandlingID, saksopplysningerLastet } = this.state;
 
@@ -191,6 +192,7 @@ class Saksbehandling extends Component {
                       oppdaterOgLagreBehandlingerHandler={this.oppdaterOgLagreBehandlingerHandler}
                       tilForsiden={tilForsiden}
                       startOgVisOppfriskModal={startOgVisOppfriskModal}
+                      behandlingOppfriskes={behandlingOppfriskes}
                     />
                   ) : (
                     <VirksomhetMelding />

--- a/src/sider/eu_eøs/saksbehandling/stegMap/inngang.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/inngang.js
@@ -5,7 +5,7 @@ class SaksbehandlingInngang extends Inngang {
   constructor(propsLight, stegPosisjon) {
     super(propsLight, stegPosisjon);
 
-    const harAvklaring = this.harAvklaring(propsLight);
+    const harAvklaring = this.harAvklaring(propsLight) && !propsLight.behandlingOppfriskes;
 
     this.kriterier = [
       {


### PR DESCRIPTION
Legger til sjekk på behandlingOppfriskes som styrer om inngangssteget til eøs-flyten (den generelle for søknader) viser resterende steg. Dette løser endel problematikk vi har hatt med at steg som feks Yrkessituasjon husker ting som er slettet i backend etter oppfriskning.

https://jira.adeo.no/browse/MELOSYS-6252