### PR TITLE
MELOSYS-6931: Vis andre brev enn SED når BUC er lukket i utpeking

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -352,7 +352,11 @@ const VurderingVedtak = ({
             {stegErGyldig && (
               <Dokumentliste
                 behandlingID={behandlingID}
-                dokumenter={mapDokumenter(pdfDokumenter as BrevDokumentMetadataType[])}
+                dokumenter={
+                  bucLukketOgLovvalgNorge
+                    ? pdfDokumenter.filter((dok) => !("sedType" in dok))
+                    : mapDokumenter(pdfDokumenter as BrevDokumentMetadataType[])
+                }
               />
             )}
           </Nav.Column>

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -354,7 +354,7 @@ const VurderingVedtak = ({
                 behandlingID={behandlingID}
                 dokumenter={
                   bucLukketOgLovvalgNorge
-                    ? pdfDokumenter.filter((dok) => !("sedType" in dok))
+                    ? mapDokumenter(pdfDokumenter.filter((dok) => !("sedType" in dok)) as BrevDokumentMetadataType[])
                     : mapDokumenter(pdfDokumenter as BrevDokumentMetadataType[])
                 }
               />


### PR DESCRIPTION
Forrige PR https://github.com/navikt/melosys-web/pull/2491 fjernet litt for mye begrensninger. Vi skal fortsatt skjule SED-dokumenter dersom BUC er låst.