### PR TITLE
7241 TOGGLE Beregning viser feil tall i ett halvt sekund.

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningForm.tsx
@@ -150,20 +150,6 @@ export function AarsavregningForm({
     }
   }, [formErrors.medlemskapsperioder]);
 
-  useEffect(() => {
-    if (redigerbart && aarsavregningResponse?.nyttGrunnlag) {
-      if (aarsavregningResponse.nyttGrunnlag?.avgift.totalAvgift !== aarsavregningResponse.avregning?.nyttTotalbeloep) {
-        Api.Aarsavregning.oppdaterTotalAvgift(
-          behandlingID,
-          aarsavregningID,
-          aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift,
-        ).then((response: AarsavregningResponse) => {
-          setAarsavregningResponse(response);
-        });
-      }
-    }
-  }, [aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift]);
-
   const lagreMedlemskapsperiodeHvisEndret = async (medlemskapsperiode: Medlemskapsperiode, index: number) => {
     const periodeRequest = {
       fomDato: Utils.dato.formatterDatoTilISO(medlemskapsperiode.fomDato, "") as string,
@@ -457,6 +443,13 @@ export function AarsavregningForm({
       setHarValidertSkjema(true);
     }
     if (stegErGyldig && !beregningPaagar) {
+      Api.Aarsavregning.oppdaterTotalAvgift(
+        behandlingID,
+        aarsavregningID,
+        aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift,
+      ).then((response: AarsavregningResponse) => {
+        setAarsavregningResponse(response);
+      });
       bekreft();
     }
   };
@@ -569,7 +562,7 @@ export function AarsavregningForm({
 
       {formIsValid && !beregningPaagar && !feilmelding && (
         <SumArsavregningTabell
-          nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
+          nyTrygdeavgift={aarsavregningResponse?.nyttGrunnlag?.avgift.totalAvgift}
           tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
           tidligereTrygdeavgiftAvgiftssystem={aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem}
         />


### PR DESCRIPTION
Fjerner useefect i uten/delt grunnlag for å unngå midlertidig feil beløp.
Jeg gjør ikke det samme i med grunnlag, da dette ikke skjer lenger etter refaktoreringen til Fredrik.
Jeg har prøvd å unngå bruk av useeffect i Med grunnlag også, men dette lar seg ikke gjøre.
https://jira.adeo.no/browse/MELOSYS-7241