### PR TITLE
6618 TOGGLE Fjerner barn-steget og hopper videre til steg etter det igjen.

### DIFF
--- a/src/sider/eu_eøs/saksbehandling/stegMap/artikkel12_1.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/artikkel12_1.js
@@ -28,6 +28,14 @@ class Artikkel12_1 extends Steg {
 
     this.kriterier = [
       {
+        exec: () => propsLight.konvensjonStorbritanniaToggleEnabled && utsendingsvilkår?.oppfylt,
+        nesteSteg: STEG.VEDTAK,
+      },
+      {
+        exec: () => propsLight.konvensjonStorbritanniaToggleEnabled && unntaksvilkår?.oppfylt && harAvklaring,
+        nesteSteg: STEG.ARTIKKEL_16_ANMODNING,
+      },
+      {
         exec: () => utsendingsvilkår?.oppfylt || (unntaksvilkår?.oppfylt && harAvklaring),
         nesteSteg: STEG.MEDFOLGENDE_BARN,
       },

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel12_x/bestemmelser.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel12_x/bestemmelser.tsx
@@ -84,6 +84,7 @@ export const Bestemmelser = ({
   const slettAlleVilkår = () => alleRelevanteFeltNavn.forEach((feltNavn) => slettData(slettVilkar(feltNavn)));
 
   const handleEndreVedtakValg = (event: ChangeEvent<HTMLInputElement>) => {
+    setPending(true);
     const value = event.target.value as VedtakValg;
     setVedtakValg(value);
     setBestemmelse("");
@@ -92,13 +93,16 @@ export const Bestemmelser = ({
       if (value === VedtakValg.JA_INNVILGE) {
         slettAlleVilkår();
         if (!visStorbritanniaKonvensjon) handleEndreBestemmelse(FO_883_2004_ART12, value);
+        setPending(false);
       } else if (value === VedtakValg.NEI_ANMODNING_UNNTAK) {
         slettAlleVilkår();
         if (!visStorbritanniaKonvensjon) handleEndreBestemmelse(FO_883_2004_ART16_1, value);
+        setPending(false);
       } else if (value === VedtakValg.NEI_AVSLAG) {
         slettAlleVilkår();
         oppdaterData(lagVilkaar(finnFeltNavn(FO_883_2004_ART12), false));
         oppdaterData(lagVilkaar("art16_1_avslag", false));
+        setTimeout(() => setPending(false), 100);
       }
     } else {
       if (value === VedtakValg.JA_INNVILGE) {
@@ -116,6 +120,7 @@ export const Bestemmelser = ({
         slettData(slettVilkar("art16_1_anmodning"));
         oppdaterData(lagVilkaar("art16_1_avslag", false));
       }
+      setPending(false);
     }
   };
 


### PR DESCRIPTION
Også liten bug der begrunnelser henger igjen ved bytting av valgtVedtak. Bruker eksiterende løsning på det.

https://jira.adeo.no/browse/MELOSYS-6618