### PR TITLE
6520 DAPI: Bruk riktig endepunkt for å se mulige behandlingstyper

### DIFF
--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -117,12 +117,12 @@ function EndreBehandlingModal({
 
   useEffect(() => {
     if (sakstype && sakstema && behandlingstema) {
-      Api.LovligeKombinasjoner.hentBehandlingstyper(
+      Api.LovligeKombinasjoner.hentBehandlingstyperForEndring(
         fagsak.hovedpartRolle,
         sakstype,
         sakstema,
         behandlingstema,
-        behandlingID
+        fagsak.saksnummer
       ).then((alleMuligeBehandlingstyper) => {
         setMuligeBehandlingstyper(alleMuligeBehandlingstyper);
       });

--- a/src/services/modules/lovligekombinasjoner/lovligekombinasjoner.js
+++ b/src/services/modules/lovligekombinasjoner/lovligekombinasjoner.js
@@ -18,23 +18,33 @@ export const hentBehandlingstemaer = (hovedpart, sakstype, sakstema, aktivBehand
   const params = QS.stringify({ hovedpart, sakstype, sakstema, aktivBehandlingID, sistBehandlingstema });
   return getAsJson(`${URI_PATH}/behandlingstemaer/hent-lovlige-kombinasjoner/?${params}`);
 };
-export const hentBehandlingstyper = (
-  hovedpart,
-  sakstype,
-  sakstema,
-  behandlingstema,
-  aktivBehandlingID,
-  sisteBehandlingsID
-) => {
+
+export const hentBehandlingstyper = (hovedpart, sakstype, sakstema, behandlingstema) => {
   const params = QS.stringify({
     hovedpart,
     sakstype,
     sakstema,
     behandlingstema,
-    aktivBehandlingID,
-    sisteBehandlingsID,
   });
-  return getAsJson(`${URI_PATH}/behandlingstyper/hent-lovlige-kombinasjoner/?${params}`);
+  return getAsJson(`${URI_PATH}/behandlingstyper/kombinasjoner/?${params}`);
+};
+
+export const hentBehandlingstyperForEndring = (hovedpart, sakstype, sakstema, behandlingstema, saksnummer) => {
+  const params = QS.stringify({
+    hovedpart,
+    sakstype,
+    sakstema,
+    behandlingstema,
+  });
+  return getAsJson(`${URI_PATH}/${saksnummer}/behandlingstyper/kombinasjoner-for-endring/?${params}`);
+};
+
+export const hentBehandlingstyperForKnyttTilSak = (hovedpart, saksnummer, behandlingstema) => {
+  const params = QS.stringify({
+    hovedpart,
+    behandlingstema,
+  });
+  return getAsJson(`${URI_PATH}/${saksnummer}/behandlingstyper/kombinasjoner-for-knytt-sak/?${params}`);
 };
 
 export const hentBehandlingsårsaktyper = (behandlingstype) => {

--- a/src/sider/journalforing/komponenter/journalforingform/journalforingform.test.jsx
+++ b/src/sider/journalforing/komponenter/journalforingform/journalforingform.test.jsx
@@ -95,6 +95,13 @@ vi.mock("../../../../services/modules/lovligekombinasjoner", async () => {
         { kode: "HENVENDELSE", term: HENVENDELSE },
         { kode: "KLAGE", term: KLAGE },
       ]),
+    hentBehandlingstyperForKnyttTilSak: () =>
+      Promise.resolve([
+        { kode: "FØRSTEGANG", term: FØRSTEGANG },
+        { kode: "NY_VURDERING", term: NY_VURDERING },
+        { kode: "HENVENDELSE", term: HENVENDELSE },
+        { kode: "KLAGE", term: KLAGE },
+      ]),
   };
 });
 

--- a/src/sider/journalforing/komponenter/knyttTilSak.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.jsx
@@ -211,6 +211,7 @@ export const KnyttTilSak = (props) => {
     </div>
   );
 };
+
 KnyttTilSak.propTypes = {
   sak: MPT.Fagsak.isRequired,
   erJournalføring: PT.bool.isRequired,

--- a/src/sider/journalforing/komponenter/knyttTilSak.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.jsx
@@ -96,13 +96,10 @@ export const KnyttTilSak = (props) => {
 
   useEffect(() => {
     if (sakstype.kode && sakstema.kode && behandlingstema) {
-      Api.LovligeKombinasjoner.hentBehandlingstyper(
+      Api.LovligeKombinasjoner.hentBehandlingstyperForKnyttTilSak(
         journalforingGjelder,
-        sakstype.kode,
-        sakstema.kode,
-        behandlingstema,
-        null,
-        sisteBehandling.behandlingID
+        sak.saksnummer,
+        behandlingstema
       ).then((alleMuligeBehandlingstyper) => {
         setMuligeBehandlingstyper(alleMuligeBehandlingstyper);
       });


### PR DESCRIPTION
DAPI: https://github.com/navikt/melosys-api/pull/2440

Skiller mellom endring, knytt til sak og oppretting av ny sak/behandling når vi skal hente mulige behandlingstyper