### PR TITLE
7246 TOGGLE: Årsavregning med grunnlag teknisk opprydning

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,6 +56,7 @@
     "react/prop-types": "off",
     "react/forbid-prop-types": "off",
     "react/no-unused-prop-types": "off",
+    "react/jsx-boolean-value": "off",
     "react/jsx-props-no-spreading": "off",
     "react/require-default-props": "off",
     "react-hooks/exhaustive-deps": "off",

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -15,7 +15,19 @@ import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavre
 import { AarsavregningMedGrunnlagForm } from "./aarsavregningMedGrunnlagForm";
 import * as Nav from "../../../../../navFrontend";
 import MKV from "../../../../../melosyskodeverk";
-import { lagInnvilgetMedlemskapsPeriode, hentMedlemskapsperiodeBestemmelse } from "../komponenter/utils";
+import { hentMedlemskapsperiodeBestemmelse } from "../komponenter/utils";
+import { Medlemskapsperiode } from "../../../../../services/modules/medlemavfolketrygden/medlemskapsperioder";
+import { sorterEtterISOFomDato } from "../../../../../utils/dato";
+
+const lagInnvilgetMedlemskapsPeriode = (medlemskapsperioder: Medlemskapsperiode[]) => {
+  const sorterteInnvilgedePerioder = [...medlemskapsperioder]
+    .filter((periode) => periode.innvilgelsesResultat === MKV.Koder.innvilgelsesResultat.INNVILGET)
+    .sort(sorterEtterISOFomDato);
+  return {
+    fomDato: Utils.dato.formatterDatoTilNorsk(sorterteInnvilgedePerioder[0].fomDato),
+    tomDato: Utils.dato.formatterDatoTilNorsk(sorterteInnvilgedePerioder[sorterteInnvilgedePerioder.length - 1].tomDato),
+  };
+};
 
 interface Props {
   bekreft: () => void;
@@ -27,9 +39,8 @@ export interface InitiellData {
   aarsavregningResponse?: AarsavregningResponse;
   formDefaultValues: FieldValue<FormValuesProps>;
   erAvvik?: boolean;
-  innvilgetMedlemskapsperiode?: { fom?: string; tom?: string };
+  innvilgetMedlemskapsperiode?: { fomDato: string; tomDato: string };
   innvilgetMedlemskapsperiodeBestemmelse?: string;
-  defaultPeriode?: { fomDato: string; tomDato: string };
   medlemskapstypeErPliktig?: boolean;
 }
 
@@ -82,10 +93,6 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
           const innvilgetMedlemskapsperiode = lagInnvilgetMedlemskapsPeriode(medlemskapsperioder);
           const innvilgetMedlemskapsperiodeBestemmelse = hentMedlemskapsperiodeBestemmelse(false, medlemskapsperioder);
-          const defaultPeriode = {
-            fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom)!,
-            tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom)!,
-          };
           const medlemskapstypeErPliktig = medlemskapsperioder?.every(
             (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
           );
@@ -96,7 +103,6 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
             formDefaultValues: formValues,
             innvilgetMedlemskapsperiode,
             innvilgetMedlemskapsperiodeBestemmelse,
-            defaultPeriode,
             medlemskapstypeErPliktig,
           });
           setIsLoading(false);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -15,11 +15,11 @@ import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavre
 import { AarsavregningMedGrunnlagForm } from "./aarsavregningMedGrunnlagForm";
 import * as Nav from "../../../../../navFrontend";
 import MKV from "../../../../../melosyskodeverk";
-import { hentMedlemskapsperiodeBestemmelse } from "../komponenter/utils";
 import { Medlemskapsperiode } from "../../../../../services/modules/medlemavfolketrygden/medlemskapsperioder";
 import { sorterEtterISOFomDato } from "../../../../../utils/dato";
+import { ULAGRET_MEDLEMSKAPSPERIODE_ID } from "../aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
 
