### PR TITLE
7020 bugfix validering tom dato

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -209,6 +209,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
       harInntektsKildeType(formValues.inntektskilder, trygdeAvgiftSkalIkkeBetalesTilNav)
     ) {
       setBeregningPaagar(true);
+      setFeilmelding(undefined);
       debounceBeregnTrygdeavgiftsperioderOgOppdaterFormVerdier(formValues);
     }
   }, [formIsValid, isValidating, erAvvik, formValues.inntektskilder.length, formValues.skatteforholdsperioder.length]);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -77,14 +77,14 @@ const aarsavregningMedGrunnlagSchema = object().shape({
       .of(
         object().shape({
           fomDato: string()
+            .required(MAA_FYLLES_UT)
             .erGyldigDato()
-            .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-            .required(MAA_FYLLES_UT),
+            .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN),
           tomDato: string()
+            .required(MAA_FYLLES_UT)
             .erGyldigDato()
             .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-            .erEtterDatofelt("fomDato")
-            .required(MAA_FYLLES_UT),
+            .erEtterDatofelt("fomDato"),
           skatteplikttype: string().required(MAA_FYLLES_UT),
         }),
       ),
@@ -103,14 +103,14 @@ const aarsavregningMedGrunnlagSchema = object().shape({
             arbAvgBetales: string().test(arbAvgBetalesFyltUtNårDetKrevesTest).nullable(),
             bruttoInntekt: string().test(bruttoInntektFyltUtNårDetKrevesTest),
             fomDato: string()
+              .required(MAA_FYLLES_UT)
               .erGyldigDato()
-              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-              .required(MAA_FYLLES_UT),
+              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN),
             tomDato: string()
+              .required(MAA_FYLLES_UT)
               .erGyldigDato()
               .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-              .erEtterDatofelt("fomDato")
-              .required(MAA_FYLLES_UT),
+              .erEtterDatofelt("fomDato"),
           }),
         ),
     });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -47,6 +47,7 @@ import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversik
 import aarsavregningUtenEllerDeltGrunnlagSchema from "./aarsavregningUtenEllerDeltGrunnlagSchema";
 import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
+import { Medlemskapsperiode } from "../../../../../services/modules/medlemavfolketrygden/medlemskapsperioder";
 
 interface Props {
   bekreft: () => void;
@@ -69,16 +70,20 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
   const [brukerHarBekreftet, setBrukerHarBekreftet] = useState(false);
   const [beregningPaagar, setBeregningPaagar] = useState(false);
-
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(undefined);
   const [bestemmelser, setBestemmelser] = useState<[]>([]);
+
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
   const lagredeMedlemskapsperioder = useSelector(medlemskapsperioderSelectors.AlleMedlemskapsperioderSelector);
   const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const dispatch = useDispatch();
-  const harMedlemskapsPeriodeFeil = (response: any): boolean => response.type === medlemskapsperioderTypes.FEILET;
+
+  const medlemskapsTypeErPliktig = lagredeMedlemskapsperioder?.every(
+    (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
+  );
+  const innvilgetMedlemskapsperiode = hentMedlemskapsFomTomDato(lagredeMedlemskapsperioder);
 
   useEffect(() => {
     if (behandlingstema) {
@@ -105,30 +110,44 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     }
   }, []);
 
+  const setSkjemaverdierFraTrygdeavgiftsgrunnlag = (
+    aarsavregningResponse: AarsavregningResponse | undefined,
+    lagredeMedlemskapsperioder: Medlemskapsperiode[],
+  ) => {
+    const mappedLagredeMedlemskapsperioder = mapInitialMedlemskapsperioder(
+      lagredeMedlemskapsperioder,
+      aarsavregningResponse?.tidligereGrunnlagsopplysninger,
+    );
+    const erInitiellMappingForDeltGrunnlag =
+      harDeltGrunnlag && aarsavregningResponse && !aarsavregningResponse.nyttGrunnlag;
+
+    setValue("medlemskapsperioder", mappedLagredeMedlemskapsperioder);
+    setValue(
+      "skatteforholdsperioder",
+      mapTilSkatteforholdProps(
+        erInitiellMappingForDeltGrunnlag
+          ? aarsavregningResponse.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder
+          : aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder,
+        mappedLagredeMedlemskapsperioder,
+      ),
+    );
+    setValue(
+      "inntektskilder",
+      mapTilInntektskilderProps(
+        erInitiellMappingForDeltGrunnlag
+          ? aarsavregningResponse.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.inntektskperioder
+          : aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder,
+        mappedLagredeMedlemskapsperioder,
+      ),
+    );
+  };
+
   useEffect(() => {
     const validerMedlemskapsperioderResultat = validerMedlemskapsperioder(lagredeMedlemskapsperioder);
     setFeilmelding(validerMedlemskapsperioderResultat);
 
     if (lagredeMedlemskapsperioder) {
-      const mappedLagredeMedlemskapsperioder = mapInitialMedlemskapsperioder(
-        lagredeMedlemskapsperioder,
-        aarsavregningResponse?.tidligereGrunnlagsopplysninger,
-      );
-      setValue("medlemskapsperioder", mappedLagredeMedlemskapsperioder);
-      setValue(
-        "skatteforholdsperioder",
-        mapTilSkatteforholdProps(
-          aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder,
-          mappedLagredeMedlemskapsperioder,
-        ),
-      );
-      setValue(
-        "inntektskilder",
-        mapTilInntektskilderProps(
-          aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder,
-          mappedLagredeMedlemskapsperioder,
-        ),
-      );
+      setSkjemaverdierFraTrygdeavgiftsgrunnlag(aarsavregningResponse, lagredeMedlemskapsperioder);
     }
   }, [lagredeMedlemskapsperioder, aarsavregningResponse]);
 
@@ -145,12 +164,6 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       }
     }
   }, [aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift]);
