### PR TITLE
7177 TOGGLE  Hent kun innvilgete medlemskapsperioder for aarsavregning delt grunnlag

### DIFF
--- a/src/ducks/medlemskapsperioder/selectors.ts
+++ b/src/ducks/medlemskapsperioder/selectors.ts
@@ -27,8 +27,11 @@ export const AlleMedlemskapsperioderSelector = createSelector(
 
 export const InnvilgetEllerDelvisInnvilgetMedlemskapsperioderSelector = createSelector(
   AlleMedlemskapsperioderSelector,
-  (medlemskapsperioder) => medlemskapsperioder.filter((periode) => periode.innvilgelsesResultat === INNVILGET || periode.innvilgelsesResultat === DELVIS_INNVILGET)
-)
+  (medlemskapsperioder) =>
+    medlemskapsperioder.filter(
+      (periode) => periode.innvilgelsesResultat === INNVILGET || periode.innvilgelsesResultat === DELVIS_INNVILGET,
+    ),
+);
 
 export const SamletInnvilgetMedlemskapsperiodeSelector = createSelector(
   AlleMedlemskapsperioderSelector,

--- a/src/ducks/medlemskapsperioder/selectors.ts
+++ b/src/ducks/medlemskapsperioder/selectors.ts
@@ -3,6 +3,7 @@ import { createSelector, Selector } from "reselect";
 import * as Types from "./types";
 import MKV from "../../melosyskodeverk";
 import { sorterEtterISOFomDato } from "../../utils/dato";
+const { DELVIS_INNVILGET, INNVILGET } = MKV.Koder.innvilgelsesResultat;
 
 export const MedlemskapsperioderSelector: Selector<RootState, StateSection<Types.Data>> = createSelector(
   (state: RootState) => state.medlemskapsperioder,
@@ -24,11 +25,16 @@ export const AlleMedlemskapsperioderSelector = createSelector(
   (medlemskapsperioder) => medlemskapsperioder.medlemskapsperioder || [],
 );
 
+export const InnvilgetEllerDelvisInnvilgetMedlemskapsperioderSelector = createSelector(
+  AlleMedlemskapsperioderSelector,
+  (medlemskapsperioder) => medlemskapsperioder.filter((periode) => periode.innvilgelsesResultat === INNVILGET || periode.innvilgelsesResultat === DELVIS_INNVILGET)
+)
+
 export const SamletInnvilgetMedlemskapsperiodeSelector = createSelector(
   AlleMedlemskapsperioderSelector,
   (medlemskapsperioder) => {
     const sorterteInnvilgedePerioder = [...medlemskapsperioder]
-      .filter((periode) => periode.innvilgelsesResultat === MKV.Koder.innvilgelsesResultat.INNVILGET)
+      .filter((periode) => periode.innvilgelsesResultat === INNVILGET)
       .sort(sorterEtterISOFomDato);
 
     if (sorterteInnvilgedePerioder.length === 0) return undefined;

--- a/src/ducks/medlemskapsperioder/selectors.ts
+++ b/src/ducks/medlemskapsperioder/selectors.ts
@@ -3,6 +3,7 @@ import { createSelector, Selector } from "reselect";
 import * as Types from "./types";
 import MKV from "../../melosyskodeverk";
 import { sorterEtterISOFomDato } from "../../utils/dato";
+
 const { DELVIS_INNVILGET, INNVILGET } = MKV.Koder.innvilgelsesResultat;
 
 export const MedlemskapsperioderSelector: Selector<RootState, StateSection<Types.Data>> = createSelector(

--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
@@ -4,7 +4,6 @@ import { harUnntaksregistreringFlyt, skalViseIngenFlyt } from "../../../url";
 import { ContentProps, LinkGroup } from "./types";
 import LinkgroupsBuilder from "./linkgroupsBuilder";
 import LinksBuilder from "./linksBuilder";
-import { link } from "fs";
 
 const {
   UTSENDT_ARBEIDSTAKER,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -74,7 +74,9 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
-  const lagredeMedlemskapsperioder = useSelector(medlemskapsperioderSelectors.InnvilgetEllerDelvisInnvilgetMedlemskapsperioderSelector);
+  const lagredeMedlemskapsperioder = useSelector(
+    medlemskapsperioderSelectors.InnvilgetEllerDelvisInnvilgetMedlemskapsperioderSelector,
+  );
   const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const dispatch = useDispatch();
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -74,7 +74,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
-  const lagredeMedlemskapsperioder = useSelector(medlemskapsperioderSelectors.AlleMedlemskapsperioderSelector);
+  const lagredeMedlemskapsperioder = useSelector(medlemskapsperioderSelectors.InnvilgetEllerDelvisInnvilgetMedlemskapsperioderSelector);
   const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const dispatch = useDispatch();
 


### PR DESCRIPTION
Selectoren benyttet i aarsavregningUtenEllerDeltGrunnlag.tsx tar alle medlemskapsperioder på brukeren og validerer senere disse i js. Dette skapte krøll fordi listen kan inneholde avslåtte perioder som har overlapp med innvilgede