### PR TITLE
6840 Sperrer for å hente behandlingstype hvis det er årsavregning

### DIFF
--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -53,6 +53,7 @@ type EndreBehandlingModalProps = PropsFromRedux &
     oppsummering: Api.Behandlinger.behandling.Oppsummering;
     mottattDato?: string;
     skalViseModal: boolean;
+    erÅrsavregning?: boolean;
     lukkModal: () => void;
   };
 
@@ -68,6 +69,7 @@ function EndreBehandlingModal({
   tilAnnenSide,
   location,
   anmodningsperioderSendtTilUtlandet,
+  erÅrsavregning,
 }: EndreBehandlingModalProps) {
   const [generellFeil, setGenerellFeil] = useState("");
   const [behandlingEndret, setBehandlingEndret] = useState(false);
@@ -82,7 +84,7 @@ function EndreBehandlingModal({
   const [muligeSakstyper, setMuligeSakstyper] = useState([]);
   const [muligeSakstemaer, setMuligeSakstemaer] = useState([]);
   const [muligeBehandlingstemaer, setMuligeBehandlingstemaer] = useState([]);
-  const [muligeBehandlingstyper, setMuligeBehandlingstyper] = useState([]);
+  const [muligeBehandlingstyper, setMuligeBehandlingstyper] = useState<KTObject[]>([]);
   const erArbeidKunNorgeToggleEnabled = useFeatureToggle(MELOSYS_ARBEID_KUN_NORGE);
 
   const typeTemaKanEndres = !anmodningsperioderSendtTilUtlandet;
@@ -120,6 +122,15 @@ function EndreBehandlingModal({
   }, [sakstype, sakstema]);
 
   useEffect(() => {
+    console.log({ behandlingstype });
+  }, [behandlingstype]);
+
+  useEffect(() => {
+    if (erÅrsavregning) {
+      setBehandlingstype(oppsummering.behandlingstype?.kode);
+      setMuligeBehandlingstyper([oppsummering.behandlingstype]);
+      return;
+    }
     if (sakstype && sakstema && behandlingstema) {
       Api.LovligeKombinasjoner.hentBehandlingstyperForEndring(
         fagsak.hovedpartRolle,
@@ -131,7 +142,7 @@ function EndreBehandlingModal({
         setMuligeBehandlingstyper(alleMuligeBehandlingstyper);
       });
     }
-  }, [sakstype, sakstema, behandlingstema]);
+  }, [sakstype, sakstema, behandlingstema, erÅrsavregning]);
 
   useEffect(() => {
     if (skalViseModal) {
@@ -314,7 +325,7 @@ function EndreBehandlingModal({
           label="Behandlingstype"
           value={behandlingstype}
           koder={muligeBehandlingstyper}
-          redigerbart={!erBehandlingAvSed && typeTemaKanEndres}
+          redigerbart={!erBehandlingAvSed && typeTemaKanEndres && !erÅrsavregning}
           feil={skalViseFeilmeldinger ? behandlingstypeFeilmelding : null}
           disableForsteValg
         />

--- a/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
+++ b/src/felleskomponenter/oppsummering/endreBehandlingModal.tsx
@@ -122,10 +122,6 @@ function EndreBehandlingModal({
   }, [sakstype, sakstema]);
 
   useEffect(() => {
-    console.log({ behandlingstype });
-  }, [behandlingstype]);
-
-  useEffect(() => {
     if (erÅrsavregning) {
       setBehandlingstype(oppsummering.behandlingstype?.kode);
       setMuligeBehandlingstyper([oppsummering.behandlingstype]);

--- a/src/felleskomponenter/oppsummering/oppsummering.tsx
+++ b/src/felleskomponenter/oppsummering/oppsummering.tsx
@@ -30,7 +30,6 @@ const { AVSLUTTET, IVERKSETTER_VEDTAK, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Ko
 const { ÅRSAVREGNING } = MKV.Koder.behandlinger.behandlingstyper;
 
 const behandlingsStatusMedBegrensetRettigheter = [AVSLUTTET, IVERKSETTER_VEDTAK, MIDLERTIDIG_LOVVALGSBESLUTNING];
-const behandlingstypeMedBegrensetRettigheter = [ÅRSAVREGNING];
 
 const mapStateToProps = (state: RootState) => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
@@ -94,7 +93,8 @@ const Oppsummering = ({
   } = oppsummering;
 
   const disableEndreKnapp = behandlingsStatusMedBegrensetRettigheter.includes(behandlingsstatus.kode) || !redigerbart;
-  const erÅrsavregning = behandlingstypeMedBegrensetRettigheter.includes(behandlingstype.kode);
+  const erÅrsavregning = [ÅRSAVREGNING].includes(behandlingstype.kode);
+
   const erLitenSkjerm = Utils.mediaQuery.useMediaQuery({ maxWidth: 1440 });
 
   const erSed = MKVUtils.erBehandlingAvSed(sakstype.kode, behandlingstema.kode);

--- a/src/felleskomponenter/oppsummering/oppsummering.tsx
+++ b/src/felleskomponenter/oppsummering/oppsummering.tsx
@@ -27,7 +27,10 @@ import { useFeatureToggle } from "../../featuretoggle";
 import { MELOSYS_ARBEID_KUN_NORGE } from "../../featuretoggle/toggleNavn";
 
 const { AVSLUTTET, IVERKSETTER_VEDTAK, MIDLERTIDIG_LOVVALGSBESLUTNING } = MKV.Koder.behandlinger.behandlingsstatus;
+const { ÅRSAVREGNING } = MKV.Koder.behandlinger.behandlingstyper;
+
 const behandlingsStatusMedBegrensetRettigheter = [AVSLUTTET, IVERKSETTER_VEDTAK, MIDLERTIDIG_LOVVALGSBESLUTNING];
+const behandlingstypeMedBegrensetRettigheter = [ÅRSAVREGNING];
 
 const mapStateToProps = (state: RootState) => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
@@ -91,6 +94,7 @@ const Oppsummering = ({
   } = oppsummering;
 
   const disableEndreKnapp = behandlingsStatusMedBegrensetRettigheter.includes(behandlingsstatus.kode) || !redigerbart;
+  const erÅrsavregning = behandlingstypeMedBegrensetRettigheter.includes(behandlingstype.kode);
   const erLitenSkjerm = Utils.mediaQuery.useMediaQuery({ maxWidth: 1440 });
 
   const erSed = MKVUtils.erBehandlingAvSed(sakstype.kode, behandlingstema.kode);
@@ -218,6 +222,7 @@ const Oppsummering = ({
       <EndreBehandlingModal
         fagsak={fagsak}
         oppsummering={oppsummering}
+        erÅrsavregning={erÅrsavregning}
         mottattDato={mottaksdato}
         skalViseModal={skalViseEndreModal}
         lukkModal={() => setSkalViseEndreModal(false)}


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6840

Hvis behandlingen er av type årsavregning, er det ikke vits å gjøre kall for å spørre om hvilken behandlingstype som er mulig å endre til. Skaper bare unødvendig støy i loggene