### PR TITLE
7269: Fiks tre bugs i MED grunnlag

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -125,6 +125,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   );
 
   const debouncedBeregning = useCallback(() => {
+    console.log("[debouncedBeregning] debouncedBeregningPagaar set false", debouncedBeregningPagaar);
     setDebouncedBeregningPagaar(false);
     if (!redigerbart || !aarsavregningID || erAvvik !== true || beregningPaagar || endrerAvvik) {
       return;
@@ -177,6 +178,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     return () => {
       if (debouncedBeregningRef.current?.cancel) {
         debouncedBeregningRef.current.cancel();
+        setDebouncedBeregningPagaar(false);
       }
     };
   }, [debouncedBeregning]);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -93,19 +93,23 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     skatteforholdsperioderFormState: Skatteforhold[],
     inntektskilderFormState: Inntektskilde[],
   ) => ({
-    skatteforholdsperioder: skatteforholdsperioderFormState.map((skatteforhold: Skatteforhold) => ({
-      fomDato: skatteforhold.fomDato,
-      tomDato: skatteforhold.tomDato,
-      skatteplikttype: skatteforhold.skatteplikttype,
-    })),
-    inntektskilder: inntektskilderFormState.map((inntektskilde: Inntektskilde) => ({
-      fomDato: inntektskilde.fomDato,
-      tomDato: inntektskilde.tomDato,
-      kildetype: inntektskilde.kildetype,
-      bruttoInntekt: inntektskilde.bruttoInntekt,
-      arbAvgBetales: inntektskilde.arbAvgBetales,
-      erMaanedsbelop: inntektskilde.erMaanedsbelop,
-    })),
+    skatteforholdsperioder: skatteforholdsperioderFormState
+      .map((skatteforhold: Skatteforhold) => ({
+        fomDato: skatteforhold.fomDato,
+        tomDato: skatteforhold.tomDato,
+        skatteplikttype: skatteforhold.skatteplikttype,
+      }))
+      .sort(Utils.dato.sorterEtterNorskFomDato),
+    inntektskilder: inntektskilderFormState
+      .map((inntektskilde: Inntektskilde) => ({
+        fomDato: inntektskilde.fomDato,
+        tomDato: inntektskilde.tomDato,
+        kildetype: inntektskilde.kildetype,
+        bruttoInntekt: inntektskilde.bruttoInntekt,
+        arbAvgBetales: inntektskilde.arbAvgBetales,
+        erMaanedsbelop: inntektskilde.erMaanedsbelop,
+      }))
+      .sort(Utils.dato.sorterEtterNorskFomDato),
   });
 
   const handleBeregnTrygdeavgiftsperioder = useCallback(
@@ -188,6 +192,8 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         const currentFormState = mapFormState(getValues("skatteforholdsperioder"), getValues("inntektskilder"));
 
         if (!Utils._isEqual(currentFormState, previousFormValues)) {
+          console.log("[useEffect] currentFormState", currentFormState);
+          console.log("[useEffect] previousFormValues", previousFormValues);
           setDebouncedBeregningPagaar(true);
           debouncedBeregningRef.current();
         } else {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
@@ -17,7 +17,6 @@ const dekkerHeleMedlemskapsperiode = (perioder: any[], medlemskapsperiode: any):
   const medlemskapsperiodeFom = Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.fomDato);
   const medlemskapsperiodeTom = Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.tomDato);
 
