### PR TITLE
7091: La standardvedlegg være null by default i valgteVedlegg

### DIFF
--- a/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.jsx
+++ b/src/felleskomponenter/sideDialog/sideDialogOpprettNyBuc.jsx
@@ -39,7 +39,7 @@ function SideDialogOpprettNyBuc({ behandlingID, behandlingstema, sakstype, dokum
   const [valgteMottakerinstitusjoner, setValgteMottakerinstitusjoner] = useState([]);
   const [valgteVedlegg, setValgteVedlegg] = useState({
     saksvedlegg: [],
-    standardvedlegg: [],
+    standardvedlegg: null,
   });
 
   const [opprettetBucUrl, setOpprettetBucUrl] = useState("");
@@ -79,7 +79,7 @@ function SideDialogOpprettNyBuc({ behandlingID, behandlingstema, sakstype, dokum
     setValgtFagomrade(EKV.Koder.sektor.LA);
     setValgteVedlegg({
       saksvedlegg: [],
-      standardvedlegg: [],
+      standardvedlegg: null,
     });
     setFeilmeldinger({ buc: undefined, land: undefined, mottakerinstitusjoner: undefined });
     setOppdaterteFelt({ buc: false, land: false, mottakerinstitusjoner: false });


### PR DESCRIPTION
Standardvedlegg er ikke av typen array. Der det senere gjøres sjekk for å se om standardvedlegg er satt (dvs ikke null), så ble det feil.