### PR TITLE
7088 TOGGLE Oppfrisk kun ved opprettelse av ny årsavregning.

### DIFF
--- a/src/sider/aarsavregning/saksbehandling.tsx
+++ b/src/sider/aarsavregning/saksbehandling.tsx
@@ -44,7 +44,6 @@ function Saksbehandling({ match, location }: Props) {
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
 
   const registeropplysningerHentet = useSelector(behandlingerSelectors.RegisteropplysningerHentetSelector);
-  const { oppfriskOgLastInnSaksopplysninger } = useContext(FellesHandlersContext) as any;
 
   const { startOgVisOppfriskModal, visOppfriskModal, behandlingOppfriskes } = useContext(FellesHandlersContext) as any;
 

--- a/src/sider/aarsavregning/saksbehandling.tsx
+++ b/src/sider/aarsavregning/saksbehandling.tsx
@@ -86,12 +86,6 @@ function Saksbehandling({ match, location }: Props) {
   };
 
   useEffect(() => {
-    if (aar !== undefined) {
-      oppfriskOgLastInnSaksopplysninger();
-    }
-  }, [aar]);
-
-  useEffect(() => {
     lastInnSaksopplysninger();
 
     return () => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningHelpers.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningHelpers.ts
@@ -15,7 +15,7 @@ export const hentMedlemskapsFomTomDato = (medlemskapsperioder?: any[]) => {
 
 export const mapTilMedlemskapsperiodeFieldProps = (
   medlemskapsperiode: any,
-  tidligereGrunnlag?: Api.Aarsavregning.Trygdeavgiftsgrunnlag
+  tidligereGrunnlag?: Api.Aarsavregning.Trygdeavgiftsgrunnlag,
 ) => {
   const grunnlagsperioder = tidligereGrunnlag?.medlemskapsperioder;
   const medlemskapsperiodeErFraGrunnlag = grunnlagsperioder?.some(
@@ -28,21 +28,16 @@ export const mapTilMedlemskapsperiodeFieldProps = (
     tomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsperiode.tomDato),
     feil: undefined,
     redigerbar: !medlemskapsperiodeErFraGrunnlag,
-    id: medlemskapsperiode.id
+    id: medlemskapsperiode.id,
   };
 };
 
-export const mapMedlemskapsperioderFraGrunnlag = (
-  tidligereGrunnlag: Api.Aarsavregning.Trygdeavgiftsgrunnlag,
-) =>
+export const mapMedlemskapsperioderFraGrunnlag = (tidligereGrunnlag: Api.Aarsavregning.Trygdeavgiftsgrunnlag) =>
   [...tidligereGrunnlag.medlemskapsperioder]
     .sort((a, b) => Utils.dato.sorterEtterISOFomDato(a, b))
     .map((periode) => mapTilMedlemskapsperiodeFieldProps(periode, tidligereGrunnlag));
 
-export const mapMedlemskapsperioder = (
-  perioder: any[],
-  tidligereGrunnlag?: Api.Aarsavregning.Trygdeavgiftsgrunnlag,
-) =>
+export const mapMedlemskapsperioder = (perioder: any[], tidligereGrunnlag?: Api.Aarsavregning.Trygdeavgiftsgrunnlag) =>
   [...perioder]
     .sort((a, b) => Utils.dato.sorterEtterISOFomDato(a, b))
     .map((periode) => mapTilMedlemskapsperiodeFieldProps(periode, tidligereGrunnlag));

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningHelpers.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningHelpers.ts
@@ -13,12 +13,12 @@ export const hentMedlemskapsFomTomDato = (medlemskapsperioder?: any[]) => {
   return {};
 };
 
-export const mapTilMedlemskapsperiode = (
+export const mapTilMedlemskapsperiodeFieldProps = (
   medlemskapsperiode: any,
-  tidligereGrunnlagsopplysninger?: Api.Aarsavregning.Grunnlagsopplysninger,
+  tidligereGrunnlag?: Api.Aarsavregning.Trygdeavgiftsgrunnlag
 ) => {
-  const grunnlagsperioder = tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
-  const redigerbar = !grunnlagsperioder?.some(
+  const grunnlagsperioder = tidligereGrunnlag?.medlemskapsperioder;
+  const medlemskapsperiodeErFraGrunnlag = grunnlagsperioder?.some(
     (periode) => periode.fomDato === medlemskapsperiode.fomDato && periode.tomDato === medlemskapsperiode.tomDato,
   );
 
@@ -27,17 +27,25 @@ export const mapTilMedlemskapsperiode = (
     fomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsperiode.fomDato),
     tomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsperiode.tomDato),
     feil: undefined,
-    redigerbar,
+    redigerbar: !medlemskapsperiodeErFraGrunnlag,
+    id: medlemskapsperiode.id
   };
 };
 
-export const mapInitialMedlemskapsperioder = (
+export const mapMedlemskapsperioderFraGrunnlag = (
+  tidligereGrunnlag: Api.Aarsavregning.Trygdeavgiftsgrunnlag,
+) =>
+  [...tidligereGrunnlag.medlemskapsperioder]
+    .sort((a, b) => Utils.dato.sorterEtterISOFomDato(a, b))
+    .map((periode) => mapTilMedlemskapsperiodeFieldProps(periode, tidligereGrunnlag));
+
+export const mapMedlemskapsperioder = (
   perioder: any[],
-  tidligereGrunnlagsopplysninger?: Api.Aarsavregning.Grunnlagsopplysninger,
+  tidligereGrunnlag?: Api.Aarsavregning.Trygdeavgiftsgrunnlag,
 ) =>
   [...perioder]
     .sort((a, b) => Utils.dato.sorterEtterISOFomDato(a, b))
-    .map((periode) => mapTilMedlemskapsperiode(periode, tidligereGrunnlagsopplysninger));
+    .map((periode) => mapTilMedlemskapsperiodeFieldProps(periode, tidligereGrunnlag));
 
 export const mapTilSkatteforholdProps = (skatteforholdsperioder?: any[], medlemskapsperioder?: any[]) => {
   const { fom, tom } = hentMedlemskapsFomTomDato(medlemskapsperioder);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -28,9 +28,10 @@ import { Inntektskilder } from "../../../../../felleskomponenter/trygdeavgift/ko
 import { beregnTrygdeavgiftsperioder, erBrukerSkattepliktigIHelePerioden } from "../komponenter/utils";
 import {
   hentMedlemskapsFomTomDato,
-  mapMedlemskapsperioder, mapMedlemskapsperioderFraGrunnlag,
+  mapMedlemskapsperioder,
+  mapMedlemskapsperioderFraGrunnlag,
   mapTilInntektskilderProps,
-  mapTilSkatteforholdProps
+  mapTilSkatteforholdProps,
 } from "../aarsavregningHelpers";
 import { MedlemskapsperiodeSkjema } from "../komponenter/medlemskapsperiodeSkjema";
 import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversikt";
@@ -126,16 +127,20 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     innvilgedeMedlemskapsperioder: Medlemskapsperiode[],
   ) => {
     let mappedMedlemskapsperioder;
-    if (harDeltGrunnlag && innvilgedeMedlemskapsperioder.length === 0 && aarsavregningRes?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
+    if (
+      harDeltGrunnlag &&
+      innvilgedeMedlemskapsperioder.length === 0 &&
+      aarsavregningRes?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag
+    ) {
       // Må opprette medlemskapsperioder fra grunnlag på behandlingsresultat. Overstyrer ID til -1.
       mappedMedlemskapsperioder = mapMedlemskapsperioderFraGrunnlag(
-        aarsavregningRes.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag
-      ).map((periode) => ({...periode, id: -1}));
+        aarsavregningRes.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
+      ).map((periode) => ({ ...periode, id: -1 }));
       await Promise.all(mappedMedlemskapsperioder.map(lagreMedlemskapsperiode));
     } else {
       mappedMedlemskapsperioder = mapMedlemskapsperioder(
         innvilgedeMedlemskapsperioder,
-        aarsavregningRes.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag
+        aarsavregningRes.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag,
       );
     }
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -28,9 +28,9 @@ import { Inntektskilder } from "../../../../../felleskomponenter/trygdeavgift/ko
 import { beregnTrygdeavgiftsperioder, erBrukerSkattepliktigIHelePerioden } from "../komponenter/utils";
 import {
   hentMedlemskapsFomTomDato,
-  mapInitialMedlemskapsperioder,
+  mapMedlemskapsperioder, mapMedlemskapsperioderFraGrunnlag,
   mapTilInntektskilderProps,
-  mapTilSkatteforholdProps,
+  mapTilSkatteforholdProps
 } from "../aarsavregningHelpers";
 import { MedlemskapsperiodeSkjema } from "../komponenter/medlemskapsperiodeSkjema";
 import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversikt";
@@ -70,6 +70,7 @@ interface AarsavregningFormValuesProps extends FormValuesProps {
 export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, harDeltGrunnlag }: Props) {
   const [valgtÅr, setValgtÅr] = useState<number | undefined>();
   const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
+  const [medlemskapsperiodeFeilmelding, setMedlemskapsperiodeFeilmelding] = useState<undefined | string>(undefined);
   const [beregningPaagar, setBeregningPaagar] = useState(false);
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(undefined);
   const [bestemmelser, setBestemmelser] = useState<[]>([]);
@@ -119,19 +120,30 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     }
   }, []);
 
-  const setSkjemaverdierFraTrygdeavgiftsgrunnlag = (
+  // Skal kun kalles onMount
+  const setSkjemaverdierFraTrygdeavgiftsgrunnlag = async (
     aarsavregningRes: AarsavregningResponse,
     innvilgedeMedlemskapsperioder: Medlemskapsperiode[],
   ) => {
-    const mappedLagredeMedlemskapsperioder = mapInitialMedlemskapsperioder(
-      innvilgedeMedlemskapsperioder,
-      aarsavregningRes.tidligereGrunnlagsopplysninger,
-    );
+    let mappedMedlemskapsperioder;
+    if (harDeltGrunnlag && innvilgedeMedlemskapsperioder.length === 0 && aarsavregningRes?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
+      // Må opprette medlemskapsperioder fra grunnlag på behandlingsresultat. Overstyrer ID til -1.
+      mappedMedlemskapsperioder = mapMedlemskapsperioderFraGrunnlag(
+        aarsavregningRes.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag
+      ).map((periode) => ({...periode, id: -1}));
+      await Promise.all(mappedMedlemskapsperioder.map(lagreMedlemskapsperiode));
+    } else {
+      mappedMedlemskapsperioder = mapMedlemskapsperioder(
+        innvilgedeMedlemskapsperioder,
+        aarsavregningRes.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag
+      );
+    }
+
     const erInitiellMappingForDeltGrunnlag = harDeltGrunnlag && aarsavregningRes && !aarsavregningRes.nyttGrunnlag;
 
     setValue(
       "medlemskapsperioder",
-      mappedLagredeMedlemskapsperioder.length ? mappedLagredeMedlemskapsperioder : [DEFAULT_MEDLEMSKAPSPERIODE],
+      mappedMedlemskapsperioder.length ? mappedMedlemskapsperioder : [DEFAULT_MEDLEMSKAPSPERIODE],
     );
     setValue("totaltForskuddsvisFakturert", aarsavregningRes.avregning?.tidligereFakturertBeloepAvgiftssystem);
     setValue(
@@ -140,7 +152,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         erInitiellMappingForDeltGrunnlag
           ? aarsavregningRes.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder
           : aarsavregningRes?.nyttGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder,
-        mappedLagredeMedlemskapsperioder,
+        mappedMedlemskapsperioder,
       ),
     );
     setValue(
@@ -149,7 +161,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         erInitiellMappingForDeltGrunnlag
           ? aarsavregningRes.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.inntektskperioder
           : aarsavregningRes?.nyttGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder,
-        mappedLagredeMedlemskapsperioder,
+        mappedMedlemskapsperioder,
       ),
     );
   };
@@ -243,7 +255,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         ));
 
     if (response.type === medlemskapsperioderTypes.FEILET) {
-      setFeilmelding(response?.data?.data?.message);
+      setMedlemskapsperiodeFeilmelding(response?.data?.data?.message);
     } else {
       if (medlemskapsperiode.id === -1) {
         /* eslint-disable no-param-reassign */
@@ -251,7 +263,6 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         medlemskapsperiode.medlemskapstype = response.medlemskapstype;
         /* eslint-enable no-param-reassign */
       }
-      setFeilmelding(undefined);
     }
   };
 