-
-  const medlemskapsTypeErPliktig = lagredeMedlemskapsperioder?.every(
-    (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
-  );
-
-  const innvilgetMedlemskapsperiode = hentMedlemskapsFomTomDato(lagredeMedlemskapsperioder);
 
   const {
     control,
@@ -171,9 +184,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         lagredeMedlemskapsperioder,
         aarsavregningResponse?.tidligereGrunnlagsopplysninger,
       ),
-      skatteforholdsperioder: mapTilSkatteforholdProps(
-        aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder,
-      ),
+      skatteforholdsperioder: [{}],
       inntektskilder: [{}],
     } as FieldValue<AarsavregningFormValuesProps>,
   });
@@ -306,7 +317,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
           ),
         ));
 
-    if (harMedlemskapsPeriodeFeil(response)) {
+    if (response.type === medlemskapsperioderTypes.FEILET) {
       setFeilmelding(response?.data?.data?.message);
     } else {
       setFeilmelding(undefined);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -110,10 +110,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     }
   }, []);
 
-  const setSkjemaverdierFraTrygdeavgiftsgrunnlag = (
-    aarsavregningResponse: AarsavregningResponse | undefined,
-    lagredeMedlemskapsperioder: Medlemskapsperiode[],
-  ) => {
+  const setSkjemaverdierFraTrygdeavgiftsgrunnlag = () => {
     const mappedLagredeMedlemskapsperioder = mapInitialMedlemskapsperioder(
       lagredeMedlemskapsperioder,
       aarsavregningResponse?.tidligereGrunnlagsopplysninger,
@@ -147,7 +144,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     setFeilmelding(validerMedlemskapsperioderResultat);
 
     if (lagredeMedlemskapsperioder) {
-      setSkjemaverdierFraTrygdeavgiftsgrunnlag(aarsavregningResponse, lagredeMedlemskapsperioder);
+      setSkjemaverdierFraTrygdeavgiftsgrunnlag();
     }
   }, [lagredeMedlemskapsperioder, aarsavregningResponse]);
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -459,7 +459,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         <Aarsavregningsmeldinger.TrygdeavgiftSkalIkkeBetalesTilNav />
       )}
 
