### PR TITLE
7182 synkron lagring av medlemskapsperioder aarsavregning

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningHelpers.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningHelpers.ts
@@ -13,7 +13,7 @@ export const hentMedlemskapsFomTomDato = (medlemskapsperioder?: any[]) => {
   return {};
 };
 
-export const mapTilMedlemskapsperiodeProps = (
+export const mapTilMedlemskapsperiode = (
   medlemskapsperiode: any,
   tidligereGrunnlagsopplysninger?: Api.Aarsavregning.Grunnlagsopplysninger,
 ) => {
@@ -26,9 +26,7 @@ export const mapTilMedlemskapsperiodeProps = (
     ...medlemskapsperiode,
     fomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsperiode.fomDato),
     tomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsperiode.tomDato),
-    ny: false,
     feil: undefined,
-    periodeId: medlemskapsperiode.id,
     redigerbar,
   };
 };
@@ -39,7 +37,7 @@ export const mapInitialMedlemskapsperioder = (
 ) =>
   [...perioder]
     .sort((a, b) => Utils.dato.sorterEtterISOFomDato(a, b))
-    .map((periode) => mapTilMedlemskapsperiodeProps(periode, tidligereGrunnlagsopplysninger));
+    .map((periode) => mapTilMedlemskapsperiode(periode, tidligereGrunnlagsopplysninger));
 
 export const mapTilSkatteforholdProps = (skatteforholdsperioder?: any[], medlemskapsperioder?: any[]) => {
   const { fom, tom } = hentMedlemskapsFomTomDato(medlemskapsperioder);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -193,9 +193,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
     erAvvik === false || Boolean(formIsValid && erAvvik && aarsavregningResponse?.nyttGrunnlag && !feilmelding);
 
   useEffect(() => {
-    if (!beregningPaagar) {
-      oppdaterStatus(stegErGyldig);
-    }
+    oppdaterStatus(stegErGyldig);
   }, [stegErGyldig]);
 
   const håndterAvvik = (value: boolean) => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -252,8 +252,10 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       setFeilmelding(response?.data?.data?.message);
     } else {
       if (medlemskapsperiode.id === -1) {
+        /* eslint-disable no-param-reassign */
         medlemskapsperiode.id = response.id;
         medlemskapsperiode.medlemskapstype = response.medlemskapstype;
+        /* eslint-enable no-param-reassign */
       }
       setFeilmelding(undefined);
     }
