### PR TITLE
7062: Fiks sync av virksomhetsliste i avtaleland

### DIFF
--- a/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet/vurderingAvklarVirksomhet.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet/vurderingAvklarVirksomhet.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useSelector } from "react-redux";
 import { RootState } from "AppTypes";
-import { reduxForm, getFormValues, Field } from "redux-form";
+import { getFormValues, reduxForm } from "redux-form";
 
 import * as Api from "../../../../services/api";
 import * as KV from "../../../../kodeverk";

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet/vurderingAvklarVirksomhet.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingAvklarVirksomhet/vurderingAvklarVirksomhet.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
-import { connect, ConnectedProps } from "react-redux";
+import { useSelector } from "react-redux";
 import { RootState } from "AppTypes";
-import { reduxForm, getFormValues } from "redux-form";
+import { reduxForm, getFormValues, Field } from "redux-form";
 
 import * as Api from "../../../../services/api";
 import * as KV from "../../../../kodeverk";
@@ -18,50 +18,53 @@ import vurdering_avklar_virksomhet from "./vurderingAvklarVirksomhetSchema";
 import "./vurderingAvklarVirksomhet.css";
 import { HJELPETEKST, INGEN_VIRKSOMHETER_TEKST } from "./tekster";
 
-const mapStateToProps = (state: RootState, ownProps: Props) => ({
-  virksomheterListe:
-    ownProps.data?.virksomheter?.map((virksomhet: Api.Trygdeavtale.Virksomhet) => ({
-      kode: virksomhet.orgId,
-      term: virksomhet.navn,
-    })) || [],
-  formValues: getFormValues(KV.Form.Trygdeavtale.AVKLAR_VIRKSOMHET)(state),
-  initialValues: {
-    virksomhet: ownProps.resultat?.virksomhet,
-  },
-  formIsValid: formSelectors.TrygdeavtaleAvklarVirksomhetFormValidSelector(state),
-});
-
-const connector = connect(mapStateToProps);
-
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
 interface FormValuesProps {
   virksomhet?: string;
 }
+
 interface Props {
   data: Api.Trygdeavtale.StegData;
   fortsett: () => void;
-  formValues: FormValuesProps;
   redigerbart: boolean;
   resultat: Api.Trygdeavtale.Resultat;
   steg: Api.Trygdeavtale.Steg;
   tilbake: () => void;
   oppdaterFlyt: (resultat: Api.Trygdeavtale.Resultat) => void;
   aktivtSteg: boolean;
+  initialize: (values: object) => void;
 }
 
 function VurderingAvklarVirksomhet({
-  formValues,
-  formIsValid,
+  data,
   fortsett,
   redigerbart,
   resultat,
   steg,
   oppdaterFlyt,
   tilbake,
-  virksomheterListe,
   aktivtSteg,
-}: PropsFromRedux & Props) {
+  initialize,
+}: Props) {
+  const virksomheterListe =
+    data?.virksomheter?.map((virksomhet: Api.Trygdeavtale.Virksomhet) => ({
+      kode: virksomhet.orgId,
+      term: virksomhet.navn,
+    })) || [];
+
+  const formValues = useSelector((state: RootState) =>
+    getFormValues(KV.Form.Trygdeavtale.AVKLAR_VIRKSOMHET)(state),
+  ) as FormValuesProps;
+
+  const formIsValid = useSelector((state: RootState) =>
+    formSelectors.TrygdeavtaleAvklarVirksomhetFormValidSelector(state),
+  );
+
+  useEffect(() => {
+    initialize({
+      virksomhet: resultat?.virksomhet,
+    });
+  }, [resultat?.virksomhet, initialize]);
+
   useEffect(() => {
     if (redigerbart && formValues && aktivtSteg) {
       oppdaterFlyt({
@@ -69,7 +72,9 @@ function VurderingAvklarVirksomhet({
         virksomhet: formValues.virksomhet,
       });
     }
-  }, [formValues?.virksomhet]);
+  }, [formValues?.virksomhet, redigerbart, aktivtSteg, oppdaterFlyt, resultat]);
+
+  const harVirksomheter = Array.isArray(virksomheterListe) && virksomheterListe.length > 0;
 
   return (
     <div className="vurderingAvklarVirksomhet">
@@ -77,14 +82,14 @@ function VurderingAvklarVirksomhet({
         <LabelMedHjelpetekst label="Virksomhet" bold />
       </Nav.Heading>
 
-      {virksomheterListe?.length !== 0 ? (
+      {harVirksomheter ? (
         <Skjema.RadioGroup
           legend={<LabelMedHjelpetekst label="Velg virksomhet" hjelpetekst={HJELPETEKST} bold small />}
           hideLegend
           name="virksomhet"
           readOnly={!redigerbart}
         >
-          {virksomheterListe?.map((virksomhet) => (
+          {virksomheterListe.map((virksomhet) => (
             <Nav.Radio key={virksomhet.kode} value={virksomhet.kode}>
               {virksomhet.term}
             </Nav.Radio>
@@ -107,7 +112,7 @@ function VurderingAvklarVirksomhet({
   );
 }
 
-const VurderingAvklarVirksomhetForm = reduxForm<object, PropsFromRedux & Props>({
+const VurderingAvklarVirksomhetForm = reduxForm<FormValuesProps, Props>({
   form: KV.Form.Trygdeavtale.AVKLAR_VIRKSOMHET,
   destroyOnUnmount: true,
   enableReinitialize: true,
@@ -115,4 +120,4 @@ const VurderingAvklarVirksomhetForm = reduxForm<object, PropsFromRedux & Props>(
   validate: lagYupToReduxformErrorMapper(vurdering_avklar_virksomhet),
 })(VurderingAvklarVirksomhet);
 
-export default connector(VurderingAvklarVirksomhetForm);
+export default VurderingAvklarVirksomhetForm;


### PR DESCRIPTION
- Bruker nå eksplisitte useSelector-hooks for å hente state fra Redux, som gjør det lettere å forstå dataflyt og debugging
- Lagt til bedre sjekk for om virksomhetslisten faktisk har innhold (harVirksomheter)
- Beholdt reduxForm-dekoratøren som er nødvendig for at feltene skal fungere korrekt
- Lagt til initialize funksjon i useEffect for å sikre at skjemaet oppdateres ved endringer i resultat-objektet


Endringene løser problemet der INGEN_VIRKSOMHETER_TEKST feilaktig vises selv når virksomhetslisten har blitt oppdatert i state.

https://jira.adeo.no/browse/MELOSYS-7062