### PR TITLE
MELOSYS-6953 QA fix for vise tekst og ikke en tom tabell når det ikke er noen data i tabellen

### DIFF
--- a/src/felleskomponenter/sideDialog/__snapshots__/sideDialog.test.tsx.snap
+++ b/src/felleskomponenter/sideDialog/__snapshots__/sideDialog.test.tsx.snap
@@ -119,54 +119,56 @@ exports[`SideDialog > snapshot test 1`] = `
           id="333"
           data-state="active"
         >
-          <div class="sideDialogDokumenter">
-            <table
-              aria-label="Liste over dokumenter knyttet til saken"
-              class="navds-table navds-table--small"
-            >
-              <thead class="navds-table__header">
-                <tr class="navds-table__row navds-table__row--shade-on-hover">
-                  <th
-                    class="navds-table__header-cell navds-label navds-label--small"
-                    aria-label="Mottaksretning"
-                  >
-                  </th>
-                  <th class="navds-table__header-cell navds-label navds-label--small">
-                    Dokument
-                  </th>
-                  <th class="navds-table__header-cell navds-label navds-label--small">
-                    Avsender/mottaker
-                  </th>
-                  <th class="navds-table__header-cell navds-label navds-label--small">
-                    Dato
-                  </th>
-                </tr>
-              </thead>
-              <tbody class="navds-table__body">
-                <tr class="navds-table__row navds-table__row--shade-on-hover">
-                  <td class="navds-table__data-cell mottaksretning navds-body-short navds-body-short--small">
-                    <span class="navds-tag navds-tag--info navds-tag--small navds-body-short navds-body-short--small">
-                      inn
-                    </span>
-                  </td>
-                  <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-                    <span>
-                      <a
-                        href="#"
-                        class="navds-link navds-link--action"
-                      >
-                        tittel (åpnes i ny fane)
-                      </a>
-                    </span>
-                  </td>
-                  <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-                    avsendernavn
-                  </td>
-                  <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+          <div>
+            <div class="sideDialogDokumenter">
+              <table
+                aria-label="Liste over dokumenter knyttet til saken"
+                class="navds-table navds-table--small"
+              >
+                <thead class="navds-table__header">
+                  <tr class="navds-table__row navds-table__row--shade-on-hover">
+                    <th
+                      class="navds-table__header-cell navds-label navds-label--small"
+                      aria-label="Mottaksretning"
+                    >
+                    </th>
+                    <th class="navds-table__header-cell navds-label navds-label--small">
+                      Dokument
+                    </th>
+                    <th class="navds-table__header-cell navds-label navds-label--small">
+                      Avsender/mottaker
+                    </th>
+                    <th class="navds-table__header-cell navds-label navds-label--small">
+                      Dato
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="navds-table__body">
+                  <tr class="navds-table__row navds-table__row--shade-on-hover">
+                    <td class="navds-table__data-cell mottaksretning navds-body-short navds-body-short--small">
+                      <span class="navds-tag navds-tag--info navds-tag--small navds-body-short navds-body-short--small">
+                        inn
+                      </span>
+                    </td>
+                    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+                      <span>
+                        <a
+                          href="#"
+                          class="navds-link navds-link--action"
+                        >
+                          tittel (åpnes i ny fane)
+                        </a>
+                      </span>
+                    </td>
+                    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+                      avsendernavn
+                    </td>
+                    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
         <div

--- a/src/felleskomponenter/sideDialog/sideDialogDokumenter.tsx
+++ b/src/felleskomponenter/sideDialog/sideDialogDokumenter.tsx
@@ -105,24 +105,26 @@ const SideDialogDokumenter = ({ behandlingID, dokumentOversikt, setAktivTab }: S
   const harDokumenter = Array.isArray(dokumentOversikt) && dokumentOversikt.length > 0;
 
   return (
-    <div className="sideDialogDokumenter">
+    <div>
       <LagredeUtkast alleUtkast={utkast} settAktivtUtkast={handleValgtUtkast} />
       {harDokumenter ? (
-        <Nav.Table size="small" aria-label="Liste over dokumenter knyttet til saken">
-          <Nav.Table.Header>
-            <Nav.Table.Row>
-              <Nav.Table.HeaderCell aria-label="Mottaksretning" />
-              <Nav.Table.HeaderCell>Dokument</Nav.Table.HeaderCell>
-              <Nav.Table.HeaderCell>Avsender/mottaker</Nav.Table.HeaderCell>
-              <Nav.Table.HeaderCell>Dato</Nav.Table.HeaderCell>
-            </Nav.Table.Row>
-          </Nav.Table.Header>
-          <Nav.Table.Body>
-            {dokumentOversikt.map((oversikt) => (
-              <OversiktRad key={uuid()} dokumentOversikt={oversikt} />
-            ))}
-          </Nav.Table.Body>
-        </Nav.Table>
+        <div className="sideDialogDokumenter">
+          <Nav.Table size="small" aria-label="Liste over dokumenter knyttet til saken">
+            <Nav.Table.Header>
+              <Nav.Table.Row>
+                <Nav.Table.HeaderCell aria-label="Mottaksretning" />
+                <Nav.Table.HeaderCell>Dokument</Nav.Table.HeaderCell>
+                <Nav.Table.HeaderCell>Avsender/mottaker</Nav.Table.HeaderCell>
+                <Nav.Table.HeaderCell>Dato</Nav.Table.HeaderCell>
+              </Nav.Table.Row>
+            </Nav.Table.Header>
+            <Nav.Table.Body>
+              {dokumentOversikt.map((oversikt) => (
+                <OversiktRad key={uuid()} dokumentOversikt={oversikt} />
+              ))}
+            </Nav.Table.Body>
+          </Nav.Table>
+        </div>
       ) : (
         <BodyShort size="small" textColor="subtle">
           Det er ingen dokumenter tilknyttet saken/behandlingen.


### PR DESCRIPTION
Hindrer at css klassen sideDialogDokumenter treffer meldingen om ingen dokumenter da dette førte til at meldingen ble sånn halvveis scrollbar. 