@@ -263,6 +265,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     Utils._debounce(async (medlemskapsperioderFormValues) => {
       const isValid = await trigger("medlemskapsperioder");
       if (isValid) {
+        /* eslint-disable-next-line no-restricted-syntax */
         for (const periode of medlemskapsperioderFormValues) {
           if (periode.redigerbar) {
             await lagreMedlemskapsperiode(periode);
@@ -318,21 +321,19 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
       });
     }
-    const formIsValid = await trigger();
-    if (formIsValid) {
+    if (await trigger()) {
       setFeilmelding(undefined);
       await handleBeregnTrygdeavgiftsperioder(watch());
     }
   };
 
   const handleOppdaterTotaltForskuddsvisFakturert = async (
-    behandlingID: number,
+    behandlingid: number,
     request: Api.Aarsavregning.AarsavregningRequest,
-    aarsavregningID?: number,
+    aarsavregningid?: number,
   ) => {
-    await Api.Aarsavregning.oppdaterAarsavregning(behandlingID, request, aarsavregningID);
-    const formIsValid = await trigger();
-    if (formIsValid) {
+    await Api.Aarsavregning.oppdaterAarsavregning(behandlingid, request, aarsavregningid);
+    if (await trigger()) {
       setFeilmelding(undefined);
       await handleBeregnTrygdeavgiftsperioder(watch());
     }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -41,6 +41,16 @@ import { Medlemskapsperiode } from "../../../../../services/modules/medlemavfolk
 
 const { DELVIS_INNVILGET, INNVILGET } = MKV.Koder.innvilgelsesResultat;
 
+const DEFAULT_MEDLEMSKAPSPERIODE = {
+  id: -1,
+  fomDato: "",
+  tomDato: "",
+  innvilgelsesResultat: "",
+  trygdedekning: "",
+  bestemmelse: "",
+  redigerbar: true,
+};
+
 interface Props {
   bekreft: () => void;
   aktivtSteg: boolean;
@@ -64,6 +74,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(undefined);
   const [bestemmelser, setBestemmelser] = useState<[]>([]);
   const [harValidertSkjema, setHarValidertSkjema] = useState(false);
+  const [initiellBeregningUtført, setInitiellBeregningUtført] = useState(false);
 
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
@@ -74,12 +85,10 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const dispatch = useDispatch();
 
-  // TODO: Brukes kun i schema, tilpass schema slik at disse contextvariablene ikke lenger behøves
   const medlemskapsTypeErPliktig = lagredeMedlemskapsperioder?.every(
     (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
   );
   const innvilgetMedlemskapsperiode = hentMedlemskapsFomTomDato(lagredeMedlemskapsperioder);
-  // TODO END
 
   useEffect(() => {
     if (behandlingstema) {
@@ -89,8 +98,8 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
 
   // Initiell innlasting og skjemapopulering
   useEffect(() => {
-    dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
     if (behandlingID) {
+      dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
       Api.Aarsavregning.hentAarsavregning(behandlingID)
         .then((aarsavregningRes) => {
           Api.MedlemAvFolketrygden.Medlemskapsperioder.hentMedlemskapsperioder(behandlingID).then(
@@ -99,11 +108,12 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
                 (periode: Medlemskapsperiode) =>
                   periode.innvilgelsesResultat === INNVILGET || periode.innvilgelsesResultat === DELVIS_INNVILGET,
               );
-              setSkjemaverdierFraTrygdeavgiftsgrunnlag(aarsavregningRes, innvilgedeMedlemskapsperioder);
               setAarsavregningResponse(aarsavregningRes);
               setValgtÅr(aarsavregningRes.aar);
               // Benyttes for innhenting av saksopplysninger ifm. årsavregningsbehandlinger
               dispatch({ type: OK, data: aarsavregningRes });
+
+              setSkjemaverdierFraTrygdeavgiftsgrunnlag(aarsavregningRes, innvilgedeMedlemskapsperioder);
             },
           );
         })
@@ -125,7 +135,10 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     );
     const erInitiellMappingForDeltGrunnlag = harDeltGrunnlag && aarsavregningRes && !aarsavregningRes.nyttGrunnlag;
 
-    setValue("medlemskapsperioder", mappedLagredeMedlemskapsperioder);
+    setValue(
+      "medlemskapsperioder",
+      mappedLagredeMedlemskapsperioder.length ? mappedLagredeMedlemskapsperioder : [DEFAULT_MEDLEMSKAPSPERIODE],
+    );
     setValue("totaltForskuddsvisFakturert", aarsavregningRes.avregning?.tidligereFakturertBeloepAvgiftssystem);
     setValue(
       "skatteforholdsperioder",
@@ -171,23 +184,12 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     resolver: yupResolver(aarsavregningUtenEllerDeltGrunnlagSchema),
     context: {
       medlemskapsperiode: innvilgetMedlemskapsperiode,
-      medlemskapsTypeErPliktig,
       aar: valgtÅr,
     },
     mode: "onChange",
     reValidateMode: "onChange",
     defaultValues: {
-      medlemskapsperioder: [
-        {
-          id: -1,
-          fomDato: "",
-          tomDato: "",
-          innvilgelsesResultat: "",
-          trygdedekning: "",
-          bestemmelse: "",
-          redigerbar: true,
-        },
-      ],
+      medlemskapsperioder: [{}],
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
     } as FieldValue<AarsavregningFormValuesProps>,
@@ -220,6 +222,15 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   const skatteforholdsperioder = useWatch({ control, name: "skatteforholdsperioder" });
   const inntektskilder = useWatch({ control, name: "inntektskilder" });
 
+  // Initiell beregning
+  useEffect(() => {
+    if (formIsValid && !initiellBeregningUtført) {
+      handleBeregnTrygdeavgiftsperioder(watch()).then(() => {
+        setInitiellBeregningUtført(true);
+      });
+    }
+  }, [formIsValid]);
+
   const lagreMedlemskapsperiode = async (medlemskapsperiode: Medlemskapsperiode) => {
     const periodeRequest = {
       fomDato: Utils.dato.formatterDatoTilISO(medlemskapsperiode.fomDato, "") as string,
@@ -242,6 +253,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     } else {
       if (medlemskapsperiode.id === -1) {
         medlemskapsperiode.id = response.id;
+        medlemskapsperiode.medlemskapstype = response.medlemskapstype;
       }
       setFeilmelding(undefined);
     }
@@ -252,24 +264,32 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       const isValid = await trigger("medlemskapsperioder");
       if (isValid) {
         for (const periode of medlemskapsperioderFormValues) {
-          await lagreMedlemskapsperiode(periode);
+          if (periode.redigerbar) {
+            await lagreMedlemskapsperiode(periode);
+          }
         }
         dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
-        await trigger();
+        if (initiellBeregningUtført && (await trigger())) {
+          setFeilmelding(undefined);
+          await handleBeregnTrygdeavgiftsperioder(watch());
+        }
       }
     }, 1000),
     [],
   );
 
   // Håndterer endringer i medlemskapsperiodeSkjema.
-  // TODO: Dersom skjema er i gyldig tilstand etter lagring, beregn
   useEffect(() => {
     if (redigerbart) {
+      setFeilmelding(undefined);
       if (medlemskapsperioder.length !== medlemskapsperioderPrevLength.current) {
         medlemskapsperioderPrevLength.current = medlemskapsperioder.length;
         return;
       }
-      debouncedLagreMedlemskapsperioder(medlemskapsperioder);
+      // Unngå trigger på skjema dersom default periode er lagt inn
+      if (medlemskapsperioder.some((periode: any) => periode === DEFAULT_MEDLEMSKAPSPERIODE)) {
+        debouncedLagreMedlemskapsperioder(medlemskapsperioder);
+      }
     }
   }, [medlemskapsperioder]);
 
@@ -295,14 +315,33 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     } else {
       Api.MedlemAvFolketrygden.Medlemskapsperioder.slettMedlemskapsperiode(behandlingID, periode.id).then(() => {
         medlemskapsperioderRemove(index);
+        dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
       });
+    }
+    const formIsValid = await trigger();
+    if (formIsValid) {
+      setFeilmelding(undefined);
+      await handleBeregnTrygdeavgiftsperioder(watch());
     }
   };
 
-  const debouncedOppdaterAarsavregning = useCallback(
+  const handleOppdaterTotaltForskuddsvisFakturert = async (
+    behandlingID: number,
+    request: Api.Aarsavregning.AarsavregningRequest,
+    aarsavregningID?: number,
+  ) => {
+    await Api.Aarsavregning.oppdaterAarsavregning(behandlingID, request, aarsavregningID);
+    const formIsValid = await trigger();
+    if (formIsValid) {
+      setFeilmelding(undefined);
+      await handleBeregnTrygdeavgiftsperioder(watch());
+    }
+  };
+
+  const debouncedOppdaterTotaltForskuddsvisFakturert = useCallback(
     Utils._debounce(
       (request: Api.Aarsavregning.AarsavregningRequest) =>
-        Api.Aarsavregning.oppdaterAarsavregning(behandlingID, request, aarsavregningID),
+        handleOppdaterTotaltForskuddsvisFakturert(behandlingID, request, aarsavregningID),
       1000,
     ),
     [behandlingID, aarsavregningID],
@@ -314,7 +353,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       (totaltForskuddsvisFakturert || totaltForskuddsvisFakturert === "") &&
       totaltForskuddsvisFakturert !== aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem
     ) {
-      debouncedOppdaterAarsavregning({
+      debouncedOppdaterTotaltForskuddsvisFakturert({
         avregning: {
           tidligereFakturertBeloepAvgiftssystem: totaltForskuddsvisFakturert,
         },
@@ -343,10 +382,11 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
 
   // Håndterer endringer i inntektskilder og skatteforhold.
   useEffect(() => {
-    if (redigerbart && aarsavregningID) {
+    if (redigerbart && aarsavregningID && initiellBeregningUtført) {
       const beregnHvisSkjemaErGyldig = async () => {
         const isValid = await trigger();
         if (isValid) {
+          setBeregningPaagar(true);
           setFeilmelding(undefined);
           debounceBeregnTrygdeavgiftsperioder(formValues);
         }
@@ -357,11 +397,8 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
 
   const stegErGyldig = Boolean(formIsValid && aarsavregningResponse?.nyttGrunnlag && feilmelding === undefined);
 
-  // TODO: Må tilpasses, mister oppdateringer av stegstatus
   useEffect(() => {
-    if (!beregningPaagar) {
-      oppdaterStatus(stegErGyldig);
-    }
+    oppdaterStatus(stegErGyldig);
   }, [stegErGyldig]);
 
   const bekreftOnClick = () => {
@@ -461,7 +498,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         <Aarsavregningsmeldinger.TrygdeavgiftSkalIkkeBetalesTilNav />
       )}
 
-      {formIsValid && !feilmelding && (
+      {formIsValid && !beregningPaagar && !feilmelding && (
         <SumArsavregningTabell
           nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
           tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
@@ -469,7 +506,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         />
       )}
 
-      {formIsValid && !feilmelding && aarsavregningResponse?.nyttGrunnlag && (
+      {formIsValid && !beregningPaagar && !feilmelding && aarsavregningResponse?.nyttGrunnlag && (
         <BeregnetTrygdeavgiftDetaljer
           grunnlag={aarsavregningResponse.nyttGrunnlag}
           medlemskapsTypeErPliktig={medlemskapsTypeErPliktig!}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -23,20 +23,13 @@ import {
   medlemskapsperioderSelectors,
   medlemskapsperioderTypes,
 } from "../../../../../ducks/medlemskapsperioder";
-import { MedlemskapsperiodeProp } from "../../../../ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/types";
 import { Skatteforholdsperioder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/skatteforholdsperioder";
 import { Inntektskilder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/inntektskilder";
-import {
-  beregnTrygdeavgiftsperioder,
-  erBrukerSkattepliktigIHelePerioden,
-  harInntektsKildeType,
-  validerMedlemskapsperioder,
-} from "../komponenter/utils";
+import { beregnTrygdeavgiftsperioder, erBrukerSkattepliktigIHelePerioden } from "../komponenter/utils";
 import {
   hentMedlemskapsFomTomDato,
   mapInitialMedlemskapsperioder,
   mapTilInntektskilderProps,
-  mapTilMedlemskapsperiode,
   mapTilSkatteforholdProps,
 } from "../aarsavregningHelpers";
 import { MedlemskapsperiodeSkjema } from "../komponenter/medlemskapsperiodeSkjema";
@@ -81,7 +74,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const dispatch = useDispatch();
 
-  // TODO: Fix setting av disse i initial load useeffect
+  // TODO: Brukes kun i schema, tilpass schema slik at disse contextvariablene ikke lenger behøves
   const medlemskapsTypeErPliktig = lagredeMedlemskapsperioder?.every(
     (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
   );
@@ -225,9 +218,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   const medlemskapsperioderPrevLength = useRef(medlemskapsperioder.length);
   const totaltForskuddsvisFakturert = useWatch({ control, name: "totaltForskuddsvisFakturert" });
   const skatteforholdsperioder = useWatch({ control, name: "skatteforholdsperioder" });
-  const skatteforholdsperioderPrevLength = useRef(skatteforholdsperioder.length);
   const inntektskilder = useWatch({ control, name: "inntektskilder" });
-  const inntektskilderPrevLength = useRef(inntektskilder.length);
 
   const lagreMedlemskapsperiode = async (medlemskapsperiode: Medlemskapsperiode) => {
     const periodeRequest = {
@@ -270,6 +261,8 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     [],
   );
 
+  // Håndterer endringer i medlemskapsperiodeSkjema.
+  // TODO: Dersom skjema er i gyldig tilstand etter lagring, beregn
   useEffect(() => {
     if (redigerbart) {
       if (medlemskapsperioder.length !== medlemskapsperioderPrevLength.current) {
@@ -318,16 +311,16 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   useEffect(() => {
     if (
       redigerbart &&
-      (formValues.totaltForskuddsvisFakturert || formValues.totaltForskuddsvisFakturert === "") &&
-      formValues.totaltForskuddsvisFakturert !== aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem
+      (totaltForskuddsvisFakturert || totaltForskuddsvisFakturert === "") &&
+      totaltForskuddsvisFakturert !== aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem
     ) {
       debouncedOppdaterAarsavregning({
         avregning: {
-          tidligereFakturertBeloepAvgiftssystem: formValues.totaltForskuddsvisFakturert,
+          tidligereFakturertBeloepAvgiftssystem: totaltForskuddsvisFakturert,
         },
       });
     }
-  }, [formValues.totaltForskuddsvisFakturert]);
+  }, [totaltForskuddsvisFakturert]);
 
   const handleBeregnTrygdeavgiftsperioder = useCallback(
     async (formVerdier: FieldValue<FormValuesProps>) => {
@@ -348,6 +341,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     [handleBeregnTrygdeavgiftsperioder],
   );
 
+  // Håndterer endringer i inntektskilder og skatteforhold.
   useEffect(() => {
     if (redigerbart && aarsavregningID) {
       const beregnHvisSkjemaErGyldig = async () => {
@@ -356,10 +350,10 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
           setFeilmelding(undefined);
           debounceBeregnTrygdeavgiftsperioder(formValues);
         }
-      }
+      };
       beregnHvisSkjemaErGyldig();
     }
-  }, [totaltForskuddsvisFakturert, inntektskilder, skatteforholdsperioder]);
+  }, [inntektskilder, skatteforholdsperioder]);
 
   const stegErGyldig = Boolean(formIsValid && aarsavregningResponse?.nyttGrunnlag && feilmelding === undefined);
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -90,16 +90,10 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   );
   const innvilgetMedlemskapsperiode = hentMedlemskapsFomTomDato(lagredeMedlemskapsperioder);
 
-  useEffect(() => {
-    if (behandlingstema) {
-      Api.Ftrl.hentBestemmelser(behandlingstema).then((res: any) => setBestemmelser(res.bestemmelser));
-    }
-  }, [behandlingstema]);
-
   // Initiell innlasting og skjemapopulering
   useEffect(() => {
     if (behandlingID) {
-      dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
+      Api.Ftrl.hentBestemmelser(behandlingstema).then((res: any) => setBestemmelser(res.bestemmelser));
       Api.Aarsavregning.hentAarsavregning(behandlingID)
         .then((aarsavregningRes) => {
           Api.MedlemAvFolketrygden.Medlemskapsperioder.hentMedlemskapsperioder(behandlingID).then(
@@ -290,7 +284,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         return;
       }
       // Unngå trigger på skjema dersom default periode er lagt inn
-      if (medlemskapsperioder.some((periode: any) => periode === DEFAULT_MEDLEMSKAPSPERIODE)) {
+      if (!medlemskapsperioder.some((periode: any) => periode.fomDato === undefined || periode.fomDato === "")) {
         debouncedLagreMedlemskapsperioder(medlemskapsperioder);
       }
     }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -1,13 +1,13 @@
 import * as Api from "../../../../../services/api";
 import "../vurderingAarsavregningInngang.css";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { useDispatch, useSelector } from "react-redux";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 import * as Nav from "../../../../../navFrontend";
 import { redigerbartSelectors } from "../../../../../ducks/redigerbart";
 import { TidligereFakturertIAvgiftssystemetInput } from "../komponenter/tidligereFakturertIAvgiftssystemetInput";
-import { FieldValue, useFieldArray, useForm } from "react-hook-form";
+import { FieldValue, useFieldArray, useForm, useWatch } from "react-hook-form";
 import { FieldArrayProps, FormValuesProps } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as Utils from "../../../../../utils";
@@ -29,7 +29,6 @@ import { Inntektskilder } from "../../../../../felleskomponenter/trygdeavgift/ko
 import {
   beregnTrygdeavgiftsperioder,
   erBrukerSkattepliktigIHelePerioden,
-  fomTomErFyltUt,
   harInntektsKildeType,
   validerMedlemskapsperioder,
 } from "../komponenter/utils";
@@ -37,7 +36,7 @@ import {
   hentMedlemskapsFomTomDato,
   mapInitialMedlemskapsperioder,
   mapTilInntektskilderProps,
-  mapTilMedlemskapsperiodeProps,
+  mapTilMedlemskapsperiode,
   mapTilSkatteforholdProps,
 } from "../aarsavregningHelpers";
 import { MedlemskapsperiodeSkjema } from "../komponenter/medlemskapsperiodeSkjema";
@@ -45,6 +44,9 @@ import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversik
 import aarsavregningUtenEllerDeltGrunnlagSchema from "./aarsavregningUtenEllerDeltGrunnlagSchema";
 import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
+import { Medlemskapsperiode } from "../../../../../services/modules/medlemavfolketrygden/medlemskapsperioder";
+
+const { DELVIS_INNVILGET, INNVILGET } = MKV.Koder.innvilgelsesResultat;
 
 interface Props {
   bekreft: () => void;
@@ -65,7 +67,6 @@ interface AarsavregningFormValuesProps extends FormValuesProps {
 export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, harDeltGrunnlag }: Props) {
   const [valgtÅr, setValgtÅr] = useState<number | undefined>();
   const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
-  const [brukerHarBekreftet, setBrukerHarBekreftet] = useState(false);
   const [beregningPaagar, setBeregningPaagar] = useState(false);
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(undefined);
   const [bestemmelser, setBestemmelser] = useState<[]>([]);
@@ -80,10 +81,12 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const dispatch = useDispatch();
 
+  // TODO: Fix setting av disse i initial load useeffect
   const medlemskapsTypeErPliktig = lagredeMedlemskapsperioder?.every(
     (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
   );
   const innvilgetMedlemskapsperiode = hentMedlemskapsFomTomDato(lagredeMedlemskapsperioder);
+  // TODO END
 
   useEffect(() => {
     if (behandlingstema) {
@@ -91,16 +94,25 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     }
   }, [behandlingstema]);
 
+  // Initiell innlasting og skjemapopulering
   useEffect(() => {
     dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
     if (behandlingID) {
       Api.Aarsavregning.hentAarsavregning(behandlingID)
-        .then((res) => {
-          setAarsavregningResponse(res);
-          // Benyttes for innhenting av saksopplysninger ifm. årsavregningsbehandlinger
-          dispatch({ type: OK, data: res });
-          setValgtÅr(res.aar);
-          setValue("totaltForskuddsvisFakturert", res.avregning?.tidligereFakturertBeloepAvgiftssystem);
+        .then((aarsavregningRes) => {
+          Api.MedlemAvFolketrygden.Medlemskapsperioder.hentMedlemskapsperioder(behandlingID).then(
+            (medlemskapsperioderRes) => {
+              const innvilgedeMedlemskapsperioder = medlemskapsperioderRes?.filter(
+                (periode: Medlemskapsperiode) =>
+                  periode.innvilgelsesResultat === INNVILGET || periode.innvilgelsesResultat === DELVIS_INNVILGET,
+              );
+              setSkjemaverdierFraTrygdeavgiftsgrunnlag(aarsavregningRes, innvilgedeMedlemskapsperioder);
+              setAarsavregningResponse(aarsavregningRes);
+              setValgtÅr(aarsavregningRes.aar);
+              // Benyttes for innhenting av saksopplysninger ifm. årsavregningsbehandlinger
+              dispatch({ type: OK, data: aarsavregningRes });
+            },
+          );
         })
         .catch((err) => {
           if (err.response?.status === 404) {
@@ -110,21 +122,24 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     }
   }, []);
 
-  const setSkjemaverdierFraTrygdeavgiftsgrunnlag = () => {
+  const setSkjemaverdierFraTrygdeavgiftsgrunnlag = (
+    aarsavregningRes: AarsavregningResponse,
+    innvilgedeMedlemskapsperioder: Medlemskapsperiode[],
+  ) => {
     const mappedLagredeMedlemskapsperioder = mapInitialMedlemskapsperioder(
-      lagredeMedlemskapsperioder,
-      aarsavregningResponse?.tidligereGrunnlagsopplysninger,
+      innvilgedeMedlemskapsperioder,
+      aarsavregningRes.tidligereGrunnlagsopplysninger,
     );
-    const erInitiellMappingForDeltGrunnlag =
-      harDeltGrunnlag && aarsavregningResponse && !aarsavregningResponse.nyttGrunnlag;
+    const erInitiellMappingForDeltGrunnlag = harDeltGrunnlag && aarsavregningRes && !aarsavregningRes.nyttGrunnlag;
 
     setValue("medlemskapsperioder", mappedLagredeMedlemskapsperioder);
+    setValue("totaltForskuddsvisFakturert", aarsavregningRes.avregning?.tidligereFakturertBeloepAvgiftssystem);
     setValue(
       "skatteforholdsperioder",
       mapTilSkatteforholdProps(
         erInitiellMappingForDeltGrunnlag
-          ? aarsavregningResponse.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder
-          : aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder,
+          ? aarsavregningRes.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder
+          : aarsavregningRes?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder,
         mappedLagredeMedlemskapsperioder,
       ),
     );
@@ -132,21 +147,12 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       "inntektskilder",
       mapTilInntektskilderProps(
         erInitiellMappingForDeltGrunnlag
-          ? aarsavregningResponse.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.inntektskperioder
-          : aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder,
+          ? aarsavregningRes.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.inntektskperioder
+          : aarsavregningRes?.nyttGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder,
         mappedLagredeMedlemskapsperioder,
       ),
     );
   };
-
-  useEffect(() => {
-    const validerMedlemskapsperioderResultat = validerMedlemskapsperioder(lagredeMedlemskapsperioder);
-    setFeilmelding(validerMedlemskapsperioderResultat);
-
-    if (lagredeMedlemskapsperioder) {
-      setSkjemaverdierFraTrygdeavgiftsgrunnlag();
-    }
-  }, [lagredeMedlemskapsperioder, aarsavregningResponse]);
 
   useEffect(() => {
     if (redigerbart && aarsavregningResponse?.nyttGrunnlag) {
@@ -167,7 +173,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     watch,
     setValue,
     trigger,
-    formState: { isValid: formIsValid, isValidating },
+    formState: { isValid: formIsValid },
   } = useForm({
     resolver: yupResolver(aarsavregningUtenEllerDeltGrunnlagSchema),
     context: {
@@ -178,10 +184,17 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     mode: "onChange",
     reValidateMode: "onChange",
     defaultValues: {
-      medlemskapsperioder: mapInitialMedlemskapsperioder(
-        lagredeMedlemskapsperioder,
-        aarsavregningResponse?.tidligereGrunnlagsopplysninger,
-      ),
+      medlemskapsperioder: [
+        {
+          id: -1,
+          fomDato: "",
+          tomDato: "",
+          innvilgelsesResultat: "",
+          trygdedekning: "",
+          bestemmelse: "",
+          redigerbar: true,
+        },
+      ],
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
     } as FieldValue<AarsavregningFormValuesProps>,
@@ -208,12 +221,90 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   } = useFieldArray<FieldArrayProps, "inntektskilder", "id">({ control, name: "inntektskilder" });
 
   const formValues = watch();
+  const medlemskapsperioder = useWatch({ control, name: "medlemskapsperioder" });
+  const medlemskapsperioderPrevLength = useRef(medlemskapsperioder.length);
+  const totaltForskuddsvisFakturert = useWatch({ control, name: "totaltForskuddsvisFakturert" });
+  const skatteforholdsperioder = useWatch({ control, name: "skatteforholdsperioder" });
+  const skatteforholdsperioderPrevLength = useRef(skatteforholdsperioder.length);
+  const inntektskilder = useWatch({ control, name: "inntektskilder" });
+  const inntektskilderPrevLength = useRef(inntektskilder.length);
+
+  const lagreMedlemskapsperiode = async (medlemskapsperiode: Medlemskapsperiode) => {
+    const periodeRequest = {
+      fomDato: Utils.dato.formatterDatoTilISO(medlemskapsperiode.fomDato, "") as string,
+      tomDato: Utils.dato.formatterDatoTilISO(medlemskapsperiode.tomDato, "") as string,
+      trygdedekning: medlemskapsperiode.trygdedekning,
+      bestemmelse: medlemskapsperiode.bestemmelse,
+      innvilgelsesResultat: MKV.Koder.innvilgelsesResultat.INNVILGET,
+    };
+
+    const response: any = await (medlemskapsperiode.id === -1
+      ? Api.MedlemAvFolketrygden.Medlemskapsperioder.opprettMedlemskapsperioder(behandlingID, periodeRequest)
+      : Api.MedlemAvFolketrygden.Medlemskapsperioder.oppdaterMedlemskapsperioder(
+          behandlingID,
+          medlemskapsperiode.id,
+          periodeRequest,
+        ));
+
+    if (response.type === medlemskapsperioderTypes.FEILET) {
+      setFeilmelding(response?.data?.data?.message);
+    } else {
+      if (medlemskapsperiode.id === -1) {
+        medlemskapsperiode.id = response.id;
+      }
+      setFeilmelding(undefined);
+    }
+  };
+
+  const debouncedLagreMedlemskapsperioder = useCallback(
+    Utils._debounce(async (medlemskapsperioderFormValues) => {
+      const isValid = await trigger("medlemskapsperioder");
+      if (isValid) {
+        for (const periode of medlemskapsperioderFormValues) {
+          await lagreMedlemskapsperiode(periode);
+        }
+        dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
+        await trigger();
+      }
+    }, 1000),
+    [],
+  );
 
   useEffect(() => {
-    if (medlemskapsperioderFields.length === 0) {
-      handleLeggTilMedlemskapsperiode();
+    if (redigerbart) {
+      if (medlemskapsperioder.length !== medlemskapsperioderPrevLength.current) {
+        medlemskapsperioderPrevLength.current = medlemskapsperioder.length;
+        return;
+      }
+      debouncedLagreMedlemskapsperioder(medlemskapsperioder);
     }
-  }, [medlemskapsperioderFields]);
+  }, [medlemskapsperioder]);
+
+  const handleLeggTilMedlemskapsperiode = () => {
+    const nyMedlemskapsperiode = {
+      id: -1,
+      fomDato: "",
+      tomDato: "",
+      innvilgelsesResultat: "",
+      trygdedekning: "",
+      bestemmelse: "",
+      redigerbar: true,
+    };
+    // @ts-expect-error generisk beskrivelse
+    medlemskapsperioderAppend(nyMedlemskapsperiode);
+  };
+
+  const handleSlett = async (index: number) => {
+    const periode = medlemskapsperioder[index];
+
+    if (periode.id === -1) {
+      medlemskapsperioderRemove(index);
+    } else {
+      Api.MedlemAvFolketrygden.Medlemskapsperioder.slettMedlemskapsperiode(behandlingID, periode.id).then(() => {
+        medlemskapsperioderRemove(index);
+      });
+    }
+  };
 
   const debouncedOppdaterAarsavregning = useCallback(
     Utils._debounce(
@@ -240,6 +331,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
 
   const handleBeregnTrygdeavgiftsperioder = useCallback(
     async (formVerdier: FieldValue<FormValuesProps>) => {
+      setBeregningPaagar(true);
       await beregnTrygdeavgiftsperioder(formVerdier, {
         behandlingID,
         medlemskapsTypeErPliktig,
@@ -257,29 +349,21 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   );
 
   useEffect(() => {
-    if (
-      redigerbart &&
-      aarsavregningID &&
-      !isValidating &&
-      formIsValid &&
-      fomTomErFyltUt(formValues.inntektskilder, formValues.skatteforholdsperioder, formValues.medlemskapsperioder) &&
-      harInntektsKildeType(formValues.inntektskilder, trygdeAvgiftSkalIkkeBetalesTilNav)
-    ) {
-      setBrukerHarBekreftet(false);
-      setBeregningPaagar(true);
-      setFeilmelding(undefined);
-      debounceBeregnTrygdeavgiftsperioder(formValues);
+    if (redigerbart && aarsavregningID) {
+      const beregnHvisSkjemaErGyldig = async () => {
+        const isValid = await trigger();
+        if (isValid) {
+          setFeilmelding(undefined);
+          debounceBeregnTrygdeavgiftsperioder(formValues);
+        }
+      }
+      beregnHvisSkjemaErGyldig();
     }
-  }, [
-    formIsValid,
-    isValidating,
-    formValues.inntektskilder.length,
-    formValues.skatteforholdsperioder.length,
-    formValues.totaltForskuddsvisFakturert,
-  ]);
+  }, [totaltForskuddsvisFakturert, inntektskilder, skatteforholdsperioder]);
 
   const stegErGyldig = Boolean(formIsValid && aarsavregningResponse?.nyttGrunnlag && feilmelding === undefined);
 
+  // TODO: Må tilpasses, mister oppdateringer av stegstatus
   useEffect(() => {
     if (!beregningPaagar) {
       oppdaterStatus(stegErGyldig);
@@ -291,80 +375,8 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       trigger();
       setHarValidertSkjema(true);
     }
-    setBrukerHarBekreftet(true);
     if (stegErGyldig && !beregningPaagar) {
       bekreft();
-    }
-  };
-
-  const lagreMedlemskapsperiode = async (medlemskapsperiode: MedlemskapsperiodeProp, index: number) => {
-    const periodeRequest = {
-      fomDato: Utils.dato.formatterDatoTilISO(medlemskapsperiode.fomDato, "") as string,
-      tomDato: Utils.dato.formatterDatoTilISO(medlemskapsperiode.tomDato, "") as string,
-      trygdedekning: medlemskapsperiode.trygdedekning,
-      bestemmelse: medlemskapsperiode.bestemmelse,
-      innvilgelsesResultat: MKV.Koder.innvilgelsesResultat.INNVILGET,
-    };
-
-    const response: any = await (medlemskapsperiode.ny
-      ? dispatch(medlemskapsperioderOperations.opprettMedlemskapsperiode(behandlingID, periodeRequest))
-      : dispatch(
-          medlemskapsperioderOperations.oppdaterMedlemskapsperiode(
-            behandlingID,
-            medlemskapsperiode.periodeId,
-            periodeRequest,
-          ),
-        ));
-
-    if (response.type === medlemskapsperioderTypes.FEILET) {
-      setFeilmelding(response?.data?.data?.message);
-    } else {
-      setFeilmelding(undefined);
-    }
-
-    medlemskapsperioderUpdate(
-      index,
-      mapTilMedlemskapsperiodeProps(response.data, aarsavregningResponse?.tidligereGrunnlagsopplysninger),
-    );
-  };
-
-  const debouncedLagreMedlemskapsperioder = useCallback(
-    Utils._debounce(async (alleMedlemskapsperioder, overskrevetIndex) => {
-      const isValid = await trigger("medlemskapsperioder");
-      if (isValid) {
-        // eslint-disable-next-line no-restricted-syntax
-        for (const periode of alleMedlemskapsperioder) {
-          const index = overskrevetIndex !== undefined ? overskrevetIndex : alleMedlemskapsperioder.indexOf(periode);
-          await lagreMedlemskapsperiode(periode, index);
-        }
-        dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
-      }
-    }, 1000),
-    [],
-  );
-
-  const handleLeggTilMedlemskapsperiode = () => {
-    const nyMedlemskapsperiode = {
-      periodeId: Utils._uuid(),
-      ny: true,
-      fomDato: "",
-      tomDato: "",
-      innvilgelsesResultat: "",
-      trygdedekning: "",
-      bestemmelse: "",
-      redigerbar: true,
-    };
-    // @ts-expect-error generisk beskrivelse
-    medlemskapsperioderAppend(nyMedlemskapsperiode);
-  };
-
-  const handleSlett = async (index: number) => {
-    const medlemskapsperiode = formValues.medlemskapsperioder[index];
-
-    if (medlemskapsperiode.ny) {
-      medlemskapsperioderRemove(index);
-    } else {
-      dispatch(medlemskapsperioderOperations.slettMedlemskapsperiode(behandlingID, medlemskapsperiode.periodeId));
     }
   };
 
@@ -421,7 +433,6 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
             remove={handleSlett}
             formValues={formValues}
             bestemmelser={bestemmelser}
-            handleChange={debouncedLagreMedlemskapsperioder}
             handleUpdate={medlemskapsperioderUpdate}
             handleLeggTil={handleLeggTilMedlemskapsperiode}
             visLeggTil
@@ -472,7 +483,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         />
       )}
 
-      {brukerHarBekreftet && feilmelding && (
+      {feilmelding && (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
           {feilmelding}
         </Nav.Alert>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
@@ -23,7 +23,6 @@ export interface PeriodeElementerProps {
   formValues: FormValuesProps;
   bestemmelser: [];
   tittel?: string;
-  handleChange: (medlemskapsperiode: Medlemskapsperiode[], index: number) => void;
   handleLeggTil: () => void;
   handleUpdate: UseFieldArrayUpdate<FieldArrayProps, "medlemskapsperioder">;
   index: number;
@@ -40,7 +39,6 @@ export function MedlemskapsperiodeSkjema({
   formValues,
   bestemmelser,
   tittel,
-  handleChange,
   handleLeggTil,
   handleUpdate,
   index,
@@ -60,7 +58,7 @@ export function MedlemskapsperiodeSkjema({
     }
   }, [field.bestemmelse]);
 
-  // @ts-expect-error TODO: Fiks typing for FormValuesProps
+  // @ts-expect-error Fiks typing for FormValuesProps
   const erPeriodeFraGrunnlag = !formValues.medlemskapsperioder[index].redigerbar;
   const kanSlettePeriode = redigerbart && formValues.medlemskapsperioder.length !== 1;
   const tilOgMedDatoForrigePeriode =
@@ -86,9 +84,6 @@ export function MedlemskapsperiodeSkjema({
               name={`medlemskapsperioder[${index}].fomDato`}
               aria-label={`Fra og med periode ${index + 1}`}
               readOnly={!redigerbart || erPeriodeFraGrunnlag}
-              onChange={(value) => {
-                handleChange([{ ...formValues.medlemskapsperioder[index], fomDato: value }], index);
-              }}
             />
           </Nav.Column>
           <Nav.Column className="dato dato__tom">
@@ -100,9 +95,6 @@ export function MedlemskapsperiodeSkjema({
               minDate={Utils.dato.norskStringTilDate(formValues.medlemskapsperioder[index].fomDato)}
               maxDate={maksVerdi}
               readOnly={!redigerbart || erPeriodeFraGrunnlag}
-              onChange={(value) => {
-                handleChange([{ ...formValues.medlemskapsperioder[index], tomDato: value }], index);
-              }}
             />
           </Nav.Column>
           <Nav.Column className="bestemmelse">
@@ -113,8 +105,7 @@ export function MedlemskapsperiodeSkjema({
               aria-label={`Bestemmelse periode ${index + 1}`}
               control={control}
               readOnly={!redigerbart || erPeriodeFraGrunnlag}
-              onChange={(bestemmelse) => {
-                handleChange([{ ...formValues.medlemskapsperioder[index], bestemmelse }], index);
+              onChange={() => {
                 handleUpdate(index, { ...formValues.medlemskapsperioder[index], trygdedekning: "" });
               }}
             >
@@ -133,9 +124,6 @@ export function MedlemskapsperiodeSkjema({
               aria-label={`Trygdedekning periode ${index + 1}`}
               control={control}
               readOnly={!redigerbart || erPeriodeFraGrunnlag}
-              onChange={(value) =>
-                handleChange([{ ...formValues.medlemskapsperioder[index], trygdedekning: value }], index)
-              }
             >
               {trygdedekninger.map((dekning: any) => (
                 <option key={dekning} value={dekning}>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
@@ -93,40 +93,6 @@ export function beregnTrygdeavgiftsperioder(
     .catch((error) => setFeilmelding(mapFeilmelding(error)));
 }
 
-export function validerMedlemskapsperioder(perioder: Medlemskapsperiode[]) {
-  if (perioder.length === 0) {
-    return undefined;
-  }
-
-  const sortertePerioder = [...perioder].sort((a, b) => new Date(a.fomDato).getTime() - new Date(b.fomDato).getTime());
-  const bestemmelseSet = new Set<string>();
-  const DAY_IN_MILLISECONDS = 86400000;
-  let feilmeldingFraValidering;
-
-  sortertePerioder.forEach((periode, index) => {
-    bestemmelseSet.add(periode.bestemmelse);
-
-    if (index > 0) {
-      const forrigePeriode = sortertePerioder[index - 1];
-      const forrigeTomDato = new Date(forrigePeriode.tomDato);
-      const nyFomDato = new Date(periode.fomDato);
-
-      if (nyFomDato <= forrigeTomDato) {
-        feilmeldingFraValidering = "Medlemskapsperioder overlapper";
-      }
-      if (nyFomDato.getTime() - forrigeTomDato.getTime() > DAY_IN_MILLISECONDS) {
-        feilmeldingFraValidering = "Det er opphold mellom medlemskapsperioder";
-      }
-    }
-  });
-
-  if (bestemmelseSet.size !== 1) {
-    feilmeldingFraValidering = "Bestemmelsene må være like";
-  }
-
-  return feilmeldingFraValidering;
-}
-
 export const lagInnvilgetMedlemskapsPeriode = (medlemskapsperioder?: Medlemskapsperiode[]) => {
   if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
     const sorterteInnvilgedePerioder = [...medlemskapsperioder]

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -123,9 +123,9 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
     setValgtÅr(år || null);
   };
 
-  const håndterDeltGrunnlag = (value: boolean) => {
+  const håndterDeltGrunnlag = async (value: boolean) => {
     if (harDeltGrunnlag && !value) {
-      Api.Aarsavregning.oppdaterAarsavregning(
+      await Api.Aarsavregning.oppdaterAarsavregning(
         behandlingID,
         { avregning: { tidligereFakturertBeloepAvgiftssystem: 0 } },
         aarsavregningID,


### PR DESCRIPTION
Refaktorering gjennomført. Setter kun skjemaverdier en gang ved innlasting av data. Deler opp slik at vi har 1 useEffect som håndterer endringer i medlemskapsperioder, 1 for tidligere fakturert i avgiftssystemet og 1 effect som håndterer både inntektskilder og skatteforhold.

Har også lagt ved en useEffect som skal håndtere første beregning. Etter denne beregningen er gjennomført slippes det opp for at endringer i ulike skjemadeler kan resultere i nye beregninger.