### PR TITLE
7240 TOGGLE Beregning detaljer vises ved grunnlag != null

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -248,7 +248,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
     medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder);
   const forskuddsvisFakturertTrygdeavgift =
     (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
-  const nyttGrunnlagHarTrygdeavgiftsperioder = (aarsavregningResponse?.nyttGrunnlag?.avgift?.totalAvgift ?? 0) > 0;
+  const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
 
   return (
     <>
@@ -320,7 +320,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
           {trygdeAvgiftSkalIkkeBetalesTilNav && <Aarsavregningsmeldinger.TrygdeavgiftSkalIkkeBetalesTilNav />}
 
-          {nyttGrunnlagHarTrygdeavgiftsperioder && formIsValid && !feilmelding && (
+          {nyttGrunnlagHarTrygdeavgiftsgrunnlag && formIsValid && !feilmelding && (
             <SumArsavregningTabell
               nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
               tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
@@ -29,7 +29,7 @@ export function BeregnetTrygdeavgiftDetaljer({
   medlemskapsTypeErPliktig: boolean;
   tittel: string;
 }) {
-  if (!grunnlag || !grunnlag.avgift || grunnlag.avgift.totalAvgift === 0) return null;
+  if (!grunnlag || !grunnlag.avgift) return null;
 
   const hentDetaljer = (data: Grunnlagsopplysninger): DetaljerInterface[] => {
     return data.avgift.trygdeavgiftsperioder


### PR DESCRIPTION
Detaljer ble skjult ved totalavgift = 0, endrer dette til å vises sålenge man har trygdeavgiftsgrunnlag