### PR TITLE
6736 Fjerne 18.1 fra kodekombinasjon

### DIFF
--- a/src/melosyskodeverk/kodekombinasjoner.ts
+++ b/src/melosyskodeverk/kodekombinasjoner.ts
@@ -62,7 +62,6 @@ export const unntaksbestemmelserStorbritanniaKonv: KTObject[] = [
   MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_konv_efta_storbritannia.KONV_EFTA_STORBRITANNIA_ART15_5,
   MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_konv_efta_storbritannia.KONV_EFTA_STORBRITANNIA_ART16_1,
   MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_konv_efta_storbritannia.KONV_EFTA_STORBRITANNIA_ART16_3,
-  MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_konv_efta_storbritannia.KONV_EFTA_STORBRITANNIA_ART18_1,
 ].map((kode) =>
   kodeTilObjekt(kode, [
     ...MKV.KTObjects.lovvalgsbestemmelser.lovvalgbestemmelser_konv_efta_storbritannia,


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6736