-const lagInnvilgetMedlemskapsPeriode = (medlemskapsperioder: Medlemskapsperiode[]) => {
+const mapInnvilgetMedlemskapsPeriode = (medlemskapsperioder: Medlemskapsperiode[]) => {
   const sorterteInnvilgedePerioder = [...medlemskapsperioder]
     .filter((periode) => periode.innvilgelsesResultat === MKV.Koder.innvilgelsesResultat.INNVILGET)
     .sort(sorterEtterISOFomDato);
@@ -29,6 +29,17 @@ const lagInnvilgetMedlemskapsPeriode = (medlemskapsperioder: Medlemskapsperiode[
       sorterteInnvilgedePerioder[sorterteInnvilgedePerioder.length - 1].tomDato,
     ),
   };
+};
+
+const mapMedlemskapsperiodeBestemmelse = (harDeltGrunnlag: boolean, medlemskapsperioder?: Medlemskapsperiode[]) => {
+  if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
+    const sortertePerioder = [...medlemskapsperioder]
+      .filter((periode) => (harDeltGrunnlag ? !periode.redigerbar : true))
+      .filter((periode) => periode.id !== ULAGRET_MEDLEMSKAPSPERIODE_ID)
+      .sort(sorterEtterISOFomDato);
+    return sortertePerioder?.[0]?.bestemmelse;
+  }
+  return undefined;
 };
 
 export interface AarsavregningMedGrunnlagFormValues extends FormValuesProps {
@@ -96,21 +107,21 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
           // Benyttes for innhenting av saksopplysninger ifm. årsavregningsbehandlinger
           dispatch({ type: OK, data: res });
 
-          const formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
+          const defaultFormValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
             res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
             res.harAvvik,
           );
 
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
-          const innvilgetMedlemskapsperiode = lagInnvilgetMedlemskapsPeriode(medlemskapsperioder);
-          const innvilgetMedlemskapsperiodeBestemmelse = hentMedlemskapsperiodeBestemmelse(false, medlemskapsperioder);
+          const innvilgetMedlemskapsperiode = mapInnvilgetMedlemskapsPeriode(medlemskapsperioder);
+          const innvilgetMedlemskapsperiodeBestemmelse = mapMedlemskapsperiodeBestemmelse(false, medlemskapsperioder);
           const medlemskapstypeErPliktig = medlemskapsperioder?.every(
             (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
           );
 
           setInitiellData({
             aarsavregningResponse: res,
-            formDefaultValues: formValues,
+            formDefaultValues: defaultFormValues,
             innvilgetMedlemskapsperiode,
             innvilgetMedlemskapsperiodeBestemmelse,
             medlemskapstypeErPliktig,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -25,7 +25,9 @@ const lagInnvilgetMedlemskapsPeriode = (medlemskapsperioder: Medlemskapsperiode[
     .sort(sorterEtterISOFomDato);
   return {
     fomDato: Utils.dato.formatterDatoTilNorsk(sorterteInnvilgedePerioder[0].fomDato),
-    tomDato: Utils.dato.formatterDatoTilNorsk(sorterteInnvilgedePerioder[sorterteInnvilgedePerioder.length - 1].tomDato),
+    tomDato: Utils.dato.formatterDatoTilNorsk(
+      sorterteInnvilgedePerioder[sorterteInnvilgedePerioder.length - 1].tomDato,
+    ),
   };
 };
 
@@ -61,7 +63,10 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const dispatch = useDispatch();
 
-  const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag, harAvvik?: boolean) => {
+  const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (
+    trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag,
+    harAvvik?: boolean,
+  ) => {
     if (!trygdeavgiftsgrunnlag) return { erAvvik: undefined, skatteforholdsperioder: [{}], inntektskilder: [{}] };
     const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
     const sorterteInntekstkilder = [...inntektskperioder].sort(Utils.dato.sorterEtterISOFomDato);
@@ -93,7 +98,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
           const formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
             res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
-            res.harAvvik
+            res.harAvvik,
           );
 
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -18,6 +18,7 @@ import MKV from "../../../../../melosyskodeverk";
 import { hentMedlemskapsperiodeBestemmelse } from "../komponenter/utils";
 import { Medlemskapsperiode } from "../../../../../services/modules/medlemavfolketrygden/medlemskapsperioder";
 import { sorterEtterISOFomDato } from "../../../../../utils/dato";
+import { BOOLSK_STRING } from "../../../../../constants";
 
 const lagInnvilgetMedlemskapsPeriode = (medlemskapsperioder: Medlemskapsperiode[]) => {
   const sorterteInnvilgedePerioder = [...medlemskapsperioder]
@@ -48,6 +49,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const [initiellData, setInitiellData] = useState<InitiellData>({
     formDefaultValues: {
+      erAvvik: "",
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
     },
@@ -57,13 +59,14 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const dispatch = useDispatch();
 
-  const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag) => {
-    if (!trygdeavgiftsgrunnlag) return { skatteforholdsperioder: [{}], inntektskilder: [{}] };
+  const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag, harAvvik?: boolean) => {
+    if (!trygdeavgiftsgrunnlag) return { erAvvik: "", skatteforholdsperioder: [{}], inntektskilder: [{}] };
     const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
     const sorterteInntekstkilder = [...inntektskperioder].sort(Utils.dato.sorterEtterISOFomDato);
     const sorterteSkatteforhold = [...skatteforholdsperioder].sort(Utils.dato.sorterEtterISOFomDato);
 
     return {
+      erAvvik: harAvvik ? BOOLSK_STRING.SANN : BOOLSK_STRING.USANN,
       skatteforholdsperioder: !Utils._isEmpty(sorterteSkatteforhold)
         ? mapTilSkatteforholdProps(sorterteSkatteforhold)
         : [{}],
@@ -88,6 +91,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
           const formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
             res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
+            res.harAvvik
           );
 
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -7,14 +7,13 @@ import {
 } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { useDispatch, useSelector } from "react-redux";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
-import { redigerbartSelectors } from "../../../../../ducks/redigerbart";
 import { FieldValue } from "react-hook-form";
 import { FormValuesProps } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
 import * as Utils from "../../../../../utils";
 import { OK } from "../../../../../ducks/aarsavregning/types";
-import { behandlingsresultatSelectors } from "../../../../../ducks/behandlingsresultat";
 import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
 import { AarsavregningMedGrunnlagForm } from "./aarsavregningMedGrunnlagForm";
+import * as Nav from "../../../../../navFrontend";
 
 interface Props {
   bekreft: () => void;
@@ -34,8 +33,8 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
       inntektskilder: [{}],
     },
   });
+  const [innlastingFeilmelding, setInnlastingFeilmelding] = useState("");
 
-  const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const dispatch = useDispatch();
 
@@ -49,7 +48,9 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
       skatteforholdsperioder: !Utils._isEmpty(sorterteSkatteforhold)
         ? mapTilSkatteforholdProps(sorterteSkatteforhold)
         : [{}],
-      inntektskilder: !Utils._isEmpty(sorterteInntekstkilder) ? mapTilInntektskilderProps(sorterteInntekstkilder) : [{}],
+      inntektskilder: !Utils._isEmpty(sorterteInntekstkilder)
+        ? mapTilInntektskilderProps(sorterteInntekstkilder)
+        : [{}],
     };
   };
 
@@ -58,18 +59,17 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
       Api.Aarsavregning.hentAarsavregning(behandlingID)
         .then((res) => {
           if (!res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
-            throw new Error("Årsavregning med grunnlag må ha grunnlag");
+            setInnlastingFeilmelding("Årsavregning med grunnlag må ha grunnlag");
+            setIsLoading(false);
+            return;
           }
 
           // Benyttes for innhenting av saksopplysninger ifm. årsavregningsbehandlinger
           dispatch({ type: OK, data: res });
 
-          let formValues;
-          if (res?.nyttGrunnlag?.trygdeavgiftsgrunnlag) {
-            formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(res.nyttGrunnlag.trygdeavgiftsgrunnlag);
-          } else {
-            formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag);
-          }
+          const formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
+            res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
+          );
 
           setInitiellData({
             aarsavregningResponse: res,
@@ -78,16 +78,8 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
           });
           setIsLoading(false);
         })
-        .catch((err) => {
-          if (err.response?.status === 404) {
-            setInitiellData({
-              aarsavregningResponse: undefined,
-              formDefaultValues: {
-                skatteforholdsperioder: [{}],
-                inntektskilder: [{}],
-              },
-            });
-          }
+        .catch(() => {
+          setInnlastingFeilmelding(`Fant ikke årsavregning for behandlingID: ${behandlingID}`);
           setIsLoading(false);
         });
     }
@@ -97,7 +89,13 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
     return <div />;
   }
 
-  return (
-    <AarsavregningMedGrunnlagForm initiellData={initiellData} bekreft={bekreft} oppdaterStatus={oppdaterStatus} />
-  );
+  if (innlastingFeilmelding) {
+    return (
+      <Nav.Alert variant="error" className="alertstripe_feilmelding">
+        {innlastingFeilmelding}
+      </Nav.Alert>
+    );
+  }
+
+  return <AarsavregningMedGrunnlagForm initiellData={initiellData} bekreft={bekreft} oppdaterStatus={oppdaterStatus} />;
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -29,25 +29,29 @@ const lagInnvilgetMedlemskapsPeriode = (medlemskapsperioder: Medlemskapsperiode[
   };
 };
 
+export interface AarsavregningMedGrunnlagFormValues extends FormValuesProps {
+  erAvvik?: boolean;
+}
+
+export interface InitiellData {
+  aarsavregningResponse?: AarsavregningResponse;
+  formDefaultValues: FieldValue<AarsavregningMedGrunnlagFormValues>;
+  innvilgetMedlemskapsperiode?: { fomDato: string; tomDato: string };
+  innvilgetMedlemskapsperiodeBestemmelse?: string;
+  medlemskapstypeErPliktig?: boolean;
+}
+
 interface Props {
   bekreft: () => void;
   aktivtSteg: boolean;
   oppdaterStatus: (isValid: boolean) => void;
 }
 
-export interface InitiellData {
-  aarsavregningResponse?: AarsavregningResponse;
-  formDefaultValues: FieldValue<FormValuesProps>;
-  erAvvik?: boolean;
-  innvilgetMedlemskapsperiode?: { fomDato: string; tomDato: string };
-  innvilgetMedlemskapsperiodeBestemmelse?: string;
-  medlemskapstypeErPliktig?: boolean;
-}
-
 export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const [initiellData, setInitiellData] = useState<InitiellData>({
     formDefaultValues: {
+      erAvvik: undefined,
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
     },
@@ -57,13 +61,14 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const dispatch = useDispatch();
 
-  const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag) => {
-    if (!trygdeavgiftsgrunnlag) return { skatteforholdsperioder: [{}], inntektskilder: [{}] };
+  const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag, harAvvik?: boolean) => {
+    if (!trygdeavgiftsgrunnlag) return { erAvvik: undefined, skatteforholdsperioder: [{}], inntektskilder: [{}] };
     const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
     const sorterteInntekstkilder = [...inntektskperioder].sort(Utils.dato.sorterEtterISOFomDato);
     const sorterteSkatteforhold = [...skatteforholdsperioder].sort(Utils.dato.sorterEtterISOFomDato);
 
     return {
+      erAvvik: harAvvik,
       skatteforholdsperioder: !Utils._isEmpty(sorterteSkatteforhold)
         ? mapTilSkatteforholdProps(sorterteSkatteforhold)
         : [{}],
@@ -88,6 +93,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
           const formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
             res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
+            res.harAvvik
           );
 
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
@@ -99,7 +105,6 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
           setInitiellData({
             aarsavregningResponse: res,
-            erAvvik: res.harAvvik,
             formDefaultValues: formValues,
             innvilgetMedlemskapsperiode,
             innvilgetMedlemskapsperiodeBestemmelse,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -57,19 +57,18 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
     if (behandlingID) {
       Api.Aarsavregning.hentAarsavregning(behandlingID)
         .then((res) => {
+          if (!res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
+            throw new Error("Årsavregning med grunnlag må ha grunnlag");
+          }
+
           // Benyttes for innhenting av saksopplysninger ifm. årsavregningsbehandlinger
           dispatch({ type: OK, data: res });
 
           let formValues;
-          if (res?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
-            formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
-              res.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
-            );
+          if (res?.nyttGrunnlag?.trygdeavgiftsgrunnlag) {
+            formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(res.nyttGrunnlag.trygdeavgiftsgrunnlag);
           } else {
-            formValues = {
-              skatteforholdsperioder: [{}],
-              inntektskilder: [{}],
-            };
+            formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag);
           }
 
           setInitiellData({

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -1,40 +1,20 @@
 import * as Api from "../../../../../services/api";
-import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import "../vurderingAarsavregningInngang.css";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   AarsavregningResponse,
   Trygdeavgiftsgrunnlag,
 } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { useDispatch, useSelector } from "react-redux";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
-import * as Nav from "../../../../../navFrontend";
 import { redigerbartSelectors } from "../../../../../ducks/redigerbart";
-import { FieldValue, useFieldArray, useForm } from "react-hook-form";
-import { FieldArrayProps, FormValuesProps } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
-import { yupResolver } from "@hookform/resolvers/yup";
+import { FieldValue } from "react-hook-form";
+import { FormValuesProps } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
 import * as Utils from "../../../../../utils";
-import MKV from "../../../../../melosyskodeverk";
-import { SumArsavregningTabell } from "../komponenter/sumArsavregningTabell";
-import { BeregnetTrygdeavgiftDetaljer } from "../komponenter/beregnetTrygdeavgiftDetaljer";
 import { OK } from "../../../../../ducks/aarsavregning/types";
-import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversikt";
-
 import { behandlingsresultatSelectors } from "../../../../../ducks/behandlingsresultat";
-import aarsavregningMedGrunnlagSchema from "./aarsavregningMedGrunnlagSchema";
-import { Skatteforholdsperioder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/skatteforholdsperioder";
-import { Inntektskilder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/inntektskilder";
-import {
-  beregnTrygdeavgiftsperioder,
-  erBrukerSkattepliktigIHelePerioden,
-  fomTomErFyltUt,
-  harInntektsKildeType,
-  hentMedlemskapsperiodeBestemmelse,
-  lagInnvilgetMedlemskapsPeriode,
-  mapFeilmelding,
-} from "../komponenter/utils";
 import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
-import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
+import { AarsavregningMedGrunnlagForm } from "./aarsavregningMedGrunnlagForm";
 
 interface Props {
   bekreft: () => void;
@@ -43,309 +23,82 @@ interface Props {
 }
 
 export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
-  const [erAvvik, setErAvvik] = useState<boolean | undefined>(undefined);
-  const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
-  const [brukerHarBekreftet, setBrukerHarBekreftet] = useState(false);
-  const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(undefined);
-  const [beregningPaagar, setBeregningPaagar] = useState(false);
-  const [harValidertSkjema, setHarValidertSkjema] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [initiellData, setInitiellData] = useState<{
+    aarsavregningResponse?: AarsavregningResponse;
+    formDefaultValues: FieldValue<FormValuesProps>;
+    erAvvik?: boolean;
+  }>({
+    formDefaultValues: {
+      skatteforholdsperioder: [{}],
+      inntektskilder: [{}],
+    },
+  });
 
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
-  const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
   const dispatch = useDispatch();
 
-  const medlemskapsperioder =
-    aarsavregningResponse?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
-  const innvilgetMedlemskapsperiode = lagInnvilgetMedlemskapsPeriode(medlemskapsperioder);
-  const innvilgetMedlemskapsperiodeBestemmelse = hentMedlemskapsperiodeBestemmelse(false, medlemskapsperioder);
-  const defaultPeriode = {
-    fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
-    tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
-  };
-
-  const setSkjemaverdierFraTrygdeavgiftsgrunnlag = (trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag) => {
-    if (!trygdeavgiftsgrunnlag) return;
+  const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag) => {
+    if (!trygdeavgiftsgrunnlag) return { skatteforholdsperioder: [{}], inntektskilder: [{}] };
     const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
     const sorterteInntekstkilder = [...inntektskperioder].sort(Utils.dato.sorterEtterISOFomDato);
     const sorterteSkatteforhold = [...skatteforholdsperioder].sort(Utils.dato.sorterEtterISOFomDato);
-    resetSkatteforholdsperioder(
-      !Utils._isEmpty(sorterteSkatteforhold) ? mapTilSkatteforholdProps(sorterteSkatteforhold) : [],
-    );
 
-    resetInntektskilder(
-      !Utils._isEmpty(sorterteInntekstkilder) ? mapTilInntektskilderProps(sorterteInntekstkilder) : [],
-    );
+    return {
+      skatteforholdsperioder: !Utils._isEmpty(sorterteSkatteforhold)
+        ? mapTilSkatteforholdProps(sorterteSkatteforhold)
+        : [{}],
+      inntektskilder: !Utils._isEmpty(sorterteInntekstkilder) ? mapTilInntektskilderProps(sorterteInntekstkilder) : [{}],
+    };
   };
 
   useEffect(() => {
     if (behandlingID) {
       Api.Aarsavregning.hentAarsavregning(behandlingID)
         .then((res) => {
-          setAarsavregningResponse(res);
-          setErAvvik(res.harAvvik);
           // Benyttes for innhenting av saksopplysninger ifm. årsavregningsbehandlinger
           dispatch({ type: OK, data: res });
 
+          let formValues;
           if (res?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
-            setSkjemaverdierFraTrygdeavgiftsgrunnlag(
+            formValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
               res.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
             );
+          } else {
+            formValues = {
+              skatteforholdsperioder: [{}],
+              inntektskilder: [{}],
+            };
           }
+
+          setInitiellData({
+            aarsavregningResponse: res,
+            erAvvik: res.harAvvik,
+            formDefaultValues: formValues,
+          });
+          setIsLoading(false);
         })
         .catch((err) => {
           if (err.response?.status === 404) {
-            setAarsavregningResponse(undefined);
+            setInitiellData({
+              aarsavregningResponse: undefined,
+              formDefaultValues: {
+                skatteforholdsperioder: [{}],
+                inntektskilder: [{}],
+              },
+            });
           }
+          setIsLoading(false);
         });
     }
   }, []);
 
-  useEffect(() => {
-    if (redigerbart && aarsavregningResponse?.nyttGrunnlag) {
-      if (aarsavregningResponse.nyttGrunnlag?.avgift.totalAvgift !== aarsavregningResponse.avregning?.nyttTotalbeloep) {
-        Api.Aarsavregning.oppdaterTotalAvgift(
-          behandlingID,
-          aarsavregningID,
-          aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift,
-        ).then((res: AarsavregningResponse) => {
-          setAarsavregningResponse(res);
-        });
-      }
-    }
-  }, [aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift]);
-
-  const medlemskapsTypeErPliktig = medlemskapsperioder?.every(
-    (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
-  );
-
-  const {
-    control,
-    watch,
-    formState: { isValid: formIsValid, isValidating },
-    trigger,
-  } = useForm({
-    resolver: yupResolver(aarsavregningMedGrunnlagSchema),
-    context: {
-      medlemskapsperiode: innvilgetMedlemskapsperiode,
-      medlemskapsTypeErPliktig,
-      erÅpenSluttDato: false,
-      erAvvik,
-    },
-    mode: "onChange",
-    reValidateMode: "onChange",
-    defaultValues: {
-      skatteforholdsperioder: [{}],
-      inntektskilder: [{}],
-    } as FieldValue<FormValuesProps>,
-  });
-
-  const {
-    fields: skattFields,
-    append: skattAppend,
-    remove: skattRemove,
-    replace: resetSkatteforholdsperioder,
-  } = useFieldArray<FieldArrayProps, "skatteforholdsperioder", "id">({ control, name: "skatteforholdsperioder" });
-
-  const {
-    fields: inntektFields,
-    append: inntektAppend,
-    remove: inntektRemove,
-    update: inntektUpdate,
-    replace: resetInntektskilder,
-  } = useFieldArray<FieldArrayProps, "inntektskilder", "id">({ control, name: "inntektskilder" });
-  const formValues = watch();
-
-  // TODO: Når ryddingen skjer her husk å rename bort fra medlemskapsTypeErPliktig
-  const handleBeregnTrygdeavgiftsperioder = useCallback(
-    async (formVerdier: FieldValue<FormValuesProps>) => {
-      await beregnTrygdeavgiftsperioder(formVerdier, {
-        behandlingID,
-        medlemskapstypeErPliktig: medlemskapsTypeErPliktig,
-        setFeilmelding,
-        setAarsavregningResponse,
-      });
-      setBeregningPaagar(false);
-    },
-    [behandlingID, medlemskapsTypeErPliktig, setFeilmelding, setAarsavregningResponse],
-  );
-
-  const debounceBeregnTrygdeavgiftsperioderOgOppdaterFormVerdier = useCallback(
-    Utils._debounce((formVerdier) => handleBeregnTrygdeavgiftsperioder(formVerdier), 2000),
-    [handleBeregnTrygdeavgiftsperioder],
-  );
-
-  useEffect(() => {
-    setBrukerHarBekreftet(false);
-    if (
-      redigerbart &&
-      aarsavregningID &&
-      erAvvik &&
-      !isValidating &&
-      formIsValid &&
-      fomTomErFyltUt(formValues.inntektskilder, formValues.skatteforholdsperioder) &&
-      harInntektsKildeType(formValues.inntektskilder, trygdeAvgiftSkalIkkeBetalesTilNav)
-    ) {
-      setBeregningPaagar(true);
-      setFeilmelding(undefined);
-      debounceBeregnTrygdeavgiftsperioderOgOppdaterFormVerdier(formValues);
-    }
-  }, [formIsValid, isValidating, erAvvik, formValues.inntektskilder.length, formValues.skatteforholdsperioder.length]);
-
-  const stegErGyldig =
-    erAvvik === false || Boolean(formIsValid && erAvvik && aarsavregningResponse?.nyttGrunnlag && !feilmelding);
-
-  useEffect(() => {
-    oppdaterStatus(stegErGyldig);
-  }, [stegErGyldig]);
-
-  const håndterAvvik = (value: boolean) => {
-    if (!value) {
-      Api.Trygdeavgift.slettTrygdeavgiftsperioder(behandlingID).then(() => {
-        resetSkatteforholdsperioder([]);
-        resetInntektskilder([]);
-        Api.Aarsavregning.oppdaterTotalAvgift(
-          behandlingID,
-          aarsavregningID,
-          aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift.totalAvgift,
-        ).then((res: AarsavregningResponse) => {
-          setAarsavregningResponse(res);
-          setSkjemaverdierFraTrygdeavgiftsgrunnlag(res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag);
-          if (res.tidligereGrunnlagsopplysninger !== undefined) {
-            setBeregningPaagar(true);
-            Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
-              skatteforholdsperioder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder,
-              inntektskilder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder,
-            })
-              .catch((error) => setFeilmelding(mapFeilmelding(error)))
-              .finally(() => {
-                setBeregningPaagar(false);
-              });
-          }
-        });
-      });
-    } else if (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
-      setSkjemaverdierFraTrygdeavgiftsgrunnlag(
-        aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
-      );
-    }
-    Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID);
-    setErAvvik(value);
-  };
-
-  const bekreftOnClick = () => {
-    if (!harValidertSkjema) {
-      trigger();
-      setHarValidertSkjema(true);
-    }
-    setBrukerHarBekreftet(true);
-    if (stegErGyldig && !beregningPaagar) {
-      bekreft();
-    }
-  };
-
-  const trygdeAvgiftSkalIkkeBetalesTilNav =
-    medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder);
-  const forskuddsvisFakturertTrygdeavgift =
-    (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
-  const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
+  if (isLoading) {
+    return <div />;
+  }
 
   return (
-    <>
-      {aarsavregningResponse?.tidligereGrunnlagsopplysninger && (
-        <>
-          <MedlemskapsPerioderTabell
-            perioder={aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.medlemskapsperioder}
-          />
-          <TidligereGrunnlagsoversikt
-            skatteforholdsperioder={
-              aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder
-            }
-            inntektsperioder={
-              aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder
-            }
-            avgift={aarsavregningResponse.tidligereGrunnlagsopplysninger.avgift}
-          />
-
-          {!forskuddsvisFakturertTrygdeavgift && <Aarsavregningsmeldinger.TrygdeavgiftErIkkeForskuddsvisFakturert />}
-
-          <BeregnetTrygdeavgiftDetaljer
-            grunnlag={aarsavregningResponse?.tidligereGrunnlagsopplysninger}
-            medlemskapsTypeErPliktig={medlemskapsTypeErPliktig!}
-            tittel="Tidligere beregnet trygdeavgift"
-          />
-        </>
-      )}
-
-      <Nav.RadioGroup
-        onChange={håndterAvvik}
-        value={erAvvik}
-        legend="Er det avvik i opplysningene fra skatt eller bruker?"
-        readOnly={!redigerbart}
-      >
-        <Nav.HStack gap="6">
-          <Nav.Radio value>Ja</Nav.Radio>
-          <Nav.Radio value={false}>Nei</Nav.Radio>
-        </Nav.HStack>
-      </Nav.RadioGroup>
-
-      {erAvvik && (
-        <>
-          <Nav.Heading className="endelige_opplysninger_heading" level="2">
-            Inntekts- og skatteopplysninger for endelig trygdeavgift
-          </Nav.Heading>
-          <Skatteforholdsperioder
-            formValues={formValues}
-            redigerbart={redigerbart}
-            remove={skattRemove}
-            append={skattAppend}
-            control={control}
-            fields={skattFields}
-          />
-          {!trygdeAvgiftSkalIkkeBetalesTilNav && (
-            <Inntektskilder
-              defaultPeriode={defaultPeriode}
-              formValues={formValues}
-              redigerbart={redigerbart}
-              update={inntektUpdate}
-              remove={inntektRemove}
-              append={inntektAppend}
-              control={control}
-              fields={inntektFields}
-              medlemskapsTypeErPliktig={medlemskapsTypeErPliktig!}
-              skalViseErMaanedsBelopRadioGroup
-              bestemmelse={innvilgetMedlemskapsperiodeBestemmelse}
-            />
-          )}
-
-          {trygdeAvgiftSkalIkkeBetalesTilNav && <Aarsavregningsmeldinger.TrygdeavgiftSkalIkkeBetalesTilNav />}
-
-          {nyttGrunnlagHarTrygdeavgiftsgrunnlag && formIsValid && !feilmelding && (
-            <SumArsavregningTabell
-              nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
-              tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
-            />
-          )}
-
-          {formIsValid && !feilmelding && (
-            <BeregnetTrygdeavgiftDetaljer
-              grunnlag={aarsavregningResponse?.nyttGrunnlag}
-              medlemskapsTypeErPliktig={medlemskapsTypeErPliktig!}
-              tittel="Endelig beregnet trygdeavgift"
-            />
-          )}
-        </>
-      )}
-
-      {brukerHarBekreftet && feilmelding && (
-        <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          {feilmelding}
-        </Nav.Alert>
-      )}
-
-      <Nav.Button variant="primary" loading={beregningPaagar} disabled={!redigerbart} onClick={bekreftOnClick}>
-        Bekreft og fortsett
-      </Nav.Button>
-    </>
+    <AarsavregningMedGrunnlagForm initiellData={initiellData} bekreft={bekreft} oppdaterStatus={oppdaterStatus} />
   );
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -14,6 +14,8 @@ import { OK } from "../../../../../ducks/aarsavregning/types";
 import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
 import { AarsavregningMedGrunnlagForm } from "./aarsavregningMedGrunnlagForm";
 import * as Nav from "../../../../../navFrontend";
+import MKV from "../../../../../melosyskodeverk";
+import { lagInnvilgetMedlemskapsPeriode, hentMedlemskapsperiodeBestemmelse } from "../komponenter/utils";
 
 interface Props {
   bekreft: () => void;
@@ -21,13 +23,19 @@ interface Props {
   oppdaterStatus: (isValid: boolean) => void;
 }
 
+export interface InitiellData {
+  aarsavregningResponse?: AarsavregningResponse;
+  formDefaultValues: FieldValue<FormValuesProps>;
+  erAvvik?: boolean;
+  innvilgetMedlemskapsperiode?: { fom?: string; tom?: string };
+  innvilgetMedlemskapsperiodeBestemmelse?: string;
+  defaultPeriode?: { fomDato: string; tomDato: string };
+  medlemskapstypeErPliktig?: boolean;
+}
+
 export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const [isLoading, setIsLoading] = useState(true);
-  const [initiellData, setInitiellData] = useState<{
-    aarsavregningResponse?: AarsavregningResponse;
-    formDefaultValues: FieldValue<FormValuesProps>;
-    erAvvik?: boolean;
-  }>({
+  const [initiellData, setInitiellData] = useState<InitiellData>({
     formDefaultValues: {
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
@@ -71,10 +79,25 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
             res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
           );
 
+          const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
+          const innvilgetMedlemskapsperiode = lagInnvilgetMedlemskapsPeriode(medlemskapsperioder);
+          const innvilgetMedlemskapsperiodeBestemmelse = hentMedlemskapsperiodeBestemmelse(false, medlemskapsperioder);
+          const defaultPeriode = {
+            fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom)!,
+            tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom)!,
+          };
+          const medlemskapstypeErPliktig = medlemskapsperioder?.every(
+            (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
+          );
+
           setInitiellData({
             aarsavregningResponse: res,
             erAvvik: res.harAvvik,
             formDefaultValues: formValues,
+            innvilgetMedlemskapsperiode,
+            innvilgetMedlemskapsperiodeBestemmelse,
+            defaultPeriode,
+            medlemskapstypeErPliktig,
           });
           setIsLoading(false);
         })

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -42,7 +42,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   );
   const [beregningPaagar, setBeregningPaagar] = useState(false);
   const [harValidertSkjema, setHarValidertSkjema] = useState(false);
-  const [previousFormValues, setPreviousFormValues] = useState<string | null>(null);
+  const [previousFormValues, setPreviousFormValues] = useState<any | null>(null);
 
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
@@ -99,7 +99,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   );
 
   const debounceBeregnTrygdeavgiftsperioder = useCallback(
-    Utils._debounce((formVerdier) => handleBeregnTrygdeavgiftsperioder(formVerdier), 2000),
+    Utils._debounce((formVerdier) => handleBeregnTrygdeavgiftsperioder(formVerdier), 1500),
     [handleBeregnTrygdeavgiftsperioder],
   );
 
@@ -114,29 +114,22 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     }
 
     const formState = {
-      skatteforholdsperioder:
-        skatteforholdsperioder?.map((skatteforhold: Skatteforhold) => ({
-          fomDato: skatteforhold.fomDato,
-          tomDato: skatteforhold.tomDato,
-          skatteplikttype: skatteforhold.skatteplikttype,
-        })) || [],
-      inntektskilder:
-        inntektskilder?.map((inntektskilde: Inntektskilde) => ({
-          fomDato: inntektskilde.fomDato,
-          tomDato: inntektskilde.tomDato,
-          kildetype: inntektskilde.kildetype,
-          bruttoInntekt: inntektskilde.bruttoInntekt,
-          arbAvgBetales: inntektskilde.arbAvgBetales,
-          erMaanedsbelop: inntektskilde.erMaanedsbelop,
-        })) || [],
+      skatteforholdsperioder: getValues("skatteforholdsperioder").map((skatteforhold: Skatteforhold) => ({
+        fomDato: skatteforhold.fomDato,
+        tomDato: skatteforhold.tomDato,
+        skatteplikttype: skatteforhold.skatteplikttype,
+      })),
+      inntektskilder: getValues("inntektskilder").map((inntektskilde: Inntektskilde) => ({
+        fomDato: inntektskilde.fomDato,
+        tomDato: inntektskilde.tomDato,
+        kildetype: inntektskilde.kildetype,
+        bruttoInntekt: inntektskilde.bruttoInntekt,
+        arbAvgBetales: inntektskilde.arbAvgBetales,
+        erMaanedsbelop: inntektskilde.erMaanedsbelop,
+      })),
     };
-
-    // Serialize to compare with previous state
-    const stateStr = JSON.stringify(formState);
-
-    // Only process if form state has changed
-    if (stateStr !== previousFormValues) {
-      setPreviousFormValues(stateStr);
+    if (!Utils._isEqual(formState, previousFormValues)) {
+      setPreviousFormValues(formState);
 
       const validationTimeout = setTimeout(() => {
         trigger().then((isValid) => {
@@ -147,7 +140,10 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         });
       }, 500);
 
-      return () => clearTimeout(validationTimeout);
+      /* eslint-disable-next-line consistent-return */
+      return () => {
+        clearTimeout(validationTimeout);
+      };
     }
   }, [
     skatteforholdsperioder,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -44,6 +44,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const [harValidertSkjema, setHarValidertSkjema] = useState(false);
   const [previousFormValues, setPreviousFormValues] = useState<any | null>(null);
   const [endrerAvvik, setEndrerAvvik] = useState(false);
+  const [debouncedBeregningPagaar, setDebouncedBeregningPagaar] = useState(false);
 
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
@@ -86,6 +87,22 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const erAvvik = watch("erAvvik");
   const debouncedBeregningRef = useRef<any>(null);
 
+  const mapFormState = (skatteforholdsperioder: Skatteforhold[], inntektskilder: Inntektskilde[]) => ({
+    skatteforholdsperioder: skatteforholdsperioder.map((skatteforhold: Skatteforhold) => ({
+      fomDato: skatteforhold.fomDato,
+      tomDato: skatteforhold.tomDato,
+      skatteplikttype: skatteforhold.skatteplikttype,
+    })),
+    inntektskilder: inntektskilder.map((inntektskilde: Inntektskilde) => ({
+      fomDato: inntektskilde.fomDato,
+      tomDato: inntektskilde.tomDato,
+      kildetype: inntektskilde.kildetype,
+      bruttoInntekt: inntektskilde.bruttoInntekt,
+      arbAvgBetales: inntektskilde.arbAvgBetales,
+      erMaanedsbelop: inntektskilde.erMaanedsbelop,
+    })),
+  });
+
   const handleBeregnTrygdeavgiftsperioder = useCallback(
     async (formVerdier: FieldValue<FormValuesProps>) => {
       await beregnTrygdeavgiftsperioder(formVerdier, {
@@ -94,44 +111,30 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         setFeilmelding,
         setAarsavregningResponse,
       });
-      setBeregningPaagar(false);
     },
-    [behandlingID, medlemskapstypeErPliktig, setFeilmelding, setAarsavregningResponse],
+    [medlemskapstypeErPliktig, setFeilmelding, setAarsavregningResponse],
   );
 
   const debouncedBeregning = useCallback(() => {
+    setDebouncedBeregningPagaar(false);
     if (!redigerbart || !aarsavregningID || erAvvik !== true || beregningPaagar || endrerAvvik) {
       return;
     }
 
-    const formState = {
-      skatteforholdsperioder: getValues("skatteforholdsperioder").map((skatteforhold: Skatteforhold) => ({
-        fomDato: skatteforhold.fomDato,
-        tomDato: skatteforhold.tomDato,
-        skatteplikttype: skatteforhold.skatteplikttype,
-      })),
-      inntektskilder: getValues("inntektskilder").map((inntektskilde: Inntektskilde) => ({
-        fomDato: inntektskilde.fomDato,
-        tomDato: inntektskilde.tomDato,
-        kildetype: inntektskilde.kildetype,
-        bruttoInntekt: inntektskilde.bruttoInntekt,
-        arbAvgBetales: inntektskilde.arbAvgBetales,
-        erMaanedsbelop: inntektskilde.erMaanedsbelop,
-      })),
-    };
+    const formState = mapFormState(getValues("skatteforholdsperioder"), getValues("inntektskilder"));
 
     if (!Utils._isEqual(formState, previousFormValues)) {
       trigger().then((isValid) => {
         if (isValid && formIsValid && !isValidating) {
           setBeregningPaagar(true);
           handleBeregnTrygdeavgiftsperioder(getValues()).finally(() => {
+            setBeregningPaagar(false);
             setPreviousFormValues(formState);
           });
         }
       });
     }
   }, [
-    redigerbart,
     aarsavregningID,
     erAvvik,
     beregningPaagar,
@@ -163,7 +166,14 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       debouncedBeregningRef.current.cancel();
     }
     if (debouncedBeregningRef.current) {
-      debouncedBeregningRef.current();
+      if (redigerbart && aarsavregningID && erAvvik === true && !endrerAvvik) {
+        const currentFormState = mapFormState(getValues("skatteforholdsperioder"), getValues("inntektskilder"));
+
+        if (!Utils._isEqual(currentFormState, previousFormValues)) {
+          setDebouncedBeregningPagaar(true);
+          debouncedBeregningRef.current();
+        }
+      }
     }
   }, [skatteforholdsperioder, erAvvik, inntektskilder, formIsValid, isValidating, endrerAvvik]);
 
@@ -226,19 +236,19 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         });
     },
     [
-      behandlingID,
       aarsavregningID,
       handleBeregnTrygdeavgiftsperioder,
       setBeregningPaagar,
-      setFeilmelding,
       setAarsavregningResponse,
       setPreviousFormValues,
       setEndrerAvvik,
+      Api.Aarsavregning,
     ],
   );
 
   const håndterBekreft = useCallback(() => {
     if (!harValidertSkjema) {
+      // noinspection JSIgnoredPromiseFromCall
       trigger();
       setHarValidertSkjema(true);
     }
@@ -328,6 +338,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
 
           {nyttGrunnlagHarTrygdeavgiftsgrunnlag &&
             !beregningPaagar &&
+            !debouncedBeregningPagaar &&
             formIsValid &&
             !feilmelding &&
             aarsavregningResponse?.avregning && (
@@ -337,13 +348,17 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
               />
             )}
 
-          {formIsValid && !beregningPaagar && !feilmelding && aarsavregningResponse?.nyttGrunnlag && (
-            <BeregnetTrygdeavgiftDetaljer
-              grunnlag={aarsavregningResponse.nyttGrunnlag}
-              medlemskapsTypeErPliktig={medlemskapstypeErPliktig!}
-              tittel="Endelig beregnet trygdeavgift"
-            />
-          )}
+          {formIsValid &&
+            !beregningPaagar &&
+            !debouncedBeregningPagaar &&
+            !feilmelding &&
+            aarsavregningResponse?.nyttGrunnlag && (
+              <BeregnetTrygdeavgiftDetaljer
+                grunnlag={aarsavregningResponse.nyttGrunnlag}
+                medlemskapsTypeErPliktig={medlemskapstypeErPliktig!}
+                tittel="Endelig beregnet trygdeavgift"
+              />
+            )}
         </>
       )}
 
@@ -353,7 +368,12 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </Nav.Alert>
       )}
 
-      <Nav.Button variant="primary" loading={beregningPaagar} disabled={!redigerbart} onClick={håndterBekreft}>
+      <Nav.Button
+        variant="primary"
+        loading={beregningPaagar || debouncedBeregningPagaar}
+        disabled={!redigerbart}
+        onClick={håndterBekreft}
+      >
         Bekreft og fortsett
       </Nav.Button>
     </>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -190,13 +190,13 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           setAarsavregningResponse(res);
           if (!value) {
             setBeregningPaagar(true);
+            const skatteforholdFraGrunnlag =
+              res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder;
+            const inntektskilderFraGrunnlag =
+              res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.inntektskperioder;
             handleBeregnTrygdeavgiftsperioder({
-              skatteforholdsperioder: mapTilSkatteforholdProps(
-                res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder!,
-              ),
-              inntektskilder: mapTilInntektskilderProps(
-                res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.inntektskperioder!,
-              ),
+              skatteforholdsperioder: mapTilSkatteforholdProps(skatteforholdFraGrunnlag),
+              inntektskilder: mapTilInntektskilderProps(inntektskilderFraGrunnlag),
             }).finally(() => {
               setPreviousFormValues(null);
               setBeregningPaagar(false);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -65,7 +65,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       medlemskapsTypeErPliktig: medlemskapstypeErPliktig,
     },
     mode: "onChange",
-    reValidateMode: "onChange",
     defaultValues: initiellData.formDefaultValues,
   });
 
@@ -111,7 +110,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   );
 
   useEffect(() => {
-    if (erAvvik !== true || !redigerbart || !aarsavregningID || beregningPaagar || endrerAvvik) {
+    if (!redigerbart || !aarsavregningID || erAvvik !== true || beregningPaagar || endrerAvvik) {
       return;
     }
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -1,7 +1,7 @@
 import * as Api from "../../../../../services/api";
 import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import "../vurderingAarsavregningInngang.css";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { useSelector } from "react-redux";
 import * as Nav from "../../../../../navFrontend";
@@ -84,6 +84,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const skatteforholdsperioder = watch("skatteforholdsperioder");
   const inntektskilder = watch("inntektskilder");
   const erAvvik = watch("erAvvik");
+  const debouncedBeregningRef = useRef<any>(null);
 
   const handleBeregnTrygdeavgiftsperioder = useCallback(
     async (formVerdier: FieldValue<FormValuesProps>) => {
@@ -98,18 +99,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     [behandlingID, medlemskapstypeErPliktig, setFeilmelding, setAarsavregningResponse],
   );
 
-  const debounceBeregnTrygdeavgiftsperioder = useCallback(
-    Utils._debounce(
-      (formVerdier, callbackEtterBeregning) =>
-        handleBeregnTrygdeavgiftsperioder(formVerdier).finally(() => {
-          if (callbackEtterBeregning) callbackEtterBeregning();
-        }),
-      1500,
-    ),
-    [handleBeregnTrygdeavgiftsperioder],
-  );
-
-  useEffect(() => {
+  const debouncedBeregning = useCallback(() => {
     if (!redigerbart || !aarsavregningID || erAvvik !== true || beregningPaagar || endrerAvvik) {
       return;
     }
@@ -129,22 +119,51 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         erMaanedsbelop: inntektskilde.erMaanedsbelop,
       })),
     };
-    if (!Utils._isEqual(formState, previousFormValues)) {
-      const validationTimeout = setTimeout(() => {
-        trigger().then((isValid) => {
-          if (isValid && formIsValid && !isValidating) {
-            setBeregningPaagar(true);
-            debounceBeregnTrygdeavgiftsperioder(getValues(), () => {
-              setPreviousFormValues(formState);
-            });
-          }
-        });
-      }, 300);
 
-      /* eslint-disable-next-line consistent-return */
-      return () => {
-        clearTimeout(validationTimeout);
-      };
+    if (!Utils._isEqual(formState, previousFormValues)) {
+      trigger().then((isValid) => {
+        if (isValid && formIsValid && !isValidating) {
+          setBeregningPaagar(true);
+          handleBeregnTrygdeavgiftsperioder(getValues()).finally(() => {
+            setPreviousFormValues(formState);
+          });
+        }
+      });
+    }
+  }, [
+    redigerbart,
+    aarsavregningID,
+    erAvvik,
+    beregningPaagar,
+    endrerAvvik,
+    getValues,
+    trigger,
+    formIsValid,
+    isValidating,
+    handleBeregnTrygdeavgiftsperioder,
+    previousFormValues,
+  ]);
+
+  // Lager en ny debounce funksjon når beregning callback endres
+  useEffect(() => {
+    debouncedBeregningRef.current = Utils._debounce(debouncedBeregning, 1500);
+
+    // Cancel på unmount
+    return () => {
+      if (debouncedBeregningRef.current?.cancel) {
+        debouncedBeregningRef.current.cancel();
+      }
+    };
+  }, [debouncedBeregning]);
+
+  // Håndterer kjøring av beregninger når skjemaverdier endres
+  useEffect(() => {
+    // Avbryter hvis vi allerede har en beregning som venter
+    if (debouncedBeregningRef.current?.cancel) {
+      debouncedBeregningRef.current.cancel();
+    }
+    if (debouncedBeregningRef.current) {
+      debouncedBeregningRef.current();
     }
   }, [skatteforholdsperioder, erAvvik, inntektskilder, formIsValid, isValidating, endrerAvvik]);
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -21,6 +21,8 @@ import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversik
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 import { InitiellData } from "./aarsavregningMedGrunnlag";
+import * as Forms from "../../../../../felleskomponenter/forms";
+import { BOOLSK_STRING } from "../../../../../constants";
 
 interface Props {
   initiellData: InitiellData;
@@ -57,7 +59,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     context: {
       medlemskapsperiode: innvilgetMedlemskapsperiode,
       medlemskapsTypeErPliktig: medlemskapstypeErPliktig,
-      erAvvik,
     },
     mode: "onChange",
     reValidateMode: "onChange",
@@ -79,6 +80,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const formValues = watch();
   const skatteforholdsperioder = watch("skatteforholdsperioder");
   const inntektskilder = watch("inntektskilder");
+  const erAvvikForm = watch("erAvvik");
 
   const handleBeregnTrygdeavgiftsperioder = useCallback(
     async (formVerdier: FieldValue<FormValuesProps>) => {
@@ -101,10 +103,10 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   useEffect(() => {
     setBrukerHarBekreftet(false);
     setHarValidertSkjema(false);
-  }, [erAvvik]);
+  }, [erAvvikForm]);
 
   useEffect(() => {
-    if (!erAvvik || !redigerbart || !aarsavregningID || beregningPaagar) {
+    if (erAvvikForm !== BOOLSK_STRING.SANN || !redigerbart || !aarsavregningID || beregningPaagar) {
       return;
     }
 
@@ -145,7 +147,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   }, [
     skatteforholdsperioder,
     inntektskilder,
-    erAvvik,
+    erAvvikForm,
     redigerbart,
     formIsValid,
     isValidating,
@@ -154,8 +156,8 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   ]);
 
   const stegErGyldig = useMemo(
-    () => erAvvik === false || Boolean(formIsValid && erAvvik && aarsavregningResponse?.nyttGrunnlag && !feilmelding),
-    [erAvvik, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding],
+    () => erAvvikForm === BOOLSK_STRING.USANN || Boolean(formIsValid && erAvvikForm === BOOLSK_STRING.SANN && aarsavregningResponse?.nyttGrunnlag && !feilmelding),
+    [erAvvikForm, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding],
   );
 
   useEffect(() => {
@@ -236,7 +238,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
   const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
 
-  console.log(brukerHarBekreftet);
   return (
     <>
       {aarsavregningResponse && aarsavregningResponse.tidligereGrunnlagsopplysninger && (
@@ -264,19 +265,23 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </>
       )}
 
-      <Nav.RadioGroup
-        onChange={håndterAvvik}
-        value={erAvvik}
+      <Forms.RadioGroup
+        name="erAvvik"
+        control={control}
         legend="Er det avvik i opplysningene fra skatt eller bruker?"
         readOnly={!redigerbart}
+        onChange={(value) => {
+          const boolValue = value === BOOLSK_STRING.SANN;
+          håndterAvvik(boolValue);
+        }}
       >
         <Nav.HStack gap="6">
-          <Nav.Radio value>Ja</Nav.Radio>
-          <Nav.Radio value={false}>Nei</Nav.Radio>
+          <Nav.Radio value={BOOLSK_STRING.SANN}>Ja</Nav.Radio>
+          <Nav.Radio value={BOOLSK_STRING.USANN}>Nei</Nav.Radio>
         </Nav.HStack>
-      </Nav.RadioGroup>
+      </Forms.RadioGroup>
 
-      {erAvvik && (
+      {erAvvikForm === BOOLSK_STRING.SANN && (
         <>
           <Nav.Heading className="endelige_opplysninger_heading" level="2">
             Inntekts- og skatteopplysninger for endelig trygdeavgift

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -2,10 +2,8 @@ import * as Api from "../../../../../services/api";
 import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import "../vurderingAarsavregningInngang.css";
 import { useCallback, useEffect, useState } from "react";
-import {
-  AarsavregningResponse,
-} from "../../../../../services/modules/aarsavregning/aarsavregning";
-import { useDispatch, useSelector } from "react-redux";
+import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
+import { useSelector } from "react-redux";
 import * as Nav from "../../../../../navFrontend";
 import { redigerbartSelectors } from "../../../../../ducks/redigerbart";
 import { FieldValue, useFieldArray, useForm } from "react-hook-form";
@@ -31,7 +29,6 @@ import {
 import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversikt";
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
-import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
 
 interface Props {
   initiellData: {
@@ -48,7 +45,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
   const [brukerHarBekreftet, setBrukerHarBekreftet] = useState(false);
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(
-    initiellData.aarsavregningResponse
+    initiellData.aarsavregningResponse,
   );
   const [beregningPaagar, setBeregningPaagar] = useState(false);
   const [harValidertSkjema, setHarValidertSkjema] = useState(false);
@@ -92,7 +89,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     fields: skattFields,
     append: skattAppend,
     remove: skattRemove,
-    replace: resetSkatteforholdsperioder,
   } = useFieldArray<FieldArrayProps, "skatteforholdsperioder", "id">({ control, name: "skatteforholdsperioder" });
 
   const {
@@ -100,7 +96,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     append: inntektAppend,
     remove: inntektRemove,
     update: inntektUpdate,
-    replace: resetInntektskilder,
   } = useFieldArray<FieldArrayProps, "inntektskilder", "id">({ control, name: "inntektskilder" });
   const formValues = watch();
 
@@ -124,6 +119,11 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
 
   useEffect(() => {
     setBrukerHarBekreftet(false);
+
+    if (!erAvvik) {
+      setFeilmelding(undefined);
+    }
+
     if (
       redigerbart &&
       aarsavregningID &&
@@ -163,27 +163,13 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const håndterAvvik = (value: boolean) => {
     if (!value) {
       Api.Trygdeavgift.slettTrygdeavgiftsperioder(behandlingID).then(() => {
-        resetSkatteforholdsperioder([]);
-        resetInntektskilder([]);
         Api.Aarsavregning.oppdaterTotalAvgift(
           behandlingID,
           aarsavregningID,
           aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift.totalAvgift,
         ).then((res: AarsavregningResponse) => {
           setAarsavregningResponse(res);
-          if (res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
-            resetSkatteforholdsperioder(
-              !Utils._isEmpty(res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder)
-                ? mapTilSkatteforholdProps(res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder)
-                : []
-            );
 
-            resetInntektskilder(
-              !Utils._isEmpty(res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder)
-                ? mapTilInntektskilderProps(res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder)
-                : []
-            );
-          }
           if (res.tidligereGrunnlagsopplysninger !== undefined) {
             setBeregningPaagar(true);
             Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
@@ -197,19 +183,8 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           }
         });
       });
-    } else if (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
-      resetSkatteforholdsperioder(
-        !Utils._isEmpty(aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder)
-          ? mapTilSkatteforholdProps(aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder)
-          : []
-      );
-
-      resetInntektskilder(
-        !Utils._isEmpty(aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder)
-          ? mapTilInntektskilderProps(aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder)
-          : []
-      );
     }
+
     Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID);
     setErAvvik(value);
   };

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -7,7 +7,7 @@ import { useSelector } from "react-redux";
 import * as Nav from "../../../../../navFrontend";
 import { redigerbartSelectors } from "../../../../../ducks/redigerbart";
 import { FieldValue, useFieldArray, useForm } from "react-hook-form";
-import { FieldArrayProps, FormValuesProps } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
+import { FieldArrayProps, FormValuesProps, Inntektskilde, Skatteforhold } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as Utils from "../../../../../utils";
 import { SumArsavregningTabell } from "../komponenter/sumArsavregningTabell";
@@ -16,13 +16,7 @@ import { behandlingsresultatSelectors } from "../../../../../ducks/behandlingsre
 import aarsavregningMedGrunnlagSchema from "./aarsavregningMedGrunnlagSchema";
 import { Skatteforholdsperioder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/skatteforholdsperioder";
 import { Inntektskilder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/inntektskilder";
-import {
-  beregnTrygdeavgiftsperioder,
-  erBrukerSkattepliktigIHelePerioden,
-  fomTomErFyltUt,
-  harInntektsKildeType,
-  mapFeilmelding,
-} from "../komponenter/utils";
+import { beregnTrygdeavgiftsperioder, erBrukerSkattepliktigIHelePerioden, mapFeilmelding } from "../komponenter/utils";
 import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversikt";
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
@@ -43,29 +37,26 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   );
   const [beregningPaagar, setBeregningPaagar] = useState(false);
   const [harValidertSkjema, setHarValidertSkjema] = useState(false);
+  const [previousFormValues, setPreviousFormValues] = useState<string | null>(null);
 
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
 
-  const {
-    innvilgetMedlemskapsperiode,
-    innvilgetMedlemskapsperiodeBestemmelse,
-    defaultPeriode,
-    medlemskapstypeErPliktig,
-  } = initiellData;
+  const { innvilgetMedlemskapsperiode, innvilgetMedlemskapsperiodeBestemmelse, medlemskapstypeErPliktig } =
+    initiellData;
 
   const {
     control,
     watch,
     formState: { isValid: formIsValid, isValidating },
     trigger,
+    getValues,
   } = useForm({
     resolver: yupResolver(aarsavregningMedGrunnlagSchema),
     context: {
       medlemskapsperiode: innvilgetMedlemskapsperiode,
       medlemskapsTypeErPliktig: medlemskapstypeErPliktig,
-      erÅpenSluttDato: false,
       erAvvik,
     },
     mode: "onChange",
@@ -86,19 +77,8 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     update: inntektUpdate,
   } = useFieldArray<FieldArrayProps, "inntektskilder", "id">({ control, name: "inntektskilder" });
   const formValues = watch();
-
-  const trygdeAvgiftSkalIkkeBetalesTilNav = useMemo(
-    () => medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder),
-    [medlemskapstypeErPliktig, formValues.skatteforholdsperioder],
-  );
-  const forskuddsvisFakturertTrygdeavgift = useMemo(
-    () => (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0,
-    [aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift],
-  );
-  const nyttGrunnlagHarTrygdeavgiftsgrunnlag = useMemo(
-    () => aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null,
-    [aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag],
-  );
+  const skatteforholdsperioder = watch("skatteforholdsperioder");
+  const inntektskilder = watch("inntektskilder");
 
   const handleBeregnTrygdeavgiftsperioder = useCallback(
     async (formVerdier: FieldValue<FormValuesProps>) => {
@@ -124,21 +104,54 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   }, [erAvvik]);
 
   useEffect(() => {
-    const skalBeregne =
-      redigerbart &&
-      aarsavregningID &&
-      erAvvik &&
-      !isValidating &&
-      formIsValid &&
-      fomTomErFyltUt(formValues.inntektskilder, formValues.skatteforholdsperioder) &&
-      harInntektsKildeType(formValues.inntektskilder, trygdeAvgiftSkalIkkeBetalesTilNav);
-
-    if (skalBeregne) {
-      setBeregningPaagar(true);
-      setFeilmelding(undefined);
-      debounceBeregnTrygdeavgiftsperioder(formValues);
+    if (!erAvvik || !redigerbart || !aarsavregningID || beregningPaagar) {
+      return;
     }
-  }, [redigerbart, aarsavregningID, isValidating, formIsValid, debounceBeregnTrygdeavgiftsperioder]);
+
+    const formState = {
+      skatteforholdsperioder: skatteforholdsperioder?.map((skatteforhold: Skatteforhold) => ({
+        fomDato: skatteforhold.fomDato,
+        tomDato: skatteforhold.tomDato,
+        skatteplikttype: skatteforhold.skatteplikttype
+      })) || [],
+      inntektskilder: inntektskilder?.map((inntektskilde: Inntektskilde) => ({
+        fomDato: inntektskilde.fomDato,
+        tomDato: inntektskilde.tomDato,
+        kildetype: inntektskilde.kildetype,
+        bruttoInntekt: inntektskilde.bruttoInntekt,
+        arbAvgBetales: inntektskilde.arbAvgBetales,
+        erMaanedsbelop: inntektskilde.erMaanedsbelop
+      })) || []
+    };
+
+    // Serialize to compare with previous state
+    const stateStr = JSON.stringify(formState);
+
+    // Only process if form state has changed
+    if (stateStr !== previousFormValues) {
+      setPreviousFormValues(stateStr);
+
+      const validationTimeout = setTimeout(() => {
+        trigger().then(isValid => {
+          if (isValid && formIsValid && !isValidating) {
+            setBeregningPaagar(true);
+            debounceBeregnTrygdeavgiftsperioder(getValues());
+          }
+        });
+      }, 500);
+
+      return () => clearTimeout(validationTimeout);
+    }
+  }, [
+    skatteforholdsperioder,
+    inntektskilder,
+    erAvvik,
+    redigerbart,
+    formIsValid,
+    isValidating,
+    aarsavregningID,
+    beregningPaagar
+  ]);
 
   const stegErGyldig = useMemo(
     () => erAvvik === false || Boolean(formIsValid && erAvvik && aarsavregningResponse?.nyttGrunnlag && !feilmelding),
@@ -217,6 +230,13 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     }
   }, [harValidertSkjema, trigger, stegErGyldig, beregningPaagar, bekreft]);
 
+  const trygdeAvgiftSkalIkkeBetalesTilNav =
+    medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder);
+  const forskuddsvisFakturertTrygdeavgift =
+    (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
+  const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
+
+  console.log(brukerHarBekreftet);
   return (
     <>
       {aarsavregningResponse && aarsavregningResponse.tidligereGrunnlagsopplysninger && (
@@ -271,7 +291,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           />
           {!trygdeAvgiftSkalIkkeBetalesTilNav && (
             <Inntektskilder
-              defaultPeriode={defaultPeriode}
+              defaultPeriode={innvilgetMedlemskapsperiode}
               formValues={formValues}
               redigerbart={redigerbart}
               update={inntektUpdate}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -7,7 +7,12 @@ import { useSelector } from "react-redux";
 import * as Nav from "../../../../../navFrontend";
 import { redigerbartSelectors } from "../../../../../ducks/redigerbart";
 import { FieldValue, useFieldArray, useForm } from "react-hook-form";
-import { FieldArrayProps, FormValuesProps, Inntektskilde, Skatteforhold } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
+import {
+  FieldArrayProps,
+  FormValuesProps,
+  Inntektskilde,
+  Skatteforhold,
+} from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as Utils from "../../../../../utils";
 import { SumArsavregningTabell } from "../komponenter/sumArsavregningTabell";
@@ -21,6 +26,7 @@ import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversik
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 import { InitiellData } from "./aarsavregningMedGrunnlag";
+import * as Forms from "../../../../../felleskomponenter/forms";
 
 interface Props {
   initiellData: InitiellData;
@@ -29,7 +35,6 @@ interface Props {
 }
 
 export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterStatus }: Props) {
-  const [erAvvik, setErAvvik] = useState<boolean | undefined>(initiellData.erAvvik);
   const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
   const [brukerHarBekreftet, setBrukerHarBekreftet] = useState(false);
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(
@@ -57,7 +62,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     context: {
       medlemskapsperiode: innvilgetMedlemskapsperiode,
       medlemskapsTypeErPliktig: medlemskapstypeErPliktig,
-      erAvvik,
     },
     mode: "onChange",
     reValidateMode: "onChange",
@@ -79,6 +83,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const formValues = watch();
   const skatteforholdsperioder = watch("skatteforholdsperioder");
   const inntektskilder = watch("inntektskilder");
+  const erAvvikForm = watch("erAvvik");
 
   const handleBeregnTrygdeavgiftsperioder = useCallback(
     async (formVerdier: FieldValue<FormValuesProps>) => {
@@ -101,27 +106,29 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   useEffect(() => {
     setBrukerHarBekreftet(false);
     setHarValidertSkjema(false);
-  }, [erAvvik]);
+  }, [erAvvikForm]);
 
   useEffect(() => {
-    if (!erAvvik || !redigerbart || !aarsavregningID || beregningPaagar) {
+    if (erAvvikForm !== true || !redigerbart || !aarsavregningID || beregningPaagar) {
       return;
     }
 
     const formState = {
-      skatteforholdsperioder: skatteforholdsperioder?.map((skatteforhold: Skatteforhold) => ({
-        fomDato: skatteforhold.fomDato,
-        tomDato: skatteforhold.tomDato,
-        skatteplikttype: skatteforhold.skatteplikttype
-      })) || [],
-      inntektskilder: inntektskilder?.map((inntektskilde: Inntektskilde) => ({
-        fomDato: inntektskilde.fomDato,
-        tomDato: inntektskilde.tomDato,
-        kildetype: inntektskilde.kildetype,
-        bruttoInntekt: inntektskilde.bruttoInntekt,
-        arbAvgBetales: inntektskilde.arbAvgBetales,
-        erMaanedsbelop: inntektskilde.erMaanedsbelop
-      })) || []
+      skatteforholdsperioder:
+        skatteforholdsperioder?.map((skatteforhold: Skatteforhold) => ({
+          fomDato: skatteforhold.fomDato,
+          tomDato: skatteforhold.tomDato,
+          skatteplikttype: skatteforhold.skatteplikttype,
+        })) || [],
+      inntektskilder:
+        inntektskilder?.map((inntektskilde: Inntektskilde) => ({
+          fomDato: inntektskilde.fomDato,
+          tomDato: inntektskilde.tomDato,
+          kildetype: inntektskilde.kildetype,
+          bruttoInntekt: inntektskilde.bruttoInntekt,
+          arbAvgBetales: inntektskilde.arbAvgBetales,
+          erMaanedsbelop: inntektskilde.erMaanedsbelop,
+        })) || [],
     };
 
     // Serialize to compare with previous state
@@ -132,7 +139,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       setPreviousFormValues(stateStr);
 
       const validationTimeout = setTimeout(() => {
-        trigger().then(isValid => {
+        trigger().then((isValid) => {
           if (isValid && formIsValid && !isValidating) {
             setBeregningPaagar(true);
             debounceBeregnTrygdeavgiftsperioder(getValues());
@@ -145,17 +152,19 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   }, [
     skatteforholdsperioder,
     inntektskilder,
-    erAvvik,
+    erAvvikForm,
     redigerbart,
     formIsValid,
     isValidating,
     aarsavregningID,
-    beregningPaagar
+    beregningPaagar,
   ]);
 
   const stegErGyldig = useMemo(
-    () => erAvvik === false || Boolean(formIsValid && erAvvik && aarsavregningResponse?.nyttGrunnlag && !feilmelding),
-    [erAvvik, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding],
+    () =>
+      erAvvikForm === false ||
+      Boolean(formIsValid && erAvvikForm === true && aarsavregningResponse?.nyttGrunnlag && !feilmelding),
+    [erAvvikForm, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding],
   );
 
   useEffect(() => {
@@ -211,10 +220,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           }
         });
       }
-
-      if (aarsavregningID) {
-        Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID).then(() => setErAvvik(value));
-      }
+      Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID);
     },
     [behandlingID, aarsavregningID, aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift],
   );
@@ -236,7 +242,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
   const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
 
-  console.log(brukerHarBekreftet);
   return (
     <>
       {aarsavregningResponse && aarsavregningResponse.tidligereGrunnlagsopplysninger && (
@@ -264,19 +269,22 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </>
       )}
 
-      <Nav.RadioGroup
-        onChange={håndterAvvik}
-        value={erAvvik}
+      <Forms.RadioGroup
+        name="erAvvik"
+        control={control}
         legend="Er det avvik i opplysningene fra skatt eller bruker?"
         readOnly={!redigerbart}
+        onChange={(value) => {
+          håndterAvvik(value);
+        }}
       >
         <Nav.HStack gap="6">
-          <Nav.Radio value>Ja</Nav.Radio>
+          <Nav.Radio value={true}>Ja</Nav.Radio>
           <Nav.Radio value={false}>Nei</Nav.Radio>
         </Nav.HStack>
-      </Nav.RadioGroup>
+      </Forms.RadioGroup>
 
-      {erAvvik && (
+      {erAvvikForm === true && (
         <>
           <Nav.Heading className="endelige_opplysninger_heading" level="2">
             Inntekts- og skatteopplysninger for endelig trygdeavgift

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -149,7 +149,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
 
   // Lager en ny debounce funksjon når beregning callback endres
   useEffect(() => {
-    debouncedBeregningRef.current = Utils._debounce(debouncedBeregning, 1500);
+    debouncedBeregningRef.current = Utils._debounce(debouncedBeregning, 350);
 
     // Cancel på unmount
     return () => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -1,7 +1,7 @@
 import * as Api from "../../../../../services/api";
 import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import "../vurderingAarsavregningInngang.css";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useMemo } from "react";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { useSelector } from "react-redux";
 import * as Nav from "../../../../../navFrontend";
@@ -54,17 +54,29 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
 
-  const medlemskapsperioder =
-    aarsavregningResponse?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
-  const innvilgetMedlemskapsperiode = lagInnvilgetMedlemskapsPeriode(medlemskapsperioder);
-  const innvilgetMedlemskapsperiodeBestemmelse = hentMedlemskapsperiodeBestemmelse(false, medlemskapsperioder);
-  const defaultPeriode = {
-    fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
-    tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
-  };
+  const medlemskapsperioder = useMemo(
+    () => aarsavregningResponse?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder,
+    [aarsavregningResponse?.tidligereGrunnlagsopplysninger],
+  );
+  const innvilgetMedlemskapsperiode = useMemo(
+    () => lagInnvilgetMedlemskapsPeriode(medlemskapsperioder),
+    [medlemskapsperioder],
+  );
+  const innvilgetMedlemskapsperiodeBestemmelse = useMemo(
+    () => hentMedlemskapsperiodeBestemmelse(false, medlemskapsperioder),
+    [medlemskapsperioder],
+  );
+  const defaultPeriode = useMemo(
+    () => ({
+      fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
+      tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
+    }),
+    [innvilgetMedlemskapsperiode?.fom, innvilgetMedlemskapsperiode?.tom],
+  );
 
-  const medlemskapstypeErPliktig = medlemskapsperioder?.every(
-    (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
+  const medlemskapstypeErPliktig = useMemo(
+    () => medlemskapsperioder?.every((periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG),
+    [medlemskapsperioder],
   );
 
   const {
@@ -99,6 +111,19 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   } = useFieldArray<FieldArrayProps, "inntektskilder", "id">({ control, name: "inntektskilder" });
   const formValues = watch();
 
+  const trygdeAvgiftSkalIkkeBetalesTilNav = useMemo(
+    () => medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder),
+    [medlemskapstypeErPliktig, formValues.skatteforholdsperioder],
+  );
+  const forskuddsvisFakturertTrygdeavgift = useMemo(
+    () => (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0,
+    [aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift],
+  );
+  const nyttGrunnlagHarTrygdeavgiftsgrunnlag = useMemo(
+    () => aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null,
+    [aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag],
+  );
+
   const handleBeregnTrygdeavgiftsperioder = useCallback(
     async (formVerdier: FieldValue<FormValuesProps>) => {
       await beregnTrygdeavgiftsperioder(formVerdier, {
@@ -112,84 +137,100 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     [behandlingID, medlemskapstypeErPliktig, setFeilmelding, setAarsavregningResponse],
   );
 
-  const debounceBeregnTrygdeavgiftsperioderOgOppdaterFormVerdier = useCallback(
+  const debounceBeregnTrygdeavgiftsperioder = useCallback(
     Utils._debounce((formVerdier) => handleBeregnTrygdeavgiftsperioder(formVerdier), 2000),
     [handleBeregnTrygdeavgiftsperioder],
   );
 
   useEffect(() => {
     setBrukerHarBekreftet(false);
+    setHarValidertSkjema(false);
+  }, [erAvvik]);
 
-    if (!erAvvik) {
-      setFeilmelding(undefined);
-    }
-
-    if (
+  useEffect(() => {
+    const skalBeregne =
       redigerbart &&
       aarsavregningID &&
       erAvvik &&
       !isValidating &&
       formIsValid &&
       fomTomErFyltUt(formValues.inntektskilder, formValues.skatteforholdsperioder) &&
-      harInntektsKildeType(formValues.inntektskilder, trygdeAvgiftSkalIkkeBetalesTilNav)
-    ) {
+      harInntektsKildeType(formValues.inntektskilder, trygdeAvgiftSkalIkkeBetalesTilNav);
+
+    if (skalBeregne) {
       setBeregningPaagar(true);
       setFeilmelding(undefined);
-      debounceBeregnTrygdeavgiftsperioderOgOppdaterFormVerdier(formValues);
+      debounceBeregnTrygdeavgiftsperioder(formValues);
     }
-  }, [formIsValid, isValidating, erAvvik, formValues.inntektskilder.length, formValues.skatteforholdsperioder.length]);
+  }, [redigerbart, aarsavregningID, isValidating, formIsValid, debounceBeregnTrygdeavgiftsperioder]);
 
-  const stegErGyldig =
-    erAvvik === false || Boolean(formIsValid && erAvvik && aarsavregningResponse?.nyttGrunnlag && !feilmelding);
+  const stegErGyldig = useMemo(
+    () => erAvvik === false || Boolean(formIsValid && erAvvik && aarsavregningResponse?.nyttGrunnlag && !feilmelding),
+    [erAvvik, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding],
+  );
 
   useEffect(() => {
     oppdaterStatus(stegErGyldig);
   }, [stegErGyldig]);
 
   useEffect(() => {
-    if (redigerbart && aarsavregningResponse?.nyttGrunnlag) {
-      if (aarsavregningResponse.nyttGrunnlag?.avgift.totalAvgift !== aarsavregningResponse.avregning?.nyttTotalbeloep) {
-        Api.Aarsavregning.oppdaterTotalAvgift(
-          behandlingID,
-          aarsavregningID,
-          aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift,
-        ).then((res: AarsavregningResponse) => {
-          setAarsavregningResponse(res);
-        });
+    if (redigerbart && aarsavregningResponse?.nyttGrunnlag && aarsavregningID) {
+      const { totalAvgift } = aarsavregningResponse.nyttGrunnlag.avgift;
+      const nyttTotalbeloep = aarsavregningResponse.avregning?.nyttTotalbeloep;
+
+      if (totalAvgift !== nyttTotalbeloep) {
+        Api.Aarsavregning.oppdaterTotalAvgift(behandlingID, aarsavregningID, totalAvgift).then(
+          (res: AarsavregningResponse) => {
+            setAarsavregningResponse(res);
+          },
+        );
       }
     }
-  }, [aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift]);
+  }, [
+    redigerbart,
+    behandlingID,
+    aarsavregningID,
+    aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift,
+    aarsavregningResponse?.avregning?.nyttTotalbeloep,
+  ]);
 
-  const håndterAvvik = (value: boolean) => {
-    if (!value) {
-      Api.Trygdeavgift.slettTrygdeavgiftsperioder(behandlingID).then(() => {
-        Api.Aarsavregning.oppdaterTotalAvgift(
-          behandlingID,
-          aarsavregningID,
-          aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift.totalAvgift,
-        ).then((res: AarsavregningResponse) => {
-          setAarsavregningResponse(res);
+  const håndterAvvik = useCallback(
+    (value: boolean) => {
+      if (!value) {
+        Api.Trygdeavgift.slettTrygdeavgiftsperioder(behandlingID).then(() => {
+          const totalAvgift = aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift;
 
-          if (res.tidligereGrunnlagsopplysninger !== undefined) {
-            setBeregningPaagar(true);
-            Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
-              skatteforholdsperioder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder,
-              inntektskilder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder,
-            })
-              .catch((error) => setFeilmelding(mapFeilmelding(error)))
-              .finally(() => {
-                setBeregningPaagar(false);
-              });
+          if (aarsavregningID && totalAvgift !== undefined) {
+            Api.Aarsavregning.oppdaterTotalAvgift(behandlingID, aarsavregningID, totalAvgift).then(
+              (res: AarsavregningResponse) => {
+                setAarsavregningResponse(res);
+
+                if (res.tidligereGrunnlagsopplysninger) {
+                  setBeregningPaagar(true);
+                  Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
+                    skatteforholdsperioder:
+                      res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder,
+                    inntektskilder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder,
+                  })
+                    .catch((error) => setFeilmelding(mapFeilmelding(error)))
+                    .finally(() => {
+                      setBeregningPaagar(false);
+                    });
+                }
+              },
+            );
           }
         });
-      });
-    }
+      }
 
-    Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID);
-    setErAvvik(value);
-  };
+      if (aarsavregningID) {
+        Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID).then(() => setErAvvik(value));
+      }
+    },
+    [behandlingID, aarsavregningID, aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift],
+  );
 
-  const bekreftOnClick = () => {
+  const håndterBekreft = useCallback(() => {
     if (!harValidertSkjema) {
       trigger();
       setHarValidertSkjema(true);
@@ -198,17 +239,11 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     if (stegErGyldig && !beregningPaagar) {
       bekreft();
     }
-  };
-
-  const trygdeAvgiftSkalIkkeBetalesTilNav =
-    medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder);
-  const forskuddsvisFakturertTrygdeavgift =
-    (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
-  const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
+  }, [harValidertSkjema, trigger, stegErGyldig, beregningPaagar, bekreft]);
 
   return (
     <>
-      {aarsavregningResponse?.tidligereGrunnlagsopplysninger && (
+      {aarsavregningResponse && aarsavregningResponse.tidligereGrunnlagsopplysninger && (
         <>
           <MedlemskapsPerioderTabell
             perioder={aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.medlemskapsperioder}
@@ -226,7 +261,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           {!forskuddsvisFakturertTrygdeavgift && <Aarsavregningsmeldinger.TrygdeavgiftErIkkeForskuddsvisFakturert />}
 
           <BeregnetTrygdeavgiftDetaljer
-            grunnlag={aarsavregningResponse?.tidligereGrunnlagsopplysninger}
+            grunnlag={aarsavregningResponse.tidligereGrunnlagsopplysninger}
             medlemskapsTypeErPliktig={medlemskapstypeErPliktig!}
             tittel="Tidligere beregnet trygdeavgift"
           />
@@ -276,16 +311,16 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
 
           {trygdeAvgiftSkalIkkeBetalesTilNav && <Aarsavregningsmeldinger.TrygdeavgiftSkalIkkeBetalesTilNav />}
 
-          {nyttGrunnlagHarTrygdeavgiftsgrunnlag && formIsValid && !feilmelding && (
+          {nyttGrunnlagHarTrygdeavgiftsgrunnlag && formIsValid && !feilmelding && aarsavregningResponse?.avregning && (
             <SumArsavregningTabell
-              nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
-              tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
+              nyTrygdeavgift={aarsavregningResponse.avregning.nyttTotalbeloep}
+              tidligereTrygdeavgift={aarsavregningResponse.avregning.tidligereFakturertBeloep}
             />
           )}
 
-          {formIsValid && !feilmelding && (
+          {formIsValid && !feilmelding && aarsavregningResponse?.nyttGrunnlag && (
             <BeregnetTrygdeavgiftDetaljer
-              grunnlag={aarsavregningResponse?.nyttGrunnlag}
+              grunnlag={aarsavregningResponse.nyttGrunnlag}
               medlemskapsTypeErPliktig={medlemskapstypeErPliktig!}
               tittel="Endelig beregnet trygdeavgift"
             />
@@ -299,7 +334,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </Nav.Alert>
       )}
 
-      <Nav.Button variant="primary" loading={beregningPaagar} disabled={!redigerbart} onClick={bekreftOnClick}>
+      <Nav.Button variant="primary" loading={beregningPaagar} disabled={!redigerbart} onClick={håndterBekreft}>
         Bekreft og fortsett
       </Nav.Button>
     </>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -87,13 +87,16 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const erAvvik = watch("erAvvik");
   const debouncedBeregningRef = useRef<any>(null);
 
-  const mapFormState = (skatteforholdsperioder: Skatteforhold[], inntektskilder: Inntektskilde[]) => ({
-    skatteforholdsperioder: skatteforholdsperioder.map((skatteforhold: Skatteforhold) => ({
+  const mapFormState = (
+    skatteforholdsperioderFormState: Skatteforhold[],
+    inntektskilderFormState: Inntektskilde[],
+  ) => ({
+    skatteforholdsperioder: skatteforholdsperioderFormState.map((skatteforhold: Skatteforhold) => ({
       fomDato: skatteforhold.fomDato,
       tomDato: skatteforhold.tomDato,
       skatteplikttype: skatteforhold.skatteplikttype,
     })),
-    inntektskilder: inntektskilder.map((inntektskilde: Inntektskilde) => ({
+    inntektskilder: inntektskilderFormState.map((inntektskilde: Inntektskilde) => ({
       fomDato: inntektskilde.fomDato,
       tomDato: inntektskilde.tomDato,
       kildetype: inntektskilde.kildetype,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -21,12 +21,13 @@ import { behandlingsresultatSelectors } from "../../../../../ducks/behandlingsre
 import aarsavregningMedGrunnlagSchema from "./aarsavregningMedGrunnlagSchema";
 import { Skatteforholdsperioder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/skatteforholdsperioder";
 import { Inntektskilder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/inntektskilder";
-import { beregnTrygdeavgiftsperioder, erBrukerSkattepliktigIHelePerioden, mapFeilmelding } from "../komponenter/utils";
+import { beregnTrygdeavgiftsperioder, erBrukerSkattepliktigIHelePerioden } from "../komponenter/utils";
 import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversikt";
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 import { InitiellData } from "./aarsavregningMedGrunnlag";
 import * as Forms from "../../../../../felleskomponenter/forms";
+import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
 
 interface Props {
   initiellData: InitiellData;
@@ -36,13 +37,13 @@ interface Props {
 
 export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterStatus }: Props) {
   const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
-  const [brukerHarBekreftet, setBrukerHarBekreftet] = useState(false);
   const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(
     initiellData.aarsavregningResponse,
   );
   const [beregningPaagar, setBeregningPaagar] = useState(false);
   const [harValidertSkjema, setHarValidertSkjema] = useState(false);
-  const [previousFormValues, setPreviousFormValues] = useState<string | null>(null);
+  const [previousFormValues, setPreviousFormValues] = useState<any | null>(null);
+  const [endrerAvvik, setEndrerAvvik] = useState(false);
 
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
@@ -83,7 +84,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const formValues = watch();
   const skatteforholdsperioder = watch("skatteforholdsperioder");
   const inntektskilder = watch("inntektskilder");
-  const erAvvikForm = watch("erAvvik");
+  const erAvvik = watch("erAvvik");
 
   const handleBeregnTrygdeavgiftsperioder = useCallback(
     async (formVerdier: FieldValue<FormValuesProps>) => {
@@ -99,72 +100,60 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   );
 
   const debounceBeregnTrygdeavgiftsperioder = useCallback(
-    Utils._debounce((formVerdier) => handleBeregnTrygdeavgiftsperioder(formVerdier), 2000),
+    Utils._debounce(
+      (formVerdier, callbackEtterBeregning) =>
+        handleBeregnTrygdeavgiftsperioder(formVerdier).finally(() => {
+          if (callbackEtterBeregning) callbackEtterBeregning();
+        }),
+      1500,
+    ),
     [handleBeregnTrygdeavgiftsperioder],
   );
 
   useEffect(() => {
-    setBrukerHarBekreftet(false);
-    setHarValidertSkjema(false);
-  }, [erAvvikForm]);
-
-  useEffect(() => {
-    if (erAvvikForm !== true || !redigerbart || !aarsavregningID || beregningPaagar) {
+    if (erAvvik !== true || !redigerbart || !aarsavregningID || beregningPaagar || endrerAvvik) {
       return;
     }
 
     const formState = {
-      skatteforholdsperioder:
-        skatteforholdsperioder?.map((skatteforhold: Skatteforhold) => ({
-          fomDato: skatteforhold.fomDato,
-          tomDato: skatteforhold.tomDato,
-          skatteplikttype: skatteforhold.skatteplikttype,
-        })) || [],
-      inntektskilder:
-        inntektskilder?.map((inntektskilde: Inntektskilde) => ({
-          fomDato: inntektskilde.fomDato,
-          tomDato: inntektskilde.tomDato,
-          kildetype: inntektskilde.kildetype,
-          bruttoInntekt: inntektskilde.bruttoInntekt,
-          arbAvgBetales: inntektskilde.arbAvgBetales,
-          erMaanedsbelop: inntektskilde.erMaanedsbelop,
-        })) || [],
+      skatteforholdsperioder: getValues("skatteforholdsperioder").map((skatteforhold: Skatteforhold) => ({
+        fomDato: skatteforhold.fomDato,
+        tomDato: skatteforhold.tomDato,
+        skatteplikttype: skatteforhold.skatteplikttype,
+      })),
+      inntektskilder: getValues("inntektskilder").map((inntektskilde: Inntektskilde) => ({
+        fomDato: inntektskilde.fomDato,
+        tomDato: inntektskilde.tomDato,
+        kildetype: inntektskilde.kildetype,
+        bruttoInntekt: inntektskilde.bruttoInntekt,
+        arbAvgBetales: inntektskilde.arbAvgBetales,
+        erMaanedsbelop: inntektskilde.erMaanedsbelop,
+      })),
     };
-
-    // Serialize to compare with previous state
-    const stateStr = JSON.stringify(formState);
-
-    // Only process if form state has changed
-    if (stateStr !== previousFormValues) {
-      setPreviousFormValues(stateStr);
-
+    if (!Utils._isEqual(formState, previousFormValues)) {
       const validationTimeout = setTimeout(() => {
         trigger().then((isValid) => {
           if (isValid && formIsValid && !isValidating) {
             setBeregningPaagar(true);
-            debounceBeregnTrygdeavgiftsperioder(getValues());
+            debounceBeregnTrygdeavgiftsperioder(getValues(), () => {
+              setPreviousFormValues(formState);
+            });
           }
         });
-      }, 500);
+      }, 300);
 
-      return () => clearTimeout(validationTimeout);
+      /* eslint-disable-next-line consistent-return */
+      return () => {
+        clearTimeout(validationTimeout);
+      };
     }
-  }, [
-    skatteforholdsperioder,
-    inntektskilder,
-    erAvvikForm,
-    redigerbart,
-    formIsValid,
-    isValidating,
-    aarsavregningID,
-    beregningPaagar,
-  ]);
+  }, [skatteforholdsperioder, erAvvik, inntektskilder, formIsValid, isValidating, endrerAvvik]);
 
   const stegErGyldig = useMemo(
     () =>
-      erAvvikForm === false ||
-      Boolean(formIsValid && erAvvikForm === true && aarsavregningResponse?.nyttGrunnlag && !feilmelding),
-    [erAvvikForm, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding],
+      erAvvik === false ||
+      Boolean(formIsValid && erAvvik === true && aarsavregningResponse?.nyttGrunnlag && !feilmelding),
+    [erAvvik, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding],
   );
 
   useEffect(() => {
@@ -194,35 +183,40 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
 
   const håndterAvvik = useCallback(
     (value: boolean) => {
-      if (!value) {
-        Api.Trygdeavgift.slettTrygdeavgiftsperioder(behandlingID).then(() => {
-          const totalAvgift = aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift;
+      setEndrerAvvik(true);
 
-          if (aarsavregningID && totalAvgift !== undefined) {
-            Api.Aarsavregning.oppdaterTotalAvgift(behandlingID, aarsavregningID, totalAvgift).then(
-              (res: AarsavregningResponse) => {
-                setAarsavregningResponse(res);
-
-                if (res.tidligereGrunnlagsopplysninger) {
-                  setBeregningPaagar(true);
-                  Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
-                    skatteforholdsperioder:
-                      res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder,
-                    inntektskilder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder,
-                  })
-                    .catch((error) => setFeilmelding(mapFeilmelding(error)))
-                    .finally(() => {
-                      setBeregningPaagar(false);
-                    });
-                }
-              },
-            );
+      Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID)
+        .then((res) => {
+          setAarsavregningResponse(res);
+          if (!value) {
+            setBeregningPaagar(true);
+            handleBeregnTrygdeavgiftsperioder({
+              skatteforholdsperioder: mapTilSkatteforholdProps(
+                res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder!,
+              ),
+              inntektskilder: mapTilInntektskilderProps(
+                res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.inntektskperioder!,
+              ),
+            }).finally(() => {
+              setPreviousFormValues(null);
+              setBeregningPaagar(false);
+            });
           }
+        })
+        .finally(() => {
+          setEndrerAvvik(false);
         });
-      }
-      Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID);
     },
-    [behandlingID, aarsavregningID, aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift],
+    [
+      behandlingID,
+      aarsavregningID,
+      handleBeregnTrygdeavgiftsperioder,
+      setBeregningPaagar,
+      setFeilmelding,
+      setAarsavregningResponse,
+      setPreviousFormValues,
+      setEndrerAvvik,
+    ],
   );
 
   const håndterBekreft = useCallback(() => {
@@ -230,11 +224,10 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       trigger();
       setHarValidertSkjema(true);
     }
-    setBrukerHarBekreftet(true);
-    if (stegErGyldig && !beregningPaagar) {
+    if (stegErGyldig && !beregningPaagar && !endrerAvvik) {
       bekreft();
     }
-  }, [harValidertSkjema, trigger, stegErGyldig, beregningPaagar, bekreft]);
+  }, [harValidertSkjema, trigger, stegErGyldig, beregningPaagar, bekreft, endrerAvvik]);
 
   const trygdeAvgiftSkalIkkeBetalesTilNav =
     medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder);
@@ -284,7 +277,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </Nav.HStack>
       </Forms.RadioGroup>
 
-      {erAvvikForm === true && (
+      {erAvvik === true && !endrerAvvik && (
         <>
           <Nav.Heading className="endelige_opplysninger_heading" level="2">
             Inntekts- og skatteopplysninger for endelig trygdeavgift
@@ -315,14 +308,18 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
 
           {trygdeAvgiftSkalIkkeBetalesTilNav && <Aarsavregningsmeldinger.TrygdeavgiftSkalIkkeBetalesTilNav />}
 
-          {nyttGrunnlagHarTrygdeavgiftsgrunnlag && formIsValid && !feilmelding && aarsavregningResponse?.avregning && (
-            <SumArsavregningTabell
-              nyTrygdeavgift={aarsavregningResponse.avregning.nyttTotalbeloep}
-              tidligereTrygdeavgift={aarsavregningResponse.avregning.tidligereFakturertBeloep}
-            />
-          )}
+          {nyttGrunnlagHarTrygdeavgiftsgrunnlag &&
+            !beregningPaagar &&
+            formIsValid &&
+            !feilmelding &&
+            aarsavregningResponse?.avregning && (
+              <SumArsavregningTabell
+                nyTrygdeavgift={aarsavregningResponse.avregning.nyttTotalbeloep}
+                tidligereTrygdeavgift={aarsavregningResponse.avregning.tidligereFakturertBeloep}
+              />
+            )}
 
-          {formIsValid && !feilmelding && aarsavregningResponse?.nyttGrunnlag && (
+          {formIsValid && !beregningPaagar && !feilmelding && aarsavregningResponse?.nyttGrunnlag && (
             <BeregnetTrygdeavgiftDetaljer
               grunnlag={aarsavregningResponse.nyttGrunnlag}
               medlemskapsTypeErPliktig={medlemskapstypeErPliktig!}
@@ -332,7 +329,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </>
       )}
 
-      {brukerHarBekreftet && feilmelding && (
+      {feilmelding && !beregningPaagar && (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
           {feilmelding}
         </Nav.Alert>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -1,7 +1,7 @@
 import * as Api from "../../../../../services/api";
 import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import "../vurderingAarsavregningInngang.css";
-import { useCallback, useEffect, useState, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { useSelector } from "react-redux";
 import * as Nav from "../../../../../navFrontend";
@@ -10,7 +10,6 @@ import { FieldValue, useFieldArray, useForm } from "react-hook-form";
 import { FieldArrayProps, FormValuesProps } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as Utils from "../../../../../utils";
-import MKV from "../../../../../melosyskodeverk";
 import { SumArsavregningTabell } from "../komponenter/sumArsavregningTabell";
 import { BeregnetTrygdeavgiftDetaljer } from "../komponenter/beregnetTrygdeavgiftDetaljer";
 import { behandlingsresultatSelectors } from "../../../../../ducks/behandlingsresultat";
@@ -22,20 +21,15 @@ import {
   erBrukerSkattepliktigIHelePerioden,
   fomTomErFyltUt,
   harInntektsKildeType,
-  hentMedlemskapsperiodeBestemmelse,
-  lagInnvilgetMedlemskapsPeriode,
   mapFeilmelding,
 } from "../komponenter/utils";
 import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversikt";
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
+import { InitiellData } from "./aarsavregningMedGrunnlag";
 
 interface Props {
-  initiellData: {
-    aarsavregningResponse?: AarsavregningResponse;
-    formDefaultValues: FieldValue<FormValuesProps>;
-    erAvvik?: boolean;
-  };
+  initiellData: InitiellData;
   bekreft: () => void;
   oppdaterStatus: (isValid: boolean) => void;
 }
@@ -54,30 +48,12 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
 
-  const medlemskapsperioder = useMemo(
-    () => aarsavregningResponse?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder,
-    [aarsavregningResponse?.tidligereGrunnlagsopplysninger],
-  );
-  const innvilgetMedlemskapsperiode = useMemo(
-    () => lagInnvilgetMedlemskapsPeriode(medlemskapsperioder),
-    [medlemskapsperioder],
-  );
-  const innvilgetMedlemskapsperiodeBestemmelse = useMemo(
-    () => hentMedlemskapsperiodeBestemmelse(false, medlemskapsperioder),
-    [medlemskapsperioder],
-  );
-  const defaultPeriode = useMemo(
-    () => ({
-      fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
-      tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
-    }),
-    [innvilgetMedlemskapsperiode?.fom, innvilgetMedlemskapsperiode?.tom],
-  );
-
-  const medlemskapstypeErPliktig = useMemo(
-    () => medlemskapsperioder?.every((periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG),
-    [medlemskapsperioder],
-  );
+  const {
+    innvilgetMedlemskapsperiode,
+    innvilgetMedlemskapsperiodeBestemmelse,
+    defaultPeriode,
+    medlemskapstypeErPliktig,
+  } = initiellData;
 
   const {
     control,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -1,0 +1,332 @@
+import * as Api from "../../../../../services/api";
+import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
+import "../vurderingAarsavregningInngang.css";
+import { useCallback, useEffect, useState } from "react";
+import {
+  AarsavregningResponse,
+} from "../../../../../services/modules/aarsavregning/aarsavregning";
+import { useDispatch, useSelector } from "react-redux";
+import * as Nav from "../../../../../navFrontend";
+import { redigerbartSelectors } from "../../../../../ducks/redigerbart";
+import { FieldValue, useFieldArray, useForm } from "react-hook-form";
+import { FieldArrayProps, FormValuesProps } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as Utils from "../../../../../utils";
+import MKV from "../../../../../melosyskodeverk";
+import { SumArsavregningTabell } from "../komponenter/sumArsavregningTabell";
+import { BeregnetTrygdeavgiftDetaljer } from "../komponenter/beregnetTrygdeavgiftDetaljer";
+import { behandlingsresultatSelectors } from "../../../../../ducks/behandlingsresultat";
+import aarsavregningMedGrunnlagSchema from "./aarsavregningMedGrunnlagSchema";
+import { Skatteforholdsperioder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/skatteforholdsperioder";
+import { Inntektskilder } from "../../../../../felleskomponenter/trygdeavgift/komponenter/inntektskilder";
+import {
+  beregnTrygdeavgiftsperioder,
+  erBrukerSkattepliktigIHelePerioden,
+  fomTomErFyltUt,
+  harInntektsKildeType,
+  hentMedlemskapsperiodeBestemmelse,
+  lagInnvilgetMedlemskapsPeriode,
+  mapFeilmelding,
+} from "../komponenter/utils";
+import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversikt";
+import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
+import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
+import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
+
+interface Props {
+  initiellData: {
+    aarsavregningResponse?: AarsavregningResponse;
+    formDefaultValues: FieldValue<FormValuesProps>;
+    erAvvik?: boolean;
+  };
+  bekreft: () => void;
+  oppdaterStatus: (isValid: boolean) => void;
+}
+
+export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterStatus }: Props) {
+  const [erAvvik, setErAvvik] = useState<boolean | undefined>(initiellData.erAvvik);
+  const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
+  const [brukerHarBekreftet, setBrukerHarBekreftet] = useState(false);
+  const [aarsavregningResponse, setAarsavregningResponse] = useState<AarsavregningResponse | undefined>(
+    initiellData.aarsavregningResponse
+  );
+  const [beregningPaagar, setBeregningPaagar] = useState(false);
+  const [harValidertSkjema, setHarValidertSkjema] = useState(false);
+
+  const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
+  const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
+  const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
+
+  const medlemskapsperioder =
+    aarsavregningResponse?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
+  const innvilgetMedlemskapsperiode = lagInnvilgetMedlemskapsPeriode(medlemskapsperioder);
+  const innvilgetMedlemskapsperiodeBestemmelse = hentMedlemskapsperiodeBestemmelse(false, medlemskapsperioder);
+  const defaultPeriode = {
+    fomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom),
+    tomDato: Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom),
+  };
+
+  const medlemskapstypeErPliktig = medlemskapsperioder?.every(
+    (periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
+  );
+
+  const {
+    control,
+    watch,
+    formState: { isValid: formIsValid, isValidating },
+    trigger,
+  } = useForm({
+    resolver: yupResolver(aarsavregningMedGrunnlagSchema),
+    context: {
+      medlemskapsperiode: innvilgetMedlemskapsperiode,
+      medlemskapsTypeErPliktig: medlemskapstypeErPliktig,
+      erÅpenSluttDato: false,
+      erAvvik,
+    },
+    mode: "onChange",
+    reValidateMode: "onChange",
+    defaultValues: initiellData.formDefaultValues,
+  });
+
+  const {
+    fields: skattFields,
+    append: skattAppend,
+    remove: skattRemove,
+    replace: resetSkatteforholdsperioder,
+  } = useFieldArray<FieldArrayProps, "skatteforholdsperioder", "id">({ control, name: "skatteforholdsperioder" });
+
+  const {
+    fields: inntektFields,
+    append: inntektAppend,
+    remove: inntektRemove,
+    update: inntektUpdate,
+    replace: resetInntektskilder,
+  } = useFieldArray<FieldArrayProps, "inntektskilder", "id">({ control, name: "inntektskilder" });
+  const formValues = watch();
+
+  const handleBeregnTrygdeavgiftsperioder = useCallback(
+    async (formVerdier: FieldValue<FormValuesProps>) => {
+      await beregnTrygdeavgiftsperioder(formVerdier, {
+        behandlingID,
+        medlemskapstypeErPliktig,
+        setFeilmelding,
+        setAarsavregningResponse,
+      });
+      setBeregningPaagar(false);
+    },
+    [behandlingID, medlemskapstypeErPliktig, setFeilmelding, setAarsavregningResponse],
+  );
+
+  const debounceBeregnTrygdeavgiftsperioderOgOppdaterFormVerdier = useCallback(
+    Utils._debounce((formVerdier) => handleBeregnTrygdeavgiftsperioder(formVerdier), 2000),
+    [handleBeregnTrygdeavgiftsperioder],
+  );
+
+  useEffect(() => {
+    setBrukerHarBekreftet(false);
+    if (
+      redigerbart &&
+      aarsavregningID &&
+      erAvvik &&
+      !isValidating &&
+      formIsValid &&
+      fomTomErFyltUt(formValues.inntektskilder, formValues.skatteforholdsperioder) &&
+      harInntektsKildeType(formValues.inntektskilder, trygdeAvgiftSkalIkkeBetalesTilNav)
+    ) {
+      setBeregningPaagar(true);
+      setFeilmelding(undefined);
+      debounceBeregnTrygdeavgiftsperioderOgOppdaterFormVerdier(formValues);
+    }
+  }, [formIsValid, isValidating, erAvvik, formValues.inntektskilder.length, formValues.skatteforholdsperioder.length]);
+
+  const stegErGyldig =
+    erAvvik === false || Boolean(formIsValid && erAvvik && aarsavregningResponse?.nyttGrunnlag && !feilmelding);
+
+  useEffect(() => {
+    oppdaterStatus(stegErGyldig);
+  }, [stegErGyldig]);
+
+  useEffect(() => {
+    if (redigerbart && aarsavregningResponse?.nyttGrunnlag) {
+      if (aarsavregningResponse.nyttGrunnlag?.avgift.totalAvgift !== aarsavregningResponse.avregning?.nyttTotalbeloep) {
+        Api.Aarsavregning.oppdaterTotalAvgift(
+          behandlingID,
+          aarsavregningID,
+          aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift,
+        ).then((res: AarsavregningResponse) => {
+          setAarsavregningResponse(res);
+        });
+      }
+    }
+  }, [aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift]);
+
+  const håndterAvvik = (value: boolean) => {
+    if (!value) {
+      Api.Trygdeavgift.slettTrygdeavgiftsperioder(behandlingID).then(() => {
+        resetSkatteforholdsperioder([]);
+        resetInntektskilder([]);
+        Api.Aarsavregning.oppdaterTotalAvgift(
+          behandlingID,
+          aarsavregningID,
+          aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift.totalAvgift,
+        ).then((res: AarsavregningResponse) => {
+          setAarsavregningResponse(res);
+          if (res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
+            resetSkatteforholdsperioder(
+              !Utils._isEmpty(res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder)
+                ? mapTilSkatteforholdProps(res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder)
+                : []
+            );
+
+            resetInntektskilder(
+              !Utils._isEmpty(res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder)
+                ? mapTilInntektskilderProps(res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder)
+                : []
+            );
+          }
+          if (res.tidligereGrunnlagsopplysninger !== undefined) {
+            setBeregningPaagar(true);
+            Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
+              skatteforholdsperioder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder,
+              inntektskilder: res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder,
+            })
+              .catch((error) => setFeilmelding(mapFeilmelding(error)))
+              .finally(() => {
+                setBeregningPaagar(false);
+              });
+          }
+        });
+      });
+    } else if (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag) {
+      resetSkatteforholdsperioder(
+        !Utils._isEmpty(aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder)
+          ? mapTilSkatteforholdProps(aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder)
+          : []
+      );
+
+      resetInntektskilder(
+        !Utils._isEmpty(aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder)
+          ? mapTilInntektskilderProps(aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder)
+          : []
+      );
+    }
+    Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID);
+    setErAvvik(value);
+  };
+
+  const bekreftOnClick = () => {
+    if (!harValidertSkjema) {
+      trigger();
+      setHarValidertSkjema(true);
+    }
+    setBrukerHarBekreftet(true);
+    if (stegErGyldig && !beregningPaagar) {
+      bekreft();
+    }
+  };
+
+  const trygdeAvgiftSkalIkkeBetalesTilNav =
+    medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(formValues.skatteforholdsperioder);
+  const forskuddsvisFakturertTrygdeavgift =
+    (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
+  const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
+
+  return (
+    <>
+      {aarsavregningResponse?.tidligereGrunnlagsopplysninger && (
+        <>
+          <MedlemskapsPerioderTabell
+            perioder={aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.medlemskapsperioder}
+          />
+          <TidligereGrunnlagsoversikt
+            skatteforholdsperioder={
+              aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.skatteforholdsperioder
+            }
+            inntektsperioder={
+              aarsavregningResponse.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag.inntektskperioder
+            }
+            avgift={aarsavregningResponse.tidligereGrunnlagsopplysninger.avgift}
+          />
+
+          {!forskuddsvisFakturertTrygdeavgift && <Aarsavregningsmeldinger.TrygdeavgiftErIkkeForskuddsvisFakturert />}
+
+          <BeregnetTrygdeavgiftDetaljer
+            grunnlag={aarsavregningResponse?.tidligereGrunnlagsopplysninger}
+            medlemskapsTypeErPliktig={medlemskapstypeErPliktig!}
+            tittel="Tidligere beregnet trygdeavgift"
+          />
+        </>
+      )}
+
+      <Nav.RadioGroup
+        onChange={håndterAvvik}
+        value={erAvvik}
+        legend="Er det avvik i opplysningene fra skatt eller bruker?"
+        readOnly={!redigerbart}
+      >
+        <Nav.HStack gap="6">
+          <Nav.Radio value>Ja</Nav.Radio>
+          <Nav.Radio value={false}>Nei</Nav.Radio>
+        </Nav.HStack>
+      </Nav.RadioGroup>
+
+      {erAvvik && (
+        <>
+          <Nav.Heading className="endelige_opplysninger_heading" level="2">
+            Inntekts- og skatteopplysninger for endelig trygdeavgift
+          </Nav.Heading>
+          <Skatteforholdsperioder
+            formValues={formValues}
+            redigerbart={redigerbart}
+            remove={skattRemove}
+            append={skattAppend}
+            control={control}
+            fields={skattFields}
+          />
+          {!trygdeAvgiftSkalIkkeBetalesTilNav && (
+            <Inntektskilder
+              defaultPeriode={defaultPeriode}
+              formValues={formValues}
+              redigerbart={redigerbart}
+              update={inntektUpdate}
+              remove={inntektRemove}
+              append={inntektAppend}
+              control={control}
+              fields={inntektFields}
+              medlemskapsTypeErPliktig={medlemskapstypeErPliktig!}
+              skalViseErMaanedsBelopRadioGroup
+              bestemmelse={innvilgetMedlemskapsperiodeBestemmelse}
+            />
+          )}
+
+          {trygdeAvgiftSkalIkkeBetalesTilNav && <Aarsavregningsmeldinger.TrygdeavgiftSkalIkkeBetalesTilNav />}
+
+          {nyttGrunnlagHarTrygdeavgiftsgrunnlag && formIsValid && !feilmelding && (
+            <SumArsavregningTabell
+              nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
+              tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
+            />
+          )}
+
+          {formIsValid && !feilmelding && (
+            <BeregnetTrygdeavgiftDetaljer
+              grunnlag={aarsavregningResponse?.nyttGrunnlag}
+              medlemskapsTypeErPliktig={medlemskapstypeErPliktig!}
+              tittel="Endelig beregnet trygdeavgift"
+            />
+          )}
+        </>
+      )}
+
+      {brukerHarBekreftet && feilmelding && (
+        <Nav.Alert variant="error" className="alertstripe_feilmelding">
+          {feilmelding}
+        </Nav.Alert>
+      )}
+
+      <Nav.Button variant="primary" loading={beregningPaagar} disabled={!redigerbart} onClick={bekreftOnClick}>
+        Bekreft og fortsett
+      </Nav.Button>
+    </>
+  );
+}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -64,14 +64,13 @@ const erInnenforMedlemskapsperiodeTest = {
       const { medlemskapsperiode } = schema.options.context;
       if (!medlemskapsperiode || !medlemskapsperiode.fomDato || !medlemskapsperiode.tomDato) return true;
 
-      const membershipStart = Utils.dato.formatterDatoTilISO(medlemskapsperiode.fomDato);
-      const membershipEnd = Utils.dato.formatterDatoTilISO(medlemskapsperiode.tomDato);
-      const dateToCheck = Utils.dato.formatterDatoTilISO(datoString);
+      const medlemskapsperiodeFom = Utils.dato.formatterDatoTilISO(medlemskapsperiode.fomDato);
+      const medlemskapsperiodeTom = Utils.dato.formatterDatoTilISO(medlemskapsperiode.tomDato);
+      const isoDatoString = Utils.dato.formatterDatoTilISO(datoString);
 
-      if (!membershipStart || !membershipEnd || !dateToCheck) return true;
+      if (!medlemskapsperiodeFom || !medlemskapsperiodeTom || !isoDatoString) return true;
 
-      // Use direct comparison rather than moment.isBetween to avoid potential edge cases
-      return dateToCheck >= membershipStart && dateToCheck <= membershipEnd;
+      return isoDatoString >= medlemskapsperiodeFom && isoDatoString <= medlemskapsperiodeTom;
     } catch (error) {
       return true;
     }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -1,8 +1,7 @@
-import { array, object, string } from "yup";
+import { array, boolean, object, string } from "yup";
 import MKV from "../../../../../melosyskodeverk";
 import * as KV from "../../../../../kodeverk";
 import * as Utils from "../../../../../utils";
-import { BOOLSK_STRING } from "../../../../../constants";
 
 import { erBrukerSkattepliktigIHelePerioden } from "../komponenter/utils";
 
@@ -102,14 +101,17 @@ const inntektskildeSchema = object().shape({
 });
 
 const aarsavregningMedGrunnlagSchema = object().shape({
-  skatteforholdsperioder: array().when(["$erAvvik"], {
+  erAvvik: boolean().required(MAA_FYLLES_UT),
+  skatteforholdsperioder: array().when(["erAvvik"], {
     is: (erAvvik) => erAvvik === true,
     then: array().min(1, "Minst en skatteforholdsperiode").of(skatteforholdsperiodeSchema),
     otherwise: array(),
   }),
-  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "$erAvvik", "skatteforholdsperioder"], {
+  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "erAvvik", "skatteforholdsperioder"], {
     is: (medlemskapsTypeErPliktig, erAvvik, skatteforholdsperioder) => {
-      return erAvvik === true && (!medlemskapsTypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder));
+      return (
+        erAvvik === true && (!medlemskapsTypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder))
+      );
     },
     then: array().min(1, "Minst en inntektskilde").of(inntektskildeSchema),
     otherwise: array(),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -4,6 +4,7 @@ import * as KV from "../../../../../kodeverk";
 import * as Utils from "../../../../../utils";
 
 import { erBrukerSkattepliktigIHelePerioden } from "../komponenter/utils";
+import { BOOLSK_STRING } from "../../../../../constants";
 
 const { MAA_FYLLES_UT } = KV.Feilmeldinger;
 const {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -102,14 +102,15 @@ const inntektskildeSchema = object().shape({
 });
 
 const aarsavregningMedGrunnlagSchema = object().shape({
-  skatteforholdsperioder: array().when(["$erAvvik"], {
-    is: (erAvvik) => erAvvik === true,
+  erAvvik: string().required(MAA_FYLLES_UT),
+  skatteforholdsperioder: array().when(["erAvvik"], {
+    is: (erAvvik) => erAvvik === BOOLSK_STRING.SANN,
     then: array().min(1, "Minst en skatteforholdsperiode").of(skatteforholdsperiodeSchema),
     otherwise: array(),
   }),
-  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "$erAvvik", "skatteforholdsperioder"], {
+  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "erAvvik", "skatteforholdsperioder"], {
     is: (medlemskapsTypeErPliktig, erAvvik, skatteforholdsperioder) => {
-      return erAvvik === true && (!medlemskapsTypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder));
+      return erAvvik === BOOLSK_STRING.SANN && (!medlemskapsTypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder));
     },
     then: array().min(1, "Minst en inntektskilde").of(inntektskildeSchema),
     otherwise: array(),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -1,4 +1,4 @@
-import { array, lazy, object, string, boolean } from "yup";
+import { array, object, string } from "yup";
 import MKV from "../../../../../melosyskodeverk";
 import * as KV from "../../../../../kodeverk";
 import * as Utils from "../../../../../utils";
@@ -22,98 +22,97 @@ export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
 
 const arbAvgBetalesFyltUtNårDetKrevesTest = {
   name: "Fyll inn arb.ag. betales når det kreves",
-  message: { message: "Velg om arb.ag. betales til skatt" },
+  message: "Velg om arb.ag. betales til skatt",
   test: (arbAvgBetales, schema) => {
     const { kildetype } = schema.from[0].value;
 
-    return !(
-      arbAvgBetalesKreves(kildetype, schema?.options?.context?.medlemskapsTypeErPliktig) &&
-      Utils._isEmpty(arbAvgBetales)
-    );
+    if (!arbAvgBetalesKreves(kildetype, schema?.options?.context?.medlemskapsTypeErPliktig)) {
+      return true;
+    }
+
+    return !Utils._isEmpty(arbAvgBetales);
   },
 };
 
-export const bruttoInntektKreves = (brukerSkattepliktigIHelePerioden, kildetype, arbAvgBetales) =>
+const bruttoInntektKreves = (brukerSkattepliktigIHelePerioden, kildetype, arbAvgBetales) =>
   !brukerSkattepliktigIHelePerioden ||
   [NÆRINGSINNTEKT_FRA_NORGE, FN_SKATTEFRITAK, PENSJON_UFØRETRYGD].includes(kildetype) ||
   ([INNTEKT_FRA_UTLANDET, PENSJON_UFØRETRYGD_KILDESKATT].includes(kildetype) && arbAvgBetales === BOOLSK_STRING.USANN);
 
 const bruttoInntektFyltUtNårDetKrevesTest = {
   name: "Fyll inn brutto inntekt når det kreves",
-  message: { message: "Fyll inn brutto inntekt" },
+  message: MAA_FYLLES_UT,
   test: (bruttoInntekt, schema) => {
     const { skatteforholdsperioder } = schema.from[1].value;
     const { kildetype, arbAvgBetales } = schema.from[0].value;
 
     const brukerSkattepliktigIHelePerioden = erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder);
-
-    return !(
-      bruttoInntektKreves(brukerSkattepliktigIHelePerioden, kildetype, arbAvgBetales) && Utils._isEmpty(bruttoInntekt)
-    );
+    if (!bruttoInntektKreves(brukerSkattepliktigIHelePerioden, kildetype, arbAvgBetales)) {
+      return true;
+    }
+    return !Utils._isEmpty(bruttoInntekt);
   },
 };
 
-const kreverInntektskilder = (medlemskapsTypeErPliktig, options) => {
-  if (options?.parent?.skatteforholdsperioder) {
-    const inntektkilderErTom = options.parent.inntektskilder.length === 0;
-    return !(
-      medlemskapsTypeErPliktig &&
-      erBrukerSkattepliktigIHelePerioden(options.parent.skatteforholdsperioder) &&
-      inntektkilderErTom
-    );
-  }
-  return true;
+const erInnenforMedlemskapsperiodeTest = {
+  name: "erInnenforMedlemskapsperiode",
+  message: UTENFOR_MEDLEMSKAPSPERIODEN,
+  test: (datoString, schema) => {
+    if (Utils._isEmpty(datoString) || !Utils.dato.vaskInputDato(datoString)) return true;
+
+    try {
+      const { medlemskapsperiode } = schema.options.context;
+      if (!medlemskapsperiode || !medlemskapsperiode.fomDato || !medlemskapsperiode.tomDato) return true;
+
+      const membershipStart = Utils.dato.formatterDatoTilISO(medlemskapsperiode.fomDato);
+      const membershipEnd = Utils.dato.formatterDatoTilISO(medlemskapsperiode.tomDato);
+      const dateToCheck = Utils.dato.formatterDatoTilISO(datoString);
+
+      if (!membershipStart || !membershipEnd || !dateToCheck) return true;
+
+      // Use direct comparison rather than moment.isBetween to avoid potential edge cases
+      return dateToCheck >= membershipStart && dateToCheck <= membershipEnd;
+    } catch (error) {
+      return true;
+    }
+  },
 };
 
+const skatteforholdsperiodeSchema = object().shape({
+  fomDato: string().required(MAA_FYLLES_UT).erGyldigDato().test(erInnenforMedlemskapsperiodeTest),
+  tomDato: string()
+    .required(MAA_FYLLES_UT)
+    .erGyldigDato()
+    .erEtterDatofelt("fomDato")
+    .test(erInnenforMedlemskapsperiodeTest),
+  skatteplikttype: string().required(MAA_FYLLES_UT),
+});
+
+const inntektskildeSchema = object().shape({
+  kildetype: string().required(MAA_FYLLES_UT),
+  arbAvgBetales: string().test(arbAvgBetalesFyltUtNårDetKrevesTest).nullable(),
+  bruttoInntekt: string().test(bruttoInntektFyltUtNårDetKrevesTest),
+  fomDato: string().required(MAA_FYLLES_UT).erGyldigDato().test(erInnenforMedlemskapsperiodeTest),
+  tomDato: string()
+    .required(MAA_FYLLES_UT)
+    .erGyldigDato()
+    .erEtterDatofelt("fomDato")
+    .test(erInnenforMedlemskapsperiodeTest),
+  erMaanedsbelop: string(),
+});
+
 const aarsavregningMedGrunnlagSchema = object().shape({
-  skatteforholdsperioder: array().when(["$erÅpenSluttDato", "$erAvvik"], {
-    is: (erÅpenSluttDato, erAvvik) => {
-      if (!erAvvik) return false;
-      if (erAvvik === undefined) return true;
-      return !erÅpenSluttDato && erAvvik;
-    },
-    then: array()
-      .min(1, "Minst en skatteforholdsperiode")
-      .of(
-        object().shape({
-          fomDato: string()
-            .required(MAA_FYLLES_UT)
-            .erGyldigDato()
-            .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN),
-          tomDato: string()
-            .required(MAA_FYLLES_UT)
-            .erGyldigDato()
-            .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-            .erEtterDatofelt("fomDato"),
-          skatteplikttype: string().required(MAA_FYLLES_UT),
-        }),
-      ),
+  skatteforholdsperioder: array().when(["$erAvvik"], {
+    is: (erAvvik) => erAvvik === true,
+    then: array().min(1, "Minst en skatteforholdsperiode").of(skatteforholdsperiodeSchema),
+    otherwise: array(),
   }),
-  inntektskilder: lazy((_value, options) => {
-    return array().when(["$medlemskapsTypeErPliktig", "$erÅpenSluttDato", "$erAvvik"], {
-      is: (medlemskapsTypeErPliktig, erÅpenSluttDato, erAvvik) => {
-        if (!erAvvik) return false;
-        return !erÅpenSluttDato && kreverInntektskilder(medlemskapsTypeErPliktig, options) && erAvvik;
-      },
-      then: array()
-        .min(1, "Minst en inntektskilde")
-        .of(
-          object().shape({
-            kildetype: string().required(MAA_FYLLES_UT),
-            arbAvgBetales: string().test(arbAvgBetalesFyltUtNårDetKrevesTest).nullable(),
-            bruttoInntekt: string().test(bruttoInntektFyltUtNårDetKrevesTest),
-            fomDato: string()
-              .required(MAA_FYLLES_UT)
-              .erGyldigDato()
-              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN),
-            tomDato: string()
-              .required(MAA_FYLLES_UT)
-              .erGyldigDato()
-              .erInnenforPeriode("medlemskapsperiode", UTENFOR_MEDLEMSKAPSPERIODEN)
-              .erEtterDatofelt("fomDato"),
-          }),
-        ),
-    });
+  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "$erAvvik", "skatteforholdsperioder"], {
+    is: (medlemskapsTypeErPliktig, erAvvik, skatteforholdsperioder) => {
+      return erAvvik === true && (!medlemskapsTypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder));
+    },
+    then: array().min(1, "Minst en inntektskilde").of(inntektskildeSchema),
+    otherwise: array(),
   }),
 });
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -17,7 +17,7 @@ import {
   Medlemskapsperiode,
   OppdaterMedlemskapsperiode,
 } from "../../../../../services/modules/medlemavfolketrygden/medlemskapsperioder";
-import { AarsavregningForm } from "./aarsavregningForm";
+import { AarsavregningUtenEllerDeltGrunnlagForm } from "./aarsavregningUtenEllerDeltGrunnlagForm";
 
 const { DELVIS_INNVILGET, INNVILGET } = MKV.Koder.innvilgelsesResultat;
 
@@ -269,7 +269,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
   }
 
   return (
-    <AarsavregningForm
+    <AarsavregningUtenEllerDeltGrunnlagForm
       initiellData={initiellData}
       bekreft={bekreft}
       oppdaterStatus={memoizedOppdaterStatus}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -35,7 +35,7 @@ import {
 import aarsavregningUtenEllerDeltGrunnlagSchema from "./aarsavregningUtenEllerDeltGrunnlagSchema";
 import { medlemskapsperioderOperations } from "../../../../../ducks/medlemskapsperioder";
 
-export function AarsavregningForm({
+export function AarsavregningUtenEllerDeltGrunnlagForm({
   initiellData,
   bekreft,
   oppdaterStatus,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
@@ -30,30 +30,6 @@ export const erBrukerSkattepliktigIHelePerioden = (skatteforholdsperioder: any) 
   return !skatteforholdsperioder.some((skatteforhold: any) => skatteforhold.skatteplikttype === IKKE_SKATTEPLIKTIG);
 };
 
-export function fomTomErFyltUt(
-  inntektskildePerioder: Inntektskilde[],
-  skatteforholdsPerioder: Skatteforhold[],
-  medlemskapsperioder?: Medlemskapsperiode[],
-): boolean {
-  let allPerioder = [...inntektskildePerioder, ...skatteforholdsPerioder];
-  if (medlemskapsperioder?.length) {
-    allPerioder = [...allPerioder, ...medlemskapsperioder];
-  }
-  return allPerioder.every(
-    ({ fomDato, tomDato }) => fomDato !== undefined && fomDato !== "" && tomDato !== undefined && tomDato !== "",
-  );
-}
-
-export function harInntektsKildeType(
-  inntektskildePerioder: Inntektskilde[],
-  trygdeAvgiftSkalIkkeBetalesTilNav?: boolean | undefined,
-) {
-  if (trygdeAvgiftSkalIkkeBetalesTilNav) {
-    return true;
-  }
-  return inntektskildePerioder.every((inntektskilde) => inntektskilde?.kildetype !== undefined);
-}
-
 export function beregnTrygdeavgiftsperioder(
   formVerdier: FieldValue<FormValuesProps>,
   options: {
@@ -106,20 +82,4 @@ export const hentMedlemskapsperiodeBestemmelse = (
     return sortertePerioder?.[0]?.bestemmelse;
   }
   return undefined;
-};
-
-export const lagInnvilgetMedlemskapsPeriode = (medlemskapsperioder?: Medlemskapsperiode[]) => {
-  if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
-    const sorterteInnvilgedePerioder = [...medlemskapsperioder]
-      .filter((periode) => periode.innvilgelsesResultat === MKV.Koder.innvilgelsesResultat.INNVILGET)
-      .sort(sorterEtterISOFomDato);
-    return {
-      fom: sorterteInnvilgedePerioder[0].fomDato,
-      tom: sorterteInnvilgedePerioder[sorterteInnvilgedePerioder.length - 1].tomDato,
-    };
-  }
-  return {
-    tom: undefined,
-    fom: undefined,
-  };
 };

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/utils.ts
@@ -7,10 +7,7 @@ import {
 import * as Api from "../../../../../services/api";
 import * as Utils from "../../../../../utils";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
-import { Medlemskapsperiode } from "../../../../../services/modules/medlemavfolketrygden/medlemskapsperioder";
 import MKV from "../../../../../melosyskodeverk";
-import { sorterEtterISOFomDato } from "../../../../../utils/dato";
-import { ULAGRET_MEDLEMSKAPSPERIODE_ID } from "../aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
 
 const { IKKE_SKATTEPLIKTIG } = MKV.Koder.skatteplikttype;
 
@@ -69,17 +66,3 @@ export function beregnTrygdeavgiftsperioder(
     })
     .catch((error) => setFeilmelding(mapFeilmelding(error)));
 }
-
-export const hentMedlemskapsperiodeBestemmelse = (
-  harDeltGrunnlag: boolean,
-  medlemskapsperioder?: Medlemskapsperiode[],
-) => {
-  if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
-    const sortertePerioder = [...medlemskapsperioder]
-      .filter((periode) => (harDeltGrunnlag ? !periode.redigerbar : true))
-      .filter((periode) => periode.id !== ULAGRET_MEDLEMSKAPSPERIODE_ID)
-      .sort(sorterEtterISOFomDato);
-    return sortertePerioder?.[0]?.bestemmelse;
-  }
-  return undefined;
-};

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -6,7 +6,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { behandlingerSelectors } from "../../../../ducks/behandlinger";
 import * as Nav from "../../../../navFrontend";
 import { redigerbartSelectors } from "../../../../ducks/redigerbart";
-import * as Utils from "../../../../utils";
 import MKV from "../../../../melosyskodeverk";
 import { OK } from "../../../../ducks/aarsavregning/types";
 import { fagsakSelectors } from "../../../../ducks/fagsaker";
@@ -16,7 +15,6 @@ import { behandlingsresultatOperations } from "../../../../ducks/behandlingsresu
 import { AarsavregningMedGrunnlag } from "./aarsavregningMedGrunnlag/aarsavregningMedGrunnlag";
 import { AarsavregningUtenEllerDeltGrunnlag } from "./aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
 import LabelMedHjelpetekst from "../../../../felleskomponenter/labelMedHjelpetekst";
-import { lagInnvilgetMedlemskapsPeriode } from "./komponenter/utils";
 import { FellesHandlersContext } from "../../../../contexts";
 
 interface Props {
@@ -60,11 +58,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   const { oppfriskOgLastInnSaksopplysningerForAarsavregning } = useContext(FellesHandlersContext) as any;
 
   const utledGrunnlagstypeForAarsavregning = (res: AarsavregningResponse) => {
-    const innvilgetPeriode = lagInnvilgetMedlemskapsPeriode(
-      res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder,
-    );
-
-    if (res.tidligereGrunnlagsopplysninger === null && Utils._isEmpty(innvilgetPeriode.fom)) {
+    if (res.tidligereGrunnlagsopplysninger === null) {
       setHarGrunnlag(false);
     } else {
       setHarGrunnlag(true);


### PR DESCRIPTION
Refaktorert kode for håndtering av initiell lasting og skjemakomponent i årsavregning med grunnlag. 
Noen av de største endringene er:

  1. Delt aarsavregningMedGrunnlag.tsx i separate filer
    - aarsavregningMedGrunnlag.tsx - håndterer initiell lasting og databehandling
    - aarsavregningMedGrunnlagForm.tsx - inneholder skjemarendering og logikk
  3. Forenklet og faktisk fungerende validering i aarsavregningMedGrunnlagSchema.jsx.
  4. Flyttet erAvvik inn i react hook form
  5. Beregning useEffect er skrevet om fra bunnen av.
  6. Forbedret feilhåndtering for initiell datalasting.