### PR TITLE
7212 TOGGLE Bestemmelse som input til inntekt for årsavregning

### DIFF
--- a/src/services/modules/medlemavfolketrygden/medlemskapsperioder.ts
+++ b/src/services/modules/medlemavfolketrygden/medlemskapsperioder.ts
@@ -9,6 +9,7 @@ export interface Medlemskapsperiode {
   innvilgelsesResultat: string;
   trygdedekning: string;
   medlemskapstype: string;
+  redigerbar?: boolean;
 }
 
 export interface OppdaterMedlemskapsperiode {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -29,6 +29,7 @@ import {
   erBrukerSkattepliktigIHelePerioden,
   fomTomErFyltUt,
   harInntektsKildeType,
+  hentMedlemskapsperiodeBestemmelse,
   lagInnvilgetMedlemskapsPeriode,
   mapFeilmelding,
 } from "../komponenter/utils";
@@ -57,6 +58,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const medlemskapsperioder =
     aarsavregningResponse?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
   const innvilgetMedlemskapsperiode = lagInnvilgetMedlemskapsPeriode(medlemskapsperioder);
+  const innvilgetMedlemskapsperiodeBestemmelse = hentMedlemskapsperiodeBestemmelse(false, medlemskapsperioder);
   const defaultPeriode = {
     fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
     tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
@@ -311,6 +313,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
               fields={inntektFields}
               medlemskapsTypeErPliktig={medlemskapsTypeErPliktig!}
               skalViseErMaanedsBelopRadioGroup
+              bestemmelse={innvilgetMedlemskapsperiodeBestemmelse}
             />
           )}
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -25,7 +25,11 @@ import {
 } from "../../../../../ducks/medlemskapsperioder";
 import { Skatteforholdsperioder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/skatteforholdsperioder";
 import { Inntektskilder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/inntektskilder";
-import { beregnTrygdeavgiftsperioder, erBrukerSkattepliktigIHelePerioden } from "../komponenter/utils";
+import {
+  beregnTrygdeavgiftsperioder,
+  erBrukerSkattepliktigIHelePerioden,
+  hentMedlemskapsperiodeBestemmelse,
+} from "../komponenter/utils";
 import {
   hentMedlemskapsFomTomDato,
   mapMedlemskapsperioder,
@@ -500,6 +504,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
           fields={inntektFields}
           medlemskapsTypeErPliktig={medlemskapsTypeErPliktig!}
           skalViseErMaanedsBelopRadioGroup
+          bestemmelse={hentMedlemskapsperiodeBestemmelse(harDeltGrunnlag, medlemskapsperioder)}
         />
       )}
       {formIsValid && trygdeAvgiftSkalIkkeBetalesTilNav && (

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
@@ -58,7 +58,6 @@ export function MedlemskapsperiodeSkjema({
     }
   }, [field.bestemmelse]);
 
-  // @ts-expect-error Fiks typing for FormValuesProps
   const erPeriodeFraGrunnlag = !formValues.medlemskapsperioder[index].redigerbar;
   const kanSlettePeriode = redigerbart && formValues.medlemskapsperioder.length !== 1;
   const tilOgMedDatoForrigePeriode =

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
@@ -93,6 +93,20 @@ export function beregnTrygdeavgiftsperioder(
     .catch((error) => setFeilmelding(mapFeilmelding(error)));
 }
 
+export const hentMedlemskapsperiodeBestemmelse = (
+  harDeltGrunnlag: boolean,
+  medlemskapsperioder?: Medlemskapsperiode[],
+) => {
+  if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
+    const sorterteInnvilgedePerioder = [...medlemskapsperioder]
+      .filter((periode) => !harDeltGrunnlag || !periode.redigerbar)
+      .filter((periode) => periode.innvilgelsesResultat === MKV.Koder.innvilgelsesResultat.INNVILGET)
+      .sort(sorterEtterISOFomDato);
+    return sorterteInnvilgedePerioder?.[0]?.bestemmelse;
+  }
+  return undefined;
+};
+
 export const lagInnvilgetMedlemskapsPeriode = (medlemskapsperioder?: Medlemskapsperiode[]) => {
   if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
     const sorterteInnvilgedePerioder = [...medlemskapsperioder]


### PR DESCRIPTION
Inntekt fra NATO har ikke kommet opp i inntektkomponent i årsavregning context. Legger til bestemmelse som input slik at man kan velge dette