### PR TITLE
6738 TOGGLE fritekster

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/komponenter/delvisInnvilgelse.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/komponenter/delvisInnvilgelse.tsx
@@ -51,7 +51,7 @@ const DelvisInnvilgelse = ({
       dokumentData: {
         produserbardokument: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_EFTA_STORBRITANNIA,
         mottaker: MKV.Koder.mottakerroller.BRUKER,
-        fritekst: vedtaksbrevFritekst,
+        begrunnelseFritekst: vedtaksbrevFritekst,
       },
     });
     pdfDokumenter.push({

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/komponenter/innvilgelse.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/komponenter/innvilgelse.tsx
@@ -50,7 +50,7 @@ const Innvilgelse = ({
       dokumentData: {
         produserbardokument: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_EFTA_STORBRITANNIA,
         mottaker: MKV.Koder.mottakerroller.BRUKER,
-        fritekst: vedtaksbrevFritekst,
+        begrunnelseFritekst: vedtaksbrevFritekst,
       },
     });
     pdfDokumenter.push({

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/vurderingArtikkel16Vedtak.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/vurderingArtikkel16Vedtak.tsx
@@ -180,6 +180,7 @@ export const VurderingArtikkel16Vedtak = ({
         const request = {
           behandlingsresultatTypeKode: FASTSATT_LOVVALGSLAND,
           fritekst: formValues.vedtaksbrevFritekst,
+          begrunnelseFritekst: formValues.vedtaksbrevFritekst,
           fritekstSed: null,
           mottakerinstitusjoner: null,
           vedtakstype: formValues.vedtakstype || FØRSTEGANGSVEDTAK,


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6738

Innvilgelsesbrevet skal kunne støtte 3 fritekster etterhvert. Begrunnelse, innledning og innvilgelse. Laget nytt felt i API for alle disse tre, må gjenspeile det i frontend. 

Endrer bare i EFTA Storbritannia, alt annet er urørt. Må fortsette å støtte "fritekst", mens i EFTA bruker jeg Begrunnelsefritekst for lettere forståelse.