### PR TITLE
NOJIRA TOGGLE fiksing av gjenoppståtte og enkle bugs i aarsavregning

### DIFF
--- a/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.tsx
@@ -235,6 +235,7 @@ export function Inntektskilder({
                   control={control}
                   readOnly={!redigerbart}
                   type="number"
+                  autoComplete="off"
                 />
               ) : (
                 <div className="ikkeRelevant">

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -47,6 +47,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
   const [brukerHarBekreftet, setBrukerHarBekreftet] = useState(false);
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(undefined);
+  const [beregningPaagar, setBeregningPaagar] = useState(false);
 
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
@@ -183,6 +184,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
         setFeilmelding,
         setAarsavregningResponse,
       });
+      setBeregningPaagar(false);
     },
     [behandlingID, medlemskapsTypeErPliktig, setFeilmelding, setAarsavregningResponse],
   );
@@ -209,6 +211,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
       fomTomErFyltUt(formValues.inntektskilder, formValues.skatteforholdsperioder) &&
       harInntektsKildeType(formValues.inntektskilder)
     ) {
+      setBeregningPaagar(true);
       debounceBeregnTrygdeavgiftsperioderOgOppdaterFormVerdier(formValues);
     }
   }, [isValidating, erAvvik, formValues.inntektskilder.length, formValues.skatteforholdsperioder.length]);
@@ -233,10 +236,12 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
           setAarsavregningResponse(res);
           setSkjemaverdierFraTrygdeavgiftsgrunnlag(res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag);
           if (res.tidligereGrunnlagsopplysninger !== undefined) {
+            setBeregningPaagar(true);
             debouncedBeregnTrygdeavgiftsperioder({
               skatteforholdsperioder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder,
               inntektskilder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder,
             });
+
           }
         });
       });
@@ -366,7 +371,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
         </Nav.Alert>
       )}
 
-      <Nav.Button variant="primary" disabled={!stegErGyldig || !redigerbart} onClick={bekreftOnClick}>
+      <Nav.Button variant="primary" disabled={!redigerbart || beregningPaagar || !stegErGyldig} onClick={bekreftOnClick}>
         Bekreft og fortsett
       </Nav.Button>
     </>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -214,7 +214,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
       setBeregningPaagar(true);
       debounceBeregnTrygdeavgiftsperioderOgOppdaterFormVerdier(formValues);
     }
-  }, [isValidating, erAvvik, formValues.inntektskilder.length, formValues.skatteforholdsperioder.length]);
+  }, [formIsValid, isValidating, erAvvik, formValues.inntektskilder.length, formValues.skatteforholdsperioder.length]);
 
   const stegErGyldig =
     erAvvik === false || Boolean(formIsValid && erAvvik && aarsavregningResponse?.nyttGrunnlag && !feilmelding);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -241,7 +241,6 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
               skatteforholdsperioder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder,
               inntektskilder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder,
             });
-
           }
         });
       });
@@ -371,7 +370,11 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
         </Nav.Alert>
       )}
 
-      <Nav.Button variant="primary" disabled={!redigerbart || beregningPaagar || !stegErGyldig} onClick={bekreftOnClick}>
+      <Nav.Button
+        variant="primary"
+        disabled={!redigerbart || beregningPaagar || !stegErGyldig}
+        onClick={bekreftOnClick}
+      >
         Bekreft og fortsett
       </Nav.Button>
     </>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -68,6 +68,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   const [valgtÅr, setValgtÅr] = useState<number | undefined>();
   const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
   const [brukerHarBekreftet, setBrukerHarBekreftet] = useState(false);
+  const [beregningPaagar, setBeregningPaagar] = useState(false);
 
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(undefined);
   const [bestemmelser, setBestemmelser] = useState<[]>([]);
@@ -242,6 +243,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         setFeilmelding,
         setAarsavregningResponse,
       });
+      setBeregningPaagar(false);
     },
     [behandlingID, medlemskapsTypeErPliktig, setFeilmelding, setAarsavregningResponse, aarsavregningID],
   );
@@ -260,6 +262,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       fomTomErFyltUt(formValues.inntektskilder, formValues.skatteforholdsperioder) &&
       harInntektsKildeType(formValues.inntektskilder)
     ) {
+      setBeregningPaagar(true);
       debounceBeregnTrygdeavgiftsperioder(formValues);
     }
   }, [formIsValid, isValidating, formValues.inntektskilder.length, formValues.skatteforholdsperioder.length]);
@@ -474,7 +477,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         </Nav.Alert>
       )}
 
-      <Nav.Button variant="primary" disabled={!redigerbart || !stegErGyldig} onClick={bekreftOnClick}>
+      <Nav.Button variant="primary" disabled={!redigerbart || beregningPaagar || !stegErGyldig} onClick={bekreftOnClick}>
         Bekreft og fortsett
       </Nav.Button>
     </div>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -477,7 +477,11 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         </Nav.Alert>
       )}
 
-      <Nav.Button variant="primary" disabled={!redigerbart || beregningPaagar || !stegErGyldig} onClick={bekreftOnClick}>
+      <Nav.Button
+        variant="primary"
+        disabled={!redigerbart || beregningPaagar || !stegErGyldig}
+        onClick={bekreftOnClick}
+      >
         Bekreft og fortsett
       </Nav.Button>
     </div>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/feilmeldingOppsummering.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/feilmeldingOppsummering.tsx
