### PR TITLE
7144 Lovvalgsbestemmelse skal ikke være null 

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak11_3_og_13_3a/vurderingVedtak11_3_og_13_3a.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak11_3_og_13_3a/vurderingVedtak11_3_og_13_3a.tsx
@@ -193,7 +193,9 @@ export function VurderingVedtak11_3_og_13_3a({
         Omfattet av norsk trygdelovgivning
       </Nav.Heading>
       <Mui.KodeTermSelect
-        onChange={(e) => setValue("lovvalgsbestemmelse", e.target.value)}
+        onChange={(e) => {
+          setValue("lovvalgsbestemmelse", e.target.value, { shouldValidate: true });
+        }}
         label="Velg en lovvalgsbestemmelse"
         value={formValues.lovvalgsbestemmelse}
         koder={[

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak11_3_og_13_3a/vurderingVedtak11_3_og_13_3aSchema.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak11_3_og_13_3a/vurderingVedtak11_3_og_13_3aSchema.js
@@ -1,10 +1,14 @@
 import { object, string } from "yup";
 import * as KV from "../../../../kodeverk";
 import { MAA_FYLLES_UT } from "../../../../kodeverk/feilmeldinger";
+import { Lovvalgsbestemmelse } from "../../../../proptypes";
+import { notNull } from "ts-mockito";
 
 const { DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN } = KV.Feilmeldinger;
+const { KORTERE_PERIODE } = MKV.Lovvalgsbestemmelser;
 
 const vurderingVedtak_11_3_og_13_3aSchema = object().shape({
+  lovvalgsbestemmelse: notNull,
   begrunnelseFritekst: string().nullable().max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN),
   fom: string().when("korterePeriodeChecked", {
     is: true,

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak11_3_og_13_3a/vurderingVedtak11_3_og_13_3aSchema.js
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak11_3_og_13_3a/vurderingVedtak11_3_og_13_3aSchema.js
@@ -1,14 +1,11 @@
 import { object, string } from "yup";
 import * as KV from "../../../../kodeverk";
 import { MAA_FYLLES_UT } from "../../../../kodeverk/feilmeldinger";
-import { Lovvalgsbestemmelse } from "../../../../proptypes";
-import { notNull } from "ts-mockito";
 
 const { DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN } = KV.Feilmeldinger;
-const { KORTERE_PERIODE } = MKV.Lovvalgsbestemmelser;
 
 const vurderingVedtak_11_3_og_13_3aSchema = object().shape({
-  lovvalgsbestemmelse: notNull,
+  lovvalgsbestemmelse: string().required(),
   begrunnelseFritekst: string().nullable().max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN),
   fom: string().when("korterePeriodeChecked", {
     is: true,


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7144

La til validering slik at "Fatt vedtak" er disabled når lovvalgsbestemmelse ikke har verdi