### PR TITLE
NOJIRA: Fjern ubrukt Husky-pakke

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx pretty-quick --staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,6 @@
         "eslint-plugin-jsx-a11y": "^6.1.1",
         "eslint-plugin-react": "^7.11.1",
         "eslint-plugin-vitest-globals": "^1.3.1",
-        "husky": "^7.0.4",
         "jsdom": "^22.1.0",
         "less": "^3.13.1",
         "less-plugin-npm-import": "^2.1.0",
@@ -11494,22 +11493,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.12.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "eslint:src": "eslint src --ext .js,.jsx,.ts,.tsx",
     "prettier:write": "prettier --write .",
     "prettier:check": "prettier --check .",
-    "prepare": "husky install",
     "generate-graphql": "graphql-codegen --config ./src/graphql/codegen.yml"
   },
   "prettier": {
@@ -144,7 +143,6 @@
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-vitest-globals": "^1.3.1",
-    "husky": "^7.0.4",
     "jsdom": "^22.1.0",
     "less": "^3.13.1",
     "less-plugin-npm-import": "^2.1.0",


### PR DESCRIPTION
Ble brukt før ifm. noe git commit hooks, men vi bruker det ikke lenger i dag. Det er nokså enkelt å legge det til igjen om ønskelig, og det arbeidet blir ikke større av å fjerne dette for nå.