### PR TITLE
6615 Fikset en bug som oppstod av migreringen til aksel Button

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
@@ -279,6 +279,7 @@ export const VurderingArbeidTjenestepersonEllerFlyVedtak = ({
       setVedtakPending(false);
     }
   }
+
   const debouncedKontrollerBehandling = useCallback(Utils._debounce(kontroller, 500), [kontrollerFerdigbehandling]);
 
   useEffect(() => {
@@ -442,7 +443,13 @@ export const VurderingArbeidTjenestepersonEllerFlyVedtak = ({
           disabled: !stegErGyldig,
         }}
         bekreftTekst="Fatt vedtak"
-        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
+        tilbakeKnappProps={{
+          onClick: (e) => {
+            e.preventDefault();
+            tilbake();
+          },
+          disabled: !redigerbart,
+        }}
       />
     </form>
   );

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
@@ -238,7 +238,10 @@ export const VurderingArtikkel13_x_vedtak = ({
         }}
         bekreftTekst="Fatt vedtak"
         tilbakeKnappProps={{
-          onClick: tilbake,
+          onClick: (e) => {
+            e.preventDefault();
+            tilbake();
+          },
           disabled: !redigerbart,
         }}
       />

--- a/src/sider/eu_eøs/stegKomponenter/vurderingAvslaaUtpeking/vurderingAvslaaUtpeking.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingAvslaaUtpeking/vurderingAvslaaUtpeking.jsx
@@ -120,7 +120,10 @@ const VurderingAvslaaUtpeking = ({
         }}
         bekreftTekst="Avslutt og send SED"
         tilbakeKnappProps={{
-          onClick: tilbake,
+          onClick: (e) => {
+            e.preventDefault();
+            tilbake();
+          },
           disabled: !redigerbart,
         }}
       />

--- a/src/sider/eu_eøs/stegKomponenter/vurderingUtpekt/vurderingUtpekt.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingUtpekt/vurderingUtpekt.jsx
@@ -227,7 +227,10 @@ export const VurderingUtpekt = ({
           disabled: !(redigerbart && harAvklaring),
         }}
         tilbakeKnappProps={{
-          onClick: tilbake,
+          onClick: (e) => {
+            e.preventDefault();
+            tilbake();
+          },
           disabled: !redigerbart,
         }}
       />

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
@@ -120,7 +120,10 @@ export const VurderingVideresend = ({
               }}
               bekreftTekst="Videresend søknad"
               tilbakeKnappProps={{
-                onClick: tilbake,
+                onClick: (e) => {
+                  e.preventDefault();
+                  tilbake();
+                },
                 disabled: !redigerbart,
               }}
             />

--- a/src/sider/journalforing/komponenter/fotknapper.tsx
+++ b/src/sider/journalforing/komponenter/fotknapper.tsx
@@ -12,7 +12,13 @@ const Fotknapper = ({ avbrytJournalforing, spinner = false }: FotknapperProps) =
     <Nav.Button variant="primary" loading={spinner}>
       Journalfør
     </Nav.Button>
-    <Nav.Button variant="tertiary" onClick={avbrytJournalforing}>
+    <Nav.Button
+      variant="tertiary"
+      onClick={(e) => {
+        e.preventDefault();
+        avbrytJournalforing();
+      }}
+    >
       Avbryt
     </Nav.Button>
   </div>


### PR DESCRIPTION
Buggen oppsto som følge av at aksel Button ikke har htmlType som prop. I komponenter der disse knappene er wrappet av en form tag vil submit metoden kalles ved alle trykk. La derfor på en preventDefault i tilbakemetodene