-      {formIsValid && (
+      {formIsValid && !feilmelding && (
         <SumArsavregningTabell
           nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
           tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
@@ -467,7 +467,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         />
       )}
 
-      {formIsValid && aarsavregningResponse?.nyttGrunnlag && (
+      {formIsValid && !feilmelding && aarsavregningResponse?.nyttGrunnlag && (
         <BeregnetTrygdeavgiftDetaljer
           grunnlag={aarsavregningResponse.nyttGrunnlag}
           medlemskapsTypeErPliktig={medlemskapsTypeErPliktig!}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -259,7 +259,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       aarsavregningID &&
       !isValidating &&
       formIsValid &&
-      fomTomErFyltUt(formValues.inntektskilder, formValues.skatteforholdsperioder) &&
+      fomTomErFyltUt(formValues.inntektskilder, formValues.skatteforholdsperioder, formValues.medlemskapsperioder) &&
       harInntektsKildeType(formValues.inntektskilder, trygdeAvgiftSkalIkkeBetalesTilNav)
     ) {
       setBeregningPaagar(true);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -263,6 +263,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       harInntektsKildeType(formValues.inntektskilder, trygdeAvgiftSkalIkkeBetalesTilNav)
     ) {
       setBeregningPaagar(true);
+      setFeilmelding(undefined);
       debounceBeregnTrygdeavgiftsperioder(formValues);
     }
   }, [

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
@@ -106,24 +106,23 @@ const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
       object().shape({
         fomDato: string()
           .erGyldigDato()
+          .required(MAA_FYLLES_UT)
           .test(erInnenforValgtAarTest)
-          .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-          .required(MAA_FYLLES_UT),
+          .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN),
         tomDato: string()
           .erGyldigDato()
+          .required(MAA_FYLLES_UT)
+          .test(åpenTomTest)
           .test(erInnenforValgtAarTest)
           .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-          .erEtterDatofelt("fomDato")
-          .test(åpenTomTest)
-          .required(MAA_FYLLES_UT),
+          .erEtterDatofelt("fomDato"),
         skatteplikttype: string().defined().required(MAA_FYLLES_UT),
       }),
     ),
   inntektskilder: lazy((_value, options) => {
-    return array().when(["$medlemskapsTypeErPliktig", "$erÅpenSluttDato", "$erAvvik"], {
-      is: (medlemskapsTypeErPliktig, erÅpenSluttDato, erAvvik) => {
-        if (!erAvvik) return false;
-        return !erÅpenSluttDato && kreverInntektskilder(medlemskapsTypeErPliktig, options) && erAvvik; // TODO denne logikken er korrekt
+    return array().when(["$medlemskapsTypeErPliktig"], {
+      is: (medlemskapsTypeErPliktig) => {
+        return kreverInntektskilder(medlemskapsTypeErPliktig, options);
       },
       then: array()
         .min(1, "Minst en inntektskilde")
@@ -134,15 +133,13 @@ const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
             bruttoInntekt: string().test(bruttoInntektFyltUtNårDetKrevesTest),
             fomDato: string()
               .erGyldigDato()
-              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-              .required(MAA_FYLLES_UT),
+              .required(MAA_FYLLES_UT)
+              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN),
             tomDato: string()
               .erGyldigDato()
+              .required(MAA_FYLLES_UT)
               .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-              .erEtterDatofelt("fomDato")
-              .test(erInnenforValgtAarTest)
-              .test(åpenTomTest)
-              .required(MAA_FYLLES_UT),
+              .erEtterDatofelt("fomDato"),
           }),
         ),
     });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
@@ -49,9 +49,13 @@ export function harIkkeSkattepliktigInntektskilder(
 export function fomTomErFyltUt(
   inntektskildePerioder: Inntektskilde[],
   skatteforholdsPerioder: Skatteforhold[],
+  medlemskapsperioder?: Medlemskapsperiode[],
 ): boolean {
-  const allPerioder = [...inntektskildePerioder, ...skatteforholdsPerioder];
-  return allPerioder.every(({ fomDato, tomDato }) => fomDato !== undefined && tomDato !== undefined);
+  let allPerioder = [...inntektskildePerioder, ...skatteforholdsPerioder];
+  if (medlemskapsperioder?.length) {
+    allPerioder = [...allPerioder, ...medlemskapsperioder];
+  }
+  return allPerioder.every(({ fomDato, tomDato }) => fomDato !== undefined && fomDato !== "" && tomDato !== undefined && tomDato !== "");
 }
 
 export function harInntektsKildeType(

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
@@ -55,7 +55,9 @@ export function fomTomErFyltUt(
   if (medlemskapsperioder?.length) {
     allPerioder = [...allPerioder, ...medlemskapsperioder];
   }
-  return allPerioder.every(({ fomDato, tomDato }) => fomDato !== undefined && fomDato !== "" && tomDato !== undefined && tomDato !== "");
+  return allPerioder.every(
+    ({ fomDato, tomDato }) => fomDato !== undefined && fomDato !== "" && tomDato !== undefined && tomDato !== "",
+  );
 }
 
 export function harInntektsKildeType(

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -115,6 +115,9 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
 
   const håndterEndringAvÅr = (event: ChangeEvent<HTMLSelectElement>) => {
     setApiFeil(null);
+    setVisDeltGrunnlagRadioGroup(false);
+    setHarGrunnlag(undefined);
+    setHarDeltGrunnlag(undefined);
 
     const år = event.target.value ? parseInt(event.target.value, 10) : undefined;
     setValgtÅr(år || null);


### PR DESCRIPTION
Fikser en bug der state ikke resettes ved endring av år i vurderingAarsavregningInngang.tsx

Fikset en bug der vi sender beregningsforespørsler etter å ha fjernet en tomDato i skjemaet. Utvidet fomTomerFyltUt util med optional param for medlemskapsperioder og sjekk på tom streng verdi

Rydding/bugfixing i yup validering for alle grunnlagstyper. Flytter required sjekk øverst i valideringen. Filtrerer også bort beregningsdetaljer dersom vi har en aktiv feilmelding.