### PR TITLE
7042 TOGGLE DAPI 25 prosent regel årsavregning med grunnlag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 /yarn.lock
 /env-config.js
 CLAUDE.md
+/ai_docs

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-debug.log*
 yarn-error.log*
 /yarn.lock
 /env-config.js
+CLAUDE.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@navikt/ds-css": "^7.5.3",
         "@navikt/ds-react": "^7.5.3",
         "@navikt/fnrvalidator": "^1.1.4",
-        "@navikt/melosys-kodeverk": "5.15.301",
+        "@navikt/melosys-kodeverk": "5.15.302",
         "@sentry/integrations": "^7.30.0",
         "@sentry/react": "^7.30.0",
         "@sentry/tracing": "^7.30.0",
@@ -2523,9 +2523,9 @@
       "integrity": "sha512-IJs4Xe/AIef/6+PZ/eCCIPTnXJ7Goijvv7bimHC7vHo4NjnMxhcbKhCvukSAS+XDDtPWc+x/X2G44RckAU1g1A=="
     },
     "node_modules/@navikt/melosys-kodeverk": {
-      "version": "5.15.301",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.301/b3ebbc40649713c1e00a7c3aafd7a7717b316e38",
-      "integrity": "sha512-fklsgK3txiYgtwcd9CIs56thy1/PYcVSsWTHo30q23woBKAxM+TvGFt9Iy3B/GungfS6hwGTWQfru6jI5SEC8A==",
+      "version": "5.15.302",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.302/16fd707450304fe50f00b166d5c4c382c20b9aeb",
+      "integrity": "sha512-148Hvl6PPvpNCHHo2ueh5aQSnysEEhgVbJPpTQytyoq3uGmYKRn4P7Nell7xj27Z8elH/iIrLXs5JZ2vvWzT9A==",
       "license": "ISC",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@navikt/ds-css": "^7.5.3",
     "@navikt/ds-react": "^7.5.3",
     "@navikt/fnrvalidator": "^1.1.4",
-    "@navikt/melosys-kodeverk": "5.15.301",
+    "@navikt/melosys-kodeverk": "5.15.302",
     "@sentry/integrations": "^7.30.0",
     "@sentry/react": "^7.30.0",
     "@sentry/tracing": "^7.30.0",

--- a/src/felleskomponenter/htmlEditor/htmlEditor.less
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.less
@@ -108,10 +108,10 @@
   }
 
   .feilmelding {
-    font-style: italic;
     color: @redError;
     font-family: Arial, sans-serif;
-    font-size: 1rem;
+    font-size: 0.875rem;
+    font-weight: 600;
     line-height: 1.375rem;
   }
 

--- a/src/felleskomponenter/htmlEditor/htmlEditor.tsx
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.tsx
@@ -228,6 +228,7 @@ function HtmlEditor({ value, onChange, disabled, label, feil, className, placeho
     };
   }, []);
 
+
   return (
     <div className={classNames("htmlEditor", className)}>
       {label && <div className="editor_label">{label}</div>}

--- a/src/felleskomponenter/htmlEditor/htmlEditor.tsx
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.tsx
@@ -228,7 +228,6 @@ function HtmlEditor({ value, onChange, disabled, label, feil, className, placeho
     };
   }, []);
 
