### PR TITLE
7290 TOGGLE: Enkle UX-forbedringer for årsavregning

### DIFF
--- a/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.less
+++ b/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.less
@@ -12,11 +12,17 @@
     }
 
     .inntektskildetype {
-      min-width: 10rem;
+      select {
+        width: auto;
+      }
     }
 
+    .arbavgbetales {
+      min-width: 8rem;
+    }
+    
     .brutto_inntekt {
-      min-width: 9rem;
+      min-width: 7rem;
 
       input {
         max-height: 2rem;
@@ -25,7 +31,7 @@
 
     &:first-child {
       .hoy_inntekt_advarsel {
-        margin-top: 1.5rem;
+        margin-top: 0.5rem;
       }
     }
 
@@ -39,6 +45,10 @@
       }
 
       min-width: 8rem;
+    }
+
+    .hoy_inntekt_advarsel--hidden {
+      display: none;
     }
 
     .ikkeRelevant {

--- a/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.less
+++ b/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.less
@@ -20,7 +20,7 @@
     .arbavgbetales {
       min-width: 8rem;
     }
-    
+
     .brutto_inntekt {
       min-width: 7rem;
 

--- a/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.tsx
@@ -170,7 +170,7 @@ export function Inntektskilder({
               </Forms.Select>
             </Nav.Column>
 
-            <Nav.Column>
+            <Nav.Column className="arbavgbetales">
               {skalFylleInnArbAvgBetales ? (
                 <Forms.RadioGroup
                   legend={index === 0 ? "Betales aga.?" : ""}
@@ -228,16 +228,29 @@ export function Inntektskilder({
 
             <Nav.Column className="brutto_inntekt">
               {skalFylleInnBruttoInntekt ? (
-                <Forms.Input
-                  label={index === 0 ? "Brutto inntekt" : ""}
-                  hideLabel={index !== 0}
-                  name={`inntektskilder[${index}].bruttoInntekt`}
-                  control={control}
-                  readOnly={!redigerbart}
-                  type="text"
-                  numeric
-                  autoComplete="off"
-                />
+                <div>
+                  <Forms.Input
+                    label={index === 0 ? "Brutto inntekt" : ""}
+                    hideLabel={index !== 0}
+                    name={`inntektskilder[${index}].bruttoInntekt`}
+                    control={control}
+                    readOnly={!redigerbart}
+                    type="text"
+                    numeric
+                    autoComplete="off"
+                  />
+                  <div
+                    className={`column ${
+                      erHoyInntekt(formValues.inntektskilder[index])
+                        ? "hoy_inntekt_advarsel"
+                        : "hoy_inntekt_advarsel--hidden"
+                    }`}
+                  >
+                    <Alert variant="warning" size="small">
+                      Høy inntekt!
+                    </Alert>
+                  </div>
+                </div>
               ) : (
                 <div className="ikkeRelevant">
                   {index === 0 && (
@@ -248,18 +261,6 @@ export function Inntektskilder({
                   <p className={`undertekst ${index === 0 ? "med-overskrift" : "uten-overskrift"}`}>Ikke relevant</p>
                 </div>
               )}
-            </Nav.Column>
-
-            <Nav.Column
-              className={`column ${
-                erHoyInntekt(formValues.inntektskilder[index])
-                  ? "hoy_inntekt_advarsel"
-                  : "hoy_inntekt_advarsel invisible"
-              }`}
-            >
-              <Alert variant="warning" size="small">
-                Høy inntekt!
-              </Alert>
             </Nav.Column>
 
             <Nav.Column className="slett__knapp">

--- a/src/sider/aarsavregning/saksbehandling.less
+++ b/src/sider/aarsavregning/saksbehandling.less
@@ -1,0 +1,3 @@
+.aarsavregning_saksbehandling {
+  width: 100%;
+}

--- a/src/sider/aarsavregning/saksbehandling.tsx
+++ b/src/sider/aarsavregning/saksbehandling.tsx
@@ -26,6 +26,7 @@ import { aarsavregningOperations } from "../../ducks/aarsavregning";
 import { medlemskapsperioderSelectors } from "../../ducks/medlemskapsperioder";
 import { useFeatureToggle } from "../../featuretoggle";
 import { ÅRSAVREGNING, ÅRSAVREGNING_UTEN_FLYT } from "../../featuretoggle/toggleNavn";
+import "./saksbehandling.css";
 
 interface Props extends RouteComponentProps<MatchParams> {
   behandlingOppfriskes: boolean;
@@ -117,33 +118,35 @@ function Saksbehandling({ match, location }: Props) {
     <>
       <Informasjonlinje />
       <div className="main-container">
-        <Nav.Container fluid>
-          <Nav.Row>
-            <Nav.Column xs="7">
-              <main id="main-container">
-                {erÅrsavregningUtenFlytToggleEnabled && (
-                  <Nav.Alert variant="warning" className="ingenFlytMelding">
-                    <b>Du kan ikke gå videre</b>
-                    <p>
-                      Du kan ikke årsavregne i Meloys enda, men du kan sende et fritekstbrev for å hente inn
-                      inntektsopplysninger.
-                    </p>
-                  </Nav.Alert>
-                )}
-                {erÅrsavregningToggleEnabled && <EnkelStegvelger alleSteg={alleSteg} />}
-              </main>
-              <SoknadMenypanelForm startOgVisOppfriskModal={startOgVisOppfriskModal} />
-            </Nav.Column>
-            <Nav.Column xs="5">
-              <Oppsummering
-                medlemskapsperiodeFom={Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom)}
-                medlemskapsperiodeTom={Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom)}
-              />
-              <SaksoversiktLenke />
-              <SideDialog tabs={defaultTabs} />
-            </Nav.Column>
-          </Nav.Row>
-        </Nav.Container>
+        <div className="aarsavregning_saksbehandling">
+          <Nav.Container fluid>
+            <Nav.Row>
+              <Nav.Column xs="7">
+                <main id="main-container">
+                  {erÅrsavregningUtenFlytToggleEnabled && (
+                    <Nav.Alert variant="warning" className="ingenFlytMelding">
+                      <b>Du kan ikke gå videre</b>
+                      <p>
+                        Du kan ikke årsavregne i Meloys enda, men du kan sende et fritekstbrev for å hente inn
+                        inntektsopplysninger.
+                      </p>
+                    </Nav.Alert>
+                  )}
+                  {erÅrsavregningToggleEnabled && <EnkelStegvelger alleSteg={alleSteg} />}
+                </main>
+                <SoknadMenypanelForm startOgVisOppfriskModal={startOgVisOppfriskModal} />
+              </Nav.Column>
+              <Nav.Column xs="5">
+                <Oppsummering
+                  medlemskapsperiodeFom={Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.fom)}
+                  medlemskapsperiodeTom={Utils.dato.formatterDatoTilNorsk(innvilgetMedlemskapsperiode?.tom)}
+                />
+                <SaksoversiktLenke />
+                <SideDialog tabs={defaultTabs} />
+              </Nav.Column>
+            </Nav.Row>
+          </Nav.Container>
+        </div>
       </div>
     </>
   );

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -375,7 +375,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
               <SumArsavregningTabell
                 nyTrygdeavgift={aarsavregningResponse.avregning.nyttTotalbeloep}
                 tidligereTrygdeavgift={aarsavregningResponse.avregning.tidligereFakturertBeloep}
-                harGrunnlagIMelosys={true}
+                harGrunnlagIMelosys
               />
             )}
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -375,6 +375,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
               <SumArsavregningTabell
                 nyTrygdeavgift={aarsavregningResponse.avregning.nyttTotalbeloep}
                 tidligereTrygdeavgift={aarsavregningResponse.avregning.tidligereFakturertBeloep}
+                harGrunnlagIMelosys={true}
               />
             )}
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -771,7 +771,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
       {formIsValid && !beregningPaagar && !debouncedBeregningPagaar && !arrayValideringsfeil && !feilmelding && (
         <SumArsavregningTabell
-          harDeltGrunnlag={harDeltGrunnlag}
+          harGrunnlagIMelosys={harDeltGrunnlag}
           nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
           tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
           tidligereTrygdeavgiftAvgiftssystem={aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -771,6 +771,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
       {formIsValid && !beregningPaagar && !debouncedBeregningPagaar && !arrayValideringsfeil && !feilmelding && (
         <SumArsavregningTabell
+          harDeltGrunnlag={harDeltGrunnlag}
           nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
           tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
           tidligereTrygdeavgiftAvgiftssystem={aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.less
@@ -41,7 +41,7 @@
     }
 
     .trygdedekning {
-      width: 7.5rem;
+      width: auto;
       margin-right: 0.75rem;
     }
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
@@ -7,12 +7,12 @@ export function SumArsavregningTabell({
   nyTrygdeavgift,
   tidligereTrygdeavgift,
   tidligereTrygdeavgiftAvgiftssystem,
-  harDeltGrunnlag,
+  harGrunnlagIMelosys,
 }: {
   nyTrygdeavgift?: number;
   tidligereTrygdeavgift?: number;
   tidligereTrygdeavgiftAvgiftssystem?: number;
-  harDeltGrunnlag: boolean | undefined;
+  harGrunnlagIMelosys: boolean;
 }) {
   const sumTilFakturaEllerRefusjon =
     (nyTrygdeavgift ?? 0) - (tidligereTrygdeavgift ?? 0) - (tidligereTrygdeavgiftAvgiftssystem ?? 0);
@@ -30,7 +30,7 @@ export function SumArsavregningTabell({
               {formaterTilNorskBelop(nyTrygdeavgift || 0)} kr
             </Nav.Table.DataCell>
           </Nav.Table.Row>
-          {harDeltGrunnlag && (
+          {harGrunnlagIMelosys && (
             <Nav.Table.Row>
               <Nav.Table.DataCell scope="col">-</Nav.Table.DataCell>
               <Nav.Table.DataCell scope="col">Tidligere beregnet trygdeavgift fra Melosys</Nav.Table.DataCell>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
@@ -35,7 +35,7 @@ export function SumArsavregningTabell({
               <Nav.Table.DataCell scope="col">-</Nav.Table.DataCell>
               <Nav.Table.DataCell scope="col">Tidligere beregnet trygdeavgift fra Melosys</Nav.Table.DataCell>
               <Nav.Table.DataCell align="right" key={Utils._uuid()}>
-              {formaterTilNorskBelop(tidligereTrygdeavgift || 0)} kr
+                {formaterTilNorskBelop(tidligereTrygdeavgift || 0)} kr
               </Nav.Table.DataCell>
             </Nav.Table.Row>
           )}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
@@ -7,10 +7,12 @@ export function SumArsavregningTabell({
   nyTrygdeavgift,
   tidligereTrygdeavgift,
   tidligereTrygdeavgiftAvgiftssystem,
+  harDeltGrunnlag,
 }: {
   nyTrygdeavgift?: number;
   tidligereTrygdeavgift?: number;
   tidligereTrygdeavgiftAvgiftssystem?: number;
+  harDeltGrunnlag: boolean | undefined;
 }) {
   const sumTilFakturaEllerRefusjon =
     (nyTrygdeavgift ?? 0) - (tidligereTrygdeavgift ?? 0) - (tidligereTrygdeavgiftAvgiftssystem ?? 0);
@@ -28,13 +30,15 @@ export function SumArsavregningTabell({
               {formaterTilNorskBelop(nyTrygdeavgift || 0)} kr
             </Nav.Table.DataCell>
           </Nav.Table.Row>
-          <Nav.Table.Row>
-            <Nav.Table.DataCell scope="col">-</Nav.Table.DataCell>
-            <Nav.Table.DataCell scope="col">Tidligere beregnet trygdeavgift fra Melosys</Nav.Table.DataCell>
-            <Nav.Table.DataCell align="right" key={Utils._uuid()}>
+          {harDeltGrunnlag && (
+            <Nav.Table.Row>
+              <Nav.Table.DataCell scope="col">-</Nav.Table.DataCell>
+              <Nav.Table.DataCell scope="col">Tidligere beregnet trygdeavgift fra Melosys</Nav.Table.DataCell>
+              <Nav.Table.DataCell align="right" key={Utils._uuid()}>
               {formaterTilNorskBelop(tidligereTrygdeavgift || 0)} kr
-            </Nav.Table.DataCell>
-          </Nav.Table.Row>
+              </Nav.Table.DataCell>
+            </Nav.Table.Row>
+          )}
           {tidligereTrygdeavgiftAvgiftssystem !== undefined && (
             <Nav.Table.Row>
               <Nav.Table.DataCell scope="col">-</Nav.Table.DataCell>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -214,7 +214,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         nyTrygdeavgift={nyTrygdeavgift}
         tidligereTrygdeavgift={tidligereTrygdeavgift}
         tidligereTrygdeavgiftAvgiftssystem={tidligereTrygdeavgiftAvgiftssystem}
-        harGrunnlagIMelosys={tidligereTrygdeavgift !== undefined || lagretAarsavregning?.harDeltGrunnlag === true}
+        harGrunnlagIMelosys={tidligereTrygdeavgift !== null || lagretAarsavregning?.harDeltGrunnlag === true}
       />
 
       {fakturaMottaker ? (

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -214,6 +214,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         nyTrygdeavgift={nyTrygdeavgift}
         tidligereTrygdeavgift={tidligereTrygdeavgift}
         tidligereTrygdeavgiftAvgiftssystem={tidligereTrygdeavgiftAvgiftssystem}
+        harGrunnlagIMelosys={tidligereTrygdeavgift !== undefined || lagretAarsavregning?.harDeltGrunnlag === true}
       />
 
       {fakturaMottaker ? (


### PR DESCRIPTION
Gjør enkle UX-forbedringer:
 * I delt grunnlag: Trygdedekning har ikke full bredde, og gjør at man ikke kan se hele teksten.
 * Flyten er midstilt på årsavregningen. Dette er ikke ønskelig, og vi ønsker å benyte full bredde slik vi gjør i andre flyter.
 * "Tidligere beregnet trygdeavgift fra Melosys" under oppsummering av beregningen er synlig i både delt og uten grunnlag. Det skal kun være synlig for delt grunnlag

Forbedringer på inntektsperioder:  *(OBS: Disse punktene vil påvirke både FTRL og årsavregning. Test dermed at begge flytene ser OK ut etter endringene)*
 * Inntektskilde under inntektsperioder har ikke full bredde
 * Det er benyttet egen kolonne for "For høyt inntekt!"-melding for perioder. Kolonnen tar unødvendig mye plass, selv om meldingen ikke er der. La meldingen ligge rett under beløp-feltet. 
 * Under kolonnen _Betales aga.? -_ Dersom man har "Ikke relevant" _og_ Ja/Nei samtidig, har de forskjellige bredder, og ødelegger symmetrien i tabellen. Legg på minimum-bredde på den kolonnen.

https://jira.adeo.no/browse/MELOSYS-7290