### PR TITLE
6871 Oppdaterer fakturamottaker ved endring av fullmakt

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -113,6 +113,10 @@ export const VurderingVedtak = ({ tilbake, aktivtSteg }: Props) => {
     if (erFullmektigEndret) {
       hentOgSetHarFullmaktForTrygdeavgift();
 
+      Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
+        setFakturaMottaker(dto.navn);
+      });
+
       dispatch(menypanelOperations.setErFullmektigEndret(false));
     }
   }, [erFullmektigEndret]);


### PR DESCRIPTION
I årsavregningsflyt.

Oppgaven kom i retur, men klarer ikke å gjenskape scenarioet der fullmakt for trygdeavgift er en person, men varselet ikke dukker opp.