### PR TITLE
7038 preutfylt periode

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -251,7 +251,6 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   );
 
   useEffect(() => {
-    console.log("formvalues: ", formValues);
     if (redigerbart && aktivtSteg && !isValidating && !erÅpenSluttDato) {
       debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
     }

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -69,9 +69,11 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const medlemskapsTypeErPliktig = medlemskapsperioder.every(
     (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
   );
-  const defaultPeriode = {
-    fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
-    tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
+  const formattedDefaultPeriode = () => {
+    return {
+      fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
+      tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
+    };
   };
   const erÅpenSluttDato = !innvilgetMedlemskapsperiode?.tom;
 
@@ -133,12 +135,12 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
       setHarEndretInnvilgetMedlemskapsperiode(true);
     }
 
-    resetSkatteforholdsperioder([{ ...defaultPeriode }]);
-  }, [innvilgetMedlemskapsperiode]);
+    resetSkatteforholdsperioder([{ ...formattedDefaultPeriode() }]);
+  }, [innvilgetMedlemskapsperiode, skalViseInntektskilder]);
 
   useEffect(() => {
     if (skalViseInntektskilder) {
-      resetInntektskilder([{ ...defaultPeriode }]);
+      resetInntektskilder([{ ...formattedDefaultPeriode() }]);
     }
   }, [skalViseInntektskilder]);
 
@@ -153,7 +155,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
             tomDato: Utils.dato.formatterDatoTilNorsk(skatteforhold.tomDato),
             skatteplikttype: skatteforhold.skatteplikttype,
           }))
-        : [defaultPeriode],
+        : [formattedDefaultPeriode()],
     );
     resetInntektskilder(
       !Utils._isEmpty(sorterteInntekstkilder)
@@ -168,7 +170,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
             tomDato: Utils.dato.formatterDatoTilNorsk(inntektskilde.tomDato),
             erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(inntektskilde.erMaanedsbelop),
           }))
-        : [{ ...defaultPeriode, erMaanedsbelop: BOOLSK_STRING.SANN }],
+        : [{ ...formattedDefaultPeriode(), erMaanedsbelop: BOOLSK_STRING.SANN }],
     );
   };
 
@@ -306,7 +308,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
             remove={skattRemove}
             append={skattAppend}
             control={control}
-            defaultPeriode={defaultPeriode}
+            defaultPeriode={formattedDefaultPeriode()}
             fields={skattFields}
           />
         </>
@@ -326,7 +328,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
             remove={inntektRemove}
             append={inntektAppend}
             control={control}
-            defaultPeriode={defaultPeriode}
+            defaultPeriode={formattedDefaultPeriode()}
             fields={inntektFields}
             medlemskapsTypeErPliktig={medlemskapsTypeErPliktig}
             bestemmelse={bestemmelse}

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -85,7 +85,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     context: { medlemskapsperiode: innvilgetMedlemskapsperiode, medlemskapsTypeErPliktig, erÅpenSluttDato },
     mode: "onChange",
     defaultValues: {
-      skatteforholdsperioder: [{}],
+      skatteforholdsperioder: [{ fomDato: defaultPeriode.fomDato, tomDato: innvilgetMedlemskapsperiode?.tom }],
       inntektskilder: [{}],
     } as FieldValue<FormValuesProps>,
   });
@@ -122,13 +122,25 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const trygdeavgiftErIkkeTom = !Utils._isEmpty(lagretTrygdeavgift?.trygdeavgiftsperioder);
 
   const harBeregnetForeløpigTrygdeavgift = !skalBeregneForelopigTrygdeavgift || trygdeavgiftErIkkeTom;
+  const skalViseInntektskilder =
+    !(medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder)) &&
+    !erÅpenSluttDato;
+
   useEffect(() => {
     if (harEndretInnvilgetMedlemskapsperiode === undefined) {
       setHarEndretInnvilgetMedlemskapsperiode(false);
     } else {
       setHarEndretInnvilgetMedlemskapsperiode(true);
     }
+
+    resetSkatteforholdsperioder([{ ...defaultPeriode }]);
   }, [innvilgetMedlemskapsperiode]);
+
+  useEffect(() => {
+    if (skalViseInntektskilder) {
+      resetInntektskilder([{ ...defaultPeriode }]);
+    }
+  }, [skalViseInntektskilder]);
 
   const håndterLagretTrygdeavgiftsgrunnlag = (trygdeavgiftsgrunnlag: TrygdeavgiftsgrunnlagDto) => {
     const { inntektskilder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
@@ -239,6 +251,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   );
 
   useEffect(() => {
+    console.log("formvalues: ", formValues);
     if (redigerbart && aktivtSteg && !isValidating && !erÅpenSluttDato) {
       debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
     }
@@ -300,28 +313,27 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
         </>
       )}
 
-      {!(medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder)) &&
-        !erÅpenSluttDato && (
-          <>
-            <LabelMedHjelpetekst
-              label="Oppgi informasjon om brukers inntekt"
-              hjelpetekst="Hvis bruker har flere inntekter, f.eks. fra Norge og fra utlandet, så må de legges til enkeltvis."
-              undertittel
-            />
-            <Inntektskilder
-              formValues={formValues}
-              redigerbart={redigerbart}
-              update={inntektUpdate}
-              remove={inntektRemove}
-              append={inntektAppend}
-              control={control}
-              defaultPeriode={defaultPeriode}
-              fields={inntektFields}
-              medlemskapsTypeErPliktig={medlemskapsTypeErPliktig}
-              bestemmelse={bestemmelse}
-            />
-          </>
-        )}
+      {skalViseInntektskilder && (
+        <>
+          <LabelMedHjelpetekst
+            label="Oppgi informasjon om brukers inntekt"
+            hjelpetekst="Hvis bruker har flere inntekter, f.eks. fra Norge og fra utlandet, så må de legges til enkeltvis."
+            undertittel
+          />
+          <Inntektskilder
+            formValues={formValues}
+            redigerbart={redigerbart}
+            update={inntektUpdate}
+            remove={inntektRemove}
+            append={inntektAppend}
+            control={control}
+            defaultPeriode={defaultPeriode}
+            fields={inntektFields}
+            medlemskapsTypeErPliktig={medlemskapsTypeErPliktig}
+            bestemmelse={bestemmelse}
+          />
+        </>
+      )}
 
       <Feilmelding type={aktivFeilmeldingType} />
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -136,7 +136,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     }
 
     resetSkatteforholdsperioder([{ ...formattedDefaultPeriode() }]);