-  // Find min fom dato, and max tom dato (dates), from perioder (not sortedPerioder)
   const minFomDato = perioder
     .map((periode) => {
       const date = Utils.dato.isoStringTilDate(Utils.dato.vaskOgFormatterTilISO(periode.fomDato));

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
@@ -6,72 +6,95 @@ import * as Nav from "../../../../../navFrontend";
 export enum TypeFeilmelding {
   SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN = "SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN",
   INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN = "INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN",
+  HAR_OPPHOLDSPERIODER_SKATTEFORHOLD = "HAR_OPPHOLDSPERIODER_SKATTEFORHOLD",
   OVERLAPPENDE_SKATTEFORHOLDSPERIODER = "OVERLAPPENDE_SKATTEFORHOLDSPERIODER",
   LIKE_SKATTEPLIKTTYPER = "LIKE_SKATTEPLIKTTYPER",
 }
 
-// Helper function to sort periods by start date
-const sorterPerioderEtterStartdato = (perioder: any[]) => {
-  return [...perioder].sort((a, b) => {
-    const aFom = Utils.dato.formatterDatoTilISO(a.fomDato)!;
-    const bFom = Utils.dato.formatterDatoTilISO(b.fomDato)!;
-    return aFom.localeCompare(bFom);
-  });
-};
-
 const dekkerHeleMedlemskapsperiode = (perioder: any[], medlemskapsperiode: any): boolean => {
   if (!perioder || perioder.length === 0) return true;
 
-  try {
-    const medlemskapsperiodeFom = Utils.dato.formatterDatoTilISO(medlemskapsperiode.fomDato);
-    const medlemskapsperiodeTom = Utils.dato.formatterDatoTilISO(medlemskapsperiode.tomDato);
+  const medlemskapsperiodeFom = Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.fomDato);
+  const medlemskapsperiodeTom = Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.tomDato);
 
-    // Sort periods by start date
-    const sortedPerioder = sorterPerioderEtterStartdato(perioder);
+  // Find min fom dato, and max tom dato (dates), from perioder (not sortedPerioder)
+  const minFomDato = perioder
+    .map((periode) => {
+      const date = Utils.dato.isoStringTilDate(Utils.dato.vaskOgFormatterTilISO(periode.fomDato));
+      return date ? date.getTime() : Infinity;
+    })
+    .reduce((min, current) => Math.min(min, current), Infinity);
 
-    // Dekning
-    const firstFom = Utils.dato.formatterDatoTilISO(sortedPerioder[0].fomDato);
-    if (!firstFom || firstFom !== medlemskapsperiodeFom) return false;
+  const maxTomDato = perioder
+    .map((periode) => {
+      const date = Utils.dato.isoStringTilDate(Utils.dato.vaskOgFormatterTilISO(periode.tomDato));
+      return date ? date.getTime() : -Infinity;
+    })
+    .reduce((max, current) => Math.max(max, current), -Infinity);
 
-    const lastTom = Utils.dato.formatterDatoTilISO(sortedPerioder[sortedPerioder.length - 1].tomDato);
-    if (!lastTom || lastTom !== medlemskapsperiodeTom) return false;
+  console.log("[dekkerHeleMedlemskapsperiode] min max", {
+    minFomDato,
+    maxTomDato,
+    medlemskapsperiodeFom,
+    medlemskapsperiodeTom,
+  });
 
-    // Opphold
-    for (let i = 0; i < sortedPerioder.length - 1; i++) {
-      const currentTom = Utils.dato.formatterDatoTilISO(sortedPerioder[i].tomDato);
-      const nextFom = Utils.dato.formatterDatoTilISO(sortedPerioder[i + 1].fomDato);
-
-      // Convert to Date objects
-      const currentTomDate = Utils.dato.isoStringTilDate(currentTom);
-      const nextFomDate = Utils.dato.isoStringTilDate(nextFom);
-
-      if (currentTomDate && nextFomDate) {
-        // Add 1 day to the end date
-        const tomDateForComparison = new Date(currentTomDate);
-        tomDateForComparison.setDate(tomDateForComparison.getDate() + 1);
-
-        // Check if the next period starts more than one day after this period ends
-        if (tomDateForComparison.getTime() < nextFomDate.getTime()) return false;
-      }
-    }
-
-    return true;
-  } catch (error) {
-    return true;
+  // Dekning
+  const medlemskapsperiodeFomDate = Utils.dato.isoStringTilDate(medlemskapsperiodeFom);
+  if (!medlemskapsperiodeFomDate || minFomDato === Infinity || minFomDato !== medlemskapsperiodeFomDate.getTime()) {
+    return false;
   }
+
+  const medlemskapsperiodeTomDate = Utils.dato.isoStringTilDate(medlemskapsperiodeTom);
+  if (!medlemskapsperiodeTomDate || maxTomDato === -Infinity || maxTomDato !== medlemskapsperiodeTomDate.getTime()) {
+    return false;
+  }
+
+  return true;
 };
 
-const ingenOverlappendeSkatteforholdsperioder = (perioder: any[]): boolean => {
+const harOppholdsperioder = (perioder: any) => {
+  if (!perioder || perioder.length <= 1) {
+    return false;
+  }
+
+  const sortedPerioder = perioder.sort(Utils.dato.sorterEtterNorskFomDato);
+  console.log("[harOppholdsperioder] sortedPerioder", sortedPerioder);
+
+  // eslint-disable-next-line no-plusplus
+  for (let i = 0; i < sortedPerioder.length - 1; i++) {
+    const currentTom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i].tomDato);
+    const nextFom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i + 1].fomDato);
+
+    // Convert to Date objects
+    const currentTomDate = Utils.dato.isoStringTilDate(currentTom);
+    const nextFomDate = Utils.dato.isoStringTilDate(nextFom);
+
+    if (currentTomDate && nextFomDate) {
+      // Add 1 day to the end date
+      const tomDateForComparison = new Date(currentTomDate);
+      tomDateForComparison.setDate(tomDateForComparison.getDate() + 1);
+
+      // Check if the next period starts more than one day after this period ends
+      if (tomDateForComparison.getTime() < nextFomDate.getTime()) return true;
+    }
+  }
+
+  return false;
+};
+
+const ingenOverlappendePerioder = (perioder: any[]): boolean => {
   if (!perioder || perioder.length <= 1) return true;
 
   try {
     // Sort periods by start date
-    const sortedPerioder = sorterPerioderEtterStartdato(perioder);
+    const sortedPerioder = perioder.sort(Utils.dato.sorterEtterNorskFomDato);
+    console.log("[ingenOverlappendePerioder] sortedPerioder", sortedPerioder);
 
     // Check for overlapping periods
     for (let i = 0; i < sortedPerioder.length - 1; i++) {
-      const currentTom = Utils.dato.formatterDatoTilISO(sortedPerioder[i].tomDato);
-      const nextFom = Utils.dato.formatterDatoTilISO(sortedPerioder[i + 1].fomDato);
+      const currentTom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i].tomDato);
+      const nextFom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i + 1].fomDato);
 
       // Convert to Date objects
       const currentTomDate = Utils.dato.isoStringTilDate(currentTom);
