### PR TITLE
MELOSYS-6861: Tilpasse vedtakssteg for 11.3a

### DIFF
--- a/src/featuretoggle/toggleNavn.ts
+++ b/src/featuretoggle/toggleNavn.ts
@@ -4,7 +4,7 @@ const FEATURE_TOGGLE = "feature-toggle";
 const MELOSYS_KONVENSJON_EFTA_LAND_OG_STORBRITANNIA = "melosys.konvensjon.efta.land.og.storbritannia";
 const MELOSYS_ARBEID_KUN_NORGE = "melosys.arbeid.kun.norge";
 const MELOSYS_SPESIELLE_GRUPPER = "melosys.spesielle_grupper";
-const MELOSYS_11_3_A_NORGE_ER_UTPEKT = "melosys.11_3_a_Norge_er_utpekt";
+const MELOSYS_NORGE_ER_UTPEKT_11_3_A = "melosys.11_3_a_Norge_er_utpekt";
 
 const alleToggleNavn = [
   MELOSYS_FAKTURERINGSKOMPONENTEN_VIS_REFERANSE,
@@ -12,7 +12,7 @@ const alleToggleNavn = [
   MELOSYS_KONVENSJON_EFTA_LAND_OG_STORBRITANNIA,
   MELOSYS_ARBEID_KUN_NORGE,
   MELOSYS_SPESIELLE_GRUPPER,
-  MELOSYS_11_3_A_NORGE_ER_UTPEKT,
+  MELOSYS_NORGE_ER_UTPEKT_11_3_A,
 ];
 
 export {
@@ -22,6 +22,6 @@ export {
   MELOSYS_KONVENSJON_EFTA_LAND_OG_STORBRITANNIA,
   MELOSYS_ARBEID_KUN_NORGE,
   MELOSYS_SPESIELLE_GRUPPER,
-  MELOSYS_11_3_A_NORGE_ER_UTPEKT,
+  MELOSYS_NORGE_ER_UTPEKT_11_3_A,
   alleToggleNavn,
 };

--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -40,6 +40,7 @@ import { AvklartefaktaStore, EnkelDataStore, StegStoreTyper, VilkaarStore } from
 import "./stegvelger.css";
 import { erFeatureToggleEnabled } from "../../featuretoggle";
 import {
+  MELOSYS_NORGE_ER_UTPEKT_11_3_A,
   MELOSYS_ARBEID_KUN_NORGE,
   MELOSYS_KONVENSJON_EFTA_LAND_OG_STORBRITANNIA,
 } from "../../featuretoggle/toggleNavn";
@@ -449,6 +450,7 @@ class Stegvelger extends Component {
       harFeilmeldinger: !Utils._isEmpty(props.feilmeldinger) || !Utils._isEmpty(props.kontrollfeil),
       konvensjonStorbritanniaToggleEnabled: props.konvensjonStorbritanniaToggleEnabled,
       arbeidKunNorgeToggleEnabled: props.arbeidKunNorgeToggleEnabled,
+      norgeErUtpekt11_3AToggleEnabled: props.norgeErUtpekt11_3AToggleEnabled,
       utsendingsvilkår: props.utsendingsvilkår,
       unntaksvilkår: props.unntaksvilkår,
       behandlingOppfriskes: props.behandlingOppfriskes,
@@ -669,6 +671,7 @@ Stegvelger.propTypes = {
   ),
   konvensjonStorbritanniaToggleEnabled: PT.bool.isRequired,
   arbeidKunNorgeToggleEnabled: PT.bool.isRequired,
+  norgeErUtpekt11_3AToggleEnabled: PT.bool.isRequired,
   utsendingsvilkår: PT.object.isRequired,
   unntaksvilkår: PT.object.isRequired,
   art11_3Aeller13_3A: PT.object.isRequired,
@@ -758,6 +761,7 @@ const mapStateToProps = (state) => ({
   kontrollfeil: kontrollSelectors.KontrollFeilSelector(state),
   konvensjonStorbritanniaToggleEnabled: erFeatureToggleEnabled(MELOSYS_KONVENSJON_EFTA_LAND_OG_STORBRITANNIA, state),
   arbeidKunNorgeToggleEnabled: erFeatureToggleEnabled(MELOSYS_ARBEID_KUN_NORGE, state),
+  norgeErUtpekt11_3AToggleEnabled: erFeatureToggleEnabled(MELOSYS_NORGE_ER_UTPEKT_11_3_A, state),
 });
 
 /* eslint no-alert:off */

--- a/src/sider/eu_eøs/stegKomponenter/vurderingUtpekt/vurderingUtpekt.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingUtpekt/vurderingUtpekt.jsx
@@ -34,7 +34,7 @@ import vurderingUtpektSchema from "./vurderingUtpektSchema";
 
 import "./vurderingUtpekt.css";
 import { useFeatureToggle } from "../../../../featuretoggle";
-import { MELOSYS_11_3_A_NORGE_ER_UTPEKT } from "../../../../featuretoggle/toggleNavn";
+import { MELOSYS_NORGE_ER_UTPEKT_11_3_A } from "../../../../featuretoggle/toggleNavn";
 
 export const VurderingUtpekt = ({
   vurderingBegrunnelser,
@@ -50,7 +50,7 @@ export const VurderingUtpekt = ({
   behandlingstema,
   behandlingID,
 }) => {
-  const erToggle11_3_A_NorgeErUtpektEnabled = useFeatureToggle(MELOSYS_11_3_A_NORGE_ER_UTPEKT);
+  const erToggle11_3_A_NorgeErUtpektEnabled = useFeatureToggle(MELOSYS_NORGE_ER_UTPEKT_11_3_A);
 
   const lovvalgsbestemmelserStottetAvBrevVedNorgeUtpekt = MKV.Kodekombinasjoner.alleEØSLovvalg.filter(
     ({ kode }) =>

--- a/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
+++ b/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
@@ -2,7 +2,7 @@ import * as EKV from "eessi-kodeverk";
 
 import MKV from "../../../../melosyskodeverk";
 import Steg from "../../../../felleskomponenter/stegvelger/stegMotor/steg";
-import { STEG, FANE_STATUS } from "../../../../felleskomponenter/stegvelger";
+import { FANE_STATUS, STEG } from "../../../../felleskomponenter/stegvelger";
 import VurderingVedtak from "../../stegKomponenter/vurderingVedtak/vurderingVedtak";
 
 class GodkjennUtpekingNorge extends Steg {
@@ -15,8 +15,31 @@ class GodkjennUtpekingNorge extends Steg {
     this.komponent = VurderingVedtak;
     this.samleRelevanteData = (_propsLight) => {
       const formValues = _propsLight.artikkel12_vedtak_skjema;
+      const norgeErUtpekt11_3AToggleEnabled = _propsLight.norgeErUtpekt11_3AToggleEnabled;
 
-      const pdfDokumenter = [
+      let pdfDokumenterNorgeErUtpekt11_3_a = [
+        {
+          dokumentData: {
+            produserbardokument: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_EFTA_STORBRITANNIA,
+            mottaker: MKV.Koder.mottakerroller.BRUKER,
+            fritekst: formValues.vedtaksbrevFritekst,
+          },
+        },
+        {
+          dokumentData: {
+            produserbardokument: MKV.Koder.brev.produserbaredokumenter.ATTEST_A1,
+            mottaker: MKV.Koder.mottakerroller.BRUKER,
+          },
+        },
+        {
+          sedType: EKV.Koder.sedtyper.A012,
+          sedData: {
+            fritekst: formValues.fritekstSed,
+          },
+        },
+      ];
+
+      const godkjennUtpekingNorge = [
         {
           dokumentData: {
             produserbardokument: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV_FLERE_LAND,
@@ -31,6 +54,8 @@ class GodkjennUtpekingNorge extends Steg {
           },
         },
       ];
+
+      const pdfDokumenter = norgeErUtpekt11_3AToggleEnabled ? pdfDokumenterNorgeErUtpekt11_3_a : godkjennUtpekingNorge;
 
       return {
         redigerbart: _propsLight.generiskStegRedigerbart,

--- a/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
+++ b/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
@@ -38,7 +38,7 @@ class GodkjennUtpekingNorge extends Steg {
         },
       ];
 
-      const godkjennUtpekingNorge = [
+      const pdfDokumenterGodkjennUtpekingNorge = [
         {
           dokumentData: {
             produserbardokument: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_YRKESAKTIV_FLERE_LAND,
@@ -59,7 +59,7 @@ class GodkjennUtpekingNorge extends Steg {
         _propsLight.lovvalgsbestemmelse ===
           MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_3A
           ? pdfDokumenterNorgeErUtpekt11_3_a
-          : godkjennUtpekingNorge;
+          : pdfDokumenterGodkjennUtpekingNorge;
 
       return {
         redigerbart: _propsLight.generiskStegRedigerbart,

--- a/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
+++ b/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
@@ -15,9 +15,8 @@ class GodkjennUtpekingNorge extends Steg {
     this.komponent = VurderingVedtak;
     this.samleRelevanteData = (_propsLight) => {
       const formValues = _propsLight.artikkel12_vedtak_skjema;
-      const norgeErUtpekt11_3AToggleEnabled = _propsLight.norgeErUtpekt11_3AToggleEnabled;
 
-      let pdfDokumenterNorgeErUtpekt11_3_a = [
+      const pdfDokumenterNorgeErUtpekt11_3_a = [
         {
           dokumentData: {
             produserbardokument: MKV.Koder.brev.produserbaredokumenter.INNVILGELSE_EFTA_STORBRITANNIA,
@@ -55,7 +54,9 @@ class GodkjennUtpekingNorge extends Steg {
         },
       ];
 
-      const pdfDokumenter = norgeErUtpekt11_3AToggleEnabled ? pdfDokumenterNorgeErUtpekt11_3_a : godkjennUtpekingNorge;
+      const pdfDokumenter = _propsLight.norgeErUtpekt11_3AToggleEnabled
+        ? pdfDokumenterNorgeErUtpekt11_3_a
+        : godkjennUtpekingNorge;
 
       return {
         redigerbart: _propsLight.generiskStegRedigerbart,

--- a/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
+++ b/src/sider/eu_eøs/vurderutpeking/stegMap/godkjennutpekingnorge.js
@@ -54,9 +54,12 @@ class GodkjennUtpekingNorge extends Steg {
         },
       ];
 
-      const pdfDokumenter = _propsLight.norgeErUtpekt11_3AToggleEnabled
-        ? pdfDokumenterNorgeErUtpekt11_3_a
-        : godkjennUtpekingNorge;
+      const pdfDokumenter =
+        _propsLight.norgeErUtpekt11_3AToggleEnabled &&
+        _propsLight.lovvalgsbestemmelse ===
+          MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART11_3A
+          ? pdfDokumenterNorgeErUtpekt11_3_a
+          : godkjennUtpekingNorge;
 
       return {
         redigerbart: _propsLight.generiskStegRedigerbart,


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6861
* Rename toggle-variabel-navn
* Legge til egne dokumenter for 11.3a

NB. Virker rart å bruke EFTA-vedtaksbrevet, men har bekreftet med fag om at det er riktig.

Alt annet virker å funke ut av boksen.