### PR TITLE
6636 [DAPI] tilpasninger for brev inntektsopplysninger

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/brevFelt.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevFelt.tsx
@@ -63,6 +63,12 @@ const BrevFelt = ({ felt, visFeltBeskrivelse, width, redigerbart }: BrevFeltProp
           </Nav.Column>
         </Nav.Row>
       );
+    case DokumenterV2.FeltType.FORMTITTEL:
+      return (
+        <Nav.Row>
+          <LabelMedHjelpetekst label={felt.beskrivelse} hjelpetekst={felt.hjelpetekst} bold small />
+        </Nav.Row>
+      );
     default:
       return null;
   }

--- a/src/felleskomponenter/sideDialog/sendBrev/brevutkast/brevutkast.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevutkast/brevutkast.tsx
@@ -144,7 +144,7 @@ const Brevutkast = ({
       settFeltForInnledningFritekst();
       settFeltVerdi("MANGLER_FRITEKST", utkast.manglerFritekst);
       settFeltVerdi("FRITEKST", utkast.fritekst);
-      settFeltVerdi("STANDARDTEKST_KONTAKTINFORMASJON", utkast.kontaktopplysninger);
+      settFeltVerdi("STANDARDTEKST_KONTAKTINFORMASJON", utkast.skalViseStandardTekstOmkontaktopplysninger);
       setFritekstvedlegg(utkast.fritekstvedlegg || []);
       settFeltForSaksvedlegg(utkast.saksvedlegg || []);
       settKopiTilBruker(utkast.kopiMottakere || []);

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -323,6 +323,7 @@ const SendBrev = ({
     manglerFritekst: hentFormVerdi("MANGLER_FRITEKST"),
     fritekstTittel: hentFormVerdi("BREV_TITTEL", true),
     fritekst: hentFormVerdi("FRITEKST"),
+    skalViseStandardTekstOmOpplysninger: hentFormVerdi("STANDARDTEKST_OPPLYSNINGER"),
     kopiMottakere: hentKopiMottakere() || [],
     kontaktopplysninger: hentFormVerdi("STANDARDTEKST_KONTAKTINFORMASJON"),
     saksvedlegg: valgteVedlegg.map((vedlegg) => ({

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -325,7 +325,7 @@ const SendBrev = ({
     fritekst: hentFormVerdi("FRITEKST"),
     skalViseStandardTekstOmOpplysninger: hentFormVerdi("STANDARDTEKST_INNTEKTSOPPLYSNINGER"),
     kopiMottakere: hentKopiMottakere() || [],
-    kontaktopplysninger: hentFormVerdi("STANDARDTEKST_KONTAKTINFORMASJON"),
+    skalViseStandardTekstOmkontaktopplysninger: hentFormVerdi("STANDARDTEKST_KONTAKTINFORMASJON"),
     saksvedlegg: valgteVedlegg.map((vedlegg) => ({
       dokumentID: vedlegg.dokumentID,
       journalpostID: vedlegg.journalpostID,

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -323,7 +323,7 @@ const SendBrev = ({
     manglerFritekst: hentFormVerdi("MANGLER_FRITEKST"),
     fritekstTittel: hentFormVerdi("BREV_TITTEL", true),
     fritekst: hentFormVerdi("FRITEKST"),
-    skalViseStandardTekstOmOpplysninger: hentFormVerdi("STANDARDTEKST_OPPLYSNINGER"),
+    skalViseStandardTekstOmOpplysninger: hentFormVerdi("STANDARDTEKST_INNTEKTSOPPLYSNINGER"),
     kopiMottakere: hentKopiMottakere() || [],
     kontaktopplysninger: hentFormVerdi("STANDARDTEKST_KONTAKTINFORMASJON"),
     saksvedlegg: valgteVedlegg.map((vedlegg) => ({

--- a/src/felleskomponenter/sideDialog/sendBrev/valgAlternativer.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/valgAlternativer.tsx
@@ -13,7 +13,11 @@ interface ValgAlternativProps {
 }
 
 const renderLabel = (beskrivelse: string, hjelpetekst: string | null) => {
-  return <LabelMedHjelpetekst label={beskrivelse} hjelpetekst={hjelpetekst} bold small />;
+  return beskrivelse != null ? (
+    <LabelMedHjelpetekst label={beskrivelse} hjelpetekst={hjelpetekst} bold small />
+  ) : (
+    <span />
+  );
 };
 
 const ValgAlternativer = ({

--- a/src/services/modules/dokumenter-v2.ts
+++ b/src/services/modules/dokumenter-v2.ts
@@ -111,7 +111,7 @@ export type OpprettBrevReqDto = {
   skalViseStandardTekstOmOpplysninger?: boolean | null;
   kontaktpersonNavn?: string | null;
   kopiMottakere?: KopiMottaker[];
-  kontaktopplysninger?: boolean | null;
+  skalViseStandardTekstOmkontaktopplysninger?: boolean | null;
   saksvedlegg?: Saksvedlegg[];
   fritekstvedlegg?: {
     tittel: string;

--- a/src/services/modules/dokumenter-v2.ts
+++ b/src/services/modules/dokumenter-v2.ts
@@ -36,6 +36,7 @@ export enum FeltType {
   SJEKKBOKS = "SJEKKBOKS",
   VEDLEGG = "VEDLEGG",
   FRITEKSTVEDLEGG = "FRITEKSTVEDLEGG",
+  FORMTITTEL = "FORMTITTEL",
 }
 
 export interface Felt {
@@ -107,6 +108,7 @@ export type OpprettBrevReqDto = {
   manglerFritekst?: string | null;
   fritekstTittel?: string | null;
   fritekst?: string | null;
+  skalViseStandardTekstOmOpplysninger: boolean | false;
   kontaktpersonNavn?: string | null;
   kopiMottakere?: KopiMottaker[];
   kontaktopplysninger?: boolean | null;

--- a/src/services/modules/dokumenter-v2.ts
+++ b/src/services/modules/dokumenter-v2.ts
@@ -108,7 +108,7 @@ export type OpprettBrevReqDto = {
   manglerFritekst?: string | null;
   fritekstTittel?: string | null;
   fritekst?: string | null;
-  skalViseStandardTekstOmOpplysninger: boolean | false;
+  skalViseStandardTekstOmOpplysninger?: boolean | null;
   kontaktpersonNavn?: string | null;
   kopiMottakere?: KopiMottaker[];
   kontaktopplysninger?: boolean | null;


### PR DESCRIPTION
[https://jira.adeo.no/browse/MELOSYS-6636](url)
avhengigheter
[https://github.com/navikt/melosys-api/pull/2475](url)
Ved rendringer av felt hvor vi har tomme beskrivelser så unngår vi gap mellom checkboxene
Nytt felt er lagt til slik at vi får med oss standardtekst for opplysninger i requesten for opprettelse av brev.