@@ -122,8 +145,12 @@ export function finnAktivFeilmelding({
       return TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
     }
 
-    if (!ingenOverlappendeSkatteforholdsperioder(skatteforholdsperioder)) {
+    if (!ingenOverlappendePerioder(skatteforholdsperioder)) {
       return TypeFeilmelding.OVERLAPPENDE_SKATTEFORHOLDSPERIODER;
+    }
+
+    if (harOppholdsperioder(skatteforholdsperioder)) {
+      return TypeFeilmelding.HAR_OPPHOLDSPERIODER_SKATTEFORHOLD;
     }
 
     if (!ikkeAlleSammeSkatteforholdstyper(skatteforholdsperioder)) {
@@ -167,6 +194,12 @@ export function Feilmelding({ type }: { type?: string }) {
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
           Inntektsperioden(e) du har lagt inn dekker ikke hele medlemskapsperioden(e)
+        </Nav.Alert>
+      );
+    case TypeFeilmelding.HAR_OPPHOLDSPERIODER_SKATTEFORHOLD:
+      return (
+        <Nav.Alert variant="error" className="alertstripe_feilmelding">
+          Skatteforholdsperiodene har oppholdsperioder
         </Nav.Alert>
       );
     default:


### PR DESCRIPTION
Fikser tre bugs i denne PRen

- Spinner som spinte i evig tid når debounce ble kansellert 
- Beregning pågikk bare av å gå inn og ut av inntektsperioder. Formstate ga ikke garanti om sortering, og vi lagret heller ikke med sortering
- "Skatteforholdene dekker ikke hele medlemskapsperioden". Dette er en bug som ble fikset i _UTEN grunnlag_, som jeg har kopiert samme løsning. Problemet som lå der skyldes både sortering, sammen med "vasking av input". Det er nå mer konsekvent. 
- Har nå egen feilemdling på oppholdsperioder på skatteforholdsperioder, og går ikke inn med "dekker ikke medlemskapsperiode"-feilmeldingen.