@@ -274,15 +285,12 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   // Håndterer endringer i medlemskapsperiodeSkjema.
   useEffect(() => {
     if (redigerbart) {
-      setFeilmelding(undefined);
+      setMedlemskapsperiodeFeilmelding(undefined);
       if (medlemskapsperioder.length !== medlemskapsperioderPrevLength.current) {
         medlemskapsperioderPrevLength.current = medlemskapsperioder.length;
         return;
       }
-      // Unngå trigger på skjema dersom default periode er lagt inn
-      if (!medlemskapsperioder.some((periode: any) => periode.fomDato === undefined || periode.fomDato === "")) {
-        debouncedLagreMedlemskapsperioder(medlemskapsperioder);
-      }
+      debouncedLagreMedlemskapsperioder(medlemskapsperioder);
     }
   }, [medlemskapsperioder]);
 
@@ -503,6 +511,12 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
           medlemskapsTypeErPliktig={medlemskapsTypeErPliktig!}
           tittel="Endelig beregnet trygdeavgift"
         />
+      )}
+
+      {medlemskapsperiodeFeilmelding && (
+        <Nav.Alert variant="error" className="alertstripe_feilmelding">
+          {medlemskapsperiodeFeilmelding}
+        </Nav.Alert>
       )}
 
       {feilmelding && (

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -259,12 +259,8 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     Utils._debounce(async (medlemskapsperioderFormValues) => {
       const isValid = await trigger("medlemskapsperioder");
       if (isValid) {
-        /* eslint-disable-next-line no-restricted-syntax */
-        for (const periode of medlemskapsperioderFormValues) {
-          if (periode.redigerbar) {
-            await lagreMedlemskapsperiode(periode);
-          }
-        }
+        await Promise.all(medlemskapsperioderFormValues.map(lagreMedlemskapsperiode));
+
         dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
         if (initiellBeregningUtført && (await trigger())) {
           setFeilmelding(undefined);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -261,13 +261,11 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
 
     if (response.type === medlemskapsperioderTypes.FEILET) {
       setMedlemskapsperiodeFeilmelding(response?.data?.data?.message);
-    } else {
-      if (medlemskapsperiode.id === -1) {
-        /* eslint-disable no-param-reassign */
-        medlemskapsperiode.id = response.id;
-        medlemskapsperiode.medlemskapstype = response.medlemskapstype;
-        /* eslint-enable no-param-reassign */
-      }
+    } else if (medlemskapsperiode.id === -1) {
+      /* eslint-disable no-param-reassign */
+      medlemskapsperiode.id = response.id;
+      medlemskapsperiode.medlemskapstype = response.medlemskapstype;
+      /* eslint-enable no-param-reassign */
     }
   };
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -1,6 +1,6 @@
 import * as Api from "../../../../services/api";
 import "./vurderingAarsavregningInngang.css";
-import { ChangeEvent, useEffect, useState } from "react";
+import { ChangeEvent, useContext, useEffect, useState } from "react";
 import { AarsavregningResponse } from "../../../../services/modules/aarsavregning/aarsavregning";
 import { useDispatch, useSelector } from "react-redux";
 import { behandlingerSelectors } from "../../../../ducks/behandlinger";
@@ -17,6 +17,7 @@ import { AarsavregningMedGrunnlag } from "./aarsavregningMedGrunnlag/aarsavregni
 import { AarsavregningUtenEllerDeltGrunnlag } from "./aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
 import LabelMedHjelpetekst from "../../../../felleskomponenter/labelMedHjelpetekst";
 import { lagInnvilgetMedlemskapsPeriode } from "./komponenter/utils";
+import { FellesHandlersContext } from "../../../../contexts";
 
 interface Props {
   bekreft: () => void;
@@ -56,6 +57,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   const antallÅrTilbakeITid = 6;
   const muligeAar = Array.from({ length: antallÅrTilbakeITid }, (_, i) => sisteMuligeÅr - i);
   const dispatch = useDispatch();
+  const { oppfriskOgLastInnSaksopplysninger } = useContext(FellesHandlersContext) as any;
 
   const utledGrunnlagstypeForAarsavregning = (res: AarsavregningResponse) => {
     const innvilgetPeriode = lagInnvilgetMedlemskapsPeriode(
@@ -106,6 +108,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
           // Benyttes for innhenting av saksopplysninger ifm. årsavregningsbehandlinger
           dispatch({ type: OK, data: res });
           dispatch(behandlingsresultatOperations.hent(behandlingID));
+          oppfriskOgLastInnSaksopplysninger();
         })
         .catch((error) => {
           setApiFeil(error.body.message);


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7088
Slik koden var så kjørte den oppfrisk hver gang vi gikk inn i en årsavregning. Noe som også fører til att vi sletter medlemskapsperioder. Dette er kun ønskelig når vi faktisk oppretter en årsavregning, så endrer det slik att vi kun får dette kallet første gang vi velger år.