@@ -1,48 +1,45 @@
 import { Alert, List as NavList } from "../../../../navFrontend";
 import { Heading } from "@navikt/ds-react";
 
+const lagNavlistItem = (melding: string) => {
+  return <NavList.Item>{melding}</NavList.Item>;
+};
+
+const lagDatofeilmelding = (periodeType: string) => {
+  return lagNavlistItem(`${periodeType} kan ikke starte før eller slutte etter medlemskapsperioden(e).`);
+};
+
 export function FeilmeldingOppsummering({ errors }: any) {
-  const lagNavlistItem = (melding: string) => {
-    return <NavList.Item>{melding}</NavList.Item>;
-  };
-  const datofeilmelding = (periodeType: string) => {
-    return lagNavlistItem(`${periodeType} kan ikke starte før eller slutte etter medlemskapsperioden(e).`);
-  };
+  const skatteforholdErrors = [];
+  const harDatofeil = errors.skatteforholdsperioder?.some(
+    (error: any) => error.fomDato !== undefined || error.tomDato !== undefined,
+  );
 
-  const lagSkatteforholdsperiodeError = (skatteforholdsperiodeError: any) => {
-    const navlistItems = [];
-    const harDatofeil = skatteforholdsperiodeError?.some(
-      (error: any) => error.fomDato !== undefined || error.tomDato !== undefined,
-    );
+  if (harDatofeil) {
+    skatteforholdErrors.push(lagDatofeilmelding("Skatteforholdsperioden(e)"));
+  }
 
-    if (harDatofeil) {
-      navlistItems.push(datofeilmelding("Skatteforholdsperioden(e)"));
-    }
+  const inntektskildeErrors = [];
+  const inntektskilderHarDatofeil = errors.inntektskilder?.some(
+    (error: any) => error.fomDato !== undefined || error.tomDato !== undefined,
+  );
+  const harBruttoInntektfeil = errors.inntektskilder?.some((error: any) => error.bruttoInntekt !== undefined);
+  const harKildetypefeil = errors.inntektskilder?.some((error: any) => error.kildetype !== undefined);
 
-    return navlistItems;
-  };
+  if (inntektskilderHarDatofeil) {
+    inntektskildeErrors.push(lagDatofeilmelding("Inntektskildeperioden(e)"));
+  }
+  if (harBruttoInntektfeil) {
+    inntektskildeErrors.push(lagNavlistItem("Bruttoinntekt må fylles ut"));
+  }
 
-  const lagInntektskildeError = (inntektskildeError: any) => {
-    const navlistItems = [];
-    const harDatofeil = inntektskildeError?.some(
-      (error: any) => error.fomDato !== undefined || error.tomDato !== undefined,
-    );
-    const harBruttoInntektfeil = inntektskildeError?.some((error: any) => error.bruttoInntekt !== undefined);
-    const harKildetypefeil = inntektskildeError?.some((error: any) => error.kildetype !== undefined);
+  if (harKildetypefeil) {
+    inntektskildeErrors.push(lagNavlistItem("Inntektskilde må fylles ut"));
+  }
 
-    if (harDatofeil) {
-      navlistItems.push(datofeilmelding("Inntektskildeperioden(e)"));
-    }
-    if (harBruttoInntektfeil) {
-      navlistItems.push(lagNavlistItem("Bruttoinntekt må fylles ut"));
-    }
-
-    if (harKildetypefeil) {
-      navlistItems.push(lagNavlistItem("Inntektskilde må fylles ut"));
-    }
-
-    return navlistItems;
-  };
+  if (!skatteforholdErrors.length && !inntektskildeErrors.length) {
+    return null;
+  }
 
   return (
     <Alert variant="warning">
@@ -50,8 +47,8 @@ export function FeilmeldingOppsummering({ errors }: any) {
         Du må fikse disse feilene før du kan gå videre:
       </Heading>
       <NavList>
-        {errors.skatteforholdsperioder && lagSkatteforholdsperiodeError(errors.skatteforholdsperioder)}
-        {errors.inntektskilder && lagInntektskildeError(errors.inntektskilder)}
+        {skatteforholdErrors}
+        {inntektskildeErrors}
       </NavList>
     </Alert>
   );

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereFakturertIAvgiftssystemetInput.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereFakturertIAvgiftssystemetInput.tsx
@@ -42,6 +42,7 @@ export function TidligereFakturertIAvgiftssystemetInput({
         control={control}
         disabled={!redigerbart}
         className="tidligere_fakturert_input"
+        autoComplete="off"
       />
     </>
   );


### PR DESCRIPTION
Første bugfiks er at vi kan vise utdatert beregningsinformasjon på vedtakssteget. Dette oppstår fordi beregningskallet på steg 1 er debouncet. La til en isLoading parameter for å disable bekreftknapp under beregningskall

feilmeldingOppsummering.tsx vises selv for skjema uten errors i en render cycle etter bruker trykker på knapp. Refaktorerte filen og renderer null dersom det ikke er noen formErrors

Skrudde av autoComplete for beløpsfelt i årsavregningen. Dette er browserfunksjonalitet som ikke fungerer godt overens med koden vår.

Fikset en bug i aarsavregningMedGrunnlag.tsx der beregning ikke blir utført ved sletting av inntektskilderad.