### PR TITLE
7247 Periodesteg endringer i åpen sluttdato

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/ukjentSluttdatoMedlemskapsperiode.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/ukjentSluttdatoMedlemskapsperiode.tsx
@@ -3,11 +3,13 @@ import * as Nav from "../../../../../../navFrontend";
 interface UkjentSluttdatoProps {
   ukjentSluttdatoMedlemskapsperiode: boolean;
   onUkjentSluttdatoChange: (checked: boolean) => void;
+  erPensjonist?: boolean;
 }
 
 export function UkjentSluttdatoMedlemskapsperiode({
   ukjentSluttdatoMedlemskapsperiode,
   onUkjentSluttdatoChange,
+  erPensjonist,
 }: UkjentSluttdatoProps) {
   return (
     <div className="ukjentSluttdato">
@@ -15,7 +17,9 @@ export function UkjentSluttdatoMedlemskapsperiode({
         checked={ukjentSluttdatoMedlemskapsperiode}
         onChange={(e) => onUkjentSluttdatoChange(e.target.checked)}
       >
-        Saken er flyttet fra avgiftssystemet og har ikke sluttdato
+        {erPensjonist
+          ? "Vedtaksbrevet skal ikke ha sluttdato"
+          : "Saken er flyttet fra avgiftssystemet og har ikke sluttdato"}
       </Nav.Checkbox>
       {ukjentSluttdatoMedlemskapsperiode && (
         <Nav.Alert variant="info" size="small" className="mt-2">

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
@@ -160,8 +160,7 @@ export function VurderingPerioder({ bekreft, tilbake, aktivtSteg, oppdaterStatus
     return perioder.map((periode: any) => {
       if (periode.fomDato) {
         const fomISODate = Utils.dato.formatterDatoTilISO(periode.fomDato, "");
-        const tomISODate = Utils.dato.formatterDatoTilISO(periode.tomDato, "");
-        if (fomISODate && !tomISODate) {
+        if (fomISODate && !periode.TomDato) {
           const fomDate = new Date(fomISODate);
           const tomDate = new Date(fomDate);
           tomDate.setFullYear(tomDate.getFullYear() + 10);

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
@@ -174,21 +174,25 @@ export function VurderingPerioder({ bekreft, tilbake, aktivtSteg, oppdaterStatus
 
   const lagreUkjentSluttdatoMedlemskapsperiode = async (ukjentSluttdato: boolean) => {
     if (ukjentSluttdato) {
-      const lagretPerioder = formValues.medlemskapsperioder.map((periode: MedlemskapsperiodeProp) => {
-        if (periode.fomDato) {
-          const fomISODate = Utils.dato.formatterDatoTilISO(periode.fomDato, "");
-          if (fomISODate) {
-            const fomDate = new Date(fomISODate);
-            const tomDate = new Date(fomDate);
-            tomDate.setFullYear(tomDate.getFullYear() + 10);
-            return {
-              ...periode,
-              tomDato: Utils.dato.formatterDatoTilNorsk(tomDate.toISOString()),
-            };
+      const lagretPerioder = formValues.medlemskapsperioder.map(
+        (periode: MedlemskapsperiodeProp, index: number, medlemskapsperioderArray: any) => {
+          if (periode.fomDato) {
+            const fomISODate = Utils.dato.formatterDatoTilISO(periode.fomDato, "");
+            if (fomISODate) {
+              if (index === medlemskapsperioderArray.length - 1) {
+                const fomDate = new Date(fomISODate);
+                const tomDate = new Date(fomDate);
+                tomDate.setFullYear(tomDate.getFullYear() + 10);
+                return {
+                  ...periode,
+                  tomDato: Utils.dato.formatterDatoTilNorsk(tomDate.toISOString()),
+                };
+              }
+            }
           }
-        }
-        return periode;
-      });
+          return periode;
+        },
+      );
 
       resetMedlemskapsperioder(lagretPerioder);
 
@@ -291,9 +295,9 @@ export function VurderingPerioder({ bekreft, tilbake, aktivtSteg, oppdaterStatus
       Utils._isEmpty(periode.trygdedekning) ||
       Utils._isEmpty(periode.innvilgelsesResultat),
   );
-
+  const erPensjonist = behandlingstema === PENSJONIST;
   const ukjentSluttdatoMedlemskapsperiodeSkalVises =
-    (behandlingstema === YRKESAKTIV || behandlingstema === PENSJONIST) && lagretBestemmelse !== FTRL_KAP2_2_1;
+    (behandlingstema === YRKESAKTIV || erPensjonist) && lagretBestemmelse !== FTRL_KAP2_2_1;
 
   const visLeggTilNyPeriode = redigerbart && feltErFyltInn;
   const visFeilmeldinger = feilMeldingBlokkerer(aktivFeilmeldingType) ? feltErFyltInn : feltErFyltInn && formIsValid;
@@ -312,6 +316,7 @@ export function VurderingPerioder({ bekreft, tilbake, aktivtSteg, oppdaterStatus
         <UkjentSluttdatoMedlemskapsperiode
           ukjentSluttdatoMedlemskapsperiode={ukjentSluttdatoMedlemskapsperiode || false}
           onUkjentSluttdatoChange={lagreUkjentSluttdatoMedlemskapsperiode}
+          erPensjonist={erPensjonist}
         />
       )}
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
@@ -132,26 +132,10 @@ export function VurderingPerioder({ bekreft, tilbake, aktivtSteg, oppdaterStatus
   useEffect(() => {
     if (aktivtSteg) {
       let initialPerioder = mapInitialMedlemskapsperioder(lagredeMedlemskapsperioder);
-
       // Hvis ukjentSluttdatoMedlemskapsperiode er true, sett sluttdatoer til 10 år etter startdato
       if (ukjentSluttdatoMedlemskapsperiode) {
-        initialPerioder = initialPerioder.map((periode) => {
-          if (periode.fomDato) {
-            const fomISODate = Utils.dato.formatterDatoTilISO(periode.fomDato, "");
-            if (fomISODate) {
-              const fomDate = new Date(fomISODate);
-              const tomDate = new Date(fomDate);
-              tomDate.setFullYear(tomDate.getFullYear() + 10);
-              return {
-                ...periode,
-                tomDato: Utils.dato.formatterDatoTilNorsk(tomDate.toISOString()),
-              };
-            }
-          }
-          return periode;
-        });
+        initialPerioder = mapUkjentSluttdatoMedlemskapsperiode(initialPerioder);
       }
-
       resetMedlemskapsperioder(initialPerioder);
 
       if (!formIsValid) {
@@ -172,28 +156,28 @@ export function VurderingPerioder({ bekreft, tilbake, aktivtSteg, oppdaterStatus
     Api.Ftrl.hentGyldigeInnvilgelsesresultat(behandlingstype).then(setLovligeInnvilgelsesresultat);
   }, [lagretBestemmelse]);
 
+  const mapUkjentSluttdatoMedlemskapsperiode = (perioder: any) => {
+    return perioder.map((periode: any) => {
+      if (periode.fomDato) {
+        const fomISODate = Utils.dato.formatterDatoTilISO(periode.fomDato, "");
+        const tomISODate = Utils.dato.formatterDatoTilISO(periode.tomDato, "");
+        if (fomISODate && !tomISODate) {
+          const fomDate = new Date(fomISODate);
+          const tomDate = new Date(fomDate);
+          tomDate.setFullYear(tomDate.getFullYear() + 10);
+          return {
+            ...periode,
+            tomDato: Utils.dato.formatterDatoTilNorsk(tomDate.toISOString()),
+          };
+        }
+      }
+      return periode;
+    });
+  };
+
   const lagreUkjentSluttdatoMedlemskapsperiode = async (ukjentSluttdato: boolean) => {
     if (ukjentSluttdato) {
-      const lagretPerioder = formValues.medlemskapsperioder.map(
-        (periode: MedlemskapsperiodeProp, index: number, medlemskapsperioderArray: any) => {
-          if (periode.fomDato) {
-            const fomISODate = Utils.dato.formatterDatoTilISO(periode.fomDato, "");
-            if (fomISODate) {
-              if (index === medlemskapsperioderArray.length - 1) {
-                const fomDate = new Date(fomISODate);
-                const tomDate = new Date(fomDate);
-                tomDate.setFullYear(tomDate.getFullYear() + 10);
-                return {
-                  ...periode,
-                  tomDato: Utils.dato.formatterDatoTilNorsk(tomDate.toISOString()),
-                };
-              }
-            }
-          }
-          return periode;
-        },
-      );
-
+      const lagretPerioder = mapUkjentSluttdatoMedlemskapsperiode(formValues.medlemskapsperioder);
       resetMedlemskapsperioder(lagretPerioder);
 
       await trigger("medlemskapsperioder");


### PR DESCRIPTION
Yrkesaktiv og pensjonister får automatisk sluttdato 10 år frem i tid på alle perioder med tom sluttdato ved klikk på checkboxen. Før var det slik at alle perioder med tom eller utfylt tom-felt får det.

https://jira.adeo.no/browse/MELOSYS-7247