### PR TITLE
7041 Ved innsynsmodus i eu/eøs flyt forsvinner vedtakssteget

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidsland/vurderingVurderarbeidsland.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidsland/vurderingVurderarbeidsland.tsx
@@ -83,13 +83,13 @@ export function VurderingVurderarbeidsland({
   }, []);
 
   useEffect(() => {
-    if (initialized) {
-      // slettData(slettAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSLAND));
-      // arbeidsland
-      //   .filter((land: string) => land)
-      //   .forEach((land: string) => {
-      //     oppdaterData(lagAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSLAND, land, land, null));
-      //   });
+    if (initialized && redigerbart) {
+      slettData(slettAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSLAND));
+      arbeidsland
+        .filter((land: string) => land)
+        .forEach((land: string) => {
+          oppdaterData(lagAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSLAND, land, land, null));
+        });
     }
   }, [arbeidsland.toString(), initialized]);
 

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidsland/vurderingVurderarbeidsland.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidsland/vurderingVurderarbeidsland.tsx
@@ -64,7 +64,7 @@ export function VurderingVurderarbeidsland({
   const maritimtArbeid = useSelector(formSelectors.MaritimtArbeidSelector);
   const hjemmebaser = useSelector(mottatteOpplysningerSelectors.HjemmebaserSelector);
   const soknadsland = useSelector(mottatteOpplysningerSelectors.SoknadslandkoderSelector);
-  const arbeidsland = useSelector(avklartefaktaSelectors.ArbeidslandSelector);
+  const arbeidsland = useSelector(avklartefaktaSelectors.ArbeidslandSelector) as any;
   const fjernedeArbeidsland = useSelector(avklartefaktaSelectors.IkkeArbeidslandSoknadslandSelector);
 
   useEffect(() => {
@@ -84,13 +84,12 @@ export function VurderingVurderarbeidsland({
 
   useEffect(() => {
     if (initialized) {
-      slettData(slettAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSLAND));
-
-      arbeidsland
-        .filter((land: string) => land)
-        .forEach((land: string) => {
-          oppdaterData(lagAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSLAND, land, land, null));
-        });
+      // slettData(slettAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSLAND));
+      // arbeidsland
+      //   .filter((land: string) => land)
+      //   .forEach((land: string) => {
+      //     oppdaterData(lagAvklartfakta(MKV.Koder.avklartefaktatyper.ARBEIDSLAND, land, land, null));
+      //   });
     }
   }, [arbeidsland.toString(), initialized]);
 

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
@@ -91,6 +91,7 @@ export function VurderingArtikkel13_x_vedtak({
   };
 
   useEffect(() => {
+    if (!redigerbart) return;
     const isoTomDato = Utils.dato.formatterDatoTilISO(formValues.tomDato, null);
     if (isoTomDato) {
       oppdaterLovvalgsperiode(lovvalgsperiode.fomDato, isoTomDato);


### PR DESCRIPTION
Høres ikke helt riktig ut å oppdatere data osv når det er innsynsmodus. Legger inn en sjekk på dette. 

https://jira.adeo.no/browse/MELOSYS-7041