### PR TITLE
6631 DAPI: Beregn trygdeavgift onChange

### DIFF
--- a/src/services/modules/trygdeavgift.ts
+++ b/src/services/modules/trygdeavgift.ts
@@ -55,5 +55,8 @@ export const beregnTrygdeavgiftsperioder = (
 export const hentBeregnetTrygdeavgift = (behandlingID: number): Promise<BeregnetTrygdeavgift> =>
   getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/beregning`);
 
+export const hentOpprinneligTrygdeavgiftsgrunnlag = (behandlingID: number): Promise<TrygdeavgiftsgrunnlagDto> =>
+  getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/grunnlag/opprinnelig`);
+
 export const hentFakturamottaker = (behandlingID: number): Promise<Fakturamottaker> =>
   getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/fakturamottaker`);

--- a/src/services/modules/trygdeavgift.ts
+++ b/src/services/modules/trygdeavgift.ts
@@ -25,18 +25,6 @@ export type TrygdeavgiftMottakerDto = {
   trygdeavgiftMottaker: KTObject;
 };
 
-export const hentTrygdeavgiftsgrunnlaget = (behandlingID: number): Promise<TrygdeavgiftsgrunnlagDto> =>
-  getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/grunnlag`);
-
-export const hentTrygdeavgiftMottaker = (behandlingID: number): Promise<TrygdeavgiftMottakerDto> =>
-  getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/mottaker`);
-
-export const oppdaterTrygdeavgiftsgrunnlag = (
-  behandlingID: number,
-  grunnlag: TrygdeavgiftsgrunnlagDto
-): Promise<TrygdeavgiftsgrunnlagDto> =>
-  putAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/grunnlag`, grunnlag);
-
 export type Trygdeavgiftsperiode = {
   fom: string;
   tom: string;
@@ -48,17 +36,24 @@ export type Trygdeavgiftsperiode = {
 
 export type BeregnetTrygdeavgift = {
   trygdeavgiftsperioder: Trygdeavgiftsperiode[];
+  trygdeavgiftsgrunnlag: TrygdeavgiftsgrunnlagDto;
 };
 
 export type Fakturamottaker = {
   navn: string;
 };
 
+export const hentTrygdeavgiftMottaker = (behandlingID: number): Promise<TrygdeavgiftMottakerDto> =>
+  getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/mottaker`);
+
+export const beregnTrygdeavgiftsperioder = (
+  behandlingID: number,
+  trygdeavgiftsgrunnlag: TrygdeavgiftsgrunnlagDto
+): Promise<BeregnetTrygdeavgift> =>
+  putAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/beregning`, trygdeavgiftsgrunnlag);
+
 export const hentBeregnetTrygdeavgift = (behandlingID: number): Promise<BeregnetTrygdeavgift> =>
   getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/beregning`);
-
-export const beregnTrygdeavgift = (behandlingID: number): Promise<BeregnetTrygdeavgift> =>
-  putAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/beregning`);
 
 export const hentFakturamottaker = (behandlingID: number): Promise<Fakturamottaker> =>
   getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/fakturamottaker`);

--- a/src/sider/ftrl/saksbehandling/saksbehandling.tsx
+++ b/src/sider/ftrl/saksbehandling/saksbehandling.tsx
@@ -31,7 +31,6 @@ import { dokumenterOperations } from "../../../ducks/dokumenter";
 import { folketrygdenkodeverkOperations } from "../../../ducks/folketrygdenkodeverk";
 import { medlemskapsperioderOperations, medlemskapsperioderSelectors } from "../../../ducks/medlemskapsperioder";
 import { oppsummertfaktaOperations } from "../../../ducks/oppsummertfakta";
-import { avklartefaktaOperations } from "../../../ducks/avklartefakta";
 import { vilkarOperations } from "../../../ducks/vilkar";
 import { menypanelOperations, menypanelSelectors } from "../../../ducks/menypanel";
 import { feiletResponsOperations } from "../../../ducks/feiletRespons";
@@ -85,15 +84,12 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>)
     dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingId)),
   hentOppsummertFakta: (behandlingId: number) => dispatch(oppsummertfaktaOperations.hentOppsummertFakta(behandlingId)),
   hentVilkår: (behandlingId: number) => dispatch(vilkarOperations.hent(behandlingId)),
-  lagreAvklartefakta: () => dispatch(avklartefaktaOperations.lagre()),
-  lagreVilkar: () => dispatch(vilkarOperations.lagre()),
   resetVilkarState: () => dispatch(vilkarOperations.resetState()),
   resetOppsummertFaktaState: () => dispatch(oppsummertfaktaOperations.resetOppsummertFakta()),
   resetMedlemskapsperiodeState: () => dispatch(medlemskapsperioderOperations.resetMedlemskapsperioder()),
   resetFagsakState: () => dispatch(fagsakOperations.resetFagsakState()),
   resetBehandlingerState: () => dispatch(behandlingerOperations.resetBehandlingerState()),
   resetMottatteOpplysningerState: () => dispatch(mottatteOpplysningerOperations.resetState()),
-  resetInkluderSiste5Aar: () => dispatch(resetInkluderSiste5Aar()),
   visMenypanel: () => dispatch(menypanelOperations.visMenypanel()),
   skjulMenypanel: () => dispatch(menypanelOperations.skjulMenypanel()),
   resetFeiletrespons: () => dispatch(feiletResponsOperations.resetFeiletRespons()),

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/komponenter/meldinger.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/komponenter/meldinger.tsx
@@ -138,7 +138,7 @@ export const finnAktivFeilmelding = (
   medlemskapsperioder: Medlemskapsperiode[],
   innvilgetMedlemskapsperiode?: { fom: string; tom: string }
 ): string | undefined => {
-  if (!innvilgetMedlemskapsperiode) return undefined;
+  if (!innvilgetMedlemskapsperiode || innvilgetMedlemskapsperiode.tom == null) return undefined;
 
   // Feil
   if (finnesSkatteforholdPeriodeUtenforMedlemskapsperiode(skatteforholdsperioder, innvilgetMedlemskapsperiode)) {

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/komponenter/trygdeavgiftsperioderTabell.less
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/komponenter/trygdeavgiftsperioderTabell.less
@@ -1,0 +1,16 @@
+.tabell-container {
+  position: relative;
+}
+
+.loader-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.5);
+  z-index: 1000;
+}

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
@@ -18,7 +18,7 @@ const TrygdeavgiftsperioderTabell = ({
 
   return (
     <div className="tabell-container">
-      {lagrePending === true && (
+      {lagrePending && (
         <div className="loader-container">
           <Spinner />
         </div>

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
@@ -3,43 +3,59 @@ import * as KV from "../../../../../../kodeverk";
 import * as Utils from "../../../../../../utils";
 import { Trygdeavgiftsperiode } from "../../../../../../services/modules/trygdeavgift";
 import { Table } from "@navikt/ds-react";
+import { Spinner } from "../../../../../../felleskomponenter/spinner";
 
-const TrygdeavgiftsperioderTabell = ({ perioder }: { perioder: Trygdeavgiftsperiode[] }) => {
+import "./trygdeavgiftsperioderTabell.css";
+
+const TrygdeavgiftsperioderTabell = ({
+  perioder,
+  lagrePending,
+}: {
+  perioder: Trygdeavgiftsperiode[];
+  lagrePending: Boolean;
+}) => {
   if (!perioder) return null;
 
   return (
-    <Table size="small" className="periode_tabell">
-      <Table.Header className="header_row">
-        <Table.Row>
-          <Table.HeaderCell scope="col">Periode</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Dekning</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Inntektskilde</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Sats</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Avgift per md.</Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        {perioder.map((trygdeavgiftsperiode) => (
-          <Table.Row className="border_top" key={Utils._uuid()}>
-            <Table.DataCell key={Utils._uuid()}>
-              {`${Utils.dato.formatterDatoTilNorsk(trygdeavgiftsperiode.fom)} - ${Utils.dato.formatterDatoTilNorsk(
-                trygdeavgiftsperiode.tom
-              )}`}
-            </Table.DataCell>
-            <Table.DataCell key={Utils._uuid()}>
-              {KV.finnTermFraListe(MKV.KTObjects.trygdedekninger, trygdeavgiftsperiode.trygdedekning)}
-            </Table.DataCell>
-            <Table.DataCell key={Utils._uuid()}>
-              {KV.finnTermFraListe(MKV.KTObjects.inntektskildetype, trygdeavgiftsperiode.inntektskildetype)}
-            </Table.DataCell>
-            <Table.DataCell key={Utils._uuid()}>{trygdeavgiftsperiode.avgiftssats}</Table.DataCell>
-            <Table.DataCell key={Utils._uuid()}>
-              <b>{trygdeavgiftsperiode.avgiftPerMd}</b> nkr
-            </Table.DataCell>
+    <div className="tabell-container">
+      {lagrePending === true && (
+        <div className="loader-container">
+          <Spinner />
+        </div>
+      )}
+      <Table size="small" className="periode_tabell">
+        <Table.Header className="header_row">
+          <Table.Row>
+            <Table.HeaderCell scope="col">Periode</Table.HeaderCell>
+            <Table.HeaderCell scope="col">Dekning</Table.HeaderCell>
+            <Table.HeaderCell scope="col">Inntektskilde</Table.HeaderCell>
+            <Table.HeaderCell scope="col">Sats</Table.HeaderCell>
+            <Table.HeaderCell scope="col">Avgift per md.</Table.HeaderCell>
           </Table.Row>
-        ))}
-      </Table.Body>
-    </Table>
+        </Table.Header>
+        <Table.Body>
+          {perioder.map((trygdeavgiftsperiode) => (
+            <Table.Row className="border_top" key={Utils._uuid()}>
+              <Table.DataCell key={Utils._uuid()}>
+                {`${Utils.dato.formatterDatoTilNorsk(trygdeavgiftsperiode.fom)} - ${Utils.dato.formatterDatoTilNorsk(
+                  trygdeavgiftsperiode.tom
+                )}`}
+              </Table.DataCell>
+              <Table.DataCell key={Utils._uuid()}>
+                {KV.finnTermFraListe(MKV.KTObjects.trygdedekninger, trygdeavgiftsperiode.trygdedekning)}
+              </Table.DataCell>
+              <Table.DataCell key={Utils._uuid()}>
+                {KV.finnTermFraListe(MKV.KTObjects.inntektskildetype, trygdeavgiftsperiode.inntektskildetype)}
+              </Table.DataCell>
+              <Table.DataCell key={Utils._uuid()}>{trygdeavgiftsperiode.avgiftssats}</Table.DataCell>
+              <Table.DataCell key={Utils._uuid()}>
+                <b>{trygdeavgiftsperiode.avgiftPerMd}</b> nkr
+              </Table.DataCell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
   );
 };
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -21,6 +21,7 @@ import "./vurderingTrygdeavgift.css";
 import { Feilmelding, feilMeldingBlokkerer, finnAktivFeilmelding } from "./komponenter/meldinger";
 import { Skatteforholdsperioder } from "./komponenter/skatteforholdsperioder";
 import MKV from "../../../../../melosyskodeverk";
+import { BeregnetTrygdeavgift } from "../../../../../services/modules/trygdeavgift";
 
 interface Props {
   bekreft: () => void;
@@ -113,44 +114,49 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
     }
   }, [innvilgetMedlemskapsperiode]);
 
+  const handterLagretTrygdeavgiftsgrunnlag = (beregnetTrygdeavgift: BeregnetTrygdeavgift) => {
+    setTrygdeavgift(beregnetTrygdeavgift);
+    const lagretTrygdeavgiftsgrunnlag = beregnetTrygdeavgift.trygdeavgiftsgrunnlag;
+    const { inntektskilder, skatteforholdsperioder } = lagretTrygdeavgiftsgrunnlag;
+    const sorterteInntekstkilder = inntektskilder?.sort(Utils.dato.sorterEtterISOFomDato);
+    const sorterteSkatteforhold = skatteforholdsperioder?.sort(Utils.dato.sorterEtterISOFomDato);
+    resetSkatteforholdsperioder(
+      !Utils._isEmpty(sorterteSkatteforhold)
+        ? sorterteSkatteforhold.map((skatteforhold) => ({
+            fomDato: Utils.dato.formatterDatoTilNorsk(skatteforhold.fomDato),
+            tomDato: Utils.dato.formatterDatoTilNorsk(skatteforhold.tomDato),
+            skatteplikttype: skatteforhold.skatteplikttype,
+          }))
+        : [defaultPeriode]
+    );
+    resetInntektskilder(
+      !Utils._isEmpty(sorterteInntekstkilder)
+        ? sorterteInntekstkilder.map((inntektskilde) => ({
+            kildetype: inntektskilde.type,
+            arbAvgBetales: Utils.streng.boolTilUppercaseStreng(inntektskilde.arbeidsgiversavgiftBetales),
+            bruttoInntekt: inntektskilde.avgiftspliktigInntektMnd,
+            fomDato: Utils.dato.formatterDatoTilNorsk(inntektskilde.fomDato),
+            tomDato: Utils.dato.formatterDatoTilNorsk(inntektskilde.tomDato),
+          }))
+        : [defaultPeriode]
+    );
+    setHarHentetGrunnlag(true);
+  };
+
   useEffect(() => {
-    Api.Trygdeavgift.hentTrygdeavgiftsgrunnlaget(behandlingID).then((lagretTrygdeavgiftsgrunnlag) => {
-      const { inntektskilder, skatteforholdsperioder } = lagretTrygdeavgiftsgrunnlag;
-      const sorterteInntekstkilder = inntektskilder?.sort(Utils.dato.sorterEtterISOFomDato);
-      const sorterteSkatteforhold = skatteforholdsperioder?.sort(Utils.dato.sorterEtterISOFomDato);
-      resetSkatteforholdsperioder(
-        !Utils._isEmpty(sorterteSkatteforhold)
-          ? sorterteSkatteforhold.map((skatteforhold) => ({
-              fomDato: Utils.dato.formatterDatoTilNorsk(skatteforhold.fomDato),
-              tomDato: Utils.dato.formatterDatoTilNorsk(skatteforhold.tomDato),
-              skatteplikttype: skatteforhold.skatteplikttype,
-            }))
-          : [defaultPeriode]
-      );
-      resetInntektskilder(
-        !Utils._isEmpty(sorterteInntekstkilder)
-          ? sorterteInntekstkilder.map((inntektskilde) => ({
-              kildetype: inntektskilde.type,
-              arbAvgBetales: Utils.streng.boolTilUppercaseStreng(inntektskilde.arbeidsgiversavgiftBetales),
-              bruttoInntekt: inntektskilde.avgiftspliktigInntektMnd,
-              fomDato: Utils.dato.formatterDatoTilNorsk(inntektskilde.fomDato),
-              tomDato: Utils.dato.formatterDatoTilNorsk(inntektskilde.tomDato),
-            }))
-          : [defaultPeriode]
-      );
-      setHarHentetGrunnlag(true);
-    });
+    Api.Trygdeavgift.hentBeregnetTrygdeavgift(behandlingID).then(handterLagretTrygdeavgiftsgrunnlag);
   }, []);
 
   useEffect(() => {
     oppdaterStatus(stegErGyldig && harBeregnetForeløpigTrygdeavgift);
   }, [stegErGyldig, harBeregnetForeløpigTrygdeavgift]);
 
-  const lagreTrygdeavgiftsgrunnlag = (formVerdier: FieldValue<FormValuesProps>) => {
+  const beregnTrygdeavgiftsperioder = (formVerdier: FieldValue<FormValuesProps>) => {
+    setFeil(undefined);
     setLagrePending(true);
     const erBrukerPliktigMedlemOgSkattepliktig =
       medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(formVerdier.skatteforholdsperioder);
-    Api.Trygdeavgift.oppdaterTrygdeavgiftsgrunnlag(behandlingID, {
+    Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
       skatteforholdsperioder: formVerdier.skatteforholdsperioder.map((skatteforhold: Skatteforhold) => ({
         fomDato: Utils.dato.formatterDatoTilISO(skatteforhold.fomDato),
         tomDato: Utils.dato.formatterDatoTilISO(skatteforhold.tomDato, null),
@@ -166,8 +172,9 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
           }))
         : [],
     })
-      .then(() => {
+      .then((beregnetTrygdeavgift) => {
         setFeil(undefined);
+        setTrygdeavgift(beregnetTrygdeavgift);
       })
       .catch((error) => setFeil(mapFeilmelding(error)))
       .finally(() => setLagrePending(false));
@@ -185,15 +192,14 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
     return error.body?.feilkoder || error.body?.message || error;
   };
 
-  const debouncedLagreTrygdeavgiftsgrunnlag = useCallback(
-    Utils._debounce((formVerdier, isValid) => isValid && lagreTrygdeavgiftsgrunnlag(formVerdier), 500),
+  const debounceBeregnTrygdeavgiftsperioder = useCallback(
+    Utils._debounce((formVerdier, isValid) => isValid && beregnTrygdeavgiftsperioder(formVerdier), 500),
     []
   );
 
   useEffect(() => {
-    if (redigerbart && harHentetGrunnlag) setTrygdeavgift(undefined);
     if (redigerbart && aktivtSteg && !isValidating) {
-      debouncedLagreTrygdeavgiftsgrunnlag(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
+      debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
     }
   }, [
     formIsValid,
@@ -216,21 +222,11 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
         });
       }
       if (feil || harEndretInnvilgetMedlemskapsperiode) {
-        debouncedLagreTrygdeavgiftsgrunnlag(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
+        debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
         setHarEndretInnvilgetMedlemskapsperiode(false);
       }
     }
   }, [aktivtSteg, harEndretInnvilgetMedlemskapsperiode]);
-
-  const handleBeregnTrygdeavgift = () => {
-    setTrygdeavgift(undefined);
-    Api.Trygdeavgift.beregnTrygdeavgift(behandlingID)
-      .then((response) => {
-        setFeil(undefined);
-        setTrygdeavgift(response);
-      })
-      .catch((error) => setFeil(mapFeilmelding(error)));
-  };
 
   if (!aktivtSteg) return null;
 
@@ -274,21 +270,13 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
         />
       )}
 
-      {skalBeregneForelopigTrygdeavgift && (
-        <Nav.Button
-          variant="secondary"
-          className="beregnKnapp"
-          disabled={lagrePending || !redigerbart || !stegErGyldig || isValidating}
-          onClick={handleBeregnTrygdeavgift}
-        >
-          Beregn foreløpig trygdeavgift
-        </Nav.Button>
-      )}
-
       <Feilmelding type={aktivFeilmeldingType} />
 
       {trygdeavgiftErIkkeTom && stegErGyldig && (
-        <TrygdeavgiftsperioderTabell perioder={lagretTrygdeavgift?.trygdeavgiftsperioder!!} />
+        <TrygdeavgiftsperioderTabell
+          lagrePending={lagrePending}
+          perioder={lagretTrygdeavgift?.trygdeavgiftsperioder!!}
+        />
       )}
 
       {visFeilFraLagring && (

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -57,12 +57,12 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
     fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
     tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
   };
-  const erÅpenSluttDato = innvilgetMedlemskapsperiode?.tom === null || innvilgetMedlemskapsperiode?.tom === undefined;
+  const erÅpenSluttDato = !innvilgetMedlemskapsperiode?.tom;
 
   const {
     control,
     watch,
-    formState: { isValid: formIsValidatedByYup, isValidating },
+    formState: { isValid: formIsValid, isValidating },
     trigger,
   } = useForm({
     resolver: yupResolver(vurderingTrygdeavgiftSchema),
@@ -94,8 +94,6 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
     medlemskapsperioder,
     innvilgetMedlemskapsperiode
   );
-
-  const formIsValid = formIsValidatedByYup;
 
   const stegErGyldig = formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType) && !feil;
   const skalBeregneForelopigTrygdeavgift =
@@ -142,7 +140,7 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
     );
   };
 
-  const handterTrygdeavgiftsberegning = (beregnetTrygdeavgift: BeregnetTrygdeavgift) => {
+  const håndterTrygdeavgiftsberegning = (beregnetTrygdeavgift: BeregnetTrygdeavgift) => {
     setTrygdeavgift(beregnetTrygdeavgift);
     const lagretTrygdeavgiftsgrunnlag = beregnetTrygdeavgift.trygdeavgiftsgrunnlag;
     handterLagretTrygdeavgiftsgrunnlag(lagretTrygdeavgiftsgrunnlag);
@@ -164,7 +162,7 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
       ) {
         hentOpprinneligTrygdeavgiftsgrunnlag();
       } else {
-        handterTrygdeavgiftsberegning(beregnetTrygdeavgift);
+        håndterTrygdeavgiftsberegning(beregnetTrygdeavgift);
       }
     });
   }, []);
@@ -280,19 +278,20 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
         </Nav.Row>
       )}
 
-      {!(medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder)) && (
-        <Inntektskilder
-          formValues={formValues}
-          redigerbart={redigerbart}
-          update={inntektUpdate}
-          remove={inntektRemove}
-          append={inntektAppend}
-          control={control}
-          defaultPeriode={defaultPeriode}
-          fields={inntektFields}
-          medlemskapsTypeErPliktig={medlemskapsTypeErPliktig}
-        />
-      )}
+      {!(medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder)) &&
+        !erÅpenSluttDato && (
+          <Inntektskilder
+            formValues={formValues}
+            redigerbart={redigerbart}
+            update={inntektUpdate}
+            remove={inntektRemove}
+            append={inntektAppend}
+            control={control}
+            defaultPeriode={defaultPeriode}
+            fields={inntektFields}
+            medlemskapsTypeErPliktig={medlemskapsTypeErPliktig}
+          />
+        )}
 
       <Feilmelding type={aktivFeilmeldingType} />
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -57,15 +57,16 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
     fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
     tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
   };
+  const erÅpenSluttDato = innvilgetMedlemskapsperiode?.tom === null || innvilgetMedlemskapsperiode?.tom === undefined;
 
   const {
     control,
     watch,
-    formState: { isValid: formIsValid, isValidating },
+    formState: { isValid: formIsValidatedByYup, isValidating },
     trigger,
   } = useForm({
     resolver: yupResolver(vurderingTrygdeavgiftSchema),
-    context: { medlemskapsperiode: innvilgetMedlemskapsperiode, medlemskapsTypeErPliktig, sluttdatoKanVæreÅpen: true },
+    context: { medlemskapsperiode: innvilgetMedlemskapsperiode, medlemskapsTypeErPliktig, erÅpenSluttDato },
     mode: "onChange",
     defaultValues: {
       skatteforholdsperioder: [{}],
@@ -93,6 +94,8 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
     medlemskapsperioder,
     innvilgetMedlemskapsperiode
   );
+
+  const formIsValid = formIsValidatedByYup || erÅpenSluttDato;
 
   const stegErGyldig = formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType) && !feil;
   const skalBeregneForelopigTrygdeavgift =
@@ -150,6 +153,10 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
   };
 
   useEffect(() => {
+    if (erÅpenSluttDato) {
+      setTrygdeavgift(undefined);
+      return;
+    }
     Api.Trygdeavgift.hentBeregnetTrygdeavgift(behandlingID).then((beregnetTrygdeavgift) => {
       if (
         behandlingstype === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING &&
@@ -213,7 +220,7 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
   );
 
   useEffect(() => {
-    if (redigerbart && aktivtSteg && !isValidating) {
+    if (redigerbart && aktivtSteg && !isValidating && !erÅpenSluttDato) {
       debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
     }
   }, [
@@ -257,19 +264,21 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
         </Nav.Typo.Normaltekst>
       )}
 
-      <Nav.Row>
-        <Nav.Column>
-          <Skatteforholdsperioder
-            formValues={formValues}
-            redigerbart={redigerbart}
-            remove={skattRemove}
-            append={skattAppend}
-            control={control}
-            defaultPeriode={defaultPeriode}
-            fields={skattFields}
-          />
-        </Nav.Column>
-      </Nav.Row>
+      {!erÅpenSluttDato && (
+        <Nav.Row>
+          <Nav.Column>
+            <Skatteforholdsperioder
+              formValues={formValues}
+              redigerbart={redigerbart}
+              remove={skattRemove}
+              append={skattAppend}
+              control={control}
+              defaultPeriode={defaultPeriode}
+              fields={skattFields}
+            />
+          </Nav.Column>
+        </Nav.Row>
+      )}
 
       {!(medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder)) && (
         <Inntektskilder
@@ -303,9 +312,16 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
         </Nav.Alert>
       )}
 
-      {!skalBeregneForelopigTrygdeavgift && stegErGyldig && (
+      {!erÅpenSluttDato && !skalBeregneForelopigTrygdeavgift && stegErGyldig && (
         <Nav.Alert variant="info" className="infomelding">
           Trygdeavgift skal ikke betales til NAV
+        </Nav.Alert>
+      )}
+
+      {erÅpenSluttDato && (
+        <Nav.Alert variant="info" className="infomelding">
+          Trygdeavgift skal ikke betales til NAV. Det vil ikke bli beregnet trygdeavgift for personer med arbeidsland
+          Norge og som er bosatt i Norge.
         </Nav.Alert>
       )}
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -21,7 +21,7 @@ import "./vurderingTrygdeavgift.css";
 import { Feilmelding, feilMeldingBlokkerer, finnAktivFeilmelding } from "./komponenter/meldinger";
 import { Skatteforholdsperioder } from "./komponenter/skatteforholdsperioder";
 import MKV from "../../../../../melosyskodeverk";
-import { BeregnetTrygdeavgift } from "../../../../../services/modules/trygdeavgift";
+import { BeregnetTrygdeavgift, TrygdeavgiftsgrunnlagDto } from "../../../../../services/modules/trygdeavgift";
 
 interface Props {
   bekreft: () => void;
@@ -113,10 +113,8 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
     }
   }, [innvilgetMedlemskapsperiode]);
 
-  const handterLagretTrygdeavgiftsgrunnlag = (beregnetTrygdeavgift: BeregnetTrygdeavgift) => {
-    setTrygdeavgift(beregnetTrygdeavgift);
-    const lagretTrygdeavgiftsgrunnlag = beregnetTrygdeavgift.trygdeavgiftsgrunnlag;
-    const { inntektskilder, skatteforholdsperioder } = lagretTrygdeavgiftsgrunnlag;
+  const handterLagretTrygdeavgiftsgrunnlag = (trygdeavgiftsgrunnlag: TrygdeavgiftsgrunnlagDto) => {
+    const { inntektskilder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
     const sorterteInntekstkilder = inntektskilder?.sort(Utils.dato.sorterEtterISOFomDato);
     const sorterteSkatteforhold = skatteforholdsperioder?.sort(Utils.dato.sorterEtterISOFomDato);
     resetSkatteforholdsperioder(
@@ -141,8 +139,27 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
     );
   };
 
+  const handterTrygdeavgiftsberegning = (beregnetTrygdeavgift: BeregnetTrygdeavgift) => {
+    setTrygdeavgift(beregnetTrygdeavgift);
+    const lagretTrygdeavgiftsgrunnlag = beregnetTrygdeavgift.trygdeavgiftsgrunnlag;
+    handterLagretTrygdeavgiftsgrunnlag(lagretTrygdeavgiftsgrunnlag);
+  };
+
+  const hentOpprinneligTrygdeavgiftsgrunnlag = () => {
+    Api.Trygdeavgift.hentOpprinneligTrygdeavgiftsgrunnlag(behandlingID).then(handterLagretTrygdeavgiftsgrunnlag);
+  };
+
   useEffect(() => {
-    Api.Trygdeavgift.hentBeregnetTrygdeavgift(behandlingID).then(handterLagretTrygdeavgiftsgrunnlag);
+    Api.Trygdeavgift.hentBeregnetTrygdeavgift(behandlingID).then((beregnetTrygdeavgift) => {
+      if (
+        behandlingstype === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING &&
+        beregnetTrygdeavgift.trygdeavgiftsgrunnlag.skatteforholdsperioder.length === 0
+      ) {
+        hentOpprinneligTrygdeavgiftsgrunnlag();
+      } else {
+        handterTrygdeavgiftsberegning(beregnetTrygdeavgift);
+      }
+    });
   }, []);
 
   useEffect(() => {

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -95,7 +95,7 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
     innvilgetMedlemskapsperiode
   );
 
-  const formIsValid = formIsValidatedByYup || erÅpenSluttDato;
+  const formIsValid = formIsValidatedByYup;
 
   const stegErGyldig = formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType) && !feil;
   const skalBeregneForelopigTrygdeavgift =
@@ -243,7 +243,7 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
           trigger(`inntektskilder[${index}].tomDato`);
         });
       }
-      if (feil || harEndretInnvilgetMedlemskapsperiode) {
+      if (!erÅpenSluttDato && (feil || harEndretInnvilgetMedlemskapsperiode)) {
         debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
         setHarEndretInnvilgetMedlemskapsperiode(false);
       }

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -320,8 +320,8 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
 
       {erÅpenSluttDato && (
         <Nav.Alert variant="info" className="infomelding">
-          Trygdeavgift skal ikke betales til NAV. Det vil ikke bli beregnet trygdeavgift for personer med arbeidsland
-          Norge og som er bosatt i Norge.
+          Trygdeavgift kan ikke beregnes for medlemskapsperiode uten sluttdato. Hvis personen skal betale trygdeavgift
+          til NAV må du angi sluttdato på medlemskapsperiode.
         </Nav.Alert>
       )}
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -46,7 +46,6 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
   );
   const [feil, setFeil] = useState<string | undefined>(undefined);
   const [lagrePending, setLagrePending] = useState(false);
-  const [harHentetGrunnlag, setHarHentetGrunnlag] = useState(false);
   const [harEndretInnvilgetMedlemskapsperiode, setHarEndretInnvilgetMedlemskapsperiode] = useState<boolean | undefined>(
     undefined
   );
@@ -140,7 +139,6 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
           }))
         : [defaultPeriode]
     );
-    setHarHentetGrunnlag(true);
   };
 
   useEffect(() => {
@@ -273,10 +271,13 @@ export const VurderingTrygdeavgift = ({ bekreft, tilbake, aktivtSteg, oppdaterSt
       <Feilmelding type={aktivFeilmeldingType} />
 
       {trygdeavgiftErIkkeTom && stegErGyldig && (
-        <TrygdeavgiftsperioderTabell
-          lagrePending={lagrePending}
-          perioder={lagretTrygdeavgift?.trygdeavgiftsperioder!!}
-        />
+        <>
+          <Nav.Typo.Undertittel>Foreløpig beregnet trygdeavgift</Nav.Typo.Undertittel>
+          <TrygdeavgiftsperioderTabell
+            lagrePending={lagrePending}
+            perioder={lagretTrygdeavgift?.trygdeavgiftsperioder!!}
+          />
+        </>
       )}
 
       {visFeilFraLagring && (

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
@@ -64,7 +64,7 @@ const kreverInntektskilder = (medlemskapsTypeErPliktig, options) => {
 };
 
 const vurdering_trygdeavgift = object().shape({
-  skatteforholdsperioder: array().when(["$erÅpenSluttDato"], {
+  skatteforholdsperioder: array().when(["erÅpenSluttDato"], {
     is: (erÅpenSluttDato) => !erÅpenSluttDato,
     then: array()
       .of(
@@ -83,9 +83,9 @@ const vurdering_trygdeavgift = object().shape({
       )
       .min(1),
     inntektskilder: lazy((_value, options) => {
-      return array().when(["$medlemskapsTypeErPliktig", "$erÅpenSluttDato"], {
-        is: (medlemskapsTypeErPliktig, $erÅpenSluttDato) =>
-          !$erÅpenSluttDato && kreverInntektskilder(medlemskapsTypeErPliktig, options),
+      return array().when(["medlemskapsTypeErPliktig", "erÅpenSluttDato"], {
+        is: (medlemskapsTypeErPliktig, erÅpenSluttDato) =>
+          !erÅpenSluttDato && kreverInntektskilder(medlemskapsTypeErPliktig, options),
         then: array()
           .of(
             object().shape({

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
@@ -64,9 +64,10 @@ const kreverInntektskilder = (medlemskapsTypeErPliktig, options) => {
 };
 
 const vurdering_trygdeavgift = object().shape({
-  skatteforholdsperioder: array().when(["erÅpenSluttDato"], {
+  skatteforholdsperioder: array().when(["$erÅpenSluttDato"], {
     is: (erÅpenSluttDato) => !erÅpenSluttDato,
     then: array()
+      .min(1)
       .of(
         object().shape({
           fomDato: string()
@@ -80,32 +81,31 @@ const vurdering_trygdeavgift = object().shape({
             .required(MAA_FYLLES_UT),
           skatteplikttype: string().required(MAA_FYLLES_UT),
         })
-      )
-      .min(1),
-    inntektskilder: lazy((_value, options) => {
-      return array().when(["medlemskapsTypeErPliktig", "erÅpenSluttDato"], {
-        is: (medlemskapsTypeErPliktig, erÅpenSluttDato) =>
-          !erÅpenSluttDato && kreverInntektskilder(medlemskapsTypeErPliktig, options),
-        then: array()
-          .of(
-            object().shape({
-              kildetype: string().required(MAA_FYLLES_UT),
-              arbAvgBetales: string().test(arbAvgBetalesFyltUtNårDetKrevesTest).nullable(),
-              bruttoInntekt: string().erNummer().test(bruttoInntektFyltUtNårDetKrevesTest).nullable(),
-              fomDato: string()
-                .erGyldigDato()
-                .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-                .required(MAA_FYLLES_UT),
-              tomDato: string()
-                .erGyldigDato()
-                .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-                .erEtterDatofelt("fomDato")
-                .required(MAA_FYLLES_UT),
-            })
-          )
-          .min(1),
-      });
-    }),
+      ),
+  }),
+  inntektskilder: lazy((_value, options) => {
+    return array().when(["$medlemskapsTypeErPliktig", "$erÅpenSluttDato"], {
+      is: (medlemskapsTypeErPliktig, erÅpenSluttDato) =>
+        !erÅpenSluttDato && kreverInntektskilder(medlemskapsTypeErPliktig, options),
+      then: array()
+        .min(1)
+        .of(
+          object().shape({
+            kildetype: string().required(MAA_FYLLES_UT),
+            arbAvgBetales: string().test(arbAvgBetalesFyltUtNårDetKrevesTest).nullable(),
+            bruttoInntekt: string().erNummer().test(bruttoInntektFyltUtNårDetKrevesTest).nullable(),
+            fomDato: string()
+              .erGyldigDato()
+              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
+              .required(MAA_FYLLES_UT),
+            tomDato: string()
+              .erGyldigDato()
+              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
+              .erEtterDatofelt("fomDato")
+              .required(MAA_FYLLES_UT),
+          })
+        ),
+    });
   }),
 });
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
@@ -75,17 +75,13 @@ const vurdering_trygdeavgift = object().shape({
           .erGyldigDato()
           .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
           .erEtterDatofelt("fomDato")
-          .when("$sluttdatoKanVæreÅpen", {
-            is: false,
-            then: string().required(MAA_FYLLES_UT),
-            otherwise: string().nullable(),
-          }),
+          .required(MAA_FYLLES_UT),
         skatteplikttype: string().required(MAA_FYLLES_UT),
       })
     )
     .min(1),
   inntektskilder: lazy((_value, options) => {
-    return array().when(["$medlemskapsTypeErPliktig", "$sluttdatoKanVæreÅpen"], {
+    return array().when(["$medlemskapsTypeErPliktig"], {
       is: (medlemskapsTypeErPliktig) => kreverInntektskilder(medlemskapsTypeErPliktig, options),
       then: array()
         .of(
@@ -101,11 +97,7 @@ const vurdering_trygdeavgift = object().shape({
               .erGyldigDato()
               .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
               .erEtterDatofelt("fomDato")
-              .when("$sluttdatoKanVæreÅpen", {
-                is: false,
-                then: string().required(MAA_FYLLES_UT),
-                otherwise: string().nullable(),
-              }),
+              .required(MAA_FYLLES_UT),
           })
         )
         .min(1),

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
@@ -32,14 +32,6 @@ const arbAvgBetalesFyltUtNårDetKrevesTest = {
   },
 };
 
-const påkrevdHvisIkkeÅpenSluttDato = () => {
-  return string().when("$erÅpenSluttDato", {
-    is: false,
-    then: string().required(MAA_FYLLES_UT),
-    otherwise: string().nullable(),
-  });
-};
-
 export const erBrukerSkattepliktigIHelePerioden = (skatteforholdsperioder) => {
   return !skatteforholdsperioder.some((skatteforhold) => skatteforhold.skatteplikttype === IKKE_SKATTEPLIKTIG);
 };
@@ -72,41 +64,48 @@ const kreverInntektskilder = (medlemskapsTypeErPliktig, options) => {
 };
 
 const vurdering_trygdeavgift = object().shape({
-  skatteforholdsperioder: array()
-    .of(
-      object().shape({
-        fomDato: påkrevdHvisIkkeÅpenSluttDato()
-          .erGyldigDato()
-          .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN),
-
-        tomDato: påkrevdHvisIkkeÅpenSluttDato()
-          .erGyldigDato()
-          .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-          .erEtterDatofelt("fomDato"),
-        skatteplikttype: påkrevdHvisIkkeÅpenSluttDato(),
-      })
-    )
-    .min(1),
-  inntektskilder: lazy((_value, options) => {
-    return array().when(["$medlemskapsTypeErPliktig", "$erÅpenSluttDato"], {
-      is: (medlemskapsTypeErPliktig) => kreverInntektskilder(medlemskapsTypeErPliktig, options),
-      then: array()
-        .of(
-          object().shape({
-            kildetype: påkrevdHvisIkkeÅpenSluttDato(),
-            arbAvgBetales: string().test(arbAvgBetalesFyltUtNårDetKrevesTest).nullable(),
-            bruttoInntekt: string().erNummer().test(bruttoInntektFyltUtNårDetKrevesTest).nullable(),
-            fomDato: påkrevdHvisIkkeÅpenSluttDato()
-              .erGyldigDato()
-              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN),
-            tomDato: påkrevdHvisIkkeÅpenSluttDato()
-              .erGyldigDato()
-              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-              .erEtterDatofelt("fomDato"),
-          })
-        )
-        .min(1),
-    });
+  skatteforholdsperioder: array().when(["$erÅpenSluttDato"], {
+    is: (erÅpenSluttDato) => !erÅpenSluttDato,
+    then: array()
+      .of(
+        object().shape({
+          fomDato: string()
+            .erGyldigDato()
+            .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
+            .required(MAA_FYLLES_UT),
+          tomDato: string()
+            .erGyldigDato()
+            .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
+            .erEtterDatofelt("fomDato")
+            .required(MAA_FYLLES_UT),
+          skatteplikttype: string().required(MAA_FYLLES_UT),
+        })
+      )
+      .min(1),
+    inntektskilder: lazy((_value, options) => {
+      return array().when(["$medlemskapsTypeErPliktig", "$erÅpenSluttDato"], {
+        is: (medlemskapsTypeErPliktig, $erÅpenSluttDato) =>
+          !$erÅpenSluttDato && kreverInntektskilder(medlemskapsTypeErPliktig, options),
+        then: array()
+          .of(
+            object().shape({
+              kildetype: string().required(MAA_FYLLES_UT),
+              arbAvgBetales: string().test(arbAvgBetalesFyltUtNårDetKrevesTest).nullable(),
+              bruttoInntekt: string().erNummer().test(bruttoInntektFyltUtNårDetKrevesTest).nullable(),
+              fomDato: string()
+                .erGyldigDato()
+                .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
+                .required(MAA_FYLLES_UT),
+              tomDato: string()
+                .erGyldigDato()
+                .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
+                .erEtterDatofelt("fomDato")
+                .required(MAA_FYLLES_UT),
+            })
+          )
+          .min(1),
+      });
+    }),
   }),
 });
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
@@ -32,6 +32,14 @@ const arbAvgBetalesFyltUtNårDetKrevesTest = {
   },
 };
 
+const påkrevdHvisIkkeÅpenSluttDato = (fieldName) => {
+  return string().when("$erÅpenSluttDato", {
+    is: false,
+    then: string().required(MAA_FYLLES_UT),
+    otherwise: string().nullable(),
+  });
+};
+
 export const erBrukerSkattepliktigIHelePerioden = (skatteforholdsperioder) => {
   return !skatteforholdsperioder.some((skatteforhold) => skatteforhold.skatteplikttype === IKKE_SKATTEPLIKTIG);
 };
@@ -67,37 +75,34 @@ const vurdering_trygdeavgift = object().shape({
   skatteforholdsperioder: array()
     .of(
       object().shape({
-        fomDato: string()
+        fomDato: påkrevdHvisIkkeÅpenSluttDato()
+          .erGyldigDato()
+          .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN),
+
+        tomDato: påkrevdHvisIkkeÅpenSluttDato()
           .erGyldigDato()
           .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-          .required(MAA_FYLLES_UT),
-        tomDato: string()
-          .erGyldigDato()
-          .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-          .erEtterDatofelt("fomDato")
-          .required(MAA_FYLLES_UT),
-        skatteplikttype: string().required(MAA_FYLLES_UT),
+          .erEtterDatofelt("fomDato"),
+        skatteplikttype: påkrevdHvisIkkeÅpenSluttDato(),
       })
     )
     .min(1),
   inntektskilder: lazy((_value, options) => {
-    return array().when(["$medlemskapsTypeErPliktig"], {
+    return array().when(["$medlemskapsTypeErPliktig", "$erÅpenSluttDato"], {
       is: (medlemskapsTypeErPliktig) => kreverInntektskilder(medlemskapsTypeErPliktig, options),
       then: array()
         .of(
           object().shape({
-            kildetype: string().required(MAA_FYLLES_UT),
+            kildetype: påkrevdHvisIkkeÅpenSluttDato(),
             arbAvgBetales: string().test(arbAvgBetalesFyltUtNårDetKrevesTest).nullable(),
             bruttoInntekt: string().erNummer().test(bruttoInntektFyltUtNårDetKrevesTest).nullable(),
-            fomDato: string()
+            fomDato: påkrevdHvisIkkeÅpenSluttDato()
+              .erGyldigDato()
+              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN),
+            tomDato: påkrevdHvisIkkeÅpenSluttDato()
               .erGyldigDato()
               .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-              .required(MAA_FYLLES_UT),
-            tomDato: string()
-              .erGyldigDato()
-              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-              .erEtterDatofelt("fomDato")
-              .required(MAA_FYLLES_UT),
+              .erEtterDatofelt("fomDato"),
           })
         )
         .min(1),

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgiftSchema.jsx
@@ -32,7 +32,7 @@ const arbAvgBetalesFyltUtNårDetKrevesTest = {
   },
 };
 
-const påkrevdHvisIkkeÅpenSluttDato = (fieldName) => {
+const påkrevdHvisIkkeÅpenSluttDato = () => {
   return string().when("$erÅpenSluttDato", {
     is: false,
     then: string().required(MAA_FYLLES_UT),


### PR DESCRIPTION
Den nye datamodellen fungerer slik at inntekt- og skatteforholdsperioder lagres først når vi beregner trygdeavgiftsperioder. Det er fordi inntekt og skatteforholdsperioder blir barn av trygdeavgiftsperioder. Derfor kan vi ikke mellomlagre inntekt- og skatteforholdsperioder. 

Ved endring av inntekt- og skatteforholdsperioder så trigger vi ny beregning. Det betyr at knappen for å beregne trygdeavgift ikke lenger er nødvendig.  

DAPI: https://github.com/navikt/melosys-api/pull/2372