### PR TITLE
6814 Fjernet emptyFieldDisabled fra select i inntektskilder.tsx

### DIFF
--- a/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.tsx
@@ -113,7 +113,6 @@ export const Inntektskilder = ({
                   control={control}
                   readOnly={!redigerbart}
                   onChange={(value) => handleEndreKildetype(index, value)}
-                  emptyFieldDisabled
                 >
                   {MKV.KTObjects.inntektskildetype
                     .filter((kt: KTObject) => {

--- a/src/felleskomponenter/trygdeavgift/komponenter/skatteforholdsperioder.less
+++ b/src/felleskomponenter/trygdeavgift/komponenter/skatteforholdsperioder.less
@@ -4,6 +4,10 @@
     gap: unset;
   }
 
+  .navds-radio-buttons {
+    margin-bottom: 0;
+  }
+
   .legg-til__rad {
     margin: 0.5rem 0 1rem 0;
   }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereGrunnlagsopplysningerFinnesIkke.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereGrunnlagsopplysningerFinnesIkke.tsx
@@ -3,6 +3,7 @@ import "../vurderingAarsavregning.css";
 import { FormValuesProps } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
 import { Control } from "react-hook-form";
 import * as Forms from "../../../../../felleskomponenter/forms";
+import { Heading } from "@navikt/ds-react";
 
 interface TidligereGrunnlagProps {
   formValues: FormValuesProps;
@@ -12,7 +13,9 @@ interface TidligereGrunnlagProps {
 
 const informasjonsmeldingIngenInformasjonOmPerioder = (
   <Nav.Alert variant="info" size="small" className="informasjonsmeldingIngenInformasjonOmPerioder">
-    Det er ingen informasjon om perioder med medlemskap og forskuddsvis fakturert trygdeavgift i Melosys.
+    <Heading size="small">
+      Det er ingen informasjon om perioder med medlemskap og forskuddsvis fakturert trygdeavgift i Melosys.
+    </Heading>
     <ul>
       <li>Hvis trygdeavgiften er forskuddsvis fakturert fra avgiftssystemet, oppgi totalbeløpet som er fakturert.</li>
       <li>


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6814
Ikke direkte en bug, men for bruker så det ut som skjema var i gyldig tilstand uten å kjøre et beregningskall. Nå får bruker opp alternativ Velg... ved usatt inntektskildetype