### PR TITLE
6466 Fjerner ubrukte selectors og renamer litt

### DIFF
--- a/src/ducks/lovvalgsperioder/byggLovvalgsperioder.ts
+++ b/src/ducks/lovvalgsperioder/byggLovvalgsperioder.ts
@@ -98,7 +98,7 @@ const byggLovvalgsperiodeArtikkel11_3Aeller13_3A = (
   oppfyltLovvalg: string
 ): Lovvalgsperiode[] => {
   const søknadsperiode = mottatteOpplysningerSelectors.PeriodeSelector(reduxState);
-  const tilleggsbestemmelseFraVilkar = finnOppfyltVilkar(vilkarSelectors.valgteTilleggsVilkar(reduxState));
+  const tilleggsbestemmelseFraVilkar = finnOppfyltVilkar(vilkarSelectors.ValgteTilleggsVilkar(reduxState));
   const medlemskapsperiodeID = lovvalgsperioderSelectors.MedlemskapsperiodeIDSelector(reduxState);
   return [
     {
@@ -117,7 +117,7 @@ const byggLovvalgsperiodeArtikkel11_3Aeller13_3A = (
 
 const byggLovvalgsperiodeArtikkel11_3A = (stegState: PerioderStegState, reduxState: RootState) => {
   const periode = mottatteOpplysningerSelectors.PeriodeSelector(reduxState);
-  const tilleggsbestemmelseFraVilkar = finnOppfyltVilkar(vilkarSelectors.valgteTilleggsVilkar(reduxState));
+  const tilleggsbestemmelseFraVilkar = finnOppfyltVilkar(vilkarSelectors.ValgteTilleggsVilkar(reduxState));
   const medlemskapsperiodeID = lovvalgsperioderSelectors.MedlemskapsperiodeIDSelector(reduxState);
   const unntakFraBestemmelse = stegState.unntakfrabestemmelse;
 
@@ -347,7 +347,7 @@ const byggLovvalgsperioder = (stegState: PerioderStegState, reduxState: RootStat
 export function oppdaterLovvalgsperioderState(stegState: PerioderStegState) {
   return (dispatch: ThunkDispatch<RootState, unknown, Types.Action>, getState: () => RootState) => {
     const reduxState = getState();
-    const alleLovvalgsvilkar = vilkarSelectors.valgteLovvalgsVilkar(reduxState);
+    const alleLovvalgsvilkar = vilkarSelectors.ValgteLovvalgsVilkar(reduxState);
 
     if (alleLovvalgsvilkar.length > 0) {
       const oppfyltLovvalg = finnOppfyltVilkar(alleLovvalgsvilkar);

--- a/src/ducks/lovvalgsperioder/selectors.js
+++ b/src/ducks/lovvalgsperioder/selectors.js
@@ -6,7 +6,7 @@
  */
 
 import { createSelector } from "reselect";
-import { valgteLovvalgsVilkar } from "../vilkar/selectors";
+import { ValgteLovvalgsVilkar } from "../vilkar/selectors";
 
 // import * as Koder from '../../kodeverk';
 
@@ -22,7 +22,7 @@ export const LovvalgsperiodeSelector = createSelector(
 );
 
 export const ValgteLovvalgsVilkarBestemmelseSelector = createSelector(
-  (state) => valgteLovvalgsVilkar(state),
+  (state) => ValgteLovvalgsVilkar(state),
   (lovvalgsvilkar) => (lovvalgsvilkar.length > 0 ? lovvalgsvilkar[0].vilkaar : undefined)
 );
 

--- a/src/ducks/vilkar/selectors.js
+++ b/src/ducks/vilkar/selectors.js
@@ -22,42 +22,19 @@ export const VilkarSelector = createSelector(
   (vurdering) => vurdering
 );
 
-export const vesentligVirksomhetSelector = createSelector(
+export const VesentligVirksomhetSelector = createSelector(
   (state) => VilkarSelector(state),
   (alleVilkar) => finnVilkår(alleVilkar, MKV.Koder.vilkaar.VESENTLIG_VIRKSOMHET)
 );
 
-export const normaltDriverVirksomhetSelector = createSelector(
+export const NormaltDriverVirksomhetSelector = createSelector(
   (state) => VilkarSelector(state),
   (alleVilkar) => finnVilkår(alleVilkar, MKV.Koder.vilkaar.NORMALT_DRIVER_VIRKSOMHET)
 );
 
-export const forutgaendeMedlemskap = createSelector(
+export const ForutgaendeMedlemskapSelector = createSelector(
   (state) => VilkarSelector(state),
   (alleVilkar) => finnVilkår(alleVilkar, MKV.Koder.vilkaar.FORUTGAAENDE_MEDLEMSKAP)
-);
-
-export const art11_3A = createSelector(
-  (state) => VilkarSelector(state),
-  (alleVilkar) =>
-    finnVilkår(alleVilkar, MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_3A)
-);
-
-export const art11_4_1 = createSelector(
-  (state) => VilkarSelector(state),
-  (alleVilkar) =>
-    finnVilkår(alleVilkar, MKV.Koder.lovvalgsbestemmelser.tilleggsbestemmelser_883_2004.FO_883_2004_ART11_4_1)
-);
-
-export const art11_4_2 = createSelector(
-  (state) => VilkarSelector(state),
-  (alleVilkar) =>
-    finnVilkår(alleVilkar, MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_4_2)
-);
-
-export const nis = createSelector(
-  (state) => VilkarSelector(state),
-  (alleVilkar) => finnVilkår(alleVilkar, MKV.Koder.vilkaar.FTRL_2_12_UNNTAK_TURISTSKIP)
 );
 
 export const UtsendingsvilkårArbeidstakerSelector = createSelector(
@@ -144,24 +121,14 @@ export const Artikkel11_4_2Eller13_4_2Selector = createSelector(
   }
 );
 
-export const art12_1 = createSelector(
+export const Artikkel12_1BegrunnelserSelector = createSelector(
   (state) => VilkarSelector(state),
-  (alleVilkar) => finnVilkår(alleVilkar, MKV.Koder.vilkaar.FO_883_2004_ART12_1)
+  (alleVilkar) => finnVilkår(alleVilkar, MKV.Koder.vilkaar.FO_883_2004_ART12_1).begrunnelseKoder || []
 );
 
-export const art12_1_begrunnelserSelector = createSelector(
-  (state) => art12_1(state),
-  (art12_1_vilkar) => art12_1_vilkar.begrunnelseKoder || []
-);
-
-export const art12_2 = createSelector(
+export const Artikkel12_2BegrunnelserSelector = createSelector(
   (state) => VilkarSelector(state),
-  (alleVilkar) => finnVilkår(alleVilkar, MKV.Koder.vilkaar.FO_883_2004_ART12_2)
-);
-
-export const art12_2_begrunnelserSelector = createSelector(
-  (state) => art12_2(state),
-  (art12_2_vilkar) => art12_2_vilkar.begrunnelseKoder || []
+  (alleVilkar) => finnVilkår(alleVilkar, MKV.Koder.vilkaar.FO_883_2004_ART12_2).begrunnelseKoder || []
 );
 
 export const art16_1 = createSelector(
@@ -169,17 +136,17 @@ export const art16_1 = createSelector(
   (alleVilkar) => finnVilkår(alleVilkar, MKV.Koder.vilkaar.FO_883_2004_ART16_1)
 );
 
-export const art16_1_begrunnelserSelector = createSelector(
+export const Artikkel16_1BegrunnelserSelector = createSelector(
   (state) => art16_1(state),
   (art16_1_vilkar) => art16_1_vilkar.begrunnelseKoder || []
 );
 
-export const art16_1_fritekstSelector = createSelector(
+export const Artikkel16_1FritekstSelector = createSelector(
   (state) => art16_1(state),
   (art16_1_vilkar) => art16_1_vilkar.begrunnelseFritekst
 );
 
-export const valgteLovvalgsVilkar = createSelector(
+export const ValgteLovvalgsVilkar = createSelector(
   (state) => VilkarSelector(state),
   (alleVilkar) => {
     const alleLovvalg = [
@@ -193,7 +160,7 @@ export const valgteLovvalgsVilkar = createSelector(
   }
 );
 
-export const valgteTilleggsVilkar = createSelector(
+export const ValgteTilleggsVilkar = createSelector(
   (state) => VilkarSelector(state),
   (alleVilkar) => {
     const alleTilleggsbestemmelser = [
@@ -206,10 +173,10 @@ export const valgteTilleggsVilkar = createSelector(
   }
 );
 
-export const vilkarBegrunnelserSelector = createSelector(
-  (state) => vesentligVirksomhetSelector(state),
-  (state) => normaltDriverVirksomhetSelector(state),
-  (state) => forutgaendeMedlemskap(state),
+export const VilkarBegrunnelserSelector = createSelector(
+  (state) => VesentligVirksomhetSelector(state),
+  (state) => NormaltDriverVirksomhetSelector(state),
+  (state) => ForutgaendeMedlemskapSelector(state),
   (vesentligvirksomhet, normaltDrivervirksomhet, forutgaendemedlemskap) =>
     [
       ...(vesentligvirksomhet.begrunnelseKoder || []),

--- a/src/felleskomponenter/menypanelForm/soknad.tsx
+++ b/src/felleskomponenter/menypanelForm/soknad.tsx
@@ -17,7 +17,6 @@ import { behandlingsperioderSelectors } from "../../ducks/behandlingsperioder";
 import { mottatteOpplysningerOperations, mottatteOpplysningerSelectors } from "../../ducks/mottatteOpplysninger";
 import { behandlingerSelectors } from "../../ducks/behandlinger";
 import { avklartefaktaSelectors } from "../../ducks/avklartefakta";
-import { vilkarSelectors } from "../../ducks/vilkar";
 import { formSelectors } from "../../ducks/form";
 import { redigerbartSelectors } from "../../ducks/redigerbart";
 import { fagsakSelectors } from "../../ducks/fagsaker";
@@ -172,25 +171,6 @@ const mapStateToProps = (state: RootState) => ({
       yrkesgruppe: avklartefaktaSelectors.YrkesgruppeSelector(state),
       yrkesaktivitet: avklartefaktaSelectors.YrkesaktivitetSelector(state),
       sokkelSkipKonklusjon: avklartefaktaSelectors.ArbeidSokkelSkipSelector(state),
-    },
-    vilkar: {
-      // Klarer ikke å se hvor disse kan bli brukt... Slette?
-      vesentligVirksomhet: vilkarSelectors.vesentligVirksomhetSelector(state).oppfylt,
-      vesentligVirksomhetBegrunnelser: vilkarSelectors.vesentligVirksomhetSelector(state).begrunnelseKoder,
-      normaltDriverVirksomhet: vilkarSelectors.normaltDriverVirksomhetSelector(state).oppfylt,
-      normaltDriverVirksomhetBegrunnelser: vilkarSelectors.normaltDriverVirksomhetSelector(state).begrunnelseKoder,
-      forutgaendeMedlemskap: vilkarSelectors.forutgaendeMedlemskap(state).oppfylt,
-      forutgaendeMedlemskapBegrunnelser: vilkarSelectors.forutgaendeMedlemskap(state).begrunnelseKoder,
-      art11_3A: vilkarSelectors.art11_3A(state).oppfylt,
-      art11_4_1: vilkarSelectors.art11_4_1(state).oppfylt,
-      art11_4_2: vilkarSelectors.art11_4_2(state).oppfylt,
-      nis: vilkarSelectors.nis(state).oppfylt,
-      art12_1: vilkarSelectors.art12_1(state).oppfylt,
-      art12_1_begrunnelser: vilkarSelectors.art12_1(state).begrunnelseKoder,
-      art12_2: vilkarSelectors.art12_2(state).oppfylt,
-      art12_2_begrunnelser: vilkarSelectors.art12_2(state).begrunnelseKoder,
-      art16_1: vilkarSelectors.art16_1(state).oppfylt,
-      art16_1_begrunnelser: vilkarSelectors.art16_1(state).begrunnelseKoder,
     },
   },
 });

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/komponenter/vedtakBegrunnelser.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/komponenter/vedtakBegrunnelser.tsx
@@ -12,7 +12,7 @@ interface VedtakBegrunnelserProps {
 
 export const VedtakBegrunnelser = ({ anmodningsperiodeSvarType }: VedtakBegrunnelserProps) => {
   const konvensjonStorbritanniaToggleEnabled = useFeatureToggle(MELOSYS_KONVENSJON_EFTA_LAND_OG_STORBRITANNIA);
-  const vilkarBegrunnelser = useSelector(vilkarSelectors.vilkarBegrunnelserSelector);
+  const vilkarBegrunnelser = useSelector(vilkarSelectors.VilkarBegrunnelserSelector);
   const utsendtArbeidstakerBegrunnelser = useSelector(vilkarSelectors.UtsendingsvilkårArbeidstakerBegrunnelserSelector);
   const utsendtNaeringsdrivendeBegrunnelser = useSelector(
     vilkarSelectors.UtsendingsvilkårNæringsdrivendeBegrunnelserSelector

--- a/src/sider/eu_eøs/stegKomponenter/vurderingAvslag12_x_og_16.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingAvslag12_x_og_16.jsx
@@ -10,8 +10,8 @@ import * as KV from "../../../kodeverk";
 import * as Nav from "../../../navFrontend";
 import * as Skjema from "../../../felleskomponenter/skjema";
 import * as Mui from "../../../felleskomponenter/ui";
-import * as VilkarSelectors from "../../../ducks/vilkar/selectors";
 
+import { vilkarSelectors } from "../../../ducks/vilkar";
 import { behandlingerSelectors } from "../../../ducks/behandlinger";
 import { behandlingsresultatSelectors } from "../../../ducks/behandlingsresultat";
 import { kontrollerFerdigbehandling } from "../../../ducks/kontroll/operations";
@@ -250,11 +250,11 @@ const VurderingAvslagArtikkel12Og16Form = reduxForm({
 })(VurderingAvslag12_x_og_16);
 
 const mapStateToProps = (state) => ({
-  valgte_utsendt_arbeidstaker_begrunnelser: VilkarSelectors.art12_1_begrunnelserSelector(state),
-  valgte_utsendt_naeringsdrivende_begrunnelser: VilkarSelectors.art12_2_begrunnelserSelector(state),
-  valgte_art_16_1_begrunnelser: VilkarSelectors.art16_1_begrunnelserSelector(state),
-  art16_1_fritekst: VilkarSelectors.art16_1_fritekstSelector(state),
-  vilkarBegrunnelser: VilkarSelectors.vilkarBegrunnelserSelector(state),
+  valgte_utsendt_arbeidstaker_begrunnelser: vilkarSelectors.Artikkel12_1BegrunnelserSelector(state),
+  valgte_utsendt_naeringsdrivende_begrunnelser: vilkarSelectors.Artikkel12_2BegrunnelserSelector(state),
+  valgte_art_16_1_begrunnelser: vilkarSelectors.Artikkel16_1BegrunnelserSelector(state),
+  art16_1_fritekst: vilkarSelectors.Artikkel16_1FritekstSelector(state),
+  vilkarBegrunnelser: vilkarSelectors.VilkarBegrunnelserSelector(state),
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
   sakstype: fagsakSelectors.SakstypeKodeSelector(state),
   behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),


### PR DESCRIPTION
Hovedsaklig fjerning av vilkar: {} fra soknad-form da **jeg altså ikke klarer å se at det blir brukt noen steder**. Det gjorde at man kunne rydde litt i vilkårs-selectors.