-
   return (
     <div className={classNames("htmlEditor", className)}>
       {label && <div className="editor_label">{label}</div>}

--- a/src/felleskomponenter/trygdeavgift/komponenter/types.ts
+++ b/src/felleskomponenter/trygdeavgift/komponenter/types.ts
@@ -17,7 +17,7 @@ export interface Skatteforhold {
 }
 
 export interface FieldArrayProps {
-  medlemskapsperioder: Medlemskapsperiode[];
+  medlemskapsperioder?: Medlemskapsperiode[];
   inntektskilder: Inntektskilde[];
   skatteforholdsperioder: Skatteforhold[];
 }

--- a/src/felleskomponenter/ui/stegKnapp/stegKnapper.tsx
+++ b/src/felleskomponenter/ui/stegKnapp/stegKnapper.tsx
@@ -11,6 +11,7 @@ interface ButtonProps {
   loading?: boolean;
   disabled?: boolean;
   className?: string;
+  type?: "button" | "submit" | "reset";
 }
 
 interface StegKnapperProps {
@@ -32,7 +33,7 @@ function StegKnapper({
 
   return (
     <div className={cls}>
-      <Nav.Button variant="primary" {...bekreftKnappProps} className={bekreftKnappCls}>
+      <Nav.Button variant="primary" {...bekreftKnappProps} className={bekreftKnappCls} type={bekreftKnappProps.type}>
         {bekreftTekst}
       </Nav.Button>
       {tilbakeKnappProps && (

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -85,13 +85,6 @@ export const oppdaterHarDeltGrunnlag = (
 ): Promise<AarsavregningResponse> =>
   postAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/grunnlagstype`, request);
 
-export const oppdaterAvvik = (
-  behandlingID: number,
-  harAvvik: boolean,
-  aarsavregningID?: number,
-): Promise<AarsavregningResponse> =>
-  putAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/${aarsavregningID}/harAvvik/${harAvvik}`);
-
 export const oppdaterBehandlingsvalg = (
   behandlingID: number,
   behandlingsvalg: string,

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -12,7 +12,6 @@ export interface AarsavregningResponse {
   avregning?: Avregning;
   harDeltGrunnlag?: boolean;
   behandlingsvalg?: string;
-  manueltAvgiftBeloep?: string;
 }
 // TODO: Fix typing for behandlingsvalg
 

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -11,7 +11,10 @@ export interface AarsavregningResponse {
   nyttGrunnlag?: Grunnlagsopplysninger;
   avregning?: Avregning;
   harDeltGrunnlag?: boolean;
+  behandlingsvalg?: string;
+  avgift25Prosent?: string;
 }
+// TODO: Fix typing for behandlingsvalg
 
 export interface AarsavregningRequest {
   avregning: Avregning;
@@ -53,6 +56,7 @@ export interface Avregning {
   tidligereFakturertBeloep?: number;
   tilFaktureringBeloep?: number;
   tidligereFakturertBeloepAvgiftssystem?: number;
+  avgift25Prosent?: number;
 }
 
 export interface AarsavregningListResponse {
@@ -88,6 +92,15 @@ export const oppdaterAvvik = (
 ): Promise<AarsavregningResponse> =>
   putAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/${aarsavregningID}/harAvvik/${harAvvik}`);
 
+export const oppdaterBehandlingsvalg = (
+  behandlingID: number,
+  behandlingsvalg: string,
+  aarsavregningID?: number,
+): Promise<AarsavregningResponse> =>
+  putAsJson(
+    `${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/${aarsavregningID}/behandlingsvalg/${behandlingsvalg}`,
+  );
+
 export const hentFiltrertAarsavregningList = (
   saksnummer: string,
   resultattype?: string,
@@ -111,6 +124,21 @@ export const oppdaterTotalAvgift = async (behandlingID: number, aarsavregningID:
     {
       avregning: {
         nyttTotalbeloep: totalAvgift,
+      },
+    },
+    aarsavregningID,
+  );
+};
+export const oppdaterAvgift25Prosent = async (
+  behandlingID: number,
+  aarsavregningID: number,
+  avgift25Prosent?: number,
+) => {
+  return oppdaterAarsavregning(
+    behandlingID,
+    {
+      avregning: {
+        avgift25Prosent,
       },
     },
     aarsavregningID,

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -12,7 +12,7 @@ export interface AarsavregningResponse {
   avregning?: Avregning;
   harDeltGrunnlag?: boolean;
   behandlingsvalg?: string;
-  avgift25Prosent?: string;
+  manueltAvgiftBeloep?: string;
 }
 // TODO: Fix typing for behandlingsvalg
 
@@ -56,7 +56,7 @@ export interface Avregning {
   tidligereFakturertBeloep?: number;
   tilFaktureringBeloep?: number;
   tidligereFakturertBeloepAvgiftssystem?: number;
-  avgift25Prosent?: number;
+  manueltAvgiftBeloep?: number;
 }
 
 export interface AarsavregningListResponse {
@@ -122,16 +122,16 @@ export const oppdaterTotalAvgift = async (behandlingID: number, aarsavregningID:
     aarsavregningID,
   );
 };
-export const oppdaterAvgift25Prosent = async (
+export const oppdaterManueltAvgiftBeloep = async (
   behandlingID: number,
   aarsavregningID: number,
-  avgift25Prosent?: number,
+  manueltAvgiftBeloep?: number,
 ) => {
   return oppdaterAarsavregning(
     behandlingID,
     {
       avregning: {
-        avgift25Prosent,
+        manueltAvgiftBeloep,
       },
     },
     aarsavregningID,

--- a/src/services/modules/behandlinger/resultat.ts
+++ b/src/services/modules/behandlinger/resultat.ts
@@ -18,7 +18,7 @@ export interface OppdaterUtfallRegistreringUnntak {
 export const hentResultat = (behandlingID: string) =>
   getAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/resultat`);
 
-export const oppdaterFritekster = (behandlingID: string, data: OppdaterFritekster) =>
+export const oppdaterFritekster = (behandlingID: string | number, data: OppdaterFritekster) =>
   postAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/resultat/fritekst`, data);
 
 export const oppdaterNyVurderingBakgrunn = (behandlingID: string, nyVurderingBakgrunn?: string) =>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -121,7 +121,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
           const defaultFormValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
             res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
             res.behandlingsvalg,
-            res?.avregning?.avgift25Prosent,<
+            res?.avregning?.avgift25Prosent,
           );
 
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -44,7 +44,7 @@ const mapMedlemskapsperiodeBestemmelse = (harDeltGrunnlag: boolean, medlemskapsp
 
 export interface AarsavregningMedGrunnlagFormValues extends FormValuesProps {
   behandlingsvalg?: string;
-  avgift25Prosent?: string;
+  manueltAvgiftBeloep?: number;
 }
 
 export interface InitiellData {
@@ -68,7 +68,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
       behandlingsvalg: undefined,
-      avgift25Prosent: undefined,
+      manueltAvgiftBeloep: undefined,
     },
     medlemskapstypeErPliktig: false,
   });
@@ -80,14 +80,14 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (
     trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag,
     behandlingsvalg?: string,
-    avgift25Prosent?: string,
+    manueltAvgiftBeloep?: number,
   ) => {
     if (!trygdeavgiftsgrunnlag)
       return {
         skatteforholdsperioder: [{}],
         inntektskilder: [{}],
         behandlingsvalg: undefined,
-        avgift25Prosent: undefined,
+        manueltAvgiftBeloep: undefined,
       };
     const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
     const sorterteInntekstkilder = [...inntektskperioder].sort(Utils.dato.sorterEtterISOFomDato);
@@ -95,7 +95,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
     return {
       behandlingsvalg,
-      avgift25Prosent,
+      manueltAvgiftBeloep,
       skatteforholdsperioder: !Utils._isEmpty(sorterteSkatteforhold)
         ? mapTilSkatteforholdProps(sorterteSkatteforhold)
         : [{}],
@@ -118,11 +118,12 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
           // Benyttes for innhenting av saksopplysninger ifm. årsavregningsbehandlinger
           dispatch({ type: OK, data: res });
 
-          const defaultFormValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
-            res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
-            res.behandlingsvalg,
-            res?.avregning?.avgift25Prosent,
-          );
+          const defaultFormValues: FieldValue<AarsavregningMedGrunnlagFormValues> =
+            mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
+              res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
+              res.behandlingsvalg,
+              res?.avregning?.manueltAvgiftBeloep,
+            );
 
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
           const innvilgetMedlemskapsperiode = mapInnvilgetMedlemskapsPeriode(medlemskapsperioder);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -43,7 +43,8 @@ const mapMedlemskapsperiodeBestemmelse = (harDeltGrunnlag: boolean, medlemskapsp
 };
 
 export interface AarsavregningMedGrunnlagFormValues extends FormValuesProps {
-  erAvvik?: boolean;
+  behandlingsvalg?: string;
+  avgift25Prosent?: string;
 }
 
 export interface InitiellData {
@@ -64,9 +65,10 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const [initiellData, setInitiellData] = useState<InitiellData>({
     formDefaultValues: {
-      erAvvik: undefined,
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
+      behandlingsvalg: undefined,
+      avgift25Prosent: undefined,
     },
     medlemskapstypeErPliktig: false,
   });
@@ -77,15 +79,23 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
   const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (
     trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag,
-    harAvvik?: boolean,
+    behandlingsvalg?: string,
+    avgift25Prosent?: string,
   ) => {
-    if (!trygdeavgiftsgrunnlag) return { erAvvik: undefined, skatteforholdsperioder: [{}], inntektskilder: [{}] };
+    if (!trygdeavgiftsgrunnlag)
+      return {
+        skatteforholdsperioder: [{}],
+        inntektskilder: [{}],
+        behandlingsvalg: undefined,
+        avgift25Prosent: undefined,
+      };
     const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
     const sorterteInntekstkilder = [...inntektskperioder].sort(Utils.dato.sorterEtterISOFomDato);
     const sorterteSkatteforhold = [...skatteforholdsperioder].sort(Utils.dato.sorterEtterISOFomDato);
 
     return {
-      erAvvik: harAvvik,
+      behandlingsvalg,
+      avgift25Prosent,
       skatteforholdsperioder: !Utils._isEmpty(sorterteSkatteforhold)
         ? mapTilSkatteforholdProps(sorterteSkatteforhold)
         : [{}],
@@ -110,7 +120,8 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
           const defaultFormValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
             res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
-            res.harAvvik,
+            res.behandlingsvalg,
+            res?.avregning?.avgift25Prosent,<
           );
 
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -47,7 +47,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   );
   const [beregningPaagar, setBeregningPaagar] = useState(false);
   const [previousFormValues, setPreviousFormValues] = useState<any | null>(null);
-  const [endrerAvvik, setEndrerAvvik] = useState(false);
+  const [endrerBehandlingsvalg, setEndrerBehandlingsvalg] = useState(false);
   const [debouncedBeregningPagaar, setDebouncedBeregningPagaar] = useState(false);
   const [arrayValideringsfeil, setArrayValideringsfeil] = useState<string | undefined>(undefined);
 
@@ -131,7 +131,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const debouncedBeregning = useCallback(() => {
     console.log("[debouncedBeregning] debouncedBeregningPagaar set false", debouncedBeregningPagaar);
     setDebouncedBeregningPagaar(false);
-    if (!redigerbart || !aarsavregningID || behandlingsvalg !== OPPLYSNINGER_ENDRET || beregningPaagar || endrerAvvik) {
+    if (!redigerbart || !aarsavregningID || behandlingsvalg !== OPPLYSNINGER_ENDRET || beregningPaagar || endrerBehandlingsvalg) {
       return;
     }
 
@@ -164,7 +164,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     aarsavregningID,
     behandlingsvalg,
     beregningPaagar,
-    endrerAvvik,
+    endrerBehandlingsvalg,
     getValues,
     formIsValid,
     isValidating,
@@ -194,8 +194,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       debouncedBeregningRef.current.cancel();
     }
     if (debouncedBeregningRef.current) {
-      console.log(behandlingsvalg === OPPLYSNINGER_ENDRET);
-      if (redigerbart && aarsavregningID && behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerAvvik) {
+      if (redigerbart && aarsavregningID && behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerBehandlingsvalg) {
         const currentFormState = mapFormState(getValues("skatteforholdsperioder"), getValues("inntektskilder"));
 
         if (!Utils._isEqual(currentFormState, previousFormValues)) {
@@ -209,7 +208,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         }
       }
     }
-  }, [skatteforholdsperioder, behandlingsvalg, inntektskilder, formIsValid, isValidating, endrerAvvik]);
+  }, [skatteforholdsperioder, behandlingsvalg, inntektskilder, formIsValid, isValidating, endrerBehandlingsvalg]);
 
   const stegErGyldig = useMemo(
     () =>
@@ -251,7 +250,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
 
   const håndterAvvik = useCallback(
     (value: string) => {
-      setEndrerAvvik(true);
+      setEndrerBehandlingsvalg(true);
 
       Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
         .then((res) => {
@@ -273,7 +272,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           }
         })
         .finally(() => {
-          setEndrerAvvik(false);
+          setEndrerBehandlingsvalg(false);
         });
     },
     [
@@ -282,7 +281,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       setBeregningPaagar,
       setAarsavregningResponse,
       setPreviousFormValues,
-      setEndrerAvvik,
+      setEndrerBehandlingsvalg,
       Api.Aarsavregning,
     ],
   );
@@ -291,14 +290,14 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     // noinspection JSIgnoredPromiseFromCall
     trigger();
 
-    if (stegErGyldig && !beregningPaagar && !endrerAvvik && !debouncedBeregningPagaar) {
+    if (stegErGyldig && !beregningPaagar && !endrerBehandlingsvalg && !debouncedBeregningPagaar) {
       bekreft();
     }
-  }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerAvvik, debouncedBeregningPagaar]);
+  }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerBehandlingsvalg, debouncedBeregningPagaar]);
 
   const debouncedOppdaterAvgift25Prosent = useCallback(
     Utils._debounce(
-      async (value: string) => Api.Aarsavregning.oppdaterAvgift25Prosent(behandlingID, aarsavregningID, value),
+      async (value: string) => Api.Aarsavregning.oppdaterAvgift25Prosent(behandlingID, aarsavregningID, Number(value)),
       350,
     ),
     [aarsavregningID],
@@ -346,15 +345,11 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           håndterAvvik(value);
         }}
       >
-        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
-          {KV.kodeTilTerm(OPPLYSNINGER_ENDRET, MKV.KTObjects.aarsavregningBehandlingsvalg)}
-        </Nav.Radio>
-        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
-          {KV.kodeTilTerm(OPPLYSNINGER_UENDRET, MKV.KTObjects.aarsavregningBehandlingsvalg)}
-        </Nav.Radio>
-        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
-          {KV.kodeTilTerm(MANUELL_ENDELIG_AVGIFT, MKV.KTObjects.aarsavregningBehandlingsvalg)}
-        </Nav.Radio>
+        {[OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT].map((kode) => (
+          <Nav.Radio value={kode} key={kode}>
+            {KV.kodeTilTerm(kode, MKV.KTObjects.aarsavregningBehandlingsvalg)}
+          </Nav.Radio>
+        ))}
       </Forms.RadioGroup>
 
       {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
@@ -363,8 +358,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           name="avgift25Prosent"
           control={control}
           readOnly={!redigerbart}
-          // TODO: Rename
-          className="tidligere_fakturert_input"
+          className="avgift_input"
           autoComplete="off"
           type="text"
           numeric
@@ -373,7 +367,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         />
       )}
 
-      {behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerAvvik && (
+      {behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerBehandlingsvalg && (
         <>
           <Nav.Heading className="endelige_opplysninger_heading" level="2">
             Inntekts- og skatteopplysninger for endelig trygdeavgift

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -407,7 +407,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           {formIsValid &&
             !debouncedBeregningPagaar &&
             !beregningPaagar &&
-            behandlingsvalg !== MANUELL_ENDELIG_AVGIFT &&
             !feilmelding &&
             !arrayValideringsfeil &&
             aarsavregningResponse?.nyttGrunnlag && (

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -1,7 +1,7 @@
 import * as Api from "../../../../../services/api";
 import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import "../vurderingAarsavregningInngang.css";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { useSelector } from "react-redux";
 import * as Nav from "../../../../../navFrontend";
@@ -64,6 +64,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     formState: { isValid: formIsValid, isValidating },
     trigger,
     getValues,
+    setValue,
   } = useForm({
     resolver: yupResolver(aarsavregningMedGrunnlagSchema),
     context: {
@@ -91,6 +92,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const skatteforholdsperioder = watch("skatteforholdsperioder");
   const inntektskilder = watch("inntektskilder");
   const behandlingsvalg = watch("behandlingsvalg");
+  const manueltAvgiftBeloep = watch("manueltAvgiftBeloep");
   const debouncedBeregningRef = useRef<any>(null);
 
   const mapFormState = (
@@ -266,6 +268,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
         .then((res) => {
           setAarsavregningResponse(res);
+          setValue("manueltAvgiftBeloep", undefined, { shouldValidate: false, shouldDirty: false });
           if (value === OPPLYSNINGER_UENDRET || value === MANUELL_ENDELIG_AVGIFT) {
             // TODO: Skal beregning kjøres for MANUELL_ENDELIG_AVGIFT?
             setBeregningPaagar(true);
@@ -309,7 +312,9 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const debouncedOppdaterManueltAvgiftBeloep = useCallback(
     Utils._debounce(
       async (value: string) =>
-        Api.Aarsavregning.oppdaterManueltAvgiftBeloep(behandlingID, aarsavregningID, Number(value)),
+        Api.Aarsavregning.oppdaterManueltAvgiftBeloep(behandlingID, aarsavregningID, Number(value)).then((res) => {
+          setAarsavregningResponse(res);
+        }),
       350,
     ),
     [aarsavregningID],
@@ -321,6 +326,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
   const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
 
+  const manueltAvgiftBeloepId = useId();
   return (
     <>
       {aarsavregningResponse && aarsavregningResponse.tidligereGrunnlagsopplysninger && (
@@ -356,12 +362,17 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         onChange={(value) => {
           handleBehandlingsvalgChange(value);
         }}
+        className="behandlingsvalg_radio_group"
       >
-        {[OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT].map((kode) => (
-          <Nav.Radio value={kode} key={kode}>
-            {KV.kodeTilTerm(kode, MKV.KTObjects.aarsavregningBehandlingsvalg)}
-          </Nav.Radio>
-        ))}
+        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
+          <b>Jeg skal gjøre endringer.</b> Inntekts- og/eller skatteopplysningene er endret siden tidligere beregning
+        </Nav.Radio>
+        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
+          <b>Det er ingen endringer.</b> Inntekts- og skatteopplysningene er like som ved tidligere beregning
+        </Nav.Radio>
+        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
+          <b>Jeg skal oppgi endelig avgift selv.</b> Endelig trygdeavgift er manuelt beregnet utenfor Melosys
+        </Nav.Radio>
       </Forms.RadioGroup>
 
       {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
@@ -376,6 +387,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           numeric
           tillattNegativeTall
           onChange={debouncedOppdaterManueltAvgiftBeloep}
+          key={manueltAvgiftBeloepId}
         />
       )}
 
@@ -440,6 +452,14 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
 
           {arrayValideringsfeil && <Feilmelding type={arrayValideringsfeil} />}
         </>
+      )}
+
+      {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && manueltAvgiftBeloep && (
+        <SumArsavregningTabell
+          nyTrygdeavgift={Number(manueltAvgiftBeloep)}
+          tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
+          harGrunnlagIMelosys
+        />
       )}
 
       {feilmelding && !beregningPaagar && (

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -1,7 +1,7 @@
 import * as Api from "../../../../../services/api";
 import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import "../vurderingAarsavregningInngang.css";
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { useSelector } from "react-redux";
 import * as Nav from "../../../../../navFrontend";
@@ -26,11 +26,10 @@ import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversik
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 import { InitiellData } from "./aarsavregningMedGrunnlag";
-import * as Forms from "../../../../../felleskomponenter/forms";
 import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
 import { Feilmelding, finnAktivFeilmelding } from "./valideringsfeil";
 import MKV from "../../../../../melosyskodeverk";
-import * as KV from "../../../../../kodeverk";
+import { BehandlingsvalgRadioGroup } from "../komponenter/behandlingsvalgRadioGroup";
 
 const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
@@ -325,8 +324,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const forskuddsvisFakturertTrygdeavgift =
     (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
   const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
-
-  const manueltAvgiftBeloepId = useId();
   return (
     <>
       {aarsavregningResponse && aarsavregningResponse.tidligereGrunnlagsopplysninger && (
@@ -354,42 +351,13 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </>
       )}
 
-      <Forms.RadioGroup
-        name="behandlingsvalg"
+      <BehandlingsvalgRadioGroup
         control={control}
-        legend="Hva ønsker du å gjøre?"
-        readOnly={!redigerbart}
-        onChange={(value) => {
-          handleBehandlingsvalgChange(value);
-        }}
-        className="behandlingsvalg_radio_group"
-      >
-        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
-          <b>Jeg skal gjøre endringer.</b> Inntekts- og/eller skatteopplysningene er endret siden tidligere beregning
-        </Nav.Radio>
-        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
-          <b>Det er ingen endringer.</b> Inntekts- og skatteopplysningene er like som ved tidligere beregning
-        </Nav.Radio>
-        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
-          <b>Jeg skal oppgi endelig avgift selv.</b> Endelig trygdeavgift er manuelt beregnet utenfor Melosys
-        </Nav.Radio>
-      </Forms.RadioGroup>
-
-      {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
-        <Forms.Input
-          label="Endelig beregnet trygdeavgift"
-          name="manueltAvgiftBeloep"
-          control={control}
-          readOnly={!redigerbart}
-          className="avgift_input"
-          autoComplete="off"
-          type="text"
-          numeric
-          tillattNegativeTall
-          onChange={debouncedOppdaterManueltAvgiftBeloep}
-          key={manueltAvgiftBeloepId}
-        />
-      )}
+        redigerbart={redigerbart}
+        behandlingsvalg={behandlingsvalg}
+        handleBehandlingsvalgChange={handleBehandlingsvalgChange}
+        debouncedOppdaterManueltAvgiftBeloep={debouncedOppdaterManueltAvgiftBeloep}
+      />
 
       {behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerBehandlingsvalg && (
         <>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -29,6 +29,10 @@ import { InitiellData } from "./aarsavregningMedGrunnlag";
 import * as Forms from "../../../../../felleskomponenter/forms";
 import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
 import { Feilmelding, finnAktivFeilmelding } from "./valideringsfeil";
+import MKV from "../../../../../melosyskodeverk";
+import * as KV from "../../../../../kodeverk";
+
+const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
 interface Props {
   initiellData: InitiellData;
@@ -86,7 +90,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const formValues = watch();
   const skatteforholdsperioder = watch("skatteforholdsperioder");
   const inntektskilder = watch("inntektskilder");
-  const erAvvik = watch("erAvvik");
+  const behandlingsvalg = watch("behandlingsvalg");
   const debouncedBeregningRef = useRef<any>(null);
 
   const mapFormState = (
@@ -127,7 +131,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const debouncedBeregning = useCallback(() => {
     console.log("[debouncedBeregning] debouncedBeregningPagaar set false", debouncedBeregningPagaar);
     setDebouncedBeregningPagaar(false);
-    if (!redigerbart || !aarsavregningID || erAvvik !== true || beregningPaagar || endrerAvvik) {
+    if (!redigerbart || !aarsavregningID || behandlingsvalg !== OPPLYSNINGER_ENDRET || beregningPaagar || endrerAvvik) {
       return;
     }
 
@@ -158,7 +162,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     }
   }, [
     aarsavregningID,
-    erAvvik,
+    behandlingsvalg,
     beregningPaagar,
     endrerAvvik,
     getValues,
@@ -190,7 +194,8 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       debouncedBeregningRef.current.cancel();
     }
     if (debouncedBeregningRef.current) {
-      if (redigerbart && aarsavregningID && erAvvik === true && !endrerAvvik) {
+      console.log(behandlingsvalg === OPPLYSNINGER_ENDRET);
+      if (redigerbart && aarsavregningID && behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerAvvik) {
         const currentFormState = mapFormState(getValues("skatteforholdsperioder"), getValues("inntektskilder"));
 
         if (!Utils._isEqual(currentFormState, previousFormValues)) {
@@ -204,15 +209,19 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         }
       }
     }
-  }, [skatteforholdsperioder, erAvvik, inntektskilder, formIsValid, isValidating, endrerAvvik]);
+  }, [skatteforholdsperioder, behandlingsvalg, inntektskilder, formIsValid, isValidating, endrerAvvik]);
 
   const stegErGyldig = useMemo(
     () =>
-      erAvvik === false ||
+      behandlingsvalg === OPPLYSNINGER_UENDRET ||
       Boolean(
-        formIsValid && erAvvik === true && aarsavregningResponse?.nyttGrunnlag && !feilmelding && !arrayValideringsfeil,
+        formIsValid &&
+          behandlingsvalg === OPPLYSNINGER_ENDRET &&
+          aarsavregningResponse?.nyttGrunnlag &&
+          !feilmelding &&
+          !arrayValideringsfeil,
       ),
-    [erAvvik, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding, arrayValideringsfeil],
+    [behandlingsvalg, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding, arrayValideringsfeil],
   );
 
   useEffect(() => {
@@ -241,13 +250,14 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   ]);
 
   const håndterAvvik = useCallback(
-    (value: boolean) => {
+    (value: string) => {
       setEndrerAvvik(true);
 
-      Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID)
+      Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
         .then((res) => {
           setAarsavregningResponse(res);
-          if (!value) {
+          if (value === OPPLYSNINGER_UENDRET || value === MANUELL_ENDELIG_AVGIFT) {
+            // TODO: Skal beregning kjøres for MANUELL_ENDELIG_AVGIFT?
             setBeregningPaagar(true);
             const skatteforholdFraGrunnlag =
               res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder;
@@ -286,6 +296,14 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     }
   }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerAvvik, debouncedBeregningPagaar]);
 
+  const debouncedOppdaterAvgift25Prosent = useCallback(
+    Utils._debounce(
+      async (value: string) => Api.Aarsavregning.oppdaterAvgift25Prosent(behandlingID, aarsavregningID, value),
+      350,
+    ),
+    [aarsavregningID],
+  );
+
   const trygdeAvgiftSkalIkkeBetalesTilNav =
     medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder);
   const forskuddsvisFakturertTrygdeavgift =
@@ -320,21 +338,42 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       )}
 
       <Forms.RadioGroup
-        name="erAvvik"
+        name="behandlingsvalg"
         control={control}
-        legend="Er det avvik i opplysningene fra skatt eller bruker?"
+        legend="Hva ønsker du å gjøre?"
         readOnly={!redigerbart}
         onChange={(value) => {
           håndterAvvik(value);
         }}
       >
-        <Nav.HStack gap="6">
-          <Nav.Radio value={true}>Ja</Nav.Radio>
-          <Nav.Radio value={false}>Nei</Nav.Radio>
-        </Nav.HStack>
+        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
+          {KV.kodeTilTerm(OPPLYSNINGER_ENDRET, MKV.KTObjects.aarsavregningBehandlingsvalg)}
+        </Nav.Radio>
+        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
+          {KV.kodeTilTerm(OPPLYSNINGER_UENDRET, MKV.KTObjects.aarsavregningBehandlingsvalg)}
+        </Nav.Radio>
+        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
+          {KV.kodeTilTerm(MANUELL_ENDELIG_AVGIFT, MKV.KTObjects.aarsavregningBehandlingsvalg)}
+        </Nav.Radio>
       </Forms.RadioGroup>
 
-      {erAvvik === true && !endrerAvvik && (
+      {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
+        <Forms.Input
+          label="Endelig beregnet trygdeavgift"
+          name="avgift25Prosent"
+          control={control}
+          readOnly={!redigerbart}
+          // TODO: Rename
+          className="tidligere_fakturert_input"
+          autoComplete="off"
+          type="text"
+          numeric
+          tillattNegativeTall
+          onChange={debouncedOppdaterAvgift25Prosent}
+        />
+      )}
+
+      {behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerAvvik && (
         <>
           <Nav.Heading className="endelige_opplysninger_heading" level="2">
             Inntekts- og skatteopplysninger for endelig trygdeavgift
@@ -382,6 +421,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           {formIsValid &&
             !debouncedBeregningPagaar &&
             !beregningPaagar &&
+            behandlingsvalg !== MANUELL_ENDELIG_AVGIFT &&
             !feilmelding &&
             !arrayValideringsfeil &&
             aarsavregningResponse?.nyttGrunnlag && (

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -267,7 +267,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
         .then((res) => {
           setAarsavregningResponse(res);
-          setValue("manueltAvgiftBeloep", undefined, { shouldValidate: false, shouldDirty: false });
+          setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
           if (value === OPPLYSNINGER_UENDRET || value === MANUELL_ENDELIG_AVGIFT) {
             // TODO: Skal beregning kjøres for MANUELL_ENDELIG_AVGIFT?
             setBeregningPaagar(true);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -131,7 +131,13 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const debouncedBeregning = useCallback(() => {
     console.log("[debouncedBeregning] debouncedBeregningPagaar set false", debouncedBeregningPagaar);
     setDebouncedBeregningPagaar(false);
-    if (!redigerbart || !aarsavregningID || behandlingsvalg !== OPPLYSNINGER_ENDRET || beregningPaagar || endrerBehandlingsvalg) {
+    if (
+      !redigerbart ||
+      !aarsavregningID ||
+      behandlingsvalg !== OPPLYSNINGER_ENDRET ||
+      beregningPaagar ||
+      endrerBehandlingsvalg
+    ) {
       return;
     }
 
@@ -219,6 +225,11 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           aarsavregningResponse?.nyttGrunnlag &&
           !feilmelding &&
           !arrayValideringsfeil,
+      ) ||
+      Boolean(
+        behandlingsvalg === MANUELL_ENDELIG_AVGIFT &&
+          aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
+          !feilmelding,
       ),
     [behandlingsvalg, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding, arrayValideringsfeil],
   );
@@ -248,7 +259,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     aarsavregningResponse?.avregning?.nyttTotalbeloep,
   ]);
 
-  const håndterAvvik = useCallback(
+  const handleBehandlingsvalgChange = useCallback(
     (value: string) => {
       setEndrerBehandlingsvalg(true);
 
@@ -295,9 +306,10 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     }
   }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerBehandlingsvalg, debouncedBeregningPagaar]);
 
-  const debouncedOppdaterAvgift25Prosent = useCallback(
+  const debouncedOppdaterManueltAvgiftBeloep = useCallback(
     Utils._debounce(
-      async (value: string) => Api.Aarsavregning.oppdaterAvgift25Prosent(behandlingID, aarsavregningID, Number(value)),
+      async (value: string) =>
+        Api.Aarsavregning.oppdaterManueltAvgiftBeloep(behandlingID, aarsavregningID, Number(value)),
       350,
     ),
     [aarsavregningID],
@@ -342,7 +354,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         legend="Hva ønsker du å gjøre?"
         readOnly={!redigerbart}
         onChange={(value) => {
-          håndterAvvik(value);
+          handleBehandlingsvalgChange(value);
         }}
       >
         {[OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT].map((kode) => (
@@ -355,7 +367,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
         <Forms.Input
           label="Endelig beregnet trygdeavgift"
-          name="avgift25Prosent"
+          name="manueltAvgiftBeloep"
           control={control}
           readOnly={!redigerbart}
           className="avgift_input"
@@ -363,7 +375,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           type="text"
           numeric
           tillattNegativeTall
-          onChange={debouncedOppdaterAvgift25Prosent}
+          onChange={debouncedOppdaterManueltAvgiftBeloep}
         />
       )}
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -117,7 +117,7 @@ const aarsavregningMedGrunnlagSchema = object().shape({
     then: array().min(1, "Minst en inntektskilde").of(inntektskildeSchema),
     otherwise: array(),
   }),
-  avgift25Prosent: string().when(["behandlingsvalg"], {
+  manueltAvgiftBeloep: string().when(["behandlingsvalg"], {
     is: (behandlingsvalg) => behandlingsvalg === MANUELL_ENDELIG_AVGIFT,
     then: string().required(MAA_FYLLES_UT),
   }),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -15,6 +15,7 @@ const {
   PENSJON_UFØRETRYGD,
   PENSJON_UFØRETRYGD_KILDESKATT,
 } = MKV.Koder.inntektskildetype;
+const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 const UTENFOR_MEDLEMSKAPSPERIODEN = { melding: "Utenfor medl.periode" };
 
 export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
@@ -100,20 +101,25 @@ const inntektskildeSchema = object().shape({
 });
 
 const aarsavregningMedGrunnlagSchema = object().shape({
-  erAvvik: boolean().required(MAA_FYLLES_UT),
-  skatteforholdsperioder: array().when(["erAvvik"], {
-    is: (erAvvik) => erAvvik === true,
+  behandlingsvalg: string().required(MAA_FYLLES_UT),
+  skatteforholdsperioder: array().when(["behandlingsvalg"], {
+    is: (behandlingsvalg) => behandlingsvalg === OPPLYSNINGER_ENDRET,
     then: array().min(1, "Minst en skatteforholdsperiode").of(skatteforholdsperiodeSchema),
     otherwise: array(),
   }),
-  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "erAvvik", "skatteforholdsperioder"], {
-    is: (medlemskapsTypeErPliktig, erAvvik, skatteforholdsperioder) => {
+  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "behandlingsvalg", "skatteforholdsperioder"], {
+    is: (medlemskapsTypeErPliktig, behandlingsvalg, skatteforholdsperioder) => {
       return (
-        erAvvik === true && (!medlemskapsTypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder))
+        behandlingsvalg === OPPLYSNINGER_ENDRET &&
+        (!medlemskapsTypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder))
       );
     },
     then: array().min(1, "Minst en inntektskilde").of(inntektskildeSchema),
     otherwise: array(),
+  }),
+  avgift25Prosent: string().when(["behandlingsvalg"], {
+    is: (behandlingsvalg) => behandlingsvalg === MANUELL_ENDELIG_AVGIFT,
+    then: string().required(MAA_FYLLES_UT),
   }),
 });
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
@@ -1,8 +1,7 @@
-import { useId } from "react";
 import { Control } from "react-hook-form";
 import * as Forms from "../../../../../felleskomponenter/forms";
-import * as Nav from "../../../../../navFrontend";
 import MKV from "../../../../../melosyskodeverk";
+import * as Nav from "../../../../../navFrontend";
 
 const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
@@ -21,8 +20,6 @@ export function BehandlingsvalgRadioGroup({
   handleBehandlingsvalgChange,
   debouncedOppdaterManueltAvgiftBeloep,
 }: BehandlingsvalgRadioGroupProps) {
-  const manueltAvgiftBeloepId = useId();
-
   return (
     <>
       <Forms.RadioGroup
@@ -58,7 +55,6 @@ export function BehandlingsvalgRadioGroup({
           numeric
           tillattNegativeTall
           onChange={debouncedOppdaterManueltAvgiftBeloep}
-          key={manueltAvgiftBeloepId}
         />
       )}
     </>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
@@ -1,0 +1,66 @@
+import { useId } from "react";
+import { Control } from "react-hook-form";
+import * as Forms from "../../../../../felleskomponenter/forms";
+import * as Nav from "../../../../../navFrontend";
+import MKV from "../../../../../melosyskodeverk";
+
+const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+
+interface BehandlingsvalgRadioGroupProps {
+  control: Control<any>;
+  redigerbart: boolean;
+  behandlingsvalg: string;
+  handleBehandlingsvalgChange: (value: string) => void;
+  debouncedOppdaterManueltAvgiftBeloep: (value: string) => void;
+}
+
+export function BehandlingsvalgRadioGroup({
+  control,
+  redigerbart,
+  behandlingsvalg,
+  handleBehandlingsvalgChange,
+  debouncedOppdaterManueltAvgiftBeloep,
+}: BehandlingsvalgRadioGroupProps) {
+  const manueltAvgiftBeloepId = useId();
+
+  return (
+    <>
+      <Forms.RadioGroup
+        name="behandlingsvalg"
+        control={control}
+        legend="Hva ønsker du å gjøre?"
+        readOnly={!redigerbart}
+        onChange={(value) => {
+          handleBehandlingsvalgChange(value);
+        }}
+        className="behandlingsvalg_radio_group"
+      >
+        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
+          <b>Jeg skal gjøre endringer.</b> Inntekts- og/eller skatteopplysningene er endret siden tidligere beregning
+        </Nav.Radio>
+        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
+          <b>Det er ingen endringer.</b> Inntekts- og skatteopplysningene er like som ved tidligere beregning
+        </Nav.Radio>
+        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
+          <b>Jeg skal oppgi endelig avgift selv.</b> Endelig trygdeavgift er manuelt beregnet utenfor Melosys
+        </Nav.Radio>
+      </Forms.RadioGroup>
+
+      {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
+        <Forms.Input
+          label="Endelig beregnet trygdeavgift"
+          name="manueltAvgiftBeloep"
+          control={control}
+          readOnly={!redigerbart}
+          className="avgift_input"
+          autoComplete="off"
+          type="text"
+          numeric
+          tillattNegativeTall
+          onChange={debouncedOppdaterManueltAvgiftBeloep}
+          key={manueltAvgiftBeloepId}
+        />
+      )}
+    </>
+  );
+}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
@@ -46,11 +46,12 @@ export function MedlemskapsperiodeSkjema({
   setValue,
   errors,
 }: PeriodeElementerProps) {
-  const erPeriodeFraGrunnlag = !formValues.medlemskapsperioder[index]?.redigerbar;
-  const kanViseSletteKolonne = redigerbart && formValues.medlemskapsperioder.length > 1;
+  const medlemskapsperioder = formValues.medlemskapsperioder!;
+  const erPeriodeFraGrunnlag = !medlemskapsperioder[index]?.redigerbar;
+  const kanViseSletteKolonne = redigerbart && medlemskapsperioder.length > 1;
   const tilOgMedDatoForrigePeriode =
-    formValues.medlemskapsperioder[index - 1] !== undefined
-      ? Utils.dato.norskStringTilDate(formValues.medlemskapsperioder[index - 1]?.tomDato)
+    medlemskapsperioder[index - 1] !== undefined
+      ? Utils.dato.norskStringTilDate(medlemskapsperioder[index - 1]?.tomDato)
       : undefined;
   if (tilOgMedDatoForrigePeriode !== undefined) {
     tilOgMedDatoForrigePeriode.setDate(tilOgMedDatoForrigePeriode.getDate() + 1);
@@ -58,7 +59,7 @@ export function MedlemskapsperiodeSkjema({
 
   const kunEnTrygdedekning = trygdedekninger?.length === 1;
 
-  const lastIndex = formValues.medlemskapsperioder.length - 1;
+  const lastIndex = medlemskapsperioder.length - 1;
   let deletableIndex = -1;
 
   if (lastIndex >= 0) {
@@ -69,7 +70,7 @@ export function MedlemskapsperiodeSkjema({
     } else {
       let maxValidTomDatoIndex = -1;
       let maxValidTomDato: Date | null = null;
-      formValues.medlemskapsperioder.forEach((periode, idx) => {
+      medlemskapsperioder.forEach((periode, idx) => {
         const currentTomDato = Utils.dato.norskStringTilDate(periode.tomDato);
         if (currentTomDato && !Number.isNaN(currentTomDato.getTime())) {
           if (maxValidTomDato === null || currentTomDato >= maxValidTomDato) {
@@ -113,7 +114,7 @@ export function MedlemskapsperiodeSkjema({
               control={control}
               name={`medlemskapsperioder[${index}].tomDato`}
               aria-label={`Til og med periode ${index + 1}`}
-              minDate={Utils.dato.norskStringTilDate(formValues.medlemskapsperioder[index].fomDato)}
+              minDate={Utils.dato.norskStringTilDate(medlemskapsperioder[index].fomDato)}
               maxDate={maksVerdi}
               readOnly={!redigerbart || erPeriodeFraGrunnlag}
             />
@@ -146,7 +147,7 @@ export function MedlemskapsperiodeSkjema({
           )}
         </Nav.Row>
       </div>
-      {formValues.medlemskapsperioder.length === index + 1 && (
+      {medlemskapsperioder.length === index + 1 && (
         <div className="legg-til__rad">
           <Mui.Lenkeknapp onClick={handleLeggTil} ikon={Ikoner.Add} disabled={!redigerbart || !visLeggTil}>
             Legg til periode

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.less
@@ -2,6 +2,7 @@
   padding: 0.33rem;
   background-color: #efefef;
   border-collapse: collapse;
+  margin-bottom: 1.5rem;
 
   .navds-table {
     margin-bottom: 0;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereFakturertIAvgiftssystemetInput.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereFakturertIAvgiftssystemetInput.tsx
@@ -39,7 +39,7 @@ export function TidligereFakturertIAvgiftssystemetInput({
         name="totaltForskuddsvisFakturert"
         control={control}
         readOnly={!redigerbart}
-        className="tidligere_fakturert_input"
+        className="avgift_input"
         autoComplete="off"
         type="text"
         numeric

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
@@ -56,7 +56,7 @@
     align-self: flex-end;
   }
 
-  .tidligere_fakturert_input {
+  .avgift_input {
     .navds-text-field__input {
       width: 7.5rem;
     }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
@@ -66,4 +66,14 @@
     margin-bottom: 1.5rem;
     margin-top: 1.5rem;
   }
+
+  .beregnetTrygdeavgiftDetaljer {
+    margin-bottom: 1.5rem;
+  }
+
+  .behandlingsvalg_radio_group {
+    .navds-radio-buttons {
+      margin-top: 0.5rem;
+    }
+  }
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -1,31 +1,31 @@
-import { useDispatch, useSelector } from "react-redux";
-import { behandlingerSelectors } from "../../../../ducks/behandlinger";
-import * as Nav from "../../../../navFrontend";
-import { redigerbartSelectors } from "../../../../ducks/redigerbart";
-import Dokumentliste from "../../../../felleskomponenter/dokumentliste";
-import * as Mui from "../../../../felleskomponenter/ui";
-import { useCallback, useEffect, useState } from "react";
-import * as Api from "../../../../services/api";
-import { FieldValues, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { behandlingsresultatSelectors } from "../../../../ducks/behandlingsresultat";
-import vurdering_vedtak from "./vurderingVedtakSchema";
-import * as Utils from "../../../../utils";
-import { AarsavregningResponse } from "../../../../services/modules/aarsavregning/aarsavregning";
-import { vedtakOperations } from "../../../../ducks/vedtak";
-import { ThunkDispatch } from "redux-thunk";
 import { RootState } from "AppTypes";
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useDispatch, useSelector } from "react-redux";
 import { Action } from "redux";
-import { kontrollOperations } from "../../../../ducks/kontroll";
-import MKV from "../../../../melosyskodeverk";
-import LabelMedHjelpetekst from "../../../../felleskomponenter/labelMedHjelpetekst";
-import * as Forms from "../../../../felleskomponenter/forms";
-import { SumArsavregningTabell } from "../vurderingAarsavregning/komponenter/sumArsavregningTabell";
-import { menypanelOperations, menypanelSelectors } from "../../../../ducks/menypanel";
+import { ThunkDispatch } from "redux-thunk";
+import { behandlingerSelectors } from "../../../../ducks/behandlinger";
+import { behandlingsresultatSelectors } from "../../../../ducks/behandlingsresultat";
 import { fagsakSelectors } from "../../../../ducks/fagsaker";
+import { kontrollOperations } from "../../../../ducks/kontroll";
+import { menypanelOperations, menypanelSelectors } from "../../../../ducks/menypanel";
+import { redigerbartSelectors } from "../../../../ducks/redigerbart";
+import { vedtakOperations } from "../../../../ducks/vedtak";
+import Dokumentliste from "../../../../felleskomponenter/dokumentliste";
+import * as Forms from "../../../../felleskomponenter/forms";
 import FullmaktForTrygdeavgiftConfirmationPanel from "../../../../felleskomponenter/fullmaktForTrygdeavgiftConfirmationPanel/fullmaktForTrygdeavgiftConfirmationPanel";
-import { BrevVedleggVisningstabellInterface } from "../../../../services/modules/dokumenter-v2";
+import LabelMedHjelpetekst from "../../../../felleskomponenter/labelMedHjelpetekst";
+import * as Mui from "../../../../felleskomponenter/ui";
 import VedleggTable from "../../../../felleskomponenter/vedleggTable";
+import MKV from "../../../../melosyskodeverk";
+import * as Nav from "../../../../navFrontend";
+import * as Api from "../../../../services/api";
+import { AarsavregningResponse } from "../../../../services/modules/aarsavregning/aarsavregning";
+import { BrevVedleggVisningstabellInterface } from "../../../../services/modules/dokumenter-v2";
+import * as Utils from "../../../../utils";
+import { SumArsavregningTabell } from "../vurderingAarsavregning/komponenter/sumArsavregningTabell";
+import vurdering_vedtak from "./vurderingVedtakSchema";
 
 const { FASTSATT_TRYGDEAVGIFT } = MKV.Koder.behandlinger.behandlingsresultattyper;
 const { FØRSTEGANGSVEDTAK } = MKV.Koder.vedtakstyper;
@@ -37,7 +37,6 @@ const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 interface FormValuesProps {
   innledningFritekst?: string;
   begrunnelseFritekst?: string;
-  behandlingsvalg?: string;
 }
 
 interface Props {
@@ -66,6 +65,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     saksvedlegg: [],
     standardvedlegg: [],
   });
+  const [isFormInitialized, setIsFormInitialized] = useState(false);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as number;
   const erFullmektigEndret = useSelector(menypanelSelectors.MenypanelErFullmektigEndretSelector) as boolean;
@@ -73,95 +73,157 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   const { fattVedtak } = komponentDispatch(dispatch);
 
-  const defaultBegrunnelse = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) as string | undefined;
+  const defaultBegrunnelse = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) as
+    | string
+    | undefined;
   const defaultInnledning = useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) as string | undefined;
 
   const {
     watch,
     control,
     handleSubmit,
-    setValue,
+    reset,
     formState: { isValid: formIsValid },
-  } = useForm({
+  } = useForm<FormValuesProps>({
     resolver: yupResolver(vurdering_vedtak),
-    defaultValues: {
-      begrunnelseFritekst: defaultBegrunnelse || "",
-      innledningFritekst: defaultInnledning || "",
-      behandlingsvalg: undefined,
-    } as FieldValues,
-    mode: 'onSubmit',
-    reValidateMode: 'onChange',
+    context: { behandlingsvalg: lagretAarsavregning?.behandlingsvalg },
+    mode: "onSubmit",
+    reValidateMode: "onChange",
   });
   const formValues = watch();
 
-  const fetchAvregningsData = () => {
-    if (behandlingID === null) return Promise.resolve(undefined);
-    return Api.Aarsavregning.hentAarsavregning(behandlingID).then((response: AarsavregningResponse) => {
+  const fetchAarsavregning = useCallback(async (): Promise<AarsavregningResponse | undefined> => {
+    if (behandlingID === null) return undefined;
+    try {
+      const response = await Api.Aarsavregning.hentAarsavregning(behandlingID);
       setLagretAarsavregning(response);
       return response;
-    }).catch(error => {
+    } catch (error) {
       console.error("Error fetching aarsavregning data: ", error);
       return undefined;
-    });
-  };
+    }
+  }, [behandlingID]);
 
-  const hentMuligeMottakere = async () => {
+  const fetchMuligeMottakere = useCallback(async () => {
     if (behandlingID === null) return;
-    const res = await Api.DokumenterV2.hentMuligeMottakere(behandlingID, {
-      produserbartdokument: AARSAVREGNING_VEDTAKSBREV,
-      orgnr: null,
-    });
-    setMuligeMottakere(res);
-    await hentStandardvedleggForBrev();
-  };
+    try {
+      const res = await Api.DokumenterV2.hentMuligeMottakere(behandlingID, {
+        produserbartdokument: AARSAVREGNING_VEDTAKSBREV,
+        orgnr: null,
+      });
+      setMuligeMottakere(res);
+      await fetchStandardvedleggForBrev();
+    } catch (error) {
+      console.error("Error fetching mulige mottakere: ", error);
+    }
+  }, [behandlingID]);
 
-  const hentStandardvedleggForBrev = async () => {
-    Api.DokumenterV2.hentStandardvedleggForBrev(AARSAVREGNING_VEDTAKSBREV).then((res) => {
+  const fetchStandardvedleggForBrev = useCallback(async () => {
+    try {
+      const res = await Api.DokumenterV2.hentStandardvedleggForBrev(AARSAVREGNING_VEDTAKSBREV);
       setBrevVedlegg({
         saksvedlegg: [],
         standardvedlegg: res,
       });
-    });
-  };
+    } catch (error) {
+      console.error("Error fetching standardvedlegg: ", error);
+    }
+  }, []);
 
-  const hentOgSetHarFullmaktForTrygdeavgift = async () => {
+  const fetchFakturaMottaker = useCallback(async () => {
+    if (behandlingID === null) return;
+    try {
+      const dto = await Api.Trygdeavgift.hentFakturamottaker(behandlingID);
+      setFakturaMottaker(dto.navn);
+    } catch (error) {
+      console.error("Error fetching fakturamottaker: ", error);
+    }
+  }, [behandlingID]);
+
+  const fetchAndSetHarFullmaktForTrygdeavgift = useCallback(async () => {
     if (saksnummer === null || saksnummer === undefined) return;
-    const saksnummerString = typeof saksnummer === 'number' ? saksnummer.toString() : saksnummer;
-    if (typeof saksnummerString !== 'string') return;
+    const saksnummerString = typeof saksnummer === "number" ? saksnummer.toString() : saksnummer;
+    if (typeof saksnummerString !== "string") return;
 
-    await Api.Fagsaker.aktoer.hent(saksnummerString, FULLMEKTIG).then((res) => {
+    try {
+      const res = await Api.Fagsaker.aktoer.hent(saksnummerString, FULLMEKTIG);
       setHarBekreftetFullmaktForTrygdeavgift(false);
       setHarFullmaktForTrygdeavgift(
         res.some((aktoer) => aktoer.fullmakter?.some((fullmakt) => fullmakt === FULLMEKTIG_TRYGDEAVGIFT)),
       );
-    });
-  };
+    } catch (error) {
+      console.error("Error fetching fullmakt info: ", error);
+    }
+  }, [saksnummer]);
 
   useEffect(() => {
     if (aktivtSteg && behandlingID !== null) {
+      setIsFormInitialized(false);
       window.scrollTo(0, 0);
-      fetchAvregningsData().then((response) => {
-        if (response?.behandlingsvalg) {
-          setValue("behandlingsvalg", response.behandlingsvalg, { shouldValidate: false });
-        }
-      });
-      hentMuligeMottakere();
-      Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
-        setFakturaMottaker(dto.navn);
-      });
-      hentOgSetHarFullmaktForTrygdeavgift();
+      Promise.all([
+        fetchAarsavregning(),
+        fetchMuligeMottakere(),
+        fetchFakturaMottaker(),
+        fetchAndSetHarFullmaktForTrygdeavgift(),
+      ]);
     }
-  }, [aktivtSteg, behandlingID, setValue]);
+  }, [
+    aktivtSteg,
+    behandlingID,
+    fetchAarsavregning,
+    fetchMuligeMottakere,
+    fetchFakturaMottaker,
+    fetchAndSetHarFullmaktForTrygdeavgift,
+  ]);
+
+  useEffect(() => {
+    if (aktivtSteg && lagretAarsavregning) {
+      reset({
+        innledningFritekst: defaultInnledning ?? "",
+        begrunnelseFritekst: defaultBegrunnelse ?? "",
+      });
+      setIsFormInitialized(true);
+    }
+  }, [aktivtSteg, lagretAarsavregning, reset, defaultInnledning, defaultBegrunnelse]);
 
   useEffect(() => {
     if (aktivtSteg && erFullmektigEndret && behandlingID !== null) {
-      hentOgSetHarFullmaktForTrygdeavgift();
-      Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
-        setFakturaMottaker(dto.navn);
-      });
+      fetchAndSetHarFullmaktForTrygdeavgift();
+      fetchFakturaMottaker();
       dispatch(menypanelOperations.setErFullmektigEndret(false));
     }
-  }, [aktivtSteg, erFullmektigEndret, behandlingID, dispatch]);
+  }, [
+    aktivtSteg,
+    erFullmektigEndret,
+    behandlingID,
+    dispatch,
+    fetchAndSetHarFullmaktForTrygdeavgift,
+    fetchFakturaMottaker,
+  ]);
+
+  const oppdaterFritekster = useCallback(
+    (values: FormValuesProps) => {
+      if (values && redigerbart && !vedtakPending && behandlingID !== null) {
+        Api.Behandlinger.resultat.oppdaterFritekster(behandlingID, {
+          innledningFritekst: values.innledningFritekst,
+          begrunnelseFritekst: values.begrunnelseFritekst,
+        });
+      }
+    },
+    [behandlingID, redigerbart, vedtakPending],
+  );
+
+  const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), [oppdaterFritekster]);
+
+  useEffect(() => {
+    if (aktivtSteg && behandlingID !== null && lagretAarsavregning && isFormInitialized) {
+      debouncedOppdaterFritekster(formValues);
+    }
+  }, [aktivtSteg, formValues, debouncedOppdaterFritekster, behandlingID, lagretAarsavregning, isFormInitialized]);
+
+  if (!aktivtSteg || !lagretAarsavregning || !isFormInitialized) {
+    return null;
+  }
 
   const lagFattVedtakReqDto = (): Api.Saksflyt.Vedtak.FattVedtakÅrsavregningReqDto => {
     return {
@@ -174,11 +236,12 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   };
 
   const onSubmit = async () => {
-    if (behandlingID === null) {
+    if (behandlingID === null || !lagretAarsavregning) {
       return;
     }
 
-    const stegErGyldig = !harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift;
+    const stegErGyldig =
+      !harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift;
     if (!stegErGyldig) {
       return;
     }
@@ -187,29 +250,15 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     fattVedtak(behandlingID, lagFattVedtakReqDto())
       .then((res) => {
         if (res.data?.data?.error) {
+          console.error("Error during fattVedtak: ", res.data.data.error);
           setVedtakPending(false);
         }
       })
-      .catch(() => {
+      .catch((error) => {
+        console.error("Error submitting vedtak: ", error);
         setVedtakPending(false);
       });
   };
-
-  const oppdaterFritekster = (values: FormValuesProps) => {
-    if (values && redigerbart && !vedtakPending) {
-      Api.Behandlinger.resultat.oppdaterFritekster(behandlingID, {
-        innledningFritekst: values.innledningFritekst,
-        begrunnelseFritekst: values.begrunnelseFritekst,
-      });
-    }
-  };
-  const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), [behandlingID, redigerbart, vedtakPending]);
-
-  useEffect(() => {
-    if (aktivtSteg && behandlingID !== null) {
-      debouncedOppdaterFritekster(formValues);
-    }
-  }, [aktivtSteg, formValues, debouncedOppdaterFritekster, behandlingID]);
 
   const mapMottakerRad = (muligMottaker: Api.DokumenterV2.MuligMottaker) => {
     return {
@@ -226,17 +275,19 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   };
 
   const mapMottakerRader = (mottakere: Api.DokumenterV2.HentMuligeMottakereResDto) => {
-    return [
-      mapMottakerRad(mottakere.hovedMottaker),
-      ...mottakere.kopiMottakere.map((muligMottaker) => mapMottakerRad(muligMottaker)),
-      ...mottakere.fasteMottakere.map((muligMottaker) => mapMottakerRad(muligMottaker)),
-    ];
+    const rader = [];
+    if (mottakere.hovedMottaker) {
+      rader.push(mapMottakerRad(mottakere.hovedMottaker));
+    }
+    rader.push(...mottakere.kopiMottakere.map((muligMottaker) => mapMottakerRad(muligMottaker)));
+    rader.push(...mottakere.fasteMottakere.map((muligMottaker) => mapMottakerRad(muligMottaker)));
+    return rader;
   };
 
   const tidligereTrygdeavgift = lagretAarsavregning?.avregning?.tidligereFakturertBeloep;
   const tidligereTrygdeavgiftAvgiftssystem = lagretAarsavregning?.avregning?.tidligereFakturertBeloepAvgiftssystem;
   const nyTrygdeavgift =
-    formValues?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT
+    lagretAarsavregning?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT
       ? lagretAarsavregning?.avregning?.manueltAvgiftBeloep
       : lagretAarsavregning?.avregning?.nyttTotalbeloep;
 
@@ -246,7 +297,10 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const erNullKroner = trygdeavgiftDiff === 0;
   const skalFaktureres = trygdeavgiftDiff > 0;
 
-  const kanSubmitte = redigerbart && !vedtakPending &&
+  const kanSubmitte =
+    redigerbart &&
+    !vedtakPending &&
+    formIsValid &&
     (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift);
 
   return (
@@ -255,9 +309,10 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         Vedtak årsavregning {lagretAarsavregning ? lagretAarsavregning.aar : ""}
       </Nav.Heading>
 
-      {formValues?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
+      {lagretAarsavregning?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
         <Nav.Alert variant="warning" className="blokk-s">
-          Du har lagt inn "Endelig beregnet trygdeavgift" manuelt og må derfor oppgi en begrunnelse i fritekstfeltet.
+          Du har lagt inn &quot;Endelig beregnet trygdeavgift&quot; manuelt og må derfor oppgi en begrunnelse i
+          fritekstfeltet.
         </Nav.Alert>
       )}
 
@@ -277,8 +332,9 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
               ) : (
                 <>
                   <br />
-                  {`${skalFaktureres ? "Faktura" : "Kreditnota"} på ${Utils.formaterTilNorskBelop(Math.abs(trygdeavgiftDiff)) || "0"
-                    } kr sendes til: `}{" "}
+                  {`${skalFaktureres ? "Faktura" : "Kreditnota"} på ${
+                    Utils.formaterTilNorskBelop(Math.abs(trygdeavgiftDiff)) || "0"
+                  } kr sendes til: `}{" "}
                   <b>{fakturaMottaker}</b>
                 </>
               )}
@@ -314,19 +370,23 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         disabled={!redigerbart}
       />
 
-      {formIsValid && redigerbart && muligeMottakere && behandlingID !== null && (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift) && (
-        <>
-          <Dokumentliste behandlingID={behandlingID} dokumenter={mapMottakerRader(muligeMottakere)} />
-          <VedleggTable
-            valgteVedlegg={brevVedlegg}
-            setValgteVedlegg={() => {
-              /* Readonly */
-            }}
-            label="Vedlegg"
-            redigerbart={false /* Readonly. Ikke vis slett-knapp. */}
-          />
-        </>
-      )}
+      {formIsValid &&
+        redigerbart &&
+        muligeMottakere &&
+        behandlingID !== null &&
+        (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift) && (
+          <>
+            <Dokumentliste behandlingID={behandlingID} dokumenter={mapMottakerRader(muligeMottakere)} />
+            <VedleggTable
+              valgteVedlegg={brevVedlegg}
+              setValgteVedlegg={() => {
+                /* Readonly */
+              }}
+              label="Vedlegg"
+              redigerbart={false /* Readonly. Ikke vis slett-knapp. */}
+            />
+          </>
+        )}
 
       <Mui.StegKnapper
         bekreftKnappProps={{

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -243,7 +243,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), [oppdaterFritekster]);
 
   useEffect(() => {
-    if (aktivtSteg && behandlingID !== null && lagretAarsavregning && isFormInitialized) {
+    if (redigerbart && aktivtSteg && behandlingID !== null && lagretAarsavregning && isFormInitialized) {
       const currentValues = getValues();
       const hasInnledningChanged = (currentValues.innledningFritekst ?? "") !== lagretInnledning;
       const hasBegrunnelseChanged = (currentValues.begrunnelseFritekst ?? "") !== lagretBegrunnelse;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -66,6 +66,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     standardvedlegg: [],
   });
   const [isFormInitialized, setIsFormInitialized] = useState(false);
+  const [fritekstPending, setFritekstPending] = useState(false);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as number;
   const erFullmektigEndret = useSelector(menypanelSelectors.MenypanelErFullmektigEndretSelector) as boolean;
@@ -73,16 +74,19 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   const { fattVedtak } = komponentDispatch(dispatch);
 
-  const defaultBegrunnelse = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) as
-    | string
-    | undefined;
-  const defaultInnledning = useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) as string | undefined;
+  const [lagretInnledning, setLagretInnledning] = useState<string>(
+    useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) ?? "",
+  );
+  const [lagretBegrunnelse, setLagretBegrunnelse] = useState<string>(
+    useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) ?? "",
+  );
 
   const {
     watch,
     control,
     handleSubmit,
     reset,
+    getValues,
     formState: { isValid: formIsValid },
   } = useForm<FormValuesProps>({
     resolver: yupResolver(vurdering_vedtak),
@@ -178,13 +182,24 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   useEffect(() => {
     if (aktivtSteg && lagretAarsavregning) {
-      reset({
-        innledningFritekst: defaultInnledning ?? "",
-        begrunnelseFritekst: defaultBegrunnelse ?? "",
-      });
-      setIsFormInitialized(true);
+      const currentValues = getValues();
+      const newInnledning = currentValues.innledningFritekst ?? lagretInnledning ?? "";
+      const newBegrunnelse = currentValues.begrunnelseFritekst ?? lagretBegrunnelse ?? "";
+
+      if (!isFormInitialized) {
+        reset(
+          {
+            innledningFritekst: newInnledning,
+            begrunnelseFritekst: newBegrunnelse,
+          },
+          { keepDirty: false },
+        );
+        setLagretInnledning(newInnledning);
+        setLagretBegrunnelse(newBegrunnelse);
+        setIsFormInitialized(true);
+      }
     }
-  }, [aktivtSteg, lagretAarsavregning, reset, defaultInnledning, defaultBegrunnelse]);
+  }, [aktivtSteg, lagretAarsavregning, reset, lagretInnledning, lagretBegrunnelse, getValues, isFormInitialized]);
 
   useEffect(() => {
     if (aktivtSteg && erFullmektigEndret && behandlingID !== null) {
@@ -204,10 +219,22 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const oppdaterFritekster = useCallback(
     (values: FormValuesProps) => {
       if (values && redigerbart && !vedtakPending && behandlingID !== null) {
-        Api.Behandlinger.resultat.oppdaterFritekster(behandlingID, {
+        const payload = {
           innledningFritekst: values.innledningFritekst,
           begrunnelseFritekst: values.begrunnelseFritekst,
-        });
+        };
+        Api.Behandlinger.resultat
+          .oppdaterFritekster(behandlingID, payload)
+          .then(() => {
+            setLagretInnledning(values.innledningFritekst ?? "");
+            setLagretBegrunnelse(values.begrunnelseFritekst ?? "");
+          })
+          .catch((error) => {
+            console.error("Feil ved oppdatering av fritekster:", error);
+          })
+          .finally(() => {
+            setFritekstPending(false);
+          });
       }
     },
     [behandlingID, redigerbart, vedtakPending],
@@ -217,9 +244,26 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   useEffect(() => {
     if (aktivtSteg && behandlingID !== null && lagretAarsavregning && isFormInitialized) {
-      debouncedOppdaterFritekster(formValues);
+      const currentValues = getValues();
+      const hasInnledningChanged = (currentValues.innledningFritekst ?? "") !== lagretInnledning;
+      const hasBegrunnelseChanged = (currentValues.begrunnelseFritekst ?? "") !== lagretBegrunnelse;
+
+      if (hasInnledningChanged || hasBegrunnelseChanged) {
+        setFritekstPending(true);
+        debouncedOppdaterFritekster(currentValues);
+      }
     }
-  }, [aktivtSteg, formValues, debouncedOppdaterFritekster, behandlingID, lagretAarsavregning, isFormInitialized]);
+  }, [
+    aktivtSteg,
+    formValues,
+    debouncedOppdaterFritekster,
+    behandlingID,
+    lagretAarsavregning,
+    isFormInitialized,
+    getValues,
+    lagretInnledning,
+    lagretBegrunnelse,
+  ]);
 
   if (!aktivtSteg || !lagretAarsavregning || !isFormInitialized) {
     return null;
@@ -300,7 +344,6 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const kanSubmitte =
     redigerbart &&
     !vedtakPending &&
-    formIsValid &&
     (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift);
 
   return (
@@ -374,24 +417,18 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         redigerbart &&
         muligeMottakere &&
         behandlingID !== null &&
-        (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift) && (
+        (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift) &&
+        !fritekstPending && (
           <>
             <Dokumentliste behandlingID={behandlingID} dokumenter={mapMottakerRader(muligeMottakere)} />
-            <VedleggTable
-              valgteVedlegg={brevVedlegg}
-              setValgteVedlegg={() => {
-                /* Readonly */
-              }}
-              label="Vedlegg"
-              redigerbart={false /* Readonly. Ikke vis slett-knapp. */}
-            />
+            <VedleggTable valgteVedlegg={brevVedlegg} setValgteVedlegg={() => {}} label="Vedlegg" redigerbart={false} />
           </>
         )}
 
       <Mui.StegKnapper
         bekreftKnappProps={{
           disabled: !kanSubmitte,
-          loading: vedtakPending,
+          loading: vedtakPending || fritekstPending,
           type: "submit",
         }}
         bekreftTekst="Fatt vedtak"

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -32,10 +32,12 @@ const { FØRSTEGANGSVEDTAK } = MKV.Koder.vedtakstyper;
 const { AARSAVREGNING_VEDTAKSBREV } = MKV.Koder.brev.produserbaredokumenter;
 const { FULLMEKTIG_TRYGDEAVGIFT } = MKV.Koder.fullmaktstype;
 const { FULLMEKTIG } = MKV.Koder.aktoersroller;
+const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
 interface FormValuesProps {
   innledningFritekst?: string;
   begrunnelseFritekst?: string;
+  behandlingsvalg?: string;
 }
 
 interface Props {
@@ -64,34 +66,47 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     saksvedlegg: [],
     standardvedlegg: [],
   });
-  const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
-  const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
-  const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
-  const erFullmektigEndret = useSelector(menypanelSelectors.MenypanelErFullmektigEndretSelector);
-  const saksnummer = useSelector(fagsakSelectors.SaksnummerSelector);
+  const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
+  const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as number;
+  const erFullmektigEndret = useSelector(menypanelSelectors.MenypanelErFullmektigEndretSelector) as boolean;
+  const saksnummer = useSelector(fagsakSelectors.SaksnummerSelector) as string | number | null;
 
   const { fattVedtak } = komponentDispatch(dispatch);
+
+  const defaultBegrunnelse = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) as string | undefined;
+  const defaultInnledning = useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) as string | undefined;
 
   const {
     watch,
     control,
+    handleSubmit,
+    setValue,
     formState: { isValid: formIsValid },
   } = useForm({
     resolver: yupResolver(vurdering_vedtak),
     defaultValues: {
-      begrunnelseFritekst: useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) || "",
-      innledningFritekst: useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) || "",
+      begrunnelseFritekst: defaultBegrunnelse || "",
+      innledningFritekst: defaultInnledning || "",
+      behandlingsvalg: undefined,
     } as FieldValues,
+    mode: 'onSubmit',
+    reValidateMode: 'onChange',
   });
   const formValues = watch();
 
   const fetchAvregningsData = () => {
+    if (behandlingID === null) return Promise.resolve(undefined);
     return Api.Aarsavregning.hentAarsavregning(behandlingID).then((response: AarsavregningResponse) => {
       setLagretAarsavregning(response);
+      return response;
+    }).catch(error => {
+      console.error("Error fetching aarsavregning data: ", error);
+      return undefined;
     });
   };
 
   const hentMuligeMottakere = async () => {
+    if (behandlingID === null) return;
     const res = await Api.DokumenterV2.hentMuligeMottakere(behandlingID, {
       produserbartdokument: AARSAVREGNING_VEDTAKSBREV,
       orgnr: null,
@@ -110,7 +125,11 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   };
 
   const hentOgSetHarFullmaktForTrygdeavgift = async () => {
-    await Api.Fagsaker.aktoer.hent(saksnummer, FULLMEKTIG).then((res) => {
+    if (saksnummer === null || saksnummer === undefined) return;
+    const saksnummerString = typeof saksnummer === 'number' ? saksnummer.toString() : saksnummer;
+    if (typeof saksnummerString !== 'string') return;
+
+    await Api.Fagsaker.aktoer.hent(saksnummerString, FULLMEKTIG).then((res) => {
       setHarBekreftetFullmaktForTrygdeavgift(false);
       setHarFullmaktForTrygdeavgift(
         res.some((aktoer) => aktoer.fullmakter?.some((fullmakt) => fullmakt === FULLMEKTIG_TRYGDEAVGIFT)),
@@ -119,36 +138,30 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   };
 
   useEffect(() => {
-    if (aktivtSteg) {
-      hentOgSetHarFullmaktForTrygdeavgift();
-    }
-  }, []);
-
-  useEffect(() => {
-    if (aktivtSteg) {
-      if (erFullmektigEndret) {
-        hentOgSetHarFullmaktForTrygdeavgift();
-
-        Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
-          setFakturaMottaker(dto.navn);
-        });
-
-        dispatch(menypanelOperations.setErFullmektigEndret(false));
-      }
-    }
-  }, [erFullmektigEndret]);
-
-  useEffect(() => {
-    if (aktivtSteg) {
+    if (aktivtSteg && behandlingID !== null) {
       window.scrollTo(0, 0);
-      fetchAvregningsData();
+      fetchAvregningsData().then((response) => {
+        if (response?.behandlingsvalg) {
+          setValue("behandlingsvalg", response.behandlingsvalg, { shouldValidate: false });
+        }
+      });
       hentMuligeMottakere();
-
       Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
         setFakturaMottaker(dto.navn);
       });
+      hentOgSetHarFullmaktForTrygdeavgift();
     }
-  }, [aktivtSteg]);
+  }, [aktivtSteg, behandlingID, setValue]);
+
+  useEffect(() => {
+    if (aktivtSteg && erFullmektigEndret && behandlingID !== null) {
+      hentOgSetHarFullmaktForTrygdeavgift();
+      Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
+        setFakturaMottaker(dto.navn);
+      });
+      dispatch(menypanelOperations.setErFullmektigEndret(false));
+    }
+  }, [aktivtSteg, erFullmektigEndret, behandlingID, dispatch]);
 
   const lagFattVedtakReqDto = (): Api.Saksflyt.Vedtak.FattVedtakÅrsavregningReqDto => {
     return {
@@ -160,13 +173,26 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     };
   };
 
-  const fattVedtakOnClick = async () => {
+  const onSubmit = async () => {
+    if (behandlingID === null) {
+      return;
+    }
+
+    const stegErGyldig = !harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift;
+    if (!stegErGyldig) {
+      return;
+    }
+
     setVedtakPending(true);
-    fattVedtak(behandlingID, lagFattVedtakReqDto()).then((res) => {
-      if (res.data?.data?.error) {
+    fattVedtak(behandlingID, lagFattVedtakReqDto())
+      .then((res) => {
+        if (res.data?.data?.error) {
+          setVedtakPending(false);
+        }
+      })
+      .catch(() => {
         setVedtakPending(false);
-      }
-    });
+      });
   };
 
   const oppdaterFritekster = (values: FormValuesProps) => {
@@ -177,13 +203,13 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
       });
     }
   };
-  const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), []);
+  const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), [behandlingID, redigerbart, vedtakPending]);
 
   useEffect(() => {
-    if (aktivtSteg) {
+    if (aktivtSteg && behandlingID !== null) {
       debouncedOppdaterFritekster(formValues);
     }
-  }, [formValues?.innledningFritekst, formValues?.begrunnelseFritekst, formValues?.trygdeavgiftFritekst]);
+  }, [aktivtSteg, formValues, debouncedOppdaterFritekster, behandlingID]);
 
   const mapMottakerRad = (muligMottaker: Api.DokumenterV2.MuligMottaker) => {
     return {
@@ -209,21 +235,31 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   const tidligereTrygdeavgift = lagretAarsavregning?.avregning?.tidligereFakturertBeloep;
   const tidligereTrygdeavgiftAvgiftssystem = lagretAarsavregning?.avregning?.tidligereFakturertBeloepAvgiftssystem;
-  const nyTrygdeavgift = lagretAarsavregning?.avregning?.nyttTotalbeloep;
+  const nyTrygdeavgift =
+    formValues?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT
+      ? lagretAarsavregning?.avregning?.manueltAvgiftBeloep
+      : lagretAarsavregning?.avregning?.nyttTotalbeloep;
+
   const trygdeavgiftDiff =
     (nyTrygdeavgift ?? 0) - (tidligereTrygdeavgift ?? 0) - (tidligereTrygdeavgiftAvgiftssystem ?? 0);
   const erDifferanseUnderMinstebeløp = Math.abs(trygdeavgiftDiff) < MINSTEBELOP_FAKTURERING_ELLER_REFUSJON;
   const erNullKroner = trygdeavgiftDiff === 0;
   const skalFaktureres = trygdeavgiftDiff > 0;
 
-  const stegErGyldig =
-    formIsValid && (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift);
+  const kanSubmitte = redigerbart && !vedtakPending &&
+    (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift);
 
   return (
-    <div className="vurderingVedtak">
+    <form onSubmit={handleSubmit(onSubmit)} className="vurderingVedtak">
       <Nav.Heading level="1" className="stegvelgertittel">
         Vedtak årsavregning {lagretAarsavregning ? lagretAarsavregning.aar : ""}
       </Nav.Heading>
+
+      {formValues?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
+        <Nav.Alert variant="warning" className="blokk-s">
+          Du har lagt inn "Endelig beregnet trygdeavgift" manuelt og må derfor oppgi en begrunnelse i fritekstfeltet.
+        </Nav.Alert>
+      )}
 
       <SumArsavregningTabell
         nyTrygdeavgift={nyTrygdeavgift}
@@ -241,9 +277,8 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
               ) : (
                 <>
                   <br />
-                  {`${skalFaktureres ? "Faktura" : "Kreditnota"} på ${
-                    Utils.formaterTilNorskBelop(Math.abs(trygdeavgiftDiff)) || "0"
-                  } kr sendes til: `}{" "}
+                  {`${skalFaktureres ? "Faktura" : "Kreditnota"} på ${Utils.formaterTilNorskBelop(Math.abs(trygdeavgiftDiff)) || "0"
+                    } kr sendes til: `}{" "}
                   <b>{fakturaMottaker}</b>
                 </>
               )}
@@ -279,27 +314,29 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         disabled={!redigerbart}
       />
 
-      {stegErGyldig && redigerbart && muligeMottakere && (
-        <Dokumentliste behandlingID={behandlingID} dokumenter={mapMottakerRader(muligeMottakere)} />
+      {formIsValid && redigerbart && muligeMottakere && behandlingID !== null && (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift) && (
+        <>
+          <Dokumentliste behandlingID={behandlingID} dokumenter={mapMottakerRader(muligeMottakere)} />
+          <VedleggTable
+            valgteVedlegg={brevVedlegg}
+            setValgteVedlegg={() => {
+              /* Readonly */
+            }}
+            label="Vedlegg"
+            redigerbart={false /* Readonly. Ikke vis slett-knapp. */}
+          />
+        </>
       )}
-      <VedleggTable
-        valgteVedlegg={brevVedlegg}
-        setValgteVedlegg={() => {
-          /* Readonly */
-        }}
-        label="Vedlegg"
-        redigerbart={false /* Readonly. Ikke vis slett-knapp. */}
-      />
 
       <Mui.StegKnapper
         bekreftKnappProps={{
-          onClick: fattVedtakOnClick,
-          disabled: !stegErGyldig || !formIsValid || !redigerbart,
+          disabled: !kanSubmitte,
           loading: vedtakPending,
+          type: "submit",
         }}
         bekreftTekst="Fatt vedtak"
-        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart || vedtakPending, type: "button" }}
       />
-    </div>
+    </form>
   );
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
@@ -5,16 +5,29 @@ import * as KV from "../../../../kodeverk";
 import MKV from "../../../../melosyskodeverk";
 
 const { DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN } = KV.Feilmeldinger;
-export const DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT = { melding: "Du må oppgi en begrunnelse for \"Endelig trygdeavgift\"" };
+export const DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT = {
+  melding: 'Du må oppgi en begrunnelse for "Endelig trygdeavgift"',
+};
 
 const vurdering_vedtak = object().shape({
-  behandlingsvalg: string().nullable(),
+  // behandlingsvalg is no longer part of form values, accessed via context
   begrunnelseFritekst: string()
     .nullable()
     .max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN)
-    .when("behandlingsvalg", {
-      is: MKV.Koder.aarsavregningBehandlingsvalg.MANUELL_ENDELIG_AVGIFT,
-      then: (schema) => schema.required(DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT),
+    .when([], {
+      is: () => true, // Always run the check
+      then: (schema) =>
+        schema.test({
+          name: "begrunnelse-required-manuell",
+          message: DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT,
+          test(value) {
+            const { behandlingsvalg } = this.options.context || {};
+            if (behandlingsvalg === MKV.Koder.aarsavregningBehandlingsvalg.MANUELL_ENDELIG_AVGIFT) {
+              return !!value; // Required if MANUELL_ENDELIG_AVGIFT
+            }
+            return true; // Optional otherwise
+          },
+        }),
       otherwise: (schema) => schema.nullable(),
     }),
   innledningFritekst: string().nullable().max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
@@ -2,11 +2,21 @@
 
 import { object, string } from "yup";
 import * as KV from "../../../../kodeverk";
+import MKV from "../../../../melosyskodeverk";
 
 const { DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN } = KV.Feilmeldinger;
+export const DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT = { melding: "Du må oppgi en begrunnelse for \"Endelig trygdeavgift\"" };
 
 const vurdering_vedtak = object().shape({
-  begrunnelseFritekst: string().nullable().max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN),
+  behandlingsvalg: string().nullable(),
+  begrunnelseFritekst: string()
+    .nullable()
+    .max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN)
+    .when("behandlingsvalg", {
+      is: MKV.Koder.aarsavregningBehandlingsvalg.MANUELL_ENDELIG_AVGIFT,
+      then: (schema) => schema.required(DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT),
+      otherwise: (schema) => schema.nullable(),
+    }),
   innledningFritekst: string().nullable().max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN),
 });
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
@@ -10,12 +10,11 @@ export const DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT = {
 };
 
 const vurdering_vedtak = object().shape({
-  // behandlingsvalg is no longer part of form values, accessed via context
   begrunnelseFritekst: string()
     .nullable()
     .max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN)
     .when([], {
-      is: () => true, // Always run the check
+      is: () => true,
       then: (schema) =>
         schema.test({
           name: "begrunnelse-required-manuell",
@@ -25,7 +24,7 @@ const vurdering_vedtak = object().shape({
             if (behandlingsvalg === MKV.Koder.aarsavregningBehandlingsvalg.MANUELL_ENDELIG_AVGIFT) {
               return !!value; // Required if MANUELL_ENDELIG_AVGIFT
             }
-            return true; // Optional otherwise
+            return true;
           },
         }),
       otherwise: (schema) => schema.nullable(),


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7042
### Implementasjon av MVP 25-prosent regel for årsavregning med grunnlag og vedtakssteg

Opprettet ny komponent BehandlingsvalgRadioGroup som gir saksbehandleren mulighet
  til å velge
  - Endringer i inntekts- og skatteopplysninger
  - Ingen endringer i opplysningene
  - Manuell beregning av endelig trygdeavgift

Ved valg av manuell beregning vises et inputfelt hvor saksbehandleren kan legge inn manuelt beregnet avgift. Støtte er kun lagt til for årsavregning med grunnlag i denne PRen.

Refaktorerte også aarsavregning\vurderingVedtak for å støtte 25% regel MVP:
  - La til alert som vises ved manuell avgiftsberegning
  - La til validering som krever begrunnelseFritekst ved manuell
  avgiftsberegning
  - La til fritekstPending flag som viser
  spinner på bekreftknappen ved ulagrede endringer i fritekstfelt