### PR TITLE
7090 TOGGLE Lag default perioder basert på medlemskapsperiode

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
@@ -77,7 +77,9 @@ const mapTilSkatteforholdProps = (
       tomDato: Utils.dato.formatterDatoTilNorsk(forhold.tomDato),
       skatteplikttype: forhold.skatteplikttype,
     }));
-  } else if (medlemskapsTomFomDato.fom !== undefined && medlemskapsTomFomDato.tom !== undefined) {
+  }
+
+  if (medlemskapsTomFomDato.fom !== undefined && medlemskapsTomFomDato.tom !== undefined) {
     return [
       {
         fomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsTomFomDato.fom),
@@ -104,7 +106,9 @@ const mapTilInntektskilderProps = (
       bruttoInntekt: kilde.avgiftspliktigInntekt,
       erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(kilde.erMaanedsbelop),
     }));
-  } else if (medlemskapsTomFomDato.fom !== undefined && medlemskapsTomFomDato.tom !== undefined) {
+  }
+
+  if (medlemskapsTomFomDato.fom !== undefined && medlemskapsTomFomDato.tom !== undefined) {
     return [
       {
         fomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsTomFomDato.fom),
@@ -135,7 +139,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(undefined);
   const [bestemmelser, setBestemmelser] = useState<[]>([]);
-  const [visLeggTilMedlemskapsperioder, setVisLeggTilMedlemskapsperioder] = useState<boolean>(true); //TODO diskuter nødvendigheten av denne
+  const [visLeggTilMedlemskapsperioder, setVisLeggTilMedlemskapsperioder] = useState<boolean>(true); // TODO diskuter nødvendigheten av denne
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
@@ -40,8 +40,6 @@ interface Props {
   oppdaterStatus: (isValid: boolean) => void;
 }
 
-const { AVSLAATT } = MKV.Koder.innvilgelsesResultat;
-
 const mapTilMedlemskapsperiodeProps = (
   medlemskapsperiode: Api.MedlemAvFolketrygden.Medlemskapsperioder.Medlemskapsperiode,
 ): MedlemskapsperiodeProp => ({
@@ -82,17 +80,16 @@ const mapInitialMedlemskapsperioder = (
   medlemskapsperioder: Api.MedlemAvFolketrygden.Medlemskapsperioder.Medlemskapsperiode[],
 ): MedlemskapsperiodeProp[] =>
   [...medlemskapsperioder]
-    .sort((a, b) => Utils.dato.sorterEtterISOFomDato(a, b) || (a.innvilgelsesResultat === AVSLAATT ? -1 : 1))
+    .sort((a, b) => Utils.dato.sorterEtterISOFomDato(a, b))
     .map(mapTilMedlemskapsperiodeProps);
 
 interface AarsavregningFormValuesProps extends FormValuesProps {
   totaltForskuddsvisFakturert?: number | string;
 }
 
-const lagInnvilgetMedlemskapsPeriode = (medlemskapsperioder?: Medlemskapsperiode[]) => {
+const hentMedlemskapsTomFomDato = (medlemskapsperioder?: Medlemskapsperiode[]) => {
   if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
     const sorterteInnvilgedePerioder = [...medlemskapsperioder]
-      .filter((periode) => periode.innvilgelsesResultat === MKV.Koder.innvilgelsesResultat.INNVILGET)
       .sort(sorterEtterISOFomDato);
     return {
       fom: sorterteInnvilgedePerioder[0].fomDato,
@@ -112,7 +109,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(undefined);
   const [bestemmelser, setBestemmelser] = useState<[]>([]);
-  const [visLeggTilMedlemskapsperioder, setVisLeggTilMedlemskapsperioder] = useState<boolean>(false);
+  const [visLeggTilMedlemskapsperioder, setVisLeggTilMedlemskapsperioder] = useState<boolean>(true);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
@@ -125,12 +122,6 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
       Api.Ftrl.hentBestemmelser(behandlingstema).then((res: any) => setBestemmelser(res.bestemmelser));
     }
   }, [behandlingstema]);
-
-  const innvilgetMedlemskapsperiode = lagInnvilgetMedlemskapsPeriode(lagredeMedlemskapsperioder);
-  const defaultPeriode = {
-    fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
-    tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
-  };
 
   useEffect(() => {
     dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
@@ -153,6 +144,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
   }, []);
 
   useEffect(() => {
+    console.log("test")
     if (lagredeMedlemskapsperioder)
       setValue("medlemskapsperioder", mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder));
     setValue(
@@ -192,6 +184,8 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const medlemskapsTypeErPliktig = lagredeMedlemskapsperioder?.every(
     (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
   );
+
+  const innvilgetMedlemskapsperiode = hentMedlemskapsTomFomDato(lagredeMedlemskapsperioder);
 
   const {
     control,
@@ -341,6 +335,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const debouncedLagreMedlemskapsperioder = useCallback(
     Utils._debounce(async (alleMedlemskapsperioder, overskrevetIndex) => {
       const isValid = await trigger("medlemskapsperioder");
+      console.log(isValid)
       if (isValid) {
         // eslint-disable-next-line no-restricted-syntax
         for (const periode of alleMedlemskapsperioder) {
@@ -350,7 +345,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
         setVisLeggTilMedlemskapsperioder(true);
         dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
       } else {
-        setVisLeggTilMedlemskapsperioder(false);
+       // setVisLeggTilMedlemskapsperioder(false); TODO trenger vi denne
       }
     }, 1000),
     [],
@@ -368,7 +363,6 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
     };
     // @ts-expect-error generisk beskrivelse
     medlemskapsperioderAppend(nyMedlemskapsperiode);
-    debouncedLagreMedlemskapsperioder(formValues.medlemskapsperioder, undefined);
   };
 
   const handleSlett = async (index: number) => {
@@ -398,7 +392,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
           handleChange={debouncedLagreMedlemskapsperioder}
           handleUpdate={medlemskapsperioderUpdate}
           handleLeggTil={handleLeggTilMedlemskapsperiode}
-          visLeggTil={visLeggTilMedlemskapsperioder}
+          visLeggTil={true}
         />
       ))}
 
@@ -411,7 +405,6 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
         fields={skattFields}
       />
       <Inntektskilder
-        defaultPeriode={defaultPeriode}
         formValues={formValues}
         redigerbart={redigerbart}
         update={inntektUpdate}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
@@ -40,7 +40,14 @@ interface Props {
   oppdaterStatus: (isValid: boolean) => void;
 }
 
-const hentMedlemskapsTomFomDato = (medlemskapsperioder?: MedlemskapsperiodeProp[] | Medlemskapsperiode[]) => {
+export interface MedlemskapTomFomDatoer {
+  fom?: string;
+  tom?: string;
+}
+
+const hentMedlemskapsFomTomDato = (
+  medlemskapsperioder?: MedlemskapsperiodeProp[] | Medlemskapsperiode[],
+): MedlemskapTomFomDatoer => {
   if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
     const sorterteInnvilgedePerioder = [...medlemskapsperioder].sort(sorterEtterISOFomDato);
     return {
@@ -69,7 +76,7 @@ const mapTilSkatteforholdProps = (
   skatteforhold?: SkatteforholdDto[],
   medlemskapsperioder?: MedlemskapsperiodeProp[],
 ) => {
-  const medlemskapsTomFomDato = hentMedlemskapsTomFomDato(medlemskapsperioder);
+  const medlemskapsFomTomDato = hentMedlemskapsFomTomDato(medlemskapsperioder);
 
   if (skatteforhold !== undefined) {
     return skatteforhold?.map((forhold) => ({
@@ -79,11 +86,11 @@ const mapTilSkatteforholdProps = (
     }));
   }
 
-  if (medlemskapsTomFomDato.fom !== undefined && medlemskapsTomFomDato.tom !== undefined) {
+  if (medlemskapsFomTomDato.fom !== undefined && medlemskapsFomTomDato.tom !== undefined) {
     return [
       {
-        fomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsTomFomDato.fom),
-        tomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsTomFomDato.tom),
+        fomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsFomTomDato.fom),
+        tomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsFomTomDato.tom),
         skatteplikttype: undefined,
       },
     ];
@@ -95,7 +102,7 @@ const mapTilInntektskilderProps = (
   inntektskilder?: InntektskildeDto[],
   medlemskapsperioder?: MedlemskapsperiodeProp[],
 ) => {
-  const medlemskapsTomFomDato = hentMedlemskapsTomFomDato(medlemskapsperioder);
+  const medlemskapsTomFomDato = hentMedlemskapsFomTomDato(medlemskapsperioder);
 
   if (inntektskilder !== undefined) {
     return inntektskilder?.map((kilde) => ({
@@ -115,7 +122,7 @@ const mapTilInntektskilderProps = (
         tomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsTomFomDato.tom),
         kildetype: undefined,
         arbAvgBetales: Utils.streng.boolTilUppercaseStreng(false),
-        bruttoInntekt: 0,
+        bruttoInntekt: undefined,
         erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(false),
       },
     ];
@@ -174,19 +181,20 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
   useEffect(() => {
     if (lagredeMedlemskapsperioder) {
-      setValue("medlemskapsperioder", mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder));
+      const mappedLagredeMedlemskapsperioder = mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder);
+      setValue("medlemskapsperioder", mappedLagredeMedlemskapsperioder);
       setValue(
         "skatteforholdsperioder",
         mapTilSkatteforholdProps(
           aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder,
-          mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder),
+          mappedLagredeMedlemskapsperioder,
         ),
       );
       setValue(
         "inntektskilder",
         mapTilInntektskilderProps(
           aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder,
-          mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder),
+          mappedLagredeMedlemskapsperioder,
         ),
       );
     }
@@ -220,7 +228,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
     (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
   );
 
-  const innvilgetMedlemskapsperiode = hentMedlemskapsTomFomDato(lagredeMedlemskapsperioder);
+  const innvilgetMedlemskapsperiode = hentMedlemskapsFomTomDato(lagredeMedlemskapsperioder);
 
   const {
     control,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
@@ -42,8 +42,7 @@ interface Props {
 
 const hentMedlemskapsTomFomDatoProp = (medlemskapsperioder?: MedlemskapsperiodeProp[]) => {
   if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
-    const sorterteInnvilgedePerioder = [...medlemskapsperioder]
-      .sort(sorterEtterISOFomDato);
+    const sorterteInnvilgedePerioder = [...medlemskapsperioder].sort(sorterEtterISOFomDato);
     return {
       fom: sorterteInnvilgedePerioder[0].fomDato,
       tom: sorterteInnvilgedePerioder[sorterteInnvilgedePerioder.length - 1].tomDato,
@@ -66,9 +65,11 @@ const mapTilMedlemskapsperiodeProps = (
   periodeId: medlemskapsperiode.id,
 });
 
-const mapTilSkatteforholdProps = (skatteforhold?: SkatteforholdDto[], medlemskapsperioder?: MedlemskapsperiodeProp[]) => {
-
-  const test = hentMedlemskapsTomFomDatoProp(medlemskapsperioder)
+const mapTilSkatteforholdProps = (
+  skatteforhold?: SkatteforholdDto[],
+  medlemskapsperioder?: MedlemskapsperiodeProp[],
+) => {
+  const test = hentMedlemskapsTomFomDatoProp(medlemskapsperioder);
 
   if (skatteforhold !== undefined) {
     return skatteforhold?.map((forhold) => ({
@@ -77,18 +78,22 @@ const mapTilSkatteforholdProps = (skatteforhold?: SkatteforholdDto[], medlemskap
       skatteplikttype: forhold.skatteplikttype,
     }));
   } else if (test.fom !== undefined && test.tom !== undefined) {
-    return [{
-      fomDato: Utils.dato.formatterDatoTilNorsk(test.fom),
-      tomDato: Utils.dato.formatterDatoTilNorsk(test.tom),
-      skatteplikttype: undefined,
-    }]
+    return [
+      {
+        fomDato: Utils.dato.formatterDatoTilNorsk(test.fom),
+        tomDato: Utils.dato.formatterDatoTilNorsk(test.tom),
+        skatteplikttype: undefined,
+      },
+    ];
   }
   return [{}];
 };
 
-const mapTilInntektskilderProps = (inntektskilder?: InntektskildeDto[], medlemskapsperioder?: MedlemskapsperiodeProp[]) => {
-
-  const test = hentMedlemskapsTomFomDatoProp(medlemskapsperioder)
+const mapTilInntektskilderProps = (
+  inntektskilder?: InntektskildeDto[],
+  medlemskapsperioder?: MedlemskapsperiodeProp[],
+) => {
+  const test = hentMedlemskapsTomFomDatoProp(medlemskapsperioder);
 
   if (inntektskilder !== undefined) {
     return inntektskilder?.map((kilde) => ({
@@ -100,14 +105,16 @@ const mapTilInntektskilderProps = (inntektskilder?: InntektskildeDto[], medlemsk
       erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(kilde.erMaanedsbelop),
     }));
   } else if (test.fom !== undefined && test.tom !== undefined) {
-    return [{
-      fomDato: Utils.dato.formatterDatoTilNorsk(test.fom),
-      tomDato: Utils.dato.formatterDatoTilNorsk(test.tom),
-      kildetype: undefined,
-      arbAvgBetales: Utils.streng.boolTilUppercaseStreng(false),
-      bruttoInntekt: 0,
-      erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(false),
-    }]
+    return [
+      {
+        fomDato: Utils.dato.formatterDatoTilNorsk(test.fom),
+        tomDato: Utils.dato.formatterDatoTilNorsk(test.tom),
+        kildetype: undefined,
+        arbAvgBetales: Utils.streng.boolTilUppercaseStreng(false),
+        bruttoInntekt: 0,
+        erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(false),
+      },
+    ];
   }
   return [{}];
 };
@@ -115,9 +122,7 @@ const mapTilInntektskilderProps = (inntektskilder?: InntektskildeDto[], medlemsk
 const mapInitialMedlemskapsperioder = (
   medlemskapsperioder: Api.MedlemAvFolketrygden.Medlemskapsperioder.Medlemskapsperiode[],
 ): MedlemskapsperiodeProp[] =>
-  [...medlemskapsperioder]
-    .sort((a, b) => Utils.dato.sorterEtterISOFomDato(a, b))
-    .map(mapTilMedlemskapsperiodeProps);
+  [...medlemskapsperioder].sort((a, b) => Utils.dato.sorterEtterISOFomDato(a, b)).map(mapTilMedlemskapsperiodeProps);
 
 interface AarsavregningFormValuesProps extends FormValuesProps {
   totaltForskuddsvisFakturert?: number | string;
@@ -125,8 +130,7 @@ interface AarsavregningFormValuesProps extends FormValuesProps {
 
 const hentMedlemskapsTomFomDato = (medlemskapsperioder?: Medlemskapsperiode[]) => {
   if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
-    const sorterteInnvilgedePerioder = [...medlemskapsperioder]
-      .sort(sorterEtterISOFomDato);
+    const sorterteInnvilgedePerioder = [...medlemskapsperioder].sort(sorterEtterISOFomDato);
     return {
       fom: sorterteInnvilgedePerioder[0].fomDato,
       tom: sorterteInnvilgedePerioder[sorterteInnvilgedePerioder.length - 1].tomDato,
@@ -179,17 +183,23 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
   }, []);
 
   useEffect(() => {
-    console.log("test")
+    console.log("test");
     if (lagredeMedlemskapsperioder) {
-      console.log("test2")
+      console.log("test2");
       setValue("medlemskapsperioder", mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder));
       setValue(
         "skatteforholdsperioder",
-        mapTilSkatteforholdProps(aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder, mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder)),
+        mapTilSkatteforholdProps(
+          aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder,
+          mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder),
+        ),
       );
       setValue(
         "inntektskilder",
-        mapTilInntektskilderProps(aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder, mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder)),
+        mapTilInntektskilderProps(
+          aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder,
+          mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder),
+        ),
       );
     }
   }, [lagredeMedlemskapsperioder, aarsavregningResponse]);
@@ -372,7 +382,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const debouncedLagreMedlemskapsperioder = useCallback(
     Utils._debounce(async (alleMedlemskapsperioder, overskrevetIndex) => {
       const isValid = await trigger("medlemskapsperioder");
-      console.log(isValid)
+      console.log(isValid);
       if (isValid) {
         // eslint-disable-next-line no-restricted-syntax
         for (const periode of alleMedlemskapsperioder) {
@@ -381,7 +391,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
         }
         dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
       } else {
-       // setVisLeggTilMedlemskapsperioder(false); TODO trenger vi denne
+        // setVisLeggTilMedlemskapsperioder(false); TODO trenger vi denne
       }
     }, 1000),
     [],

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
@@ -40,6 +40,21 @@ interface Props {
   oppdaterStatus: (isValid: boolean) => void;
 }
 
+const hentMedlemskapsTomFomDatoProp = (medlemskapsperioder?: MedlemskapsperiodeProp[]) => {
+  if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
+    const sorterteInnvilgedePerioder = [...medlemskapsperioder]
+      .sort(sorterEtterISOFomDato);
+    return {
+      fom: sorterteInnvilgedePerioder[0].fomDato,
+      tom: sorterteInnvilgedePerioder[sorterteInnvilgedePerioder.length - 1].tomDato,
+    };
+  }
+  return {
+    tom: undefined,
+    fom: undefined,
+  };
+};
+
 const mapTilMedlemskapsperiodeProps = (
   medlemskapsperiode: Api.MedlemAvFolketrygden.Medlemskapsperioder.Medlemskapsperiode,
 ): MedlemskapsperiodeProp => ({
@@ -51,18 +66,30 @@ const mapTilMedlemskapsperiodeProps = (
   periodeId: medlemskapsperiode.id,
 });
 
-const mapTilSkatteforholdProps = (skatteforhold?: SkatteforholdDto[]) => {
+const mapTilSkatteforholdProps = (skatteforhold?: SkatteforholdDto[], medlemskapsperioder?: MedlemskapsperiodeProp[]) => {
+
+  const test = hentMedlemskapsTomFomDatoProp(medlemskapsperioder)
+
   if (skatteforhold !== undefined) {
     return skatteforhold?.map((forhold) => ({
       fomDato: Utils.dato.formatterDatoTilNorsk(forhold.fomDato),
       tomDato: Utils.dato.formatterDatoTilNorsk(forhold.tomDato),
       skatteplikttype: forhold.skatteplikttype,
     }));
+  } else if (test.fom !== undefined && test.tom !== undefined) {
+    return [{
+      fomDato: Utils.dato.formatterDatoTilNorsk(test.fom),
+      tomDato: Utils.dato.formatterDatoTilNorsk(test.tom),
+      skatteplikttype: undefined,
+    }]
   }
   return [{}];
 };
 
-const mapTilInntektskilderProps = (inntektskilder?: InntektskildeDto[]) => {
+const mapTilInntektskilderProps = (inntektskilder?: InntektskildeDto[], medlemskapsperioder?: MedlemskapsperiodeProp[]) => {
+
+  const test = hentMedlemskapsTomFomDatoProp(medlemskapsperioder)
+
   if (inntektskilder !== undefined) {
     return inntektskilder?.map((kilde) => ({
       fomDato: Utils.dato.formatterDatoTilNorsk(kilde.fomDato),
@@ -72,6 +99,15 @@ const mapTilInntektskilderProps = (inntektskilder?: InntektskildeDto[]) => {
       bruttoInntekt: kilde.avgiftspliktigInntekt,
       erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(kilde.erMaanedsbelop),
     }));
+  } else if (test.fom !== undefined && test.tom !== undefined) {
+    return [{
+      fomDato: Utils.dato.formatterDatoTilNorsk(test.fom),
+      tomDato: Utils.dato.formatterDatoTilNorsk(test.tom),
+      kildetype: undefined,
+      arbAvgBetales: Utils.streng.boolTilUppercaseStreng(false),
+      bruttoInntekt: 0,
+      erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(false),
+    }]
   }
   return [{}];
 };
@@ -109,7 +145,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(undefined);
   const [bestemmelser, setBestemmelser] = useState<[]>([]);
-  const [visLeggTilMedlemskapsperioder, setVisLeggTilMedlemskapsperioder] = useState<boolean>(true);
+  const [visLeggTilMedlemskapsperioder, setVisLeggTilMedlemskapsperioder] = useState<boolean>(true); //TODO diskuter nødvendigheten av denne
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
@@ -125,7 +161,6 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
   useEffect(() => {
     dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
-    trigger("medlemskapsperioder").then((isValid) => setVisLeggTilMedlemskapsperioder(isValid));
     if (behandlingID) {
       Api.Aarsavregning.hentAarsavregning(behandlingID)
         .then((res) => {
@@ -145,16 +180,18 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
   useEffect(() => {
     console.log("test")
-    if (lagredeMedlemskapsperioder)
+    if (lagredeMedlemskapsperioder) {
+      console.log("test2")
       setValue("medlemskapsperioder", mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder));
-    setValue(
-      "skatteforholdsperioder",
-      mapTilSkatteforholdProps(aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder),
-    );
-    setValue(
-      "inntektskilder",
-      mapTilInntektskilderProps(aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder),
-    );
+      setValue(
+        "skatteforholdsperioder",
+        mapTilSkatteforholdProps(aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder, mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder)),
+      );
+      setValue(
+        "inntektskilder",
+        mapTilInntektskilderProps(aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder, mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder)),
+      );
+    }
   }, [lagredeMedlemskapsperioder, aarsavregningResponse]);
 
   const oppdaterNyttTotalbeloep = async (totalAvgift?: number) => {
@@ -342,7 +379,6 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
           const index = overskrevetIndex !== undefined ? overskrevetIndex : alleMedlemskapsperioder.indexOf(periode);
           await lagreMedlemskapsperiode(periode, index);
         }
-        setVisLeggTilMedlemskapsperioder(true);
         dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
       } else {
        // setVisLeggTilMedlemskapsperioder(false); TODO trenger vi denne
@@ -373,8 +409,6 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
     } else {
       dispatch(medlemskapsperioderOperations.slettMedlemskapsperiode(behandlingID, medlemskapsperiode.periodeId));
     }
-
-    setVisLeggTilMedlemskapsperioder(await trigger("medlemskapsperioder"));
   };
   return (
     <div className="vurderingAarsavregning">

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
@@ -40,7 +40,7 @@ interface Props {
   oppdaterStatus: (isValid: boolean) => void;
 }
 
-const hentMedlemskapsTomFomDatoProp = (medlemskapsperioder?: MedlemskapsperiodeProp[]) => {
+const hentMedlemskapsTomFomDato = (medlemskapsperioder?: MedlemskapsperiodeProp[] | Medlemskapsperiode[]) => {
   if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
     const sorterteInnvilgedePerioder = [...medlemskapsperioder].sort(sorterEtterISOFomDato);
     return {
@@ -69,7 +69,7 @@ const mapTilSkatteforholdProps = (
   skatteforhold?: SkatteforholdDto[],
   medlemskapsperioder?: MedlemskapsperiodeProp[],
 ) => {
-  const test = hentMedlemskapsTomFomDatoProp(medlemskapsperioder);
+  const medlemskapsTomFomDato = hentMedlemskapsTomFomDato(medlemskapsperioder);
 
   if (skatteforhold !== undefined) {
     return skatteforhold?.map((forhold) => ({
@@ -77,11 +77,11 @@ const mapTilSkatteforholdProps = (
       tomDato: Utils.dato.formatterDatoTilNorsk(forhold.tomDato),
       skatteplikttype: forhold.skatteplikttype,
     }));
-  } else if (test.fom !== undefined && test.tom !== undefined) {
+  } else if (medlemskapsTomFomDato.fom !== undefined && medlemskapsTomFomDato.tom !== undefined) {
     return [
       {
-        fomDato: Utils.dato.formatterDatoTilNorsk(test.fom),
-        tomDato: Utils.dato.formatterDatoTilNorsk(test.tom),
+        fomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsTomFomDato.fom),
+        tomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsTomFomDato.tom),
         skatteplikttype: undefined,
       },
     ];
@@ -93,7 +93,7 @@ const mapTilInntektskilderProps = (
   inntektskilder?: InntektskildeDto[],
   medlemskapsperioder?: MedlemskapsperiodeProp[],
 ) => {
-  const test = hentMedlemskapsTomFomDatoProp(medlemskapsperioder);
+  const medlemskapsTomFomDato = hentMedlemskapsTomFomDato(medlemskapsperioder);
 
   if (inntektskilder !== undefined) {
     return inntektskilder?.map((kilde) => ({
@@ -104,11 +104,11 @@ const mapTilInntektskilderProps = (
       bruttoInntekt: kilde.avgiftspliktigInntekt,
       erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(kilde.erMaanedsbelop),
     }));
-  } else if (test.fom !== undefined && test.tom !== undefined) {
+  } else if (medlemskapsTomFomDato.fom !== undefined && medlemskapsTomFomDato.tom !== undefined) {
     return [
       {
-        fomDato: Utils.dato.formatterDatoTilNorsk(test.fom),
-        tomDato: Utils.dato.formatterDatoTilNorsk(test.tom),
+        fomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsTomFomDato.fom),
+        tomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsTomFomDato.tom),
         kildetype: undefined,
         arbAvgBetales: Utils.streng.boolTilUppercaseStreng(false),
         bruttoInntekt: 0,
@@ -127,20 +127,6 @@ const mapInitialMedlemskapsperioder = (
 interface AarsavregningFormValuesProps extends FormValuesProps {
   totaltForskuddsvisFakturert?: number | string;
 }
-
-const hentMedlemskapsTomFomDato = (medlemskapsperioder?: Medlemskapsperiode[]) => {
-  if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
-    const sorterteInnvilgedePerioder = [...medlemskapsperioder].sort(sorterEtterISOFomDato);
-    return {
-      fom: sorterteInnvilgedePerioder[0].fomDato,
-      tom: sorterteInnvilgedePerioder[sorterteInnvilgedePerioder.length - 1].tomDato,
-    };
-  }
-  return {
-    tom: undefined,
-    fom: undefined,
-  };
-};
 
 export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const [valgtÅr, setValgtÅr] = useState<number | null>(null);
@@ -183,9 +169,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
   }, []);
 
   useEffect(() => {
-    console.log("test");
     if (lagredeMedlemskapsperioder) {
-      console.log("test2");
       setValue("medlemskapsperioder", mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder));
       setValue(
         "skatteforholdsperioder",
@@ -382,7 +366,6 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const debouncedLagreMedlemskapsperioder = useCallback(
     Utils._debounce(async (alleMedlemskapsperioder, overskrevetIndex) => {
       const isValid = await trigger("medlemskapsperioder");
-      console.log(isValid);
       if (isValid) {
         // eslint-disable-next-line no-restricted-syntax
         for (const periode of alleMedlemskapsperioder) {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
@@ -132,35 +132,6 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
     tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
   };
 
-  const setSkjemaverdierFraTrygdeavgiftsgrunnlag = (trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag) => {
-    if (!trygdeavgiftsgrunnlag) return;
-    const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
-    const sorterteInntekstkilder = [...inntektskperioder].sort(Utils.dato.sorterEtterISOFomDato);
-    const sorterteSkatteforhold = [...skatteforholdsperioder].sort(Utils.dato.sorterEtterISOFomDato);
-    resetSkatteforholdsperioder(
-      !Utils._isEmpty(sorterteSkatteforhold)
-        ? sorterteSkatteforhold.map((skatteforhold) => ({
-            fomDato: Utils.dato.formatterDatoTilNorsk(skatteforhold.fomDato),
-            tomDato: Utils.dato.formatterDatoTilNorsk(skatteforhold.tomDato),
-            skatteplikttype: skatteforhold.skatteplikttype,
-          }))
-        : [],
-    );
-
-    resetInntektskilder(
-      !Utils._isEmpty(sorterteInntekstkilder)
-        ? sorterteInntekstkilder.map((inntektskilde) => ({
-            kildetype: inntektskilde.type,
-            arbAvgBetales: Utils.streng.boolTilUppercaseStreng(inntektskilde.arbeidsgiversavgiftBetales),
-            bruttoInntekt: inntektskilde.avgiftspliktigInntekt,
-            fomDato: Utils.dato.formatterDatoTilNorsk(inntektskilde.fomDato),
-            tomDato: Utils.dato.formatterDatoTilNorsk(inntektskilde.tomDato),
-            erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(inntektskilde.erMaanedsbelop),
-          }))
-        : [],
-    );
-  };
-
   useEffect(() => {
     dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
     trigger("medlemskapsperioder").then((isValid) => setVisLeggTilMedlemskapsperioder(isValid));
@@ -172,10 +143,6 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
           dispatch({ type: OK, data: res });
           setValgtÅr(res.aar);
           setValue("totaltForskuddsvisFakturert", res.avregning?.tidligereFakturertBeloep);
-
-          if (res.avvikFunnet && res?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
-            setSkjemaverdierFraTrygdeavgiftsgrunnlag(res.nyttGrunnlag?.trygdeavgiftsgrunnlag);
-          }
         })
         .catch((err) => {
           if (err.response?.status === 404) {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag.tsx
@@ -423,7 +423,7 @@ export function AarsavregningUtenGrunnlag({ bekreft, oppdaterStatus }: Props) {
           handleChange={debouncedLagreMedlemskapsperioder}
           handleUpdate={medlemskapsperioderUpdate}
           handleLeggTil={handleLeggTilMedlemskapsperiode}
-          visLeggTil={true}
+          visLeggTil
         />
       ))}
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlagSchema.jsx
@@ -75,13 +75,8 @@ const aarsavregningUtenGrunnlagSchema = object().shape({
     .min(1, "Minst en medlemskapsperiode")
     .of(
       object().shape({
-        fomDato: string()
-          .erGyldigDato()
-          .required(),
-        tomDato: string()
-          .erGyldigDato()
-          .erEtterDatofelt("fomDato")
-          .test(åpenTomNårIkkeSistePeriodeTest),
+        fomDato: string().erGyldigDato().required(),
+        tomDato: string().erGyldigDato().erEtterDatofelt("fomDato").test(åpenTomNårIkkeSistePeriodeTest),
         trygdedekning: string().required(),
         bestemmelse: string().required(),
       }),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlagSchema.jsx
@@ -77,12 +77,10 @@ const aarsavregningUtenGrunnlagSchema = object().shape({
       object().shape({
         fomDato: string()
           .erGyldigDato()
-          .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
           .required(),
         tomDato: string()
           .erGyldigDato()
           .erEtterDatofelt("fomDato")
-          .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
           .test(åpenTomNårIkkeSistePeriodeTest),
         trygdedekning: string().required(),
         bestemmelse: string().required(),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/meldinger.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/meldinger.tsx
@@ -3,6 +3,7 @@ import { Inntektskilde, Skatteforhold } from "../../../../felleskomponenter/tryg
 import * as Utils from "../../../../utils";
 import { Medlemskapsperiode } from "../../../../services/modules/medlemavfolketrygden/medlemskapsperioder";
 import { BOOLSK_STRING } from "../../../../constants";
+import { MedlemskapTomFomDatoer } from "./aarsavregningUtenGrunnlag/aarsavregningUtenGrunnlag";
 
 const HoyManedinntekt = (
   <Nav.Alert variant="warning" className="alertstripe_feilmelding">
@@ -30,7 +31,7 @@ enum TypeMelding {
 
 const finnesSkatteforholdPeriodeUtenforMedlemskapsperiode = (
   skatteforholdsperioder: Skatteforhold[],
-  innvilgetMedlemskapsperiode: { fom: string | undefined; tom: string | undefined },
+  innvilgetMedlemskapsperiode: MedlemskapTomFomDatoer,
 ) => {
   if (Utils._isEmpty(skatteforholdsperioder)) return false;
   const sorterteSkatteforhold = [...skatteforholdsperioder]
@@ -48,7 +49,7 @@ const finnesSkatteforholdPeriodeUtenforMedlemskapsperiode = (
 
 const finnesInntektskildeperiodeUtenforMedlemskapsperiode = (
   inntektskilder: Inntektskilde[],
-  innvilgetMedlemskapsperiode: { fom: string | undefined; tom: string | undefined },
+  innvilgetMedlemskapsperiode: MedlemskapTomFomDatoer,
 ) => {
   if (Utils._isEmpty(inntektskilder)) return false;
   const sorterteInntektskilder = [...inntektskilder]
@@ -74,7 +75,7 @@ export const finnAktivFeilmelding = (
   inntektskilder: Inntektskilde[],
   skatteforholdsperioder: Skatteforhold[],
   medlemskapsperioder: Medlemskapsperiode[] | undefined,
-  innvilgetMedlemskapsperiode?: { fom: string | undefined; tom: string | undefined },
+  innvilgetMedlemskapsperiode?: MedlemskapTomFomDatoer,
 ): string | undefined => {
   if (!medlemskapsperioder || !innvilgetMedlemskapsperiode || innvilgetMedlemskapsperiode.tom == null) return undefined;
 

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
@@ -16,7 +16,6 @@ import Dokumentliste from "../../../../felleskomponenter/dokumentliste";
 import Mottakerinstitusjonvelger from "../../../../felleskomponenter/mottakerinstitusjonvelger";
 import VedleggVelger from "../../../../felleskomponenter/vedleggvelger";
 import VedleggTable from "../../../../felleskomponenter/vedleggTable";
-import { TilgjengeligStandardvedlegg } from "../../../../services/modules/dokumenter-v2";
 
 import { behandlingerSelectors } from "../../../../ducks/behandlinger";
 import { avklartefaktaSelectors } from "../../../../ducks/avklartefakta";


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7090
Fjern validering for medlemskapsperiode. En medlemskapsperiode kan ikke gjøre validering på seg selv.
Lag en standard periode basert på medlemskapsperiode for skatt og inntekt.
Fjern ubrukt kode.
setVisLeggTilMedlemskapsperioder funker ikke som den skal så jeg fjerner alle instanser av denne inntil videre.