### PR TITLE
7074: Fiks logikk for adressevisning i RegistrertAdresse

### DIFF
--- a/src/felleskomponenter/adresser/registerAdresse.jsx
+++ b/src/felleskomponenter/adresser/registerAdresse.jsx
@@ -15,8 +15,7 @@ function RegisterAdresse({ adresse }) {
   }
 
   const { gateadresse, land, postnr, poststed } = adresse;
-
-  const { gatenavn, husnummer, husbokstav } = gateadresse;
+  const { gatenavn, husnummer, husbokstav } = gateadresse || {};
 
   const landNavn = typeof land === "string" ? land : KV.objektTilTermUtenFeilmelding(land);
   const visGate = gatenavn || husnummer || husbokstav;
@@ -25,23 +24,23 @@ function RegisterAdresse({ adresse }) {
     <address className="registeradresse">
       {visGate && (postnr || poststed) && landNavn ? (
         <div>
-          {gatenavn} {husnummer}
-          {husbokstav}, {postnr} {poststed}, {landNavn}
+          {gatenavn} {husnummer || ""}
+          {husbokstav || ""}, {postnr} {poststed}, {landNavn}
         </div>
       ) : (
-        (
-          visGate && (
+        <>
+          {visGate && (
             <div>
-              {gatenavn} {husnummer} {husbokstav}
+              {gatenavn} {husnummer || ""} {husbokstav || ""}
             </div>
-          )
-        )(
-          (postnr || poststed) && (
+          )}
+          {(postnr || poststed) && (
             <div>
               {postnr} {poststed}
             </div>
-          ),
-        )(landNavn && <div>{landNavn}</div>)
+          )}
+          {landNavn && <div>{landNavn}</div>}
+        </>
       )}
     </address>
   ) : (


### PR DESCRIPTION
RegisterAdresse-komponenten feilet når den mottok null-verdier i adresseobjektet. Feilen oppsto spesifikt ved rendring av gatenummer, husbokstav og husnummer.

**Løsning:**

- Endret conditional rendering logikken ved å bruke Fragment
- La til null-sjekk på adresseverdier
- Forbedret håndtering av ufullstendige adresser

Testet med både komplette og ukomplette adresseobjekter. Komponenten håndterer nå alle tilfeller uten å krasje.