-  }, [innvilgetMedlemskapsperiode, skalViseInntektskilder]);
+  }, [innvilgetMedlemskapsperiode]);
 
   useEffect(() => {
     if (skalViseInntektskilder) {

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -105,6 +105,8 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     replace: resetInntektskilder,
   } = useFieldArray<FieldArrayProps, "inntektskilder", "id">({ control, name: "inntektskilder" });
   const formValues = watch();
+  const inntektskilderWatch = watch("inntektskilder");
+  const [mellomLagringInntektskilder, setMellomLagringInntektskilder] = useState<Inntektskilde[]>([]);
 
   const aktivFeilmeldingType = finnAktivFeilmelding(
     formValues?.inntektskilder,
@@ -142,11 +144,9 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     resetSkatteforholdsperioder([{ ...formattedPeriode }]);
   }, [innvilgetMedlemskapsperiode]);
 
-  const inntektskilder = watch("inntektskilder");
-  const [mellomLagringInntektskilder, setMellomLagringInntektskilder] = useState<Inntektskilde[]>([]);
   useEffect(() => {
     if (!skalViseInntektskilder) {
-      setMellomLagringInntektskilder([...inntektskilder]);
+      setMellomLagringInntektskilder([...inntektskilderWatch]);
       resetInntektskilder([{ ...formattedDefaultPeriode() }]);
     } else {
       const defaultInntektskilder =

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -105,7 +105,6 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     replace: resetInntektskilder,
   } = useFieldArray<FieldArrayProps, "inntektskilder", "id">({ control, name: "inntektskilder" });
   const formValues = watch();
-  const inntektskilderWatch = watch("inntektskilder");
   const [mellomLagringInntektskilder, setMellomLagringInntektskilder] = useState<Inntektskilde[]>([]);
 
   const aktivFeilmeldingType = finnAktivFeilmelding(
@@ -146,7 +145,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
 
   useEffect(() => {
     if (!skalViseInntektskilder) {
-      setMellomLagringInntektskilder([...inntektskilderWatch]);
+      setMellomLagringInntektskilder([...formValues.inntektskilder]);
       resetInntektskilder([{ ...formattedDefaultPeriode() }]);
     } else {
       const defaultInntektskilder =

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -88,7 +88,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     mode: "onChange",
     defaultValues: {
       skatteforholdsperioder: [{}],
-      inntektskilder: [{}],
+      inntektskilder: [],
     } as FieldValue<FormValuesProps>,
   });
   const {
@@ -135,12 +135,23 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
       setHarEndretInnvilgetMedlemskapsperiode(true);
     }
 
-    resetSkatteforholdsperioder([{ ...formattedDefaultPeriode() }]);
+    const formattedPeriode = formattedDefaultPeriode();
+
+    setMellomLagringInntektskilder([]);
+    resetInntektskilder([{ ...formattedPeriode }]);
+    resetSkatteforholdsperioder([{ ...formattedPeriode }]);
   }, [innvilgetMedlemskapsperiode]);
 
+  const inntektskilder = watch("inntektskilder");
+  const [mellomLagringInntektskilder, setMellomLagringInntektskilder] = useState<Inntektskilde[]>([]);
   useEffect(() => {
-    if (skalViseInntektskilder) {
+    if (!skalViseInntektskilder) {
+      setMellomLagringInntektskilder([...inntektskilder]);
       resetInntektskilder([{ ...formattedDefaultPeriode() }]);
+    } else {
+      const defaultInntektskilder =
+        mellomLagringInntektskilder.length > 0 ? mellomLagringInntektskilder : [{ ...formattedDefaultPeriode() }];
+      resetInntektskilder(defaultInntektskilder);
     }
   }, [skalViseInntektskilder]);
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -85,7 +85,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     context: { medlemskapsperiode: innvilgetMedlemskapsperiode, medlemskapsTypeErPliktig, erÅpenSluttDato },
     mode: "onChange",
     defaultValues: {
-      skatteforholdsperioder: [{ fomDato: defaultPeriode.fomDato, tomDato: innvilgetMedlemskapsperiode?.tom }],
+      skatteforholdsperioder: [{}],
       inntektskilder: [{}],
     } as FieldValue<FormValuesProps>,
   });


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7038

- perioden hentes nå ut fra medlemskapsperiode og fyller ut for trygdeavgiftsperiodene til beregning
- foretar en mellomlagring av inntektskilder dersom man bytter mellom skattepliktig og ikke så man slipper å legge det inn på nytt om man velger feil