### PR TITLE
7042 TOGGLE manuelt beregnet avgift uten og delt grunnlag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,3 @@ yarn-debug.log*
 yarn-error.log*
 /yarn.lock
 /env-config.js
-CLAUDE.md
-/ai_docs

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 /yarn.lock
 /env-config.js
 CLAUDE.md
+/ai_docs

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-debug.log*
 yarn-error.log*
 /yarn.lock
 /env-config.js
+CLAUDE.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@navikt/ds-css": "^7.5.3",
         "@navikt/ds-react": "^7.5.3",
         "@navikt/fnrvalidator": "^1.1.4",
-        "@navikt/melosys-kodeverk": "5.15.302",
+        "@navikt/melosys-kodeverk": "5.15.303",
         "@sentry/integrations": "^7.30.0",
         "@sentry/react": "^7.30.0",
         "@sentry/tracing": "^7.30.0",
@@ -2523,9 +2523,9 @@
       "integrity": "sha512-IJs4Xe/AIef/6+PZ/eCCIPTnXJ7Goijvv7bimHC7vHo4NjnMxhcbKhCvukSAS+XDDtPWc+x/X2G44RckAU1g1A=="
     },
     "node_modules/@navikt/melosys-kodeverk": {
-      "version": "5.15.302",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.302/16fd707450304fe50f00b166d5c4c382c20b9aeb",
-      "integrity": "sha512-148Hvl6PPvpNCHHo2ueh5aQSnysEEhgVbJPpTQytyoq3uGmYKRn4P7Nell7xj27Z8elH/iIrLXs5JZ2vvWzT9A==",
+      "version": "5.15.303",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.303/e4394f20d19c097d432fb50e5033afc6a5d97d4a",
+      "integrity": "sha512-xlmJEm9/X30TPDrPLYPW5W3rl6AHgvVstIam/ZkTiFzEyMDbbMRK9VqpsUP4PoOK5Rz2dc7SA1S9T46skEbdJA==",
       "license": "ISC",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@navikt/ds-css": "^7.5.3",
         "@navikt/ds-react": "^7.5.3",
         "@navikt/fnrvalidator": "^1.1.4",
-        "@navikt/melosys-kodeverk": "5.15.301",
+        "@navikt/melosys-kodeverk": "5.15.302",
         "@sentry/integrations": "^7.30.0",
         "@sentry/react": "^7.30.0",
         "@sentry/tracing": "^7.30.0",
@@ -2523,9 +2523,9 @@
       "integrity": "sha512-IJs4Xe/AIef/6+PZ/eCCIPTnXJ7Goijvv7bimHC7vHo4NjnMxhcbKhCvukSAS+XDDtPWc+x/X2G44RckAU1g1A=="
     },
     "node_modules/@navikt/melosys-kodeverk": {
-      "version": "5.15.301",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.301/b3ebbc40649713c1e00a7c3aafd7a7717b316e38",
-      "integrity": "sha512-fklsgK3txiYgtwcd9CIs56thy1/PYcVSsWTHo30q23woBKAxM+TvGFt9Iy3B/GungfS6hwGTWQfru6jI5SEC8A==",
+      "version": "5.15.302",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/melosys-kodeverk/5.15.302/16fd707450304fe50f00b166d5c4c382c20b9aeb",
+      "integrity": "sha512-148Hvl6PPvpNCHHo2ueh5aQSnysEEhgVbJPpTQytyoq3uGmYKRn4P7Nell7xj27Z8elH/iIrLXs5JZ2vvWzT9A==",
       "license": "ISC",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@navikt/ds-css": "^7.5.3",
     "@navikt/ds-react": "^7.5.3",
     "@navikt/fnrvalidator": "^1.1.4",
-    "@navikt/melosys-kodeverk": "5.15.302",
+    "@navikt/melosys-kodeverk": "5.15.303",
     "@sentry/integrations": "^7.30.0",
     "@sentry/react": "^7.30.0",
     "@sentry/tracing": "^7.30.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@navikt/ds-css": "^7.5.3",
     "@navikt/ds-react": "^7.5.3",
     "@navikt/fnrvalidator": "^1.1.4",
-    "@navikt/melosys-kodeverk": "5.15.301",
+    "@navikt/melosys-kodeverk": "5.15.302",
     "@sentry/integrations": "^7.30.0",
     "@sentry/react": "^7.30.0",
     "@sentry/tracing": "^7.30.0",

--- a/src/felleskomponenter/htmlEditor/htmlEditor.less
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.less
@@ -108,10 +108,10 @@
   }
 
   .feilmelding {
-    font-style: italic;
     color: @redError;
     font-family: Arial, sans-serif;
-    font-size: 1rem;
+    font-size: 0.875rem;
+    font-weight: 600;
     line-height: 1.375rem;
   }
 

--- a/src/felleskomponenter/htmlEditor/htmlEditor.tsx
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.tsx
@@ -228,6 +228,7 @@ function HtmlEditor({ value, onChange, disabled, label, feil, className, placeho
     };
   }, []);
 
+
   return (
     <div className={classNames("htmlEditor", className)}>
       {label && <div className="editor_label">{label}</div>}

--- a/src/felleskomponenter/htmlEditor/htmlEditor.tsx
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.tsx
@@ -228,7 +228,6 @@ function HtmlEditor({ value, onChange, disabled, label, feil, className, placeho
     };
   }, []);
 
-
   return (
     <div className={classNames("htmlEditor", className)}>
       {label && <div className="editor_label">{label}</div>}

--- a/src/felleskomponenter/trygdeavgift/komponenter/types.ts
+++ b/src/felleskomponenter/trygdeavgift/komponenter/types.ts
@@ -17,7 +17,7 @@ export interface Skatteforhold {
 }
 
 export interface FieldArrayProps {
-  medlemskapsperioder: Medlemskapsperiode[];
+  medlemskapsperioder?: Medlemskapsperiode[];
   inntektskilder: Inntektskilde[];
   skatteforholdsperioder: Skatteforhold[];
 }

--- a/src/felleskomponenter/ui/stegKnapp/stegKnapper.tsx
+++ b/src/felleskomponenter/ui/stegKnapp/stegKnapper.tsx
@@ -11,6 +11,7 @@ interface ButtonProps {
   loading?: boolean;
   disabled?: boolean;
   className?: string;
+  type?: "button" | "submit" | "reset";
 }
 
 interface StegKnapperProps {
@@ -32,7 +33,7 @@ function StegKnapper({
 
   return (
     <div className={cls}>
-      <Nav.Button variant="primary" {...bekreftKnappProps} className={bekreftKnappCls}>
+      <Nav.Button variant="primary" {...bekreftKnappProps} className={bekreftKnappCls} type={bekreftKnappProps.type}>
         {bekreftTekst}
       </Nav.Button>
       {tilbakeKnappProps && (

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -85,13 +85,6 @@ export const oppdaterHarDeltGrunnlag = (
 ): Promise<AarsavregningResponse> =>
   postAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/grunnlagstype`, request);
 
-export const oppdaterAvvik = (
-  behandlingID: number,
-  harAvvik: boolean,
-  aarsavregningID?: number,
-): Promise<AarsavregningResponse> =>
-  putAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/${aarsavregningID}/harAvvik/${harAvvik}`);
-
 export const oppdaterBehandlingsvalg = (
   behandlingID: number,
   behandlingsvalg: string,

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -11,7 +11,7 @@ export interface AarsavregningResponse {
   nyttGrunnlag?: Grunnlagsopplysninger;
   avregning?: Avregning;
   harDeltGrunnlag?: boolean;
-  behandlingsvalg?: string;
+  endeligAvgiftValg?: string;
 }
 
 export interface AarsavregningRequest {
@@ -83,13 +83,13 @@ export const oppdaterHarDeltGrunnlag = (
 ): Promise<AarsavregningResponse> =>
   postAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/grunnlagstype`, request);
 
-export const oppdaterBehandlingsvalg = (
+export const oppdaterEndeligAvgiftValg = (
   behandlingID: number,
-  behandlingsvalg: string,
+  endeligAvgiftValg: string,
   aarsavregningID?: number,
 ): Promise<AarsavregningResponse> =>
   putAsJson(
-    `${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/${aarsavregningID}/behandlingsvalg/${behandlingsvalg}`,
+    `${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/${aarsavregningID}/endeligAvgift/${endeligAvgiftValg}`,
   );
 
 export const hentFiltrertAarsavregningList = (

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -12,7 +12,6 @@ export interface AarsavregningResponse {
   avregning?: Avregning;
   harDeltGrunnlag?: boolean;
   behandlingsvalg?: string;
-  manueltAvgiftBeloep?: string;
 }
 // TODO: Fix typing for behandlingsvalg
 

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -11,7 +11,10 @@ export interface AarsavregningResponse {
   nyttGrunnlag?: Grunnlagsopplysninger;
   avregning?: Avregning;
   harDeltGrunnlag?: boolean;
+  behandlingsvalg?: string;
+  avgift25Prosent?: string;
 }
+// TODO: Fix typing for behandlingsvalg
 
 export interface AarsavregningRequest {
   avregning: Avregning;
@@ -53,6 +56,7 @@ export interface Avregning {
   tidligereFakturertBeloep?: number;
   tilFaktureringBeloep?: number;
   tidligereFakturertBeloepAvgiftssystem?: number;
+  avgift25Prosent?: number;
 }
 
 export interface AarsavregningListResponse {
@@ -88,6 +92,15 @@ export const oppdaterAvvik = (
 ): Promise<AarsavregningResponse> =>
   putAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/${aarsavregningID}/harAvvik/${harAvvik}`);
 
+export const oppdaterBehandlingsvalg = (
+  behandlingID: number,
+  behandlingsvalg: string,
+  aarsavregningID?: number,
+): Promise<AarsavregningResponse> =>
+  putAsJson(
+    `${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/${aarsavregningID}/behandlingsvalg/${behandlingsvalg}`,
+  );
+
 export const hentFiltrertAarsavregningList = (
   saksnummer: string,
   resultattype?: string,
@@ -111,6 +124,21 @@ export const oppdaterTotalAvgift = async (behandlingID: number, aarsavregningID:
     {
       avregning: {
         nyttTotalbeloep: totalAvgift,
+      },
+    },
+    aarsavregningID,
+  );
+};
+export const oppdaterAvgift25Prosent = async (
+  behandlingID: number,
+  aarsavregningID: number,
+  avgift25Prosent?: number,
+) => {
+  return oppdaterAarsavregning(
+    behandlingID,
+    {
+      avregning: {
+        avgift25Prosent,
       },
     },
     aarsavregningID,

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -12,7 +12,7 @@ export interface AarsavregningResponse {
   avregning?: Avregning;
   harDeltGrunnlag?: boolean;
   behandlingsvalg?: string;
-  avgift25Prosent?: string;
+  manueltAvgiftBeloep?: string;
 }
 // TODO: Fix typing for behandlingsvalg
 
@@ -56,7 +56,7 @@ export interface Avregning {
   tidligereFakturertBeloep?: number;
   tilFaktureringBeloep?: number;
   tidligereFakturertBeloepAvgiftssystem?: number;
-  avgift25Prosent?: number;
+  manueltAvgiftBeloep?: number;
 }
 
 export interface AarsavregningListResponse {
@@ -122,16 +122,16 @@ export const oppdaterTotalAvgift = async (behandlingID: number, aarsavregningID:
     aarsavregningID,
   );
 };
-export const oppdaterAvgift25Prosent = async (
+export const oppdaterManueltAvgiftBeloep = async (
   behandlingID: number,
   aarsavregningID: number,
-  avgift25Prosent?: number,
+  manueltAvgiftBeloep?: number,
 ) => {
   return oppdaterAarsavregning(
     behandlingID,
     {
       avregning: {
-        avgift25Prosent,
+        manueltAvgiftBeloep,
       },
     },
     aarsavregningID,

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -13,7 +13,6 @@ export interface AarsavregningResponse {
   harDeltGrunnlag?: boolean;
   behandlingsvalg?: string;
 }
-// TODO: Fix typing for behandlingsvalg
 
 export interface AarsavregningRequest {
   avregning: Avregning;

--- a/src/services/modules/behandlinger/resultat.ts
+++ b/src/services/modules/behandlinger/resultat.ts
@@ -18,7 +18,7 @@ export interface OppdaterUtfallRegistreringUnntak {
 export const hentResultat = (behandlingID: string) =>
   getAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/resultat`);
 
-export const oppdaterFritekster = (behandlingID: string, data: OppdaterFritekster) =>
+export const oppdaterFritekster = (behandlingID: string | number, data: OppdaterFritekster) =>
   postAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/resultat/fritekst`, data);
 
 export const oppdaterNyVurderingBakgrunn = (behandlingID: string, nyVurderingBakgrunn?: string) =>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -43,7 +43,7 @@ const mapMedlemskapsperiodeBestemmelse = (harDeltGrunnlag: boolean, medlemskapsp
 };
 
 export interface AarsavregningMedGrunnlagFormValues extends FormValuesProps {
-  behandlingsvalg?: string;
+  endeligAvgiftValg?: string;
   manueltAvgiftBeloep?: number;
 }
 
@@ -67,7 +67,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
     formDefaultValues: {
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
-      behandlingsvalg: undefined,
+      endeligAvgiftValg: undefined,
       manueltAvgiftBeloep: undefined,
     },
     medlemskapstypeErPliktig: false,
@@ -79,14 +79,14 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
   const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (
     trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag,
-    behandlingsvalg?: string,
+    endeligAvgiftValg?: string,
     manueltAvgiftBeloep?: number,
   ) => {
     if (!trygdeavgiftsgrunnlag)
       return {
         skatteforholdsperioder: [{}],
         inntektskilder: [{}],
-        behandlingsvalg: undefined,
+        endeligAvgiftValg: undefined,
         manueltAvgiftBeloep: undefined,
       };
     const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
@@ -94,7 +94,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
     const sorterteSkatteforhold = [...skatteforholdsperioder].sort(Utils.dato.sorterEtterISOFomDato);
 
     return {
-      behandlingsvalg,
+      endeligAvgiftValg,
       manueltAvgiftBeloep,
       skatteforholdsperioder: !Utils._isEmpty(sorterteSkatteforhold)
         ? mapTilSkatteforholdProps(sorterteSkatteforhold)
@@ -121,7 +121,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
           const defaultFormValues: FieldValue<AarsavregningMedGrunnlagFormValues> =
             mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
               res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
-              res.behandlingsvalg,
+              res.endeligAvgiftValg,
               res?.avregning?.manueltAvgiftBeloep,
             );
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -121,7 +121,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
           const defaultFormValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
             res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
             res.behandlingsvalg,
-            res?.avregning?.avgift25Prosent,<
+            res?.avregning?.avgift25Prosent,
           );
 
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -44,7 +44,7 @@ const mapMedlemskapsperiodeBestemmelse = (harDeltGrunnlag: boolean, medlemskapsp
 
 export interface AarsavregningMedGrunnlagFormValues extends FormValuesProps {
   behandlingsvalg?: string;
-  avgift25Prosent?: string;
+  manueltAvgiftBeloep?: number;
 }
 
 export interface InitiellData {
@@ -68,7 +68,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
       behandlingsvalg: undefined,
-      avgift25Prosent: undefined,
+      manueltAvgiftBeloep: undefined,
     },
     medlemskapstypeErPliktig: false,
   });
@@ -80,14 +80,14 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (
     trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag,
     behandlingsvalg?: string,
-    avgift25Prosent?: string,
+    manueltAvgiftBeloep?: number,
   ) => {
     if (!trygdeavgiftsgrunnlag)
       return {
         skatteforholdsperioder: [{}],
         inntektskilder: [{}],
         behandlingsvalg: undefined,
-        avgift25Prosent: undefined,
+        manueltAvgiftBeloep: undefined,
       };
     const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
     const sorterteInntekstkilder = [...inntektskperioder].sort(Utils.dato.sorterEtterISOFomDato);
@@ -95,7 +95,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
     return {
       behandlingsvalg,
-      avgift25Prosent,
+      manueltAvgiftBeloep,
       skatteforholdsperioder: !Utils._isEmpty(sorterteSkatteforhold)
         ? mapTilSkatteforholdProps(sorterteSkatteforhold)
         : [{}],
@@ -118,11 +118,12 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
           // Benyttes for innhenting av saksopplysninger ifm. årsavregningsbehandlinger
           dispatch({ type: OK, data: res });
 
-          const defaultFormValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
-            res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
-            res.behandlingsvalg,
-            res?.avregning?.avgift25Prosent,
-          );
+          const defaultFormValues: FieldValue<AarsavregningMedGrunnlagFormValues> =
+            mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
+              res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
+              res.behandlingsvalg,
+              res?.avregning?.manueltAvgiftBeloep,
+            );
 
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;
           const innvilgetMedlemskapsperiode = mapInnvilgetMedlemskapsPeriode(medlemskapsperioder);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -43,7 +43,8 @@ const mapMedlemskapsperiodeBestemmelse = (harDeltGrunnlag: boolean, medlemskapsp
 };
 
 export interface AarsavregningMedGrunnlagFormValues extends FormValuesProps {
-  erAvvik?: boolean;
+  behandlingsvalg?: string;
+  avgift25Prosent?: string;
 }
 
 export interface InitiellData {
@@ -64,9 +65,10 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const [initiellData, setInitiellData] = useState<InitiellData>({
     formDefaultValues: {
-      erAvvik: undefined,
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
+      behandlingsvalg: undefined,
+      avgift25Prosent: undefined,
     },
     medlemskapstypeErPliktig: false,
   });
@@ -77,15 +79,23 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
   const mapSkjemaverdierFraTrygdeavgiftsgrunnlag = (
     trygdeavgiftsgrunnlag?: Trygdeavgiftsgrunnlag,
-    harAvvik?: boolean,
+    behandlingsvalg?: string,
+    avgift25Prosent?: string,
   ) => {
-    if (!trygdeavgiftsgrunnlag) return { erAvvik: undefined, skatteforholdsperioder: [{}], inntektskilder: [{}] };
+    if (!trygdeavgiftsgrunnlag)
+      return {
+        skatteforholdsperioder: [{}],
+        inntektskilder: [{}],
+        behandlingsvalg: undefined,
+        avgift25Prosent: undefined,
+      };
     const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
     const sorterteInntekstkilder = [...inntektskperioder].sort(Utils.dato.sorterEtterISOFomDato);
     const sorterteSkatteforhold = [...skatteforholdsperioder].sort(Utils.dato.sorterEtterISOFomDato);
 
     return {
-      erAvvik: harAvvik,
+      behandlingsvalg,
+      avgift25Prosent,
       skatteforholdsperioder: !Utils._isEmpty(sorterteSkatteforhold)
         ? mapTilSkatteforholdProps(sorterteSkatteforhold)
         : [{}],
@@ -110,7 +120,8 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
 
           const defaultFormValues = mapSkjemaverdierFraTrygdeavgiftsgrunnlag(
             res?.nyttGrunnlag?.trygdeavgiftsgrunnlag || res.tidligereGrunnlagsopplysninger.trygdeavgiftsgrunnlag,
-            res.harAvvik,
+            res.behandlingsvalg,
+            res?.avregning?.avgift25Prosent,<
           );
 
           const medlemskapsperioder = res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -223,15 +223,15 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       behandlingsvalg === OPPLYSNINGER_UENDRET ||
       Boolean(
         formIsValid &&
-        behandlingsvalg === OPPLYSNINGER_ENDRET &&
-        aarsavregningResponse?.nyttGrunnlag &&
-        !feilmelding &&
-        !arrayValideringsfeil,
+          behandlingsvalg === OPPLYSNINGER_ENDRET &&
+          aarsavregningResponse?.nyttGrunnlag &&
+          !feilmelding &&
+          !arrayValideringsfeil,
       ) ||
       Boolean(
         behandlingsvalg === MANUELL_ENDELIG_AVGIFT &&
-        aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
-        !feilmelding,
+          aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
+          !feilmelding,
       ),
     [behandlingsvalg, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding, arrayValideringsfeil],
   );

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -223,15 +223,15 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       behandlingsvalg === OPPLYSNINGER_UENDRET ||
       Boolean(
         formIsValid &&
-          behandlingsvalg === OPPLYSNINGER_ENDRET &&
-          aarsavregningResponse?.nyttGrunnlag &&
-          !feilmelding &&
-          !arrayValideringsfeil,
+        behandlingsvalg === OPPLYSNINGER_ENDRET &&
+        aarsavregningResponse?.nyttGrunnlag &&
+        !feilmelding &&
+        !arrayValideringsfeil,
       ) ||
       Boolean(
         behandlingsvalg === MANUELL_ENDELIG_AVGIFT &&
-          aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
-          !feilmelding,
+        aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
+        !feilmelding,
       ),
     [behandlingsvalg, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding, arrayValideringsfeil],
   );
@@ -422,6 +422,12 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </>
       )}
 
+      {feilmelding && !beregningPaagar && (
+        <Nav.Alert variant="error" className="alertstripe_feilmelding">
+          {feilmelding}
+        </Nav.Alert>
+      )}
+
       <ManuellAvgiftFormPart
         control={control}
         redigerbart={redigerbart}
@@ -432,12 +438,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         erMedGrunnlagFlyt={true}
         harDeltGrunnlag={false}
       />
-
-      {feilmelding && !beregningPaagar && (
-        <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          {feilmelding}
-        </Nav.Alert>
-      )}
 
       <Nav.Button
         variant="primary"

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -1,5 +1,4 @@
 import * as Api from "../../../../../services/api";
-import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import "../vurderingAarsavregningInngang.css";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
@@ -29,10 +28,11 @@ import { InitiellData } from "./aarsavregningMedGrunnlag";
 import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
 import { Feilmelding, finnAktivFeilmelding } from "./valideringsfeil";
 import MKV from "../../../../../melosyskodeverk";
-import { BehandlingsvalgRadioGroup } from "../komponenter/behandlingsvalgRadioGroup";
+import { EndeligAvgiftValgRadioGroup } from "../komponenter/endeligAvgiftValgRadioGroup";
 import { ManuellAvgiftFormPart } from "../komponenter/manuellAvgiftFormPart";
+import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 
-const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
 interface Props {
   initiellData: InitiellData;
@@ -47,7 +47,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   );
   const [beregningPaagar, setBeregningPaagar] = useState(false);
   const [previousFormValues, setPreviousFormValues] = useState<any | null>(null);
-  const [endrerBehandlingsvalg, setEndrerBehandlingsvalg] = useState(false);
+  const [endrerEndeligAvgiftValg, setEndrerEndeligAvgiftValg] = useState(false);
   const [debouncedBeregningPagaar, setDebouncedBeregningPagaar] = useState(false);
   const [arrayValideringsfeil, setArrayValideringsfeil] = useState<string | undefined>(undefined);
 
@@ -91,7 +91,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const formValues = watch();
   const skatteforholdsperioder = watch("skatteforholdsperioder");
   const inntektskilder = watch("inntektskilder");
-  const behandlingsvalg = watch("behandlingsvalg");
+  const endeligAvgiftValg = watch("endeligAvgiftValg");
   const manueltAvgiftBeloep = watch("manueltAvgiftBeloep");
   const debouncedBeregningRef = useRef<any>(null);
 
@@ -136,9 +136,9 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     if (
       !redigerbart ||
       !aarsavregningID ||
-      behandlingsvalg !== OPPLYSNINGER_ENDRET ||
+      endeligAvgiftValg !== OPPLYSNINGER_ENDRET ||
       beregningPaagar ||
-      endrerBehandlingsvalg
+      endrerEndeligAvgiftValg
     ) {
       return;
     }
@@ -170,9 +170,9 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     }
   }, [
     aarsavregningID,
-    behandlingsvalg,
+    endeligAvgiftValg,
     beregningPaagar,
-    endrerBehandlingsvalg,
+    endrerEndeligAvgiftValg,
     getValues,
     formIsValid,
     isValidating,
@@ -202,7 +202,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       debouncedBeregningRef.current.cancel();
     }
     if (debouncedBeregningRef.current) {
-      if (redigerbart && aarsavregningID && behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerBehandlingsvalg) {
+      if (redigerbart && aarsavregningID && endeligAvgiftValg === OPPLYSNINGER_ENDRET && !endrerEndeligAvgiftValg) {
         const currentFormState = mapFormState(getValues("skatteforholdsperioder"), getValues("inntektskilder"));
 
         if (!Utils._isEqual(currentFormState, previousFormValues)) {
@@ -216,24 +216,24 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         }
       }
     }
-  }, [skatteforholdsperioder, behandlingsvalg, inntektskilder, formIsValid, isValidating, endrerBehandlingsvalg]);
+  }, [skatteforholdsperioder, endeligAvgiftValg, inntektskilder, formIsValid, isValidating, endrerEndeligAvgiftValg]);
 
   const stegErGyldig = useMemo(
     () =>
-      behandlingsvalg === OPPLYSNINGER_UENDRET ||
+      endeligAvgiftValg === OPPLYSNINGER_UENDRET ||
       Boolean(
         formIsValid &&
-          behandlingsvalg === OPPLYSNINGER_ENDRET &&
+          endeligAvgiftValg === OPPLYSNINGER_ENDRET &&
           aarsavregningResponse?.nyttGrunnlag &&
           !feilmelding &&
           !arrayValideringsfeil,
       ) ||
       Boolean(
-        behandlingsvalg === MANUELL_ENDELIG_AVGIFT &&
+        endeligAvgiftValg === MANUELL_ENDELIG_AVGIFT &&
           aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
           !feilmelding,
       ),
-    [behandlingsvalg, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding, arrayValideringsfeil],
+    [endeligAvgiftValg, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding, arrayValideringsfeil],
   );
 
   useEffect(() => {
@@ -261,11 +261,10 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     aarsavregningResponse?.avregning?.nyttTotalbeloep,
   ]);
 
-  const handleBehandlingsvalgChange = useCallback(
+  const handleEndeligAvgiftValgChange = useCallback(
     (value: string) => {
-      setEndrerBehandlingsvalg(true);
-
-      Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
+      setEndrerEndeligAvgiftValg(true);
+      Api.Aarsavregning.oppdaterEndeligAvgiftValg(behandlingID, value, aarsavregningID)
         .then((res) => {
           setAarsavregningResponse(res);
           setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
@@ -286,7 +285,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           }
         })
         .finally(() => {
-          setEndrerBehandlingsvalg(false);
+          setEndrerEndeligAvgiftValg(false);
         });
     },
     [
@@ -295,8 +294,10 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       setBeregningPaagar,
       setAarsavregningResponse,
       setPreviousFormValues,
-      setEndrerBehandlingsvalg,
+      setEndrerEndeligAvgiftValg,
       Api.Aarsavregning,
+      behandlingID,
+      setValue,
     ],
   );
 
@@ -308,17 +309,17 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         }),
       350,
     ),
-    [aarsavregningID],
+    [aarsavregningID, behandlingID],
   );
 
   const håndterBekreft = useCallback(() => {
     // noinspection JSIgnoredPromiseFromCall
     trigger();
 
-    if (stegErGyldig && !beregningPaagar && !endrerBehandlingsvalg && !debouncedBeregningPagaar) {
+    if (stegErGyldig && !beregningPaagar && !endrerEndeligAvgiftValg && !debouncedBeregningPagaar) {
       bekreft();
     }
-  }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerBehandlingsvalg, debouncedBeregningPagaar]);
+  }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerEndeligAvgiftValg, debouncedBeregningPagaar]);
 
   const trygdeAvgiftSkalIkkeBetalesTilNav =
     medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder);
@@ -352,14 +353,14 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </>
       )}
 
-      <BehandlingsvalgRadioGroup
+      <EndeligAvgiftValgRadioGroup
         control={control}
         redigerbart={redigerbart}
-        handleBehandlingsvalgChange={handleBehandlingsvalgChange}
+        handleEndeligAvgiftValgChange={handleEndeligAvgiftValgChange}
         erMedGrunnlagFlyt={true}
       />
 
-      {behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerBehandlingsvalg && (
+      {endeligAvgiftValg === OPPLYSNINGER_ENDRET && !endrerEndeligAvgiftValg && (
         <>
           <Nav.Heading className="endelige_opplysninger_heading" level="2">
             Inntekts- og skatteopplysninger for endelig trygdeavgift
@@ -407,7 +408,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           {formIsValid &&
             !debouncedBeregningPagaar &&
             !beregningPaagar &&
-            behandlingsvalg !== MANUELL_ENDELIG_AVGIFT &&
+            endeligAvgiftValg !== MANUELL_ENDELIG_AVGIFT &&
             !feilmelding &&
             !arrayValideringsfeil &&
             aarsavregningResponse?.nyttGrunnlag && (
@@ -431,7 +432,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       <ManuellAvgiftFormPart
         control={control}
         redigerbart={redigerbart}
-        behandlingsvalg={behandlingsvalg}
+        endeligAvgiftValg={endeligAvgiftValg}
         manueltAvgiftBeloep={manueltAvgiftBeloep}
         debouncedOppdaterManueltAvgiftBeloep={debouncedOppdaterManueltAvgiftBeloep}
         tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -47,7 +47,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   );
   const [beregningPaagar, setBeregningPaagar] = useState(false);
   const [previousFormValues, setPreviousFormValues] = useState<any | null>(null);
-  const [endrerAvvik, setEndrerAvvik] = useState(false);
+  const [endrerBehandlingsvalg, setEndrerBehandlingsvalg] = useState(false);
   const [debouncedBeregningPagaar, setDebouncedBeregningPagaar] = useState(false);
   const [arrayValideringsfeil, setArrayValideringsfeil] = useState<string | undefined>(undefined);
 
@@ -131,7 +131,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const debouncedBeregning = useCallback(() => {
     console.log("[debouncedBeregning] debouncedBeregningPagaar set false", debouncedBeregningPagaar);
     setDebouncedBeregningPagaar(false);
-    if (!redigerbart || !aarsavregningID || behandlingsvalg !== OPPLYSNINGER_ENDRET || beregningPaagar || endrerAvvik) {
+    if (!redigerbart || !aarsavregningID || behandlingsvalg !== OPPLYSNINGER_ENDRET || beregningPaagar || endrerBehandlingsvalg) {
       return;
     }
 
@@ -164,7 +164,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     aarsavregningID,
     behandlingsvalg,
     beregningPaagar,
-    endrerAvvik,
+    endrerBehandlingsvalg,
     getValues,
     formIsValid,
     isValidating,
@@ -194,8 +194,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       debouncedBeregningRef.current.cancel();
     }
     if (debouncedBeregningRef.current) {
-      console.log(behandlingsvalg === OPPLYSNINGER_ENDRET);
-      if (redigerbart && aarsavregningID && behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerAvvik) {
+      if (redigerbart && aarsavregningID && behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerBehandlingsvalg) {
         const currentFormState = mapFormState(getValues("skatteforholdsperioder"), getValues("inntektskilder"));
 
         if (!Utils._isEqual(currentFormState, previousFormValues)) {
@@ -209,7 +208,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         }
       }
     }
-  }, [skatteforholdsperioder, behandlingsvalg, inntektskilder, formIsValid, isValidating, endrerAvvik]);
+  }, [skatteforholdsperioder, behandlingsvalg, inntektskilder, formIsValid, isValidating, endrerBehandlingsvalg]);
 
   const stegErGyldig = useMemo(
     () =>
@@ -251,7 +250,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
 
   const håndterAvvik = useCallback(
     (value: string) => {
-      setEndrerAvvik(true);
+      setEndrerBehandlingsvalg(true);
 
       Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
         .then((res) => {
@@ -273,7 +272,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           }
         })
         .finally(() => {
-          setEndrerAvvik(false);
+          setEndrerBehandlingsvalg(false);
         });
     },
     [
@@ -282,7 +281,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       setBeregningPaagar,
       setAarsavregningResponse,
       setPreviousFormValues,
-      setEndrerAvvik,
+      setEndrerBehandlingsvalg,
       Api.Aarsavregning,
     ],
   );
@@ -291,14 +290,14 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     // noinspection JSIgnoredPromiseFromCall
     trigger();
 
-    if (stegErGyldig && !beregningPaagar && !endrerAvvik && !debouncedBeregningPagaar) {
+    if (stegErGyldig && !beregningPaagar && !endrerBehandlingsvalg && !debouncedBeregningPagaar) {
       bekreft();
     }
-  }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerAvvik, debouncedBeregningPagaar]);
+  }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerBehandlingsvalg, debouncedBeregningPagaar]);
 
   const debouncedOppdaterAvgift25Prosent = useCallback(
     Utils._debounce(
-      async (value: string) => Api.Aarsavregning.oppdaterAvgift25Prosent(behandlingID, aarsavregningID, value),
+      async (value: string) => Api.Aarsavregning.oppdaterAvgift25Prosent(behandlingID, aarsavregningID, Number(value)),
       350,
     ),
     [aarsavregningID],
@@ -346,15 +345,11 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           håndterAvvik(value);
         }}
       >
-        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
-          {KV.kodeTilTerm(OPPLYSNINGER_ENDRET, MKV.KTObjects.aarsavregningBehandlingsvalg)}
-        </Nav.Radio>
-        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
-          {KV.kodeTilTerm(OPPLYSNINGER_UENDRET, MKV.KTObjects.aarsavregningBehandlingsvalg)}
-        </Nav.Radio>
-        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
-          {KV.kodeTilTerm(MANUELL_ENDELIG_AVGIFT, MKV.KTObjects.aarsavregningBehandlingsvalg)}
-        </Nav.Radio>
+        {[OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT].map((kode) => (
+          <Nav.Radio value={kode} key={kode}>
+            {KV.kodeTilTerm(kode, MKV.KTObjects.aarsavregningBehandlingsvalg)}
+          </Nav.Radio>
+        ))}
       </Forms.RadioGroup>
 
       {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
@@ -363,8 +358,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           name="avgift25Prosent"
           control={control}
           readOnly={!redigerbart}
-          // TODO: Rename
-          className="tidligere_fakturert_input"
+          className="avgift_input"
           autoComplete="off"
           type="text"
           numeric
@@ -373,7 +367,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         />
       )}
 
-      {behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerAvvik && (
+      {behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerBehandlingsvalg && (
         <>
           <Nav.Heading className="endelige_opplysninger_heading" level="2">
             Inntekts- og skatteopplysninger for endelig trygdeavgift

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -428,7 +428,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         behandlingsvalg={behandlingsvalg}
         manueltAvgiftBeloep={manueltAvgiftBeloep}
         debouncedOppdaterManueltAvgiftBeloep={debouncedOppdaterManueltAvgiftBeloep}
-        aarsavregningResponse={aarsavregningResponse}
+        tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
         erMedGrunnlagFlyt={true}
         harDeltGrunnlag={false}
       />

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -269,8 +269,8 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         .then((res) => {
           setAarsavregningResponse(res);
           setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
+          // TODO: Beregning skal ikke være nødvendig. API må gjøre opprydning ved endring av behandlingsvalg
           if (value === OPPLYSNINGER_UENDRET || value === MANUELL_ENDELIG_AVGIFT) {
-            // TODO: Skal beregning kjøres for MANUELL_ENDELIG_AVGIFT?
             setBeregningPaagar(true);
             const skatteforholdFraGrunnlag =
               res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder;
@@ -300,15 +300,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     ],
   );
 
-  const håndterBekreft = useCallback(() => {
-    // noinspection JSIgnoredPromiseFromCall
-    trigger();
-
-    if (stegErGyldig && !beregningPaagar && !endrerBehandlingsvalg && !debouncedBeregningPagaar) {
-      bekreft();
-    }
-  }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerBehandlingsvalg, debouncedBeregningPagaar]);
-
   const debouncedOppdaterManueltAvgiftBeloep = useCallback(
     Utils._debounce(
       async (value: string) =>
@@ -319,6 +310,15 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     ),
     [aarsavregningID],
   );
+
+  const håndterBekreft = useCallback(() => {
+    // noinspection JSIgnoredPromiseFromCall
+    trigger();
+
+    if (stegErGyldig && !beregningPaagar && !endrerBehandlingsvalg && !debouncedBeregningPagaar) {
+      bekreft();
+    }
+  }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerBehandlingsvalg, debouncedBeregningPagaar]);
 
   const trygdeAvgiftSkalIkkeBetalesTilNav =
     medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -1,7 +1,7 @@
 import * as Api from "../../../../../services/api";
 import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import "../vurderingAarsavregningInngang.css";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { useSelector } from "react-redux";
 import * as Nav from "../../../../../navFrontend";
@@ -64,6 +64,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     formState: { isValid: formIsValid, isValidating },
     trigger,
     getValues,
+    setValue,
   } = useForm({
     resolver: yupResolver(aarsavregningMedGrunnlagSchema),
     context: {
@@ -91,6 +92,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const skatteforholdsperioder = watch("skatteforholdsperioder");
   const inntektskilder = watch("inntektskilder");
   const behandlingsvalg = watch("behandlingsvalg");
+  const manueltAvgiftBeloep = watch("manueltAvgiftBeloep");
   const debouncedBeregningRef = useRef<any>(null);
 
   const mapFormState = (
@@ -266,6 +268,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
         .then((res) => {
           setAarsavregningResponse(res);
+          setValue("manueltAvgiftBeloep", undefined, { shouldValidate: false, shouldDirty: false });
           if (value === OPPLYSNINGER_UENDRET || value === MANUELL_ENDELIG_AVGIFT) {
             // TODO: Skal beregning kjøres for MANUELL_ENDELIG_AVGIFT?
             setBeregningPaagar(true);
@@ -309,7 +312,9 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const debouncedOppdaterManueltAvgiftBeloep = useCallback(
     Utils._debounce(
       async (value: string) =>
-        Api.Aarsavregning.oppdaterManueltAvgiftBeloep(behandlingID, aarsavregningID, Number(value)),
+        Api.Aarsavregning.oppdaterManueltAvgiftBeloep(behandlingID, aarsavregningID, Number(value)).then((res) => {
+          setAarsavregningResponse(res);
+        }),
       350,
     ),
     [aarsavregningID],
@@ -321,6 +326,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
   const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
 
+  const manueltAvgiftBeloepId = useId();
   return (
     <>
       {aarsavregningResponse && aarsavregningResponse.tidligereGrunnlagsopplysninger && (
@@ -356,12 +362,17 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         onChange={(value) => {
           handleBehandlingsvalgChange(value);
         }}
+        className="behandlingsvalg_radio_group"
       >
-        {[OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT].map((kode) => (
-          <Nav.Radio value={kode} key={kode}>
-            {KV.kodeTilTerm(kode, MKV.KTObjects.aarsavregningBehandlingsvalg)}
-          </Nav.Radio>
-        ))}
+        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
+          <b>Jeg skal gjøre endringer.</b> Inntekts- og/eller skatteopplysningene er endret siden tidligere beregning
+        </Nav.Radio>
+        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
+          <b>Det er ingen endringer.</b> Inntekts- og skatteopplysningene er like som ved tidligere beregning
+        </Nav.Radio>
+        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
+          <b>Jeg skal oppgi endelig avgift selv.</b> Endelig trygdeavgift er manuelt beregnet utenfor Melosys
+        </Nav.Radio>
       </Forms.RadioGroup>
 
       {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
@@ -376,6 +387,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           numeric
           tillattNegativeTall
           onChange={debouncedOppdaterManueltAvgiftBeloep}
+          key={manueltAvgiftBeloepId}
         />
       )}
 
@@ -440,6 +452,14 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
 
           {arrayValideringsfeil && <Feilmelding type={arrayValideringsfeil} />}
         </>
+      )}
+
+      {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && manueltAvgiftBeloep && (
+        <SumArsavregningTabell
+          nyTrygdeavgift={Number(manueltAvgiftBeloep)}
+          tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
+          harGrunnlagIMelosys
+        />
       )}
 
       {feilmelding && !beregningPaagar && (

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -1,7 +1,7 @@
 import * as Api from "../../../../../services/api";
 import MedlemskapsPerioderTabell from "../komponenter/medlemskapsPerioderTabell";
 import "../vurderingAarsavregningInngang.css";
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { useSelector } from "react-redux";
 import * as Nav from "../../../../../navFrontend";
@@ -26,11 +26,10 @@ import TidligereGrunnlagsoversikt from "../komponenter/tidligereGrunnlagsoversik
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 import { InitiellData } from "./aarsavregningMedGrunnlag";
-import * as Forms from "../../../../../felleskomponenter/forms";
 import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
 import { Feilmelding, finnAktivFeilmelding } from "./valideringsfeil";
 import MKV from "../../../../../melosyskodeverk";
-import * as KV from "../../../../../kodeverk";
+import { BehandlingsvalgRadioGroup } from "../komponenter/behandlingsvalgRadioGroup";
 
 const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
@@ -325,8 +324,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const forskuddsvisFakturertTrygdeavgift =
     (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
   const nyttGrunnlagHarTrygdeavgiftsgrunnlag = aarsavregningResponse?.nyttGrunnlag?.trygdeavgiftsgrunnlag != null;
-
-  const manueltAvgiftBeloepId = useId();
   return (
     <>
       {aarsavregningResponse && aarsavregningResponse.tidligereGrunnlagsopplysninger && (
@@ -354,42 +351,13 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </>
       )}
 
-      <Forms.RadioGroup
-        name="behandlingsvalg"
+      <BehandlingsvalgRadioGroup
         control={control}
-        legend="Hva ønsker du å gjøre?"
-        readOnly={!redigerbart}
-        onChange={(value) => {
-          handleBehandlingsvalgChange(value);
-        }}
-        className="behandlingsvalg_radio_group"
-      >
-        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
-          <b>Jeg skal gjøre endringer.</b> Inntekts- og/eller skatteopplysningene er endret siden tidligere beregning
-        </Nav.Radio>
-        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
-          <b>Det er ingen endringer.</b> Inntekts- og skatteopplysningene er like som ved tidligere beregning
-        </Nav.Radio>
-        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
-          <b>Jeg skal oppgi endelig avgift selv.</b> Endelig trygdeavgift er manuelt beregnet utenfor Melosys
-        </Nav.Radio>
-      </Forms.RadioGroup>
-
-      {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
-        <Forms.Input
-          label="Endelig beregnet trygdeavgift"
-          name="manueltAvgiftBeloep"
-          control={control}
-          readOnly={!redigerbart}
-          className="avgift_input"
-          autoComplete="off"
-          type="text"
-          numeric
-          tillattNegativeTall
-          onChange={debouncedOppdaterManueltAvgiftBeloep}
-          key={manueltAvgiftBeloepId}
-        />
-      )}
+        redigerbart={redigerbart}
+        behandlingsvalg={behandlingsvalg}
+        handleBehandlingsvalgChange={handleBehandlingsvalgChange}
+        debouncedOppdaterManueltAvgiftBeloep={debouncedOppdaterManueltAvgiftBeloep}
+      />
 
       {behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerBehandlingsvalg && (
         <>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -29,6 +29,10 @@ import { InitiellData } from "./aarsavregningMedGrunnlag";
 import * as Forms from "../../../../../felleskomponenter/forms";
 import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavregningHelpers";
 import { Feilmelding, finnAktivFeilmelding } from "./valideringsfeil";
+import MKV from "../../../../../melosyskodeverk";
+import * as KV from "../../../../../kodeverk";
+
+const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
 interface Props {
   initiellData: InitiellData;
@@ -86,7 +90,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const formValues = watch();
   const skatteforholdsperioder = watch("skatteforholdsperioder");
   const inntektskilder = watch("inntektskilder");
-  const erAvvik = watch("erAvvik");
+  const behandlingsvalg = watch("behandlingsvalg");
   const debouncedBeregningRef = useRef<any>(null);
 
   const mapFormState = (
@@ -127,7 +131,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const debouncedBeregning = useCallback(() => {
     console.log("[debouncedBeregning] debouncedBeregningPagaar set false", debouncedBeregningPagaar);
     setDebouncedBeregningPagaar(false);
-    if (!redigerbart || !aarsavregningID || erAvvik !== true || beregningPaagar || endrerAvvik) {
+    if (!redigerbart || !aarsavregningID || behandlingsvalg !== OPPLYSNINGER_ENDRET || beregningPaagar || endrerAvvik) {
       return;
     }
 
@@ -158,7 +162,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     }
   }, [
     aarsavregningID,
-    erAvvik,
+    behandlingsvalg,
     beregningPaagar,
     endrerAvvik,
     getValues,
@@ -190,7 +194,8 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       debouncedBeregningRef.current.cancel();
     }
     if (debouncedBeregningRef.current) {
-      if (redigerbart && aarsavregningID && erAvvik === true && !endrerAvvik) {
+      console.log(behandlingsvalg === OPPLYSNINGER_ENDRET);
+      if (redigerbart && aarsavregningID && behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerAvvik) {
         const currentFormState = mapFormState(getValues("skatteforholdsperioder"), getValues("inntektskilder"));
 
         if (!Utils._isEqual(currentFormState, previousFormValues)) {
@@ -204,15 +209,19 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         }
       }
     }
-  }, [skatteforholdsperioder, erAvvik, inntektskilder, formIsValid, isValidating, endrerAvvik]);
+  }, [skatteforholdsperioder, behandlingsvalg, inntektskilder, formIsValid, isValidating, endrerAvvik]);
 
   const stegErGyldig = useMemo(
     () =>
-      erAvvik === false ||
+      behandlingsvalg === OPPLYSNINGER_UENDRET ||
       Boolean(
-        formIsValid && erAvvik === true && aarsavregningResponse?.nyttGrunnlag && !feilmelding && !arrayValideringsfeil,
+        formIsValid &&
+          behandlingsvalg === OPPLYSNINGER_ENDRET &&
+          aarsavregningResponse?.nyttGrunnlag &&
+          !feilmelding &&
+          !arrayValideringsfeil,
       ),
-    [erAvvik, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding, arrayValideringsfeil],
+    [behandlingsvalg, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding, arrayValideringsfeil],
   );
 
   useEffect(() => {
@@ -241,13 +250,14 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   ]);
 
   const håndterAvvik = useCallback(
-    (value: boolean) => {
+    (value: string) => {
       setEndrerAvvik(true);
 
-      Api.Aarsavregning.oppdaterAvvik(behandlingID, value, aarsavregningID)
+      Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
         .then((res) => {
           setAarsavregningResponse(res);
-          if (!value) {
+          if (value === OPPLYSNINGER_UENDRET || value === MANUELL_ENDELIG_AVGIFT) {
+            // TODO: Skal beregning kjøres for MANUELL_ENDELIG_AVGIFT?
             setBeregningPaagar(true);
             const skatteforholdFraGrunnlag =
               res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder;
@@ -286,6 +296,14 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     }
   }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerAvvik, debouncedBeregningPagaar]);
 
+  const debouncedOppdaterAvgift25Prosent = useCallback(
+    Utils._debounce(
+      async (value: string) => Api.Aarsavregning.oppdaterAvgift25Prosent(behandlingID, aarsavregningID, value),
+      350,
+    ),
+    [aarsavregningID],
+  );
+
   const trygdeAvgiftSkalIkkeBetalesTilNav =
     medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder);
   const forskuddsvisFakturertTrygdeavgift =
@@ -320,21 +338,42 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       )}
 
       <Forms.RadioGroup
-        name="erAvvik"
+        name="behandlingsvalg"
         control={control}
-        legend="Er det avvik i opplysningene fra skatt eller bruker?"
+        legend="Hva ønsker du å gjøre?"
         readOnly={!redigerbart}
         onChange={(value) => {
           håndterAvvik(value);
         }}
       >
-        <Nav.HStack gap="6">
-          <Nav.Radio value={true}>Ja</Nav.Radio>
-          <Nav.Radio value={false}>Nei</Nav.Radio>
-        </Nav.HStack>
+        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
+          {KV.kodeTilTerm(OPPLYSNINGER_ENDRET, MKV.KTObjects.aarsavregningBehandlingsvalg)}
+        </Nav.Radio>
+        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
+          {KV.kodeTilTerm(OPPLYSNINGER_UENDRET, MKV.KTObjects.aarsavregningBehandlingsvalg)}
+        </Nav.Radio>
+        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
+          {KV.kodeTilTerm(MANUELL_ENDELIG_AVGIFT, MKV.KTObjects.aarsavregningBehandlingsvalg)}
+        </Nav.Radio>
       </Forms.RadioGroup>
 
-      {erAvvik === true && !endrerAvvik && (
+      {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
+        <Forms.Input
+          label="Endelig beregnet trygdeavgift"
+          name="avgift25Prosent"
+          control={control}
+          readOnly={!redigerbart}
+          // TODO: Rename
+          className="tidligere_fakturert_input"
+          autoComplete="off"
+          type="text"
+          numeric
+          tillattNegativeTall
+          onChange={debouncedOppdaterAvgift25Prosent}
+        />
+      )}
+
+      {behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerAvvik && (
         <>
           <Nav.Heading className="endelige_opplysninger_heading" level="2">
             Inntekts- og skatteopplysninger for endelig trygdeavgift
@@ -382,6 +421,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           {formIsValid &&
             !debouncedBeregningPagaar &&
             !beregningPaagar &&
+            behandlingsvalg !== MANUELL_ENDELIG_AVGIFT &&
             !feilmelding &&
             !arrayValideringsfeil &&
             aarsavregningResponse?.nyttGrunnlag && (

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -267,7 +267,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
         .then((res) => {
           setAarsavregningResponse(res);
-          setValue("manueltAvgiftBeloep", undefined, { shouldValidate: false, shouldDirty: false });
+          setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
           if (value === OPPLYSNINGER_UENDRET || value === MANUELL_ENDELIG_AVGIFT) {
             // TODO: Skal beregning kjøres for MANUELL_ENDELIG_AVGIFT?
             setBeregningPaagar(true);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -131,7 +131,13 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   const debouncedBeregning = useCallback(() => {
     console.log("[debouncedBeregning] debouncedBeregningPagaar set false", debouncedBeregningPagaar);
     setDebouncedBeregningPagaar(false);
-    if (!redigerbart || !aarsavregningID || behandlingsvalg !== OPPLYSNINGER_ENDRET || beregningPaagar || endrerBehandlingsvalg) {
+    if (
+      !redigerbart ||
+      !aarsavregningID ||
+      behandlingsvalg !== OPPLYSNINGER_ENDRET ||
+      beregningPaagar ||
+      endrerBehandlingsvalg
+    ) {
       return;
     }
 
@@ -219,6 +225,11 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           aarsavregningResponse?.nyttGrunnlag &&
           !feilmelding &&
           !arrayValideringsfeil,
+      ) ||
+      Boolean(
+        behandlingsvalg === MANUELL_ENDELIG_AVGIFT &&
+          aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
+          !feilmelding,
       ),
     [behandlingsvalg, formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding, arrayValideringsfeil],
   );
@@ -248,7 +259,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     aarsavregningResponse?.avregning?.nyttTotalbeloep,
   ]);
 
-  const håndterAvvik = useCallback(
+  const handleBehandlingsvalgChange = useCallback(
     (value: string) => {
       setEndrerBehandlingsvalg(true);
 
@@ -295,9 +306,10 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     }
   }, [trigger, stegErGyldig, beregningPaagar, bekreft, endrerBehandlingsvalg, debouncedBeregningPagaar]);
 
-  const debouncedOppdaterAvgift25Prosent = useCallback(
+  const debouncedOppdaterManueltAvgiftBeloep = useCallback(
     Utils._debounce(
-      async (value: string) => Api.Aarsavregning.oppdaterAvgift25Prosent(behandlingID, aarsavregningID, Number(value)),
+      async (value: string) =>
+        Api.Aarsavregning.oppdaterManueltAvgiftBeloep(behandlingID, aarsavregningID, Number(value)),
       350,
     ),
     [aarsavregningID],
@@ -342,7 +354,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         legend="Hva ønsker du å gjøre?"
         readOnly={!redigerbart}
         onChange={(value) => {
-          håndterAvvik(value);
+          handleBehandlingsvalgChange(value);
         }}
       >
         {[OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT].map((kode) => (
@@ -355,7 +367,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
         <Forms.Input
           label="Endelig beregnet trygdeavgift"
-          name="avgift25Prosent"
+          name="manueltAvgiftBeloep"
           control={control}
           readOnly={!redigerbart}
           className="avgift_input"
@@ -363,7 +375,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
           type="text"
           numeric
           tillattNegativeTall
-          onChange={debouncedOppdaterAvgift25Prosent}
+          onChange={debouncedOppdaterManueltAvgiftBeloep}
         />
       )}
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -30,6 +30,7 @@ import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../aarsavre
 import { Feilmelding, finnAktivFeilmelding } from "./valideringsfeil";
 import MKV from "../../../../../melosyskodeverk";
 import { BehandlingsvalgRadioGroup } from "../komponenter/behandlingsvalgRadioGroup";
+import { ManuellAvgiftFormPart } from "../komponenter/manuellAvgiftFormPart";
 
 const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
@@ -354,9 +355,8 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       <BehandlingsvalgRadioGroup
         control={control}
         redigerbart={redigerbart}
-        behandlingsvalg={behandlingsvalg}
         handleBehandlingsvalgChange={handleBehandlingsvalgChange}
-        debouncedOppdaterManueltAvgiftBeloep={debouncedOppdaterManueltAvgiftBeloep}
+        erMedGrunnlagFlyt={true}
       />
 
       {behandlingsvalg === OPPLYSNINGER_ENDRET && !endrerBehandlingsvalg && (
@@ -422,13 +422,16 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         </>
       )}
 
-      {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && manueltAvgiftBeloep && (
-        <SumArsavregningTabell
-          nyTrygdeavgift={Number(manueltAvgiftBeloep)}
-          tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
-          harGrunnlagIMelosys
-        />
-      )}
+      <ManuellAvgiftFormPart
+        control={control}
+        redigerbart={redigerbart}
+        behandlingsvalg={behandlingsvalg}
+        manueltAvgiftBeloep={manueltAvgiftBeloep}
+        debouncedOppdaterManueltAvgiftBeloep={debouncedOppdaterManueltAvgiftBeloep}
+        aarsavregningResponse={aarsavregningResponse}
+        erMedGrunnlagFlyt={true}
+        harDeltGrunnlag={false}
+      />
 
       {feilmelding && !beregningPaagar && (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -15,7 +15,7 @@ const {
   PENSJON_UFØRETRYGD,
   PENSJON_UFØRETRYGD_KILDESKATT,
 } = MKV.Koder.inntektskildetype;
-const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 const UTENFOR_MEDLEMSKAPSPERIODEN = { melding: "Utenfor medl.periode" };
 
 export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
@@ -101,24 +101,24 @@ const inntektskildeSchema = object().shape({
 });
 
 const aarsavregningMedGrunnlagSchema = object().shape({
-  behandlingsvalg: string().required(MAA_FYLLES_UT),
-  skatteforholdsperioder: array().when(["behandlingsvalg"], {
-    is: (behandlingsvalg) => behandlingsvalg === OPPLYSNINGER_ENDRET,
+  endeligAvgiftValg: string().required(MAA_FYLLES_UT),
+  skatteforholdsperioder: array().when(["endeligAvgiftValg"], {
+    is: (endeligAvgiftValg) => endeligAvgiftValg === OPPLYSNINGER_ENDRET,
     then: array().min(1, "Minst en skatteforholdsperiode").of(skatteforholdsperiodeSchema),
     otherwise: array(),
   }),
-  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "behandlingsvalg", "skatteforholdsperioder"], {
-    is: (medlemskapsTypeErPliktig, behandlingsvalg, skatteforholdsperioder) => {
+  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "endeligAvgiftValg", "skatteforholdsperioder"], {
+    is: (medlemskapsTypeErPliktig, endeligAvgiftValg, skatteforholdsperioder) => {
       return (
-        behandlingsvalg === OPPLYSNINGER_ENDRET &&
+        endeligAvgiftValg === OPPLYSNINGER_ENDRET &&
         (!medlemskapsTypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder))
       );
     },
     then: array().min(1, "Minst en inntektskilde").of(inntektskildeSchema),
     otherwise: array(),
   }),
-  manueltAvgiftBeloep: string().when(["behandlingsvalg"], {
-    is: (behandlingsvalg) => behandlingsvalg === MANUELL_ENDELIG_AVGIFT,
+  manueltAvgiftBeloep: string().when(["endeligAvgiftValg"], {
+    is: (endeligAvgiftValg) => endeligAvgiftValg === MANUELL_ENDELIG_AVGIFT,
     then: string().required(MAA_FYLLES_UT),
   }),
 });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -117,7 +117,7 @@ const aarsavregningMedGrunnlagSchema = object().shape({
     then: array().min(1, "Minst en inntektskilde").of(inntektskildeSchema),
     otherwise: array(),
   }),
-  avgift25Prosent: string().when(["behandlingsvalg"], {
+  manueltAvgiftBeloep: string().when(["behandlingsvalg"], {
     is: (behandlingsvalg) => behandlingsvalg === MANUELL_ENDELIG_AVGIFT,
     then: string().required(MAA_FYLLES_UT),
   }),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -15,6 +15,7 @@ const {
   PENSJON_UFØRETRYGD,
   PENSJON_UFØRETRYGD_KILDESKATT,
 } = MKV.Koder.inntektskildetype;
+const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 const UTENFOR_MEDLEMSKAPSPERIODEN = { melding: "Utenfor medl.periode" };
 
 export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
@@ -100,20 +101,25 @@ const inntektskildeSchema = object().shape({
 });
 
 const aarsavregningMedGrunnlagSchema = object().shape({
-  erAvvik: boolean().required(MAA_FYLLES_UT),
-  skatteforholdsperioder: array().when(["erAvvik"], {
-    is: (erAvvik) => erAvvik === true,
+  behandlingsvalg: string().required(MAA_FYLLES_UT),
+  skatteforholdsperioder: array().when(["behandlingsvalg"], {
+    is: (behandlingsvalg) => behandlingsvalg === OPPLYSNINGER_ENDRET,
     then: array().min(1, "Minst en skatteforholdsperiode").of(skatteforholdsperiodeSchema),
     otherwise: array(),
   }),
-  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "erAvvik", "skatteforholdsperioder"], {
-    is: (medlemskapsTypeErPliktig, erAvvik, skatteforholdsperioder) => {
+  inntektskilder: array().when(["$medlemskapsTypeErPliktig", "behandlingsvalg", "skatteforholdsperioder"], {
+    is: (medlemskapsTypeErPliktig, behandlingsvalg, skatteforholdsperioder) => {
       return (
-        erAvvik === true && (!medlemskapsTypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder))
+        behandlingsvalg === OPPLYSNINGER_ENDRET &&
+        (!medlemskapsTypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder))
       );
     },
     then: array().min(1, "Minst en inntektskilde").of(inntektskildeSchema),
     otherwise: array(),
+  }),
+  avgift25Prosent: string().when(["behandlingsvalg"], {
+    is: (behandlingsvalg) => behandlingsvalg === MANUELL_ENDELIG_AVGIFT,
+    then: string().required(MAA_FYLLES_UT),
   }),
 });
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -20,7 +20,7 @@ import {
 import { AarsavregningUtenEllerDeltGrunnlagForm } from "./aarsavregningUtenEllerDeltGrunnlagForm";
 
 const { DELVIS_INNVILGET, INNVILGET } = MKV.Koder.innvilgelsesResultat;
-const { OPPLYSNINGER_ENDRET } = MKV.Koder.aarsavregningBehandlingsvalg;
+const { OPPLYSNINGER_ENDRET } = MKV.Koder.endeligAvgiftValg;
 
 export const ULAGRET_MEDLEMSKAPSPERIODE_ID = -1;
 
@@ -74,7 +74,7 @@ export interface MedlemskapTomFomDatoer {
 export interface AarsavregningFormValuesProps extends FormValuesProps {
   totaltForskuddsvisFakturert?: number | string;
   bestemmelse?: string;
-  behandlingsvalg?: string;
+  endeligAvgiftValg?: string;
   manueltAvgiftBeloep?: number;
 }
 
@@ -94,7 +94,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
       totaltForskuddsvisFakturert: "",
-      behandlingsvalg: undefined,
+      endeligAvgiftValg: undefined,
       manueltAvgiftBeloep: undefined,
     },
   });
@@ -232,7 +232,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
             : [DEFAULT_MEDLEMSKAPSPERIODE],
           bestemmelse,
           totaltForskuddsvisFakturert: aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem || "",
-          behandlingsvalg: aarsavregningRes?.behandlingsvalg,
+          endeligAvgiftValg: aarsavregningRes?.endeligAvgiftValg,
           manueltAvgiftBeloep: aarsavregningRes?.avregning?.manueltAvgiftBeloep,
           skatteforholdsperioder: mapTilSkatteforholdProps(
             deltGrunnlagAarsavregningHarIkkeNyttGrunnlag

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -20,6 +20,7 @@ import {
 import { AarsavregningUtenEllerDeltGrunnlagForm } from "./aarsavregningUtenEllerDeltGrunnlagForm";
 
 const { DELVIS_INNVILGET, INNVILGET } = MKV.Koder.innvilgelsesResultat;
+const { OPPLYSNINGER_ENDRET } = MKV.Koder.aarsavregningBehandlingsvalg;
 
 export const ULAGRET_MEDLEMSKAPSPERIODE_ID = -1;
 
@@ -73,6 +74,8 @@ export interface MedlemskapTomFomDatoer {
 export interface AarsavregningFormValuesProps extends FormValuesProps {
   totaltForskuddsvisFakturert?: number | string;
   bestemmelse?: string;
+  behandlingsvalg?: string;
+  manueltAvgiftBeloep?: number;
 }
 
 export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, harDeltGrunnlag }: Props) {
@@ -91,6 +94,8 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
       totaltForskuddsvisFakturert: "",
+      behandlingsvalg: undefined,
+      manueltAvgiftBeloep: undefined,
     },
   });
 
@@ -227,6 +232,8 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
             : [DEFAULT_MEDLEMSKAPSPERIODE],
           bestemmelse,
           totaltForskuddsvisFakturert: aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem || "",
+          behandlingsvalg: aarsavregningRes?.behandlingsvalg,
+          manueltAvgiftBeloep: aarsavregningRes?.avregning?.manueltAvgiftBeloep,
           skatteforholdsperioder: mapTilSkatteforholdProps(
             deltGrunnlagAarsavregningHarIkkeNyttGrunnlag
               ? aarsavregningRes?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -258,10 +258,10 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         const response: any = await (periode.id === ULAGRET_MEDLEMSKAPSPERIODE_ID
           ? Api.MedlemAvFolketrygden.Medlemskapsperioder.opprettMedlemskapsperioder(behandlingID, periodeRequest)
           : Api.MedlemAvFolketrygden.Medlemskapsperioder.oppdaterMedlemskapsperioder(
-            behandlingID,
-            periode.id,
-            periodeRequest,
-          ));
+              behandlingID,
+              periode.id,
+              periodeRequest,
+            ));
 
         return response;
       } catch (error) {
@@ -692,17 +692,17 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     if (behandlingsvalg === OPPLYSNINGER_ENDRET) {
       return Boolean(
         formIsValid &&
-        aarsavregningResponse?.nyttGrunnlag &&
-        feilmelding === undefined &&
-        arrayValideringsfeil === undefined,
+          aarsavregningResponse?.nyttGrunnlag &&
+          feilmelding === undefined &&
+          arrayValideringsfeil === undefined,
       );
     }
     if (behandlingsvalg === MANUELL_ENDELIG_AVGIFT) {
       return Boolean(
         formIsValid &&
-        aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem &&
-        aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
-        feilmelding === undefined,
+          aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem &&
+          aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
+          feilmelding === undefined,
       );
     }
     return false;
@@ -915,7 +915,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         behandlingsvalg={behandlingsvalg}
         manueltAvgiftBeloep={manueltAvgiftBeloep}
         debouncedOppdaterManueltAvgiftBeloep={debouncedOppdaterManueltAvgiftBeloep}
-        aarsavregningResponse={aarsavregningResponse}
+        tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
         erMedGrunnlagFlyt={false}
         harDeltGrunnlag={harDeltGrunnlag}
         totaltForskuddsvisFakturert={totaltForskuddsvisFakturert}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -40,6 +40,10 @@ import {
 } from "./aarsavregningUtenEllerDeltGrunnlag";
 import aarsavregningUtenEllerDeltGrunnlagSchema from "./aarsavregningUtenEllerDeltGrunnlagSchema";
 import { Feilmelding, finnAktivFeilmelding, finnAktivFeilmeldingForMedlemskapsperioder } from "./valideringsfeil";
+import { BehandlingsvalgRadioGroup } from "../komponenter/behandlingsvalgRadioGroup";
+import { ManuellAvgiftFormPart } from "../komponenter/manuellAvgiftFormPart";
+
+const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
 // Helper function to log and return changed dependencies
 const getChangedDependencies = (currentDeps: Record<string, any>, previousDepsRef: React.MutableRefObject<any>) => {
@@ -103,6 +107,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const [lagredeMedlemskapsperioder, setLagredeMedlemskapsperioder] = useState<Medlemskapsperiode[]>(
     initiellData.formDefaultValues.medlemskapsperioder || [],
   );
+  const [endrerBehandlingsvalg, setEndrerBehandlingsvalg] = useState(false);
 
   // Redux selectors
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
@@ -152,6 +157,8 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const totaltForskuddsvisFakturert = useWatch({ control, name: "totaltForskuddsvisFakturert" });
   const skatteforholdsperioder = useWatch({ control, name: "skatteforholdsperioder" });
   const inntektskilder = useWatch({ control, name: "inntektskilder" });
+  const behandlingsvalg = useWatch({ control, name: "behandlingsvalg" });
+  const manueltAvgiftBeloep = useWatch({ control, name: "manueltAvgiftBeloep" });
 
   const debouncedBeregningRef = useRef<any>(null);
   const forrigeTotaltForskuddsvisFakturert = useRef(totaltForskuddsvisFakturert);
@@ -251,10 +258,10 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         const response: any = await (periode.id === ULAGRET_MEDLEMSKAPSPERIODE_ID
           ? Api.MedlemAvFolketrygden.Medlemskapsperioder.opprettMedlemskapsperioder(behandlingID, periodeRequest)
           : Api.MedlemAvFolketrygden.Medlemskapsperioder.oppdaterMedlemskapsperioder(
-              behandlingID,
-              periode.id,
-              periodeRequest,
-            ));
+            behandlingID,
+            periode.id,
+            periodeRequest,
+          ));
 
         return response;
       } catch (error) {
@@ -284,7 +291,14 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const debouncedBeregning = useCallback(() => {
     console.log("[debouncedBeregning] setter debouncedBeregningPagaar til false");
     setDebouncedBeregningPagaar(false);
-    if (!redigerbart || !aarsavregningID || endrerBestemmelse || beregningPaagar || lagreMedlemskapsperioderPaagar) {
+    if (
+      !redigerbart ||
+      !aarsavregningID ||
+      endrerBestemmelse ||
+      beregningPaagar ||
+      lagreMedlemskapsperioderPaagar ||
+      behandlingsvalg !== OPPLYSNINGER_ENDRET
+    ) {
       console.log("[debouncedBeregning] return tidlig i debouncedBeregning");
       return;
     }
@@ -341,6 +355,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     previousFormState,
     lagreMedlemskapsperioderPaagar,
     finnMedlemskapsperiode,
+    behandlingsvalg,
   ]);
 
   const lagreMedlemskapsperioder = useCallback(
@@ -504,7 +519,9 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     request: Api.Aarsavregning.AarsavregningRequest,
     aarsavregningid?: number,
   ) => {
-    await Api.Aarsavregning.oppdaterAarsavregning(behandlingid, request, aarsavregningid);
+    await Api.Aarsavregning.oppdaterAarsavregning(behandlingid, request, aarsavregningid).then(
+      setAarsavregningResponse,
+    );
   };
 
   const debouncedOppdaterTotaltForskuddsvisFakturert = useCallback(
@@ -553,6 +570,16 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
   // Håndterer kjøring av beregninger når skjemaverdier endres
   useEffect(() => {
+    // Only run calculation logic if behandlingsvalg is OPPLYSNINGER_ENDRET
+    if (behandlingsvalg !== OPPLYSNINGER_ENDRET) {
+      setDebouncedBeregningPagaar(false);
+      setArrayValideringsfeil(undefined); // Clear potential errors if switching away
+      if (debouncedBeregningRef.current?.cancel) {
+        debouncedBeregningRef.current.cancel();
+      }
+      return;
+    }
+
     const currentDeps = {
       skatteforholdsperioder,
       inntektskilder,
@@ -560,6 +587,14 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       lagreMedlemskapsperioderPaagar,
       endrerBestemmelse,
       totaltForskuddsvisFakturert,
+      behandlingsvalg,
+      aarsavregningID,
+      redigerbart,
+      beregningPaagar,
+      trigger,
+      getValues,
+      previousFormState,
+      errors,
     };
 
     // Get the changed dependencies
@@ -643,21 +678,57 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     lagreMedlemskapsperioderPaagar,
     endrerBestemmelse,
     totaltForskuddsvisFakturert,
+    behandlingsvalg,
+    aarsavregningID,
+    redigerbart,
+    beregningPaagar,
+    trigger,
+    getValues,
+    previousFormState,
+    errors,
   ]);
 
-  const stegErGyldig = useMemo(
-    () => Boolean(formIsValid && aarsavregningResponse?.nyttGrunnlag && feilmelding === undefined),
-    [formIsValid, aarsavregningResponse?.nyttGrunnlag, feilmelding],
-  );
+  const stegErGyldig = useMemo(() => {
+    if (behandlingsvalg === OPPLYSNINGER_ENDRET) {
+      return Boolean(
+        formIsValid &&
+        aarsavregningResponse?.nyttGrunnlag &&
+        feilmelding === undefined &&
+        arrayValideringsfeil === undefined,
+      );
+    }
+    if (behandlingsvalg === MANUELL_ENDELIG_AVGIFT) {
+      return Boolean(
+        formIsValid &&
+        aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem &&
+        aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
+        feilmelding === undefined,
+      );
+    }
+    return false;
+  }, [
+    formIsValid,
+    aarsavregningResponse?.nyttGrunnlag,
+    aarsavregningResponse?.avregning?.manueltAvgiftBeloep,
+    feilmelding,
+    behandlingsvalg,
+    arrayValideringsfeil,
+  ]);
 
   useEffect(() => {
     oppdaterStatus(stegErGyldig);
   }, [stegErGyldig, oppdaterStatus]);
 
-  const bekreftOnClick = () => {
+  const håndterBekreft = () => {
     trigger();
 
-    if (stegErGyldig && arrayValideringsfeil === undefined && !beregningPaagar) {
+    if (
+      stegErGyldig &&
+      !beregningPaagar &&
+      !endrerBestemmelse &&
+      !lagreMedlemskapsperioderPaagar &&
+      !debouncedBeregningPagaar
+    ) {
       bekreft();
     }
   };
@@ -667,6 +738,36 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const forskuddsvisFakturertTrygdeavgift =
     (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
   const skjemaErRedigerbart = redigerbart && !endrerBestemmelse;
+
+  const handleBehandlingsvalgChange = useCallback(
+    (value: string) => {
+      setEndrerBehandlingsvalg(true);
+
+      Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
+        .then((res) => {
+          setAarsavregningResponse(res);
+          if (value !== MANUELL_ENDELIG_AVGIFT) {
+            setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
+          }
+          setPreviousFormState(null);
+        })
+        .finally(() => {
+          setEndrerBehandlingsvalg(false);
+        });
+    },
+    [aarsavregningID, behandlingID, setValue],
+  );
+
+  const debouncedOppdaterManueltAvgiftBeloep = useCallback(
+    Utils._debounce(
+      async (value: string) =>
+        Api.Aarsavregning.oppdaterManueltAvgiftBeloep(behandlingID, aarsavregningID, Number(value)).then((res) => {
+          setAarsavregningResponse(res);
+        }),
+      350,
+    ),
+    [aarsavregningID, behandlingID],
+  );
 
   return (
     <div className="vurderingAarsavregning">
@@ -695,115 +796,136 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         </>
       )}
 
-      <TidligereFakturertIAvgiftssystemetInput
+      <BehandlingsvalgRadioGroup
         control={control}
         redigerbart={skjemaErRedigerbart}
-        harDeltGrunnlag={harDeltGrunnlag}
+        handleBehandlingsvalgChange={handleBehandlingsvalgChange}
+        erMedGrunnlagFlyt={false}
       />
 
-      <Nav.Heading className="endelige_opplysninger_heading" level="2">
-        Inntekts- og skatteopplysninger for endelig trygdeavgift
-      </Nav.Heading>
-
-      <BestemmelseSelect
-        control={control}
-        setValue={setValue}
-        bestemmelser={initiellData.bestemmelser}
-        harDeltGrunnlag={harDeltGrunnlag}
-        behandlingID={behandlingID}
-        redigerbart={skjemaErRedigerbart}
-        setTrygdedekninger={setTrygdedekninger}
-        setFeilmelding={setFeilmelding}
-        setEndrerBestemmelse={setEndrerBestemmelse}
-        lagreMedlemskapsperioderHvisGyldig={lagreMedlemskapsperioderEtterBestemmelseEndringHvisGyldig}
-      />
-
-      <div className="medlemskapsperioder">
-        {medlemskapsperioderFields.map((field, index) => (
-          <MedlemskapsperiodeSkjema
-            key={field.id}
-            redigerbart={skjemaErRedigerbart}
+      {behandlingsvalg === OPPLYSNINGER_ENDRET && (
+        <>
+          <TidligereFakturertIAvgiftssystemetInput
             control={control}
-            field={field}
-            index={index}
-            remove={slettMedlemskapsperiode}
-            formValues={formValues}
-            handleLeggTil={leggTilDefaultMedlemskapsperiode}
-            visLeggTil
-            maksVerdi={
-              initiellData.valgtÅr !== undefined ? new Date(initiellData.valgtÅr, 11, 31, 23, 59, 59, 999) : undefined
-            }
-            minVerdi={initiellData.valgtÅr !== undefined ? new Date(initiellData.valgtÅr, 0, 1) : undefined}
-            trygdedekninger={trygdedekninger}
+            redigerbart={skjemaErRedigerbart}
+            harDeltGrunnlag={harDeltGrunnlag}
+          />
+
+          <Nav.Heading className="endelige_opplysninger_heading" level="2">
+            Inntekts- og skatteopplysninger for endelig trygdeavgift
+          </Nav.Heading>
+
+          <BestemmelseSelect
+            control={control}
             setValue={setValue}
-            errors={errors}
+            bestemmelser={initiellData.bestemmelser}
+            harDeltGrunnlag={harDeltGrunnlag}
+            behandlingID={behandlingID}
+            redigerbart={skjemaErRedigerbart}
+            setTrygdedekninger={setTrygdedekninger}
+            setFeilmelding={setFeilmelding}
+            setEndrerBestemmelse={setEndrerBestemmelse}
+            lagreMedlemskapsperioderHvisGyldig={lagreMedlemskapsperioderEtterBestemmelseEndringHvisGyldig}
           />
-        ))}
-      </div>
 
-      <Skatteforholdsperioder
-        defaultPeriode={medlemskapsperiode}
-        formValues={formValues}
-        redigerbart={skjemaErRedigerbart}
-        remove={skattRemove}
-        append={skattAppend}
+          <div className="medlemskapsperioder">
+            {medlemskapsperioderFields.map((field, index) => (
+              <MedlemskapsperiodeSkjema
+                key={field.id}
+                redigerbart={skjemaErRedigerbart}
+                control={control}
+                field={field}
+                index={index}
+                remove={slettMedlemskapsperiode}
+                formValues={formValues}
+                handleLeggTil={leggTilDefaultMedlemskapsperiode}
+                visLeggTil
+                maksVerdi={
+                  initiellData.valgtÅr !== undefined
+                    ? new Date(initiellData.valgtÅr, 11, 31, 23, 59, 59, 999)
+                    : undefined
+                }
+                minVerdi={initiellData.valgtÅr !== undefined ? new Date(initiellData.valgtÅr, 0, 1) : undefined}
+                trygdedekninger={trygdedekninger}
+                setValue={setValue}
+                errors={errors}
+              />
+            ))}
+          </div>
+
+          <Skatteforholdsperioder
+            defaultPeriode={medlemskapsperiode}
+            formValues={formValues}
+            redigerbart={skjemaErRedigerbart}
+            remove={skattRemove}
+            append={skattAppend}
+            control={control}
+            fields={skattFields}
+          />
+          {!trygdeAvgiftSkalIkkeBetalesTilNav && (
+            <Inntektskilder
+              defaultPeriode={medlemskapsperiode}
+              formValues={formValues}
+              redigerbart={skjemaErRedigerbart}
+              update={inntektUpdate}
+              remove={inntektRemove}
+              append={inntektAppend}
+              control={control}
+              fields={inntektFields}
+              medlemskapsTypeErPliktig={medlemskapstypeErPliktig}
+              skalViseErMaanedsBelopRadioGroup
+              bestemmelse={bestemmelse}
+            />
+          )}
+          {formIsValid && trygdeAvgiftSkalIkkeBetalesTilNav && (
+            <Aarsavregningsmeldinger.TrygdeavgiftSkalIkkeBetalesTilNav />
+          )}
+
+          {formIsValid && !beregningPaagar && !debouncedBeregningPagaar && !arrayValideringsfeil && !feilmelding && (
+            <SumArsavregningTabell
+              harGrunnlagIMelosys={harDeltGrunnlag}
+              nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
+              tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
+              tidligereTrygdeavgiftAvgiftssystem={
+                aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem
+              }
+            />
+          )}
+
+          {formIsValid &&
+            !beregningPaagar &&
+            !debouncedBeregningPagaar &&
+            !feilmelding &&
+            !arrayValideringsfeil &&
+            aarsavregningResponse?.nyttGrunnlag && (
+              <BeregnetTrygdeavgiftDetaljer
+                grunnlag={aarsavregningResponse.nyttGrunnlag}
+                medlemskapsTypeErPliktig={medlemskapstypeErPliktig}
+                tittel="Endelig beregnet trygdeavgift"
+              />
+            )}
+
+          {arrayValideringsfeil && <Feilmelding type={arrayValideringsfeil} />}
+        </>
+      )}
+
+      <ManuellAvgiftFormPart
         control={control}
-        fields={skattFields}
+        redigerbart={redigerbart}
+        behandlingsvalg={behandlingsvalg}
+        manueltAvgiftBeloep={manueltAvgiftBeloep}
+        debouncedOppdaterManueltAvgiftBeloep={debouncedOppdaterManueltAvgiftBeloep}
+        aarsavregningResponse={aarsavregningResponse}
+        erMedGrunnlagFlyt={false}
+        harDeltGrunnlag={harDeltGrunnlag}
+        totaltForskuddsvisFakturert={totaltForskuddsvisFakturert}
       />
-      {!trygdeAvgiftSkalIkkeBetalesTilNav && (
-        <Inntektskilder
-          defaultPeriode={medlemskapsperiode}
-          formValues={formValues}
-          redigerbart={skjemaErRedigerbart}
-          update={inntektUpdate}
-          remove={inntektRemove}
-          append={inntektAppend}
-          control={control}
-          fields={inntektFields}
-          medlemskapsTypeErPliktig={medlemskapstypeErPliktig}
-          skalViseErMaanedsBelopRadioGroup
-          bestemmelse={bestemmelse}
-        />
-      )}
-      {formIsValid && trygdeAvgiftSkalIkkeBetalesTilNav && (
-        <Aarsavregningsmeldinger.TrygdeavgiftSkalIkkeBetalesTilNav />
-      )}
-
-      {formIsValid && !beregningPaagar && !debouncedBeregningPagaar && !arrayValideringsfeil && !feilmelding && (
-        <SumArsavregningTabell
-          harGrunnlagIMelosys={harDeltGrunnlag}
-          nyTrygdeavgift={aarsavregningResponse?.avregning?.nyttTotalbeloep}
-          tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
-          tidligereTrygdeavgiftAvgiftssystem={aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem}
-        />
-      )}
-
-      {formIsValid &&
-        !beregningPaagar &&
-        !debouncedBeregningPagaar &&
-        !feilmelding &&
-        !arrayValideringsfeil &&
-        aarsavregningResponse?.nyttGrunnlag && (
-          <BeregnetTrygdeavgiftDetaljer
-            grunnlag={aarsavregningResponse.nyttGrunnlag}
-            medlemskapsTypeErPliktig={medlemskapstypeErPliktig}
-            tittel="Endelig beregnet trygdeavgift"
-          />
-        )}
-
-      {arrayValideringsfeil && <Feilmelding type={arrayValideringsfeil} />}
-
-      {feilmelding && (
-        <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          {feilmelding}
-        </Nav.Alert>
-      )}
 
       <Nav.Button
         variant="primary"
         loading={beregningPaagar || endrerBestemmelse || lagreMedlemskapsperioderPaagar || debouncedBeregningPagaar}
         disabled={!redigerbart}
-        onClick={bekreftOnClick}
+        onClick={håndterBekreft}
       >
         Bekreft og fortsett
       </Nav.Button>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -569,10 +569,9 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
   // Håndterer kjøring av beregninger når skjemaverdier endres
   useEffect(() => {
-    // Only run calculation logic if behandlingsvalg is OPPLYSNINGER_ENDRET
     if (behandlingsvalg !== OPPLYSNINGER_ENDRET) {
       setDebouncedBeregningPagaar(false);
-      setArrayValideringsfeil(undefined); // Clear potential errors if switching away
+      setArrayValideringsfeil(undefined);
       if (debouncedBeregningRef.current?.cancel) {
         debouncedBeregningRef.current.cancel();
       }
@@ -621,7 +620,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     }
 
     if (debouncedBeregningRef.current) {
-      // You might adjust this condition based on the changes detected
       const currentFormState = mapFormState(
         getValues("skatteforholdsperioder"),
         getValues("inntektskilder"),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -40,10 +40,10 @@ import {
 } from "./aarsavregningUtenEllerDeltGrunnlag";
 import aarsavregningUtenEllerDeltGrunnlagSchema from "./aarsavregningUtenEllerDeltGrunnlagSchema";
 import { Feilmelding, finnAktivFeilmelding, finnAktivFeilmeldingForMedlemskapsperioder } from "./valideringsfeil";
-import { BehandlingsvalgRadioGroup } from "../komponenter/behandlingsvalgRadioGroup";
 import { ManuellAvgiftFormPart } from "../komponenter/manuellAvgiftFormPart";
+import { EndeligAvgiftValgRadioGroup } from "../komponenter/endeligAvgiftValgRadioGroup";
 
-const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
 // Helper function to log and return changed dependencies
 const getChangedDependencies = (currentDeps: Record<string, any>, previousDepsRef: React.MutableRefObject<any>) => {
@@ -156,7 +156,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const totaltForskuddsvisFakturert = useWatch({ control, name: "totaltForskuddsvisFakturert" });
   const skatteforholdsperioder = useWatch({ control, name: "skatteforholdsperioder" });
   const inntektskilder = useWatch({ control, name: "inntektskilder" });
-  const behandlingsvalg = useWatch({ control, name: "behandlingsvalg" });
+  const endeligAvgiftValg = useWatch({ control, name: "endeligAvgiftValg" });
   const manueltAvgiftBeloep = useWatch({ control, name: "manueltAvgiftBeloep" });
 
   const debouncedBeregningRef = useRef<any>(null);
@@ -296,7 +296,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       endrerBestemmelse ||
       beregningPaagar ||
       lagreMedlemskapsperioderPaagar ||
-      behandlingsvalg !== OPPLYSNINGER_ENDRET
+      endeligAvgiftValg !== OPPLYSNINGER_ENDRET
     ) {
       console.log("[debouncedBeregning] return tidlig i debouncedBeregning");
       return;
@@ -354,7 +354,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     previousFormState,
     lagreMedlemskapsperioderPaagar,
     finnMedlemskapsperiode,
-    behandlingsvalg,
+    endeligAvgiftValg,
   ]);
 
   const lagreMedlemskapsperioder = useCallback(
@@ -569,7 +569,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
   // Håndterer kjøring av beregninger når skjemaverdier endres
   useEffect(() => {
-    if (behandlingsvalg !== OPPLYSNINGER_ENDRET) {
+    if (endeligAvgiftValg !== OPPLYSNINGER_ENDRET) {
       setDebouncedBeregningPagaar(false);
       setArrayValideringsfeil(undefined);
       if (debouncedBeregningRef.current?.cancel) {
@@ -585,7 +585,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       lagreMedlemskapsperioderPaagar,
       endrerBestemmelse,
       totaltForskuddsvisFakturert,
-      behandlingsvalg,
+      endeligAvgiftValg,
       aarsavregningID,
       redigerbart,
       beregningPaagar,
@@ -675,7 +675,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     lagreMedlemskapsperioderPaagar,
     endrerBestemmelse,
     totaltForskuddsvisFakturert,
-    behandlingsvalg,
+    endeligAvgiftValg,
     aarsavregningID,
     redigerbart,
     beregningPaagar,
@@ -686,7 +686,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   ]);
 
   const stegErGyldig = useMemo(() => {
-    if (behandlingsvalg === OPPLYSNINGER_ENDRET) {
+    if (endeligAvgiftValg === OPPLYSNINGER_ENDRET) {
       return Boolean(
         formIsValid &&
           aarsavregningResponse?.nyttGrunnlag &&
@@ -694,7 +694,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
           arrayValideringsfeil === undefined,
       );
     }
-    if (behandlingsvalg === MANUELL_ENDELIG_AVGIFT) {
+    if (endeligAvgiftValg === MANUELL_ENDELIG_AVGIFT) {
       return Boolean(
         formIsValid &&
           aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem &&
@@ -708,7 +708,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     aarsavregningResponse?.nyttGrunnlag,
     aarsavregningResponse?.avregning?.manueltAvgiftBeloep,
     feilmelding,
-    behandlingsvalg,
+    endeligAvgiftValg,
     arrayValideringsfeil,
   ]);
 
@@ -716,14 +716,16 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     oppdaterStatus(stegErGyldig);
   }, [stegErGyldig, oppdaterStatus]);
 
-  const handleBehandlingsvalgChange = useCallback(
+  const handleEndeligAvgiftValgChange = useCallback(
     (value: string) => {
-      Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID).then((res) => {
-        setAarsavregningResponse(res);
-        if (value !== MANUELL_ENDELIG_AVGIFT) {
-          setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
+      Api.Aarsavregning.oppdaterEndeligAvgiftValg(behandlingID, value, aarsavregningID).then((res) => {
+        if (res) {
+          setAarsavregningResponse(res);
+          if (value !== MANUELL_ENDELIG_AVGIFT) {
+            setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
+          }
+          setPreviousFormState(null);
         }
-        setPreviousFormState(null);
       });
     },
     [aarsavregningID, behandlingID, setValue],
@@ -787,14 +789,14 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         </>
       )}
 
-      <BehandlingsvalgRadioGroup
+      <EndeligAvgiftValgRadioGroup
         control={control}
         redigerbart={skjemaErRedigerbart}
-        handleBehandlingsvalgChange={handleBehandlingsvalgChange}
+        handleEndeligAvgiftValgChange={handleEndeligAvgiftValgChange}
         erMedGrunnlagFlyt={false}
       />
 
-      {behandlingsvalg === OPPLYSNINGER_ENDRET && (
+      {endeligAvgiftValg === OPPLYSNINGER_ENDRET && (
         <>
           <TidligereFakturertIAvgiftssystemetInput
             control={control}
@@ -909,7 +911,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       <ManuellAvgiftFormPart
         control={control}
         redigerbart={redigerbart}
-        behandlingsvalg={behandlingsvalg}
+        endeligAvgiftValg={endeligAvgiftValg}
         manueltAvgiftBeloep={manueltAvgiftBeloep}
         debouncedOppdaterManueltAvgiftBeloep={debouncedOppdaterManueltAvgiftBeloep}
         tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -107,7 +107,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const [lagredeMedlemskapsperioder, setLagredeMedlemskapsperioder] = useState<Medlemskapsperiode[]>(
     initiellData.formDefaultValues.medlemskapsperioder || [],
   );
-  const [endrerBehandlingsvalg, setEndrerBehandlingsvalg] = useState(false);
 
   // Redux selectors
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
@@ -741,22 +740,17 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
   const handleBehandlingsvalgChange = useCallback(
     (value: string) => {
-      setEndrerBehandlingsvalg(true);
-
-      Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID)
-        .then((res) => {
-          setAarsavregningResponse(res);
-          if (value !== MANUELL_ENDELIG_AVGIFT) {
-            setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
-          }
-          setPreviousFormState(null);
-        })
-        .finally(() => {
-          setEndrerBehandlingsvalg(false);
-        });
+      Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID).then((res) => {
+        setAarsavregningResponse(res);
+        if (value !== MANUELL_ENDELIG_AVGIFT) {
+          setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
+        }
+        setPreviousFormState(null);
+      });
     },
     [aarsavregningID, behandlingID, setValue],
   );
+  console.log("feilmelding", feilmelding);
 
   const debouncedOppdaterManueltAvgiftBeloep = useCallback(
     Utils._debounce(
@@ -907,6 +901,12 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
           {arrayValideringsfeil && <Feilmelding type={arrayValideringsfeil} />}
         </>
+      )}
+
+      {feilmelding && (
+        <Nav.Alert variant="error" className="alertstripe_feilmelding">
+          {feilmelding}
+        </Nav.Alert>
       )}
 
       <ManuellAvgiftFormPart

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -718,6 +718,30 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     oppdaterStatus(stegErGyldig);
   }, [stegErGyldig, oppdaterStatus]);
 
+  const handleBehandlingsvalgChange = useCallback(
+    (value: string) => {
+      Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID).then((res) => {
+        setAarsavregningResponse(res);
+        if (value !== MANUELL_ENDELIG_AVGIFT) {
+          setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
+        }
+        setPreviousFormState(null);
+      });
+    },
+    [aarsavregningID, behandlingID, setValue],
+  );
+
+  const debouncedOppdaterManueltAvgiftBeloep = useCallback(
+    Utils._debounce(
+      async (value: string) =>
+        Api.Aarsavregning.oppdaterManueltAvgiftBeloep(behandlingID, aarsavregningID, Number(value)).then((res) => {
+          setAarsavregningResponse(res);
+        }),
+      350,
+    ),
+    [aarsavregningID, behandlingID],
+  );
+
   const håndterBekreft = () => {
     trigger();
 
@@ -737,31 +761,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const forskuddsvisFakturertTrygdeavgift =
     (aarsavregningResponse?.tidligereGrunnlagsopplysninger?.avgift?.totalAvgift ?? 0) > 0;
   const skjemaErRedigerbart = redigerbart && !endrerBestemmelse;
-
-  const handleBehandlingsvalgChange = useCallback(
-    (value: string) => {
-      Api.Aarsavregning.oppdaterBehandlingsvalg(behandlingID, value, aarsavregningID).then((res) => {
-        setAarsavregningResponse(res);
-        if (value !== MANUELL_ENDELIG_AVGIFT) {
-          setValue("manueltAvgiftBeloep", "", { shouldValidate: false, shouldDirty: false });
-        }
-        setPreviousFormState(null);
-      });
-    },
-    [aarsavregningID, behandlingID, setValue],
-  );
-  console.log("feilmelding", feilmelding);
-
-  const debouncedOppdaterManueltAvgiftBeloep = useCallback(
-    Utils._debounce(
-      async (value: string) =>
-        Api.Aarsavregning.oppdaterManueltAvgiftBeloep(behandlingID, aarsavregningID, Number(value)).then((res) => {
-          setAarsavregningResponse(res);
-        }),
-      350,
-    ),
-    [aarsavregningID, behandlingID],
-  );
 
   return (
     <div className="vurderingAarsavregning">

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
@@ -18,6 +18,7 @@ const {
   PENSJON_UFØRETRYGD_KILDESKATT,
 } = MKV.Koder.inntektskildetype;
 const UTENFOR_MEDLEMSKAPSPERIODEN = { melding: "Utenfor medlemskapsperiode" };
+const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
 export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
   !medlemskapsTypeErPliktig && kildetype !== MISJONÆR;
@@ -115,42 +116,52 @@ const erInnenforMedlemskapsperiodeTest = {
 
 const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
   bestemmelse: string().required(MAA_FYLLES_UT),
-  medlemskapsperioder: array()
-    .min(1, "Minst en medlemskapsperiode")
-    .of(
-      object().shape({
-        fomDato: string().required(MAA_FYLLES_UT).erGyldigDato().test(erInnenforValgtAarTest),
-        tomDato: string()
-          .required(MAA_FYLLES_UT)
-          .erGyldigDato()
-          .erEtterDatofelt("fomDato")
-          .test(åpenTomTest)
-          .test(erInnenforValgtAarTest),
-        trygdedekning: string().required(MAA_FYLLES_UT),
-      }),
-    ),
+  behandlingsvalg: string().required(MAA_FYLLES_UT),
+  medlemskapsperioder: array().when(["behandlingsvalg"], {
+    is: (behandlingsvalg) => behandlingsvalg === OPPLYSNINGER_ENDRET,
+    then: array()
+      .min(1, "Minst en medlemskapsperiode")
+      .of(
+        object().shape({
+          fomDato: string().required(MAA_FYLLES_UT).erGyldigDato().test(erInnenforValgtAarTest),
+          tomDato: string()
+            .required(MAA_FYLLES_UT)
+            .erGyldigDato()
+            .erEtterDatofelt("fomDato")
+            .test(åpenTomTest)
+            .test(erInnenforValgtAarTest),
+          trygdedekning: string().required(MAA_FYLLES_UT),
+        }),
+      ),
+    otherwise: array(),
+  }),
   totaltForskuddsvisFakturert: string().nullable().required(MAA_FYLLES_UT),
-  skatteforholdsperioder: array()
-    .min(1, "Minst en skatteforholdsperiode")
-    .of(
-      object().shape({
-        fomDato: string()
-          .required(MAA_FYLLES_UT)
-          .erGyldigDato()
-          .test(erInnenforValgtAarTest)
-          .test(erInnenforMedlemskapsperiodeTest),
-        tomDato: string()
-          .required(MAA_FYLLES_UT)
-          .erGyldigDato()
-          .test(åpenTomTest)
-          .test(erInnenforValgtAarTest)
-          .test(erInnenforMedlemskapsperiodeTest)
-          .erEtterDatofelt("fomDato"),
-        skatteplikttype: string().required(MAA_FYLLES_UT),
-      }),
-    ),
-  inntektskilder: array().when(["medlemskapsperioder", "skatteforholdsperioder"], {
-    is: (medlemskapsperioder, skatteforholdsperioder) => {
+  skatteforholdsperioder: array().when(["behandlingsvalg"], {
+    is: (behandlingsvalg) => behandlingsvalg === OPPLYSNINGER_ENDRET,
+    then: array()
+      .min(1, "Minst en skatteforholdsperiode")
+      .of(
+        object().shape({
+          fomDato: string()
+            .required(MAA_FYLLES_UT)
+            .erGyldigDato()
+            .test(erInnenforValgtAarTest)
+            .test(erInnenforMedlemskapsperiodeTest),
+          tomDato: string()
+            .required(MAA_FYLLES_UT)
+            .erGyldigDato()
+            .test(åpenTomTest)
+            .test(erInnenforValgtAarTest)
+            .test(erInnenforMedlemskapsperiodeTest)
+            .erEtterDatofelt("fomDato"),
+          skatteplikttype: string().required(MAA_FYLLES_UT),
+        }),
+      ),
+    otherwise: array(),
+  }),
+  inntektskilder: array().when(["medlemskapsperioder", "skatteforholdsperioder", "behandlingsvalg"], {
+    is: (medlemskapsperioder, skatteforholdsperioder, behandlingsvalg) => {
+      if (behandlingsvalg !== OPPLYSNINGER_ENDRET) return false;
       const medlemskapsTypeErPliktig = erMedlemskapsTypePliktig(medlemskapsperioder);
 
       return !(medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder));
@@ -171,6 +182,11 @@ const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
         }),
       ),
     otherwise: array(),
+  }),
+  manueltAvgiftBeloep: string().when(["behandlingsvalg"], {
+    is: (behandlingsvalg) => behandlingsvalg === MANUELL_ENDELIG_AVGIFT,
+    then: string().required(MAA_FYLLES_UT),
+    otherwise: string().nullable(),
   }),
 });
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
@@ -18,7 +18,7 @@ const {
   PENSJON_UFØRETRYGD_KILDESKATT,
 } = MKV.Koder.inntektskildetype;
 const UTENFOR_MEDLEMSKAPSPERIODEN = { melding: "Utenfor medlemskapsperiode" };
-const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
 export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
   !medlemskapsTypeErPliktig && kildetype !== MISJONÆR;
@@ -116,9 +116,9 @@ const erInnenforMedlemskapsperiodeTest = {
 
 const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
   bestemmelse: string().required(MAA_FYLLES_UT),
-  behandlingsvalg: string().required(MAA_FYLLES_UT),
-  medlemskapsperioder: array().when(["behandlingsvalg"], {
-    is: (behandlingsvalg) => behandlingsvalg === OPPLYSNINGER_ENDRET,
+  endeligAvgiftValg: string().required(MAA_FYLLES_UT),
+  medlemskapsperioder: array().when(["endeligAvgiftValg"], {
+    is: (endeligAvgiftValg) => endeligAvgiftValg === OPPLYSNINGER_ENDRET,
     then: array()
       .min(1, "Minst en medlemskapsperiode")
       .of(
@@ -136,8 +136,8 @@ const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
     otherwise: array(),
   }),
   totaltForskuddsvisFakturert: string().nullable().required(MAA_FYLLES_UT),
-  skatteforholdsperioder: array().when(["behandlingsvalg"], {
-    is: (behandlingsvalg) => behandlingsvalg === OPPLYSNINGER_ENDRET,
+  skatteforholdsperioder: array().when(["endeligAvgiftValg"], {
+    is: (endeligAvgiftValg) => endeligAvgiftValg === OPPLYSNINGER_ENDRET,
     then: array()
       .min(1, "Minst en skatteforholdsperiode")
       .of(
@@ -159,9 +159,9 @@ const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
       ),
     otherwise: array(),
   }),
-  inntektskilder: array().when(["medlemskapsperioder", "skatteforholdsperioder", "behandlingsvalg"], {
-    is: (medlemskapsperioder, skatteforholdsperioder, behandlingsvalg) => {
-      if (behandlingsvalg !== OPPLYSNINGER_ENDRET) return false;
+  inntektskilder: array().when(["medlemskapsperioder", "skatteforholdsperioder", "endeligAvgiftValg"], {
+    is: (medlemskapsperioder, skatteforholdsperioder, endeligAvgiftValg) => {
+      if (endeligAvgiftValg !== OPPLYSNINGER_ENDRET) return false;
       const medlemskapsTypeErPliktig = erMedlemskapsTypePliktig(medlemskapsperioder);
 
       return !(medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder));
@@ -183,8 +183,8 @@ const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
       ),
     otherwise: array(),
   }),
-  manueltAvgiftBeloep: string().when(["behandlingsvalg"], {
-    is: (behandlingsvalg) => behandlingsvalg === MANUELL_ENDELIG_AVGIFT,
+  manueltAvgiftBeloep: string().when(["endeligAvgiftValg"], {
+    is: (endeligAvgiftValg) => endeligAvgiftValg === MANUELL_ENDELIG_AVGIFT,
     then: string().required(MAA_FYLLES_UT),
     otherwise: string().nullable(),
   }),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
@@ -1,8 +1,7 @@
-import { useId } from "react";
 import { Control } from "react-hook-form";
 import * as Forms from "../../../../../felleskomponenter/forms";
-import * as Nav from "../../../../../navFrontend";
 import MKV from "../../../../../melosyskodeverk";
+import * as Nav from "../../../../../navFrontend";
 
 const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
@@ -21,8 +20,6 @@ export function BehandlingsvalgRadioGroup({
   handleBehandlingsvalgChange,
   debouncedOppdaterManueltAvgiftBeloep,
 }: BehandlingsvalgRadioGroupProps) {
-  const manueltAvgiftBeloepId = useId();
-
   return (
     <>
       <Forms.RadioGroup
@@ -58,7 +55,6 @@ export function BehandlingsvalgRadioGroup({
           numeric
           tillattNegativeTall
           onChange={debouncedOppdaterManueltAvgiftBeloep}
-          key={manueltAvgiftBeloepId}
         />
       )}
     </>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
@@ -8,55 +8,55 @@ const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MK
 interface BehandlingsvalgRadioGroupProps {
   control: Control<any>;
   redigerbart: boolean;
-  behandlingsvalg: string;
   handleBehandlingsvalgChange: (value: string) => void;
-  debouncedOppdaterManueltAvgiftBeloep: (value: string) => void;
+  erMedGrunnlagFlyt: boolean;
 }
 
 export function BehandlingsvalgRadioGroup({
   control,
   redigerbart,
-  behandlingsvalg,
   handleBehandlingsvalgChange,
-  debouncedOppdaterManueltAvgiftBeloep,
+  erMedGrunnlagFlyt,
 }: BehandlingsvalgRadioGroupProps) {
-  return (
-    <>
-      <Forms.RadioGroup
-        name="behandlingsvalg"
-        control={control}
-        legend="Hva ønsker du å gjøre?"
-        readOnly={!redigerbart}
-        onChange={(value) => {
-          handleBehandlingsvalgChange(value);
-        }}
-        className="behandlingsvalg_radio_group"
-      >
-        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
-          <b>Jeg skal gjøre endringer.</b> Inntekts- og/eller skatteopplysningene er endret siden tidligere beregning
-        </Nav.Radio>
-        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
-          <b>Det er ingen endringer.</b> Inntekts- og skatteopplysningene er like som ved tidligere beregning
-        </Nav.Radio>
-        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
-          <b>Jeg skal oppgi endelig avgift selv.</b> Endelig trygdeavgift er manuelt beregnet utenfor Melosys
-        </Nav.Radio>
-      </Forms.RadioGroup>
+  const radioOptions = [
+    {
+      value: OPPLYSNINGER_ENDRET,
+      label: <b>Jeg skal gjøre endringer.</b>,
+      description: " Inntekts- og/eller skatteopplysningene er endret siden tidligere beregning",
+    },
+    {
+      value: OPPLYSNINGER_UENDRET,
+      label: <b>Det er ingen endringer.</b>,
+      description: " Inntekts- og skatteopplysningene er like som ved tidligere beregning",
+    },
+    {
+      value: MANUELL_ENDELIG_AVGIFT,
+      label: <b>Jeg skal oppgi endelig avgift selv.</b>,
+      description: " Endelig trygdeavgift er manuelt beregnet utenfor Melosys",
+    },
+  ];
 
-      {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
-        <Forms.Input
-          label="Endelig beregnet trygdeavgift"
-          name="manueltAvgiftBeloep"
-          control={control}
-          readOnly={!redigerbart}
-          className="avgift_input"
-          autoComplete="off"
-          type="text"
-          numeric
-          tillattNegativeTall
-          onChange={debouncedOppdaterManueltAvgiftBeloep}
-        />
-      )}
-    </>
+  const filteredOptions = erMedGrunnlagFlyt
+    ? radioOptions
+    : radioOptions.filter((option) => option.value !== OPPLYSNINGER_UENDRET);
+
+  return (
+    <Forms.RadioGroup
+      name="behandlingsvalg"
+      control={control}
+      legend="Hva ønsker du å gjøre?"
+      readOnly={!redigerbart}
+      onChange={(value) => {
+        handleBehandlingsvalgChange(value);
+      }}
+      className="behandlingsvalg_radio_group"
+    >
+      {filteredOptions.map((option) => (
+        <Nav.Radio key={option.value} value={option.value}>
+          {option.label}
+          {option.description}
+        </Nav.Radio>
+      ))}
+    </Forms.RadioGroup>
   );
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
@@ -21,8 +21,10 @@ export function BehandlingsvalgRadioGroup({
   const radioOptions = [
     {
       value: OPPLYSNINGER_ENDRET,
-      label: <b>Jeg skal gjøre endringer.</b>,
-      description: " Inntekts- og/eller skatteopplysningene er endret siden tidligere beregning",
+      label: <b>{erMedGrunnlagFlyt ? "Jeg skal gjøre endringer." : "Jeg skal registrere opplysninger."}</b>,
+      description: erMedGrunnlagFlyt
+        ? " Inntekts- og/eller skatteopplysningene er endret siden tidligere beregning"
+        : " Endelig trygdeavgift beregnes i Melosys",
     },
     {
       value: OPPLYSNINGER_UENDRET,
@@ -31,7 +33,7 @@ export function BehandlingsvalgRadioGroup({
     },
     {
       value: MANUELL_ENDELIG_AVGIFT,
-      label: <b>Jeg skal oppgi endelig avgift selv.</b>,
+      label: <b>{erMedGrunnlagFlyt ? "Jeg skal gjøre endringer." : "Jeg skal oppgi endelig avgift."}</b>,
       description: " Endelig trygdeavgift er manuelt beregnet utenfor Melosys",
     },
   ];

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/behandlingsvalgRadioGroup.tsx
@@ -1,0 +1,66 @@
+import { useId } from "react";
+import { Control } from "react-hook-form";
+import * as Forms from "../../../../../felleskomponenter/forms";
+import * as Nav from "../../../../../navFrontend";
+import MKV from "../../../../../melosyskodeverk";
+
+const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+
+interface BehandlingsvalgRadioGroupProps {
+  control: Control<any>;
+  redigerbart: boolean;
+  behandlingsvalg: string;
+  handleBehandlingsvalgChange: (value: string) => void;
+  debouncedOppdaterManueltAvgiftBeloep: (value: string) => void;
+}
+
+export function BehandlingsvalgRadioGroup({
+  control,
+  redigerbart,
+  behandlingsvalg,
+  handleBehandlingsvalgChange,
+  debouncedOppdaterManueltAvgiftBeloep,
+}: BehandlingsvalgRadioGroupProps) {
+  const manueltAvgiftBeloepId = useId();
+
+  return (
+    <>
+      <Forms.RadioGroup
+        name="behandlingsvalg"
+        control={control}
+        legend="Hva ønsker du å gjøre?"
+        readOnly={!redigerbart}
+        onChange={(value) => {
+          handleBehandlingsvalgChange(value);
+        }}
+        className="behandlingsvalg_radio_group"
+      >
+        <Nav.Radio value={OPPLYSNINGER_ENDRET}>
+          <b>Jeg skal gjøre endringer.</b> Inntekts- og/eller skatteopplysningene er endret siden tidligere beregning
+        </Nav.Radio>
+        <Nav.Radio value={OPPLYSNINGER_UENDRET}>
+          <b>Det er ingen endringer.</b> Inntekts- og skatteopplysningene er like som ved tidligere beregning
+        </Nav.Radio>
+        <Nav.Radio value={MANUELL_ENDELIG_AVGIFT}>
+          <b>Jeg skal oppgi endelig avgift selv.</b> Endelig trygdeavgift er manuelt beregnet utenfor Melosys
+        </Nav.Radio>
+      </Forms.RadioGroup>
+
+      {behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
+        <Forms.Input
+          label="Endelig beregnet trygdeavgift"
+          name="manueltAvgiftBeloep"
+          control={control}
+          readOnly={!redigerbart}
+          className="avgift_input"
+          autoComplete="off"
+          type="text"
+          numeric
+          tillattNegativeTall
+          onChange={debouncedOppdaterManueltAvgiftBeloep}
+          key={manueltAvgiftBeloepId}
+        />
+      )}
+    </>
+  );
+}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.tsx
@@ -3,21 +3,21 @@ import * as Forms from "../../../../../felleskomponenter/forms";
 import MKV from "../../../../../melosyskodeverk";
 import * as Nav from "../../../../../navFrontend";
 
-const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+const { OPPLYSNINGER_ENDRET, OPPLYSNINGER_UENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
-interface BehandlingsvalgRadioGroupProps {
+interface EndeligAvgiftValgRadioGroupProps {
   control: Control<any>;
   redigerbart: boolean;
-  handleBehandlingsvalgChange: (value: string) => void;
+  handleEndeligAvgiftValgChange: (value: string) => void;
   erMedGrunnlagFlyt: boolean;
 }
 
-export function BehandlingsvalgRadioGroup({
+export function EndeligAvgiftValgRadioGroup({
   control,
   redigerbart,
-  handleBehandlingsvalgChange,
+  handleEndeligAvgiftValgChange,
   erMedGrunnlagFlyt,
-}: BehandlingsvalgRadioGroupProps) {
+}: EndeligAvgiftValgRadioGroupProps) {
   const radioOptions = [
     {
       value: OPPLYSNINGER_ENDRET,
@@ -33,7 +33,7 @@ export function BehandlingsvalgRadioGroup({
     },
     {
       value: MANUELL_ENDELIG_AVGIFT,
-      label: <b>{erMedGrunnlagFlyt ? "Jeg skal gjøre endringer." : "Jeg skal oppgi endelig avgift."}</b>,
+      label: <b>Jeg skal oppgi endelig avgift selv.</b>,
       description: " Endelig trygdeavgift er manuelt beregnet utenfor Melosys",
     },
   ];
@@ -44,14 +44,14 @@ export function BehandlingsvalgRadioGroup({
 
   return (
     <Forms.RadioGroup
-      name="behandlingsvalg"
+      name="endeligAvgiftValg"
       control={control}
       legend="Hva ønsker du å gjøre?"
       readOnly={!redigerbart}
       onChange={(value) => {
-        handleBehandlingsvalgChange(value);
+        handleEndeligAvgiftValgChange(value);
       }}
-      className="behandlingsvalg_radio_group"
+      className="endeligAvgiftValg_radio_group"
     >
       {filteredOptions.map((option) => (
         <Nav.Radio key={option.value} value={option.value}>
@@ -61,4 +61,4 @@ export function BehandlingsvalgRadioGroup({
       ))}
     </Forms.RadioGroup>
   );
-}
+} 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.tsx
@@ -33,7 +33,7 @@ export function EndeligAvgiftValgRadioGroup({
     },
     {
       value: MANUELL_ENDELIG_AVGIFT,
-      label: <b>Jeg skal oppgi endelig avgift selv.</b>,
+      label: <b>Jeg skal oppgi endelig avgift.</b>,
       description: " Endelig trygdeavgift er manuelt beregnet utenfor Melosys",
     },
   ];
@@ -61,4 +61,4 @@ export function EndeligAvgiftValgRadioGroup({
       ))}
     </Forms.RadioGroup>
   );
-} 
+}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/manuellAvgiftFormPart.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/manuellAvgiftFormPart.tsx
@@ -1,0 +1,77 @@
+import { Control } from "react-hook-form";
+import * as Forms from "../../../../../felleskomponenter/forms";
+import MKV from "../../../../../melosyskodeverk";
+import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
+import { SumArsavregningTabell } from "./sumArsavregningTabell"; // Adjusted import path
+import { TidligereFakturertIAvgiftssystemetInput } from "./tidligereFakturertIAvgiftssystemetInput"; // Added import
+
+const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+
+interface ManuellAvgiftFormPartProps {
+  control: Control<any>;
+  redigerbart: boolean;
+  behandlingsvalg: string;
+  manueltAvgiftBeloep?: number | string;
+  debouncedOppdaterManueltAvgiftBeloep: (value: string) => void;
+  aarsavregningResponse?: AarsavregningResponse;
+  erMedGrunnlagFlyt: boolean;
+  harDeltGrunnlag: boolean;
+  totaltForskuddsvisFakturert?: string;
+}
+
+export function ManuellAvgiftFormPart({
+  control,
+  redigerbart,
+  behandlingsvalg,
+  manueltAvgiftBeloep,
+  debouncedOppdaterManueltAvgiftBeloep,
+  aarsavregningResponse,
+  erMedGrunnlagFlyt,
+  harDeltGrunnlag,
+  totaltForskuddsvisFakturert,
+}: ManuellAvgiftFormPartProps) {
+  if (behandlingsvalg !== MANUELL_ENDELIG_AVGIFT) {
+    return null;
+  }
+
+  const tidligereTrygdeavgiftAvgiftssystem = totaltForskuddsvisFakturert
+    ? Number(totaltForskuddsvisFakturert)
+    : undefined;
+
+  return (
+    <>
+      {!erMedGrunnlagFlyt && (
+        <TidligereFakturertIAvgiftssystemetInput
+          control={control}
+          redigerbart={redigerbart}
+          harDeltGrunnlag={harDeltGrunnlag}
+        />
+      )}
+
+      <Forms.Input
+        label="Endelig beregnet trygdeavgift"
+        name="manueltAvgiftBeloep"
+        control={control}
+        readOnly={!redigerbart}
+        className="avgift_input"
+        autoComplete="off"
+        type="text"
+        numeric
+        tillattNegativeTall
+        onChange={debouncedOppdaterManueltAvgiftBeloep}
+      />
+
+      {manueltAvgiftBeloep !== undefined &&
+        manueltAvgiftBeloep !== null &&
+        manueltAvgiftBeloep !== "" &&
+        tidligereTrygdeavgiftAvgiftssystem && (
+          <SumArsavregningTabell
+            harGrunnlagIMelosys={harDeltGrunnlag}
+            nyTrygdeavgift={Number(manueltAvgiftBeloep)}
+            tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
+            tidligereTrygdeavgiftAvgiftssystem={tidligereTrygdeavgiftAvgiftssystem}
+          />
+        )}
+    </>
+  );
+}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/manuellAvgiftFormPart.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/manuellAvgiftFormPart.tsx
@@ -4,12 +4,12 @@ import MKV from "../../../../../melosyskodeverk";
 import { SumArsavregningTabell } from "./sumArsavregningTabell";
 import { TidligereFakturertIAvgiftssystemetInput } from "./tidligereFakturertIAvgiftssystemetInput";
 
-const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
 interface ManuellAvgiftFormPartProps {
   control: Control<any>;
   redigerbart: boolean;
-  behandlingsvalg: string;
+  endeligAvgiftValg: string;
   manueltAvgiftBeloep?: number | string;
   debouncedOppdaterManueltAvgiftBeloep: (value: string) => void;
   tidligereTrygdeavgift?: number;
@@ -21,7 +21,7 @@ interface ManuellAvgiftFormPartProps {
 export function ManuellAvgiftFormPart({
   control,
   redigerbart,
-  behandlingsvalg,
+  endeligAvgiftValg,
   manueltAvgiftBeloep,
   debouncedOppdaterManueltAvgiftBeloep,
   tidligereTrygdeavgift,
@@ -29,7 +29,7 @@ export function ManuellAvgiftFormPart({
   harDeltGrunnlag,
   totaltForskuddsvisFakturert,
 }: ManuellAvgiftFormPartProps) {
-  if (behandlingsvalg !== MANUELL_ENDELIG_AVGIFT) {
+  if (endeligAvgiftValg !== MANUELL_ENDELIG_AVGIFT) {
     return null;
   }
 
@@ -62,7 +62,7 @@ export function ManuellAvgiftFormPart({
 
       {manueltAvgiftBeloep !== undefined && manueltAvgiftBeloep !== null && manueltAvgiftBeloep !== "" && (
         <SumArsavregningTabell
-          harGrunnlagIMelosys={harDeltGrunnlag}
+          harGrunnlagIMelosys={erMedGrunnlagFlyt}
           nyTrygdeavgift={Number(manueltAvgiftBeloep)}
           tidligereTrygdeavgift={tidligereTrygdeavgift}
           tidligereTrygdeavgiftAvgiftssystem={tidligereTrygdeavgiftAvgiftssystem}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/manuellAvgiftFormPart.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/manuellAvgiftFormPart.tsx
@@ -1,11 +1,10 @@
 import { Control } from "react-hook-form";
 import * as Forms from "../../../../../felleskomponenter/forms";
 import MKV from "../../../../../melosyskodeverk";
-import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
-import { SumArsavregningTabell } from "./sumArsavregningTabell"; // Adjusted import path
-import { TidligereFakturertIAvgiftssystemetInput } from "./tidligereFakturertIAvgiftssystemetInput"; // Added import
+import { SumArsavregningTabell } from "./sumArsavregningTabell";
+import { TidligereFakturertIAvgiftssystemetInput } from "./tidligereFakturertIAvgiftssystemetInput";
 
-const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningsBehandlingsvalg;
 
 interface ManuellAvgiftFormPartProps {
   control: Control<any>;
@@ -13,10 +12,10 @@ interface ManuellAvgiftFormPartProps {
   behandlingsvalg: string;
   manueltAvgiftBeloep?: number | string;
   debouncedOppdaterManueltAvgiftBeloep: (value: string) => void;
-  aarsavregningResponse?: AarsavregningResponse;
+  tidligereTrygdeavgift?: number;
   erMedGrunnlagFlyt: boolean;
   harDeltGrunnlag: boolean;
-  totaltForskuddsvisFakturert?: string;
+  totaltForskuddsvisFakturert?: number | string;
 }
 
 export function ManuellAvgiftFormPart({
@@ -25,7 +24,7 @@ export function ManuellAvgiftFormPart({
   behandlingsvalg,
   manueltAvgiftBeloep,
   debouncedOppdaterManueltAvgiftBeloep,
-  aarsavregningResponse,
+  tidligereTrygdeavgift,
   erMedGrunnlagFlyt,
   harDeltGrunnlag,
   totaltForskuddsvisFakturert,
@@ -61,17 +60,14 @@ export function ManuellAvgiftFormPart({
         onChange={debouncedOppdaterManueltAvgiftBeloep}
       />
 
-      {manueltAvgiftBeloep !== undefined &&
-        manueltAvgiftBeloep !== null &&
-        manueltAvgiftBeloep !== "" &&
-        tidligereTrygdeavgiftAvgiftssystem && (
-          <SumArsavregningTabell
-            harGrunnlagIMelosys={harDeltGrunnlag}
-            nyTrygdeavgift={Number(manueltAvgiftBeloep)}
-            tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
-            tidligereTrygdeavgiftAvgiftssystem={tidligereTrygdeavgiftAvgiftssystem}
-          />
-        )}
+      {manueltAvgiftBeloep !== undefined && manueltAvgiftBeloep !== null && manueltAvgiftBeloep !== "" && (
+        <SumArsavregningTabell
+          harGrunnlagIMelosys={harDeltGrunnlag}
+          nyTrygdeavgift={Number(manueltAvgiftBeloep)}
+          tidligereTrygdeavgift={tidligereTrygdeavgift}
+          tidligereTrygdeavgiftAvgiftssystem={tidligereTrygdeavgiftAvgiftssystem}
+        />
+      )}
     </>
   );
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/manuellAvgiftFormPart.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/manuellAvgiftFormPart.tsx
@@ -4,7 +4,7 @@ import MKV from "../../../../../melosyskodeverk";
 import { SumArsavregningTabell } from "./sumArsavregningTabell";
 import { TidligereFakturertIAvgiftssystemetInput } from "./tidligereFakturertIAvgiftssystemetInput";
 
-const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningsBehandlingsvalg;
+const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
 interface ManuellAvgiftFormPartProps {
   control: Control<any>;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
@@ -46,11 +46,12 @@ export function MedlemskapsperiodeSkjema({
   setValue,
   errors,
 }: PeriodeElementerProps) {
-  const erPeriodeFraGrunnlag = !formValues.medlemskapsperioder[index]?.redigerbar;
-  const kanViseSletteKolonne = redigerbart && formValues.medlemskapsperioder.length > 1;
+  const medlemskapsperioder = formValues.medlemskapsperioder!;
+  const erPeriodeFraGrunnlag = !medlemskapsperioder[index]?.redigerbar;
+  const kanViseSletteKolonne = redigerbart && medlemskapsperioder.length > 1;
   const tilOgMedDatoForrigePeriode =
-    formValues.medlemskapsperioder[index - 1] !== undefined
-      ? Utils.dato.norskStringTilDate(formValues.medlemskapsperioder[index - 1]?.tomDato)
+    medlemskapsperioder[index - 1] !== undefined
+      ? Utils.dato.norskStringTilDate(medlemskapsperioder[index - 1]?.tomDato)
       : undefined;
   if (tilOgMedDatoForrigePeriode !== undefined) {
     tilOgMedDatoForrigePeriode.setDate(tilOgMedDatoForrigePeriode.getDate() + 1);
@@ -58,7 +59,7 @@ export function MedlemskapsperiodeSkjema({
 
   const kunEnTrygdedekning = trygdedekninger?.length === 1;
 
-  const lastIndex = formValues.medlemskapsperioder.length - 1;
+  const lastIndex = medlemskapsperioder.length - 1;
   let deletableIndex = -1;
 
   if (lastIndex >= 0) {
@@ -69,7 +70,7 @@ export function MedlemskapsperiodeSkjema({
     } else {
       let maxValidTomDatoIndex = -1;
       let maxValidTomDato: Date | null = null;
-      formValues.medlemskapsperioder.forEach((periode, idx) => {
+      medlemskapsperioder.forEach((periode, idx) => {
         const currentTomDato = Utils.dato.norskStringTilDate(periode.tomDato);
         if (currentTomDato && !Number.isNaN(currentTomDato.getTime())) {
           if (maxValidTomDato === null || currentTomDato >= maxValidTomDato) {
@@ -113,7 +114,7 @@ export function MedlemskapsperiodeSkjema({
               control={control}
               name={`medlemskapsperioder[${index}].tomDato`}
               aria-label={`Til og med periode ${index + 1}`}
-              minDate={Utils.dato.norskStringTilDate(formValues.medlemskapsperioder[index].fomDato)}
+              minDate={Utils.dato.norskStringTilDate(medlemskapsperioder[index].fomDato)}
               maxDate={maksVerdi}
               readOnly={!redigerbart || erPeriodeFraGrunnlag}
             />
@@ -146,7 +147,7 @@ export function MedlemskapsperiodeSkjema({
           )}
         </Nav.Row>
       </div>
-      {formValues.medlemskapsperioder.length === index + 1 && (
+      {medlemskapsperioder.length === index + 1 && (
         <div className="legg-til__rad">
           <Mui.Lenkeknapp onClick={handleLeggTil} ikon={Ikoner.Add} disabled={!redigerbart || !visLeggTil}>
             Legg til periode

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.less
@@ -2,6 +2,7 @@
   padding: 0.33rem;
   background-color: #efefef;
   border-collapse: collapse;
+  margin-bottom: 1.5rem;
 
   .navds-table {
     margin-bottom: 0;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereFakturertIAvgiftssystemetInput.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereFakturertIAvgiftssystemetInput.tsx
@@ -39,7 +39,7 @@ export function TidligereFakturertIAvgiftssystemetInput({
         name="totaltForskuddsvisFakturert"
         control={control}
         readOnly={!redigerbart}
-        className="tidligere_fakturert_input"
+        className="avgift_input"
         autoComplete="off"
         type="text"
         numeric

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
@@ -56,7 +56,7 @@
     align-self: flex-end;
   }
 
-  .tidligere_fakturert_input {
+  .avgift_input {
     .navds-text-field__input {
       width: 7.5rem;
     }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
@@ -71,7 +71,7 @@
     margin-bottom: 1.5rem;
   }
 
-  .behandlingsvalg_radio_group {
+  .endeligAvgiftValg_radio_group {
     .navds-radio-buttons {
       margin-top: 0.5rem;
     }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
@@ -66,4 +66,14 @@
     margin-bottom: 1.5rem;
     margin-top: 1.5rem;
   }
+
+  .beregnetTrygdeavgiftDetaljer {
+    margin-bottom: 1.5rem;
+  }
+
+  .behandlingsvalg_radio_group {
+    .navds-radio-buttons {
+      margin-top: 0.5rem;
+    }
+  }
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -1,31 +1,31 @@
-import { useDispatch, useSelector } from "react-redux";
-import { behandlingerSelectors } from "../../../../ducks/behandlinger";
-import * as Nav from "../../../../navFrontend";
-import { redigerbartSelectors } from "../../../../ducks/redigerbart";
-import Dokumentliste from "../../../../felleskomponenter/dokumentliste";
-import * as Mui from "../../../../felleskomponenter/ui";
-import { useCallback, useEffect, useState } from "react";
-import * as Api from "../../../../services/api";
-import { FieldValues, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { behandlingsresultatSelectors } from "../../../../ducks/behandlingsresultat";
-import vurdering_vedtak from "./vurderingVedtakSchema";
-import * as Utils from "../../../../utils";
-import { AarsavregningResponse } from "../../../../services/modules/aarsavregning/aarsavregning";
-import { vedtakOperations } from "../../../../ducks/vedtak";
-import { ThunkDispatch } from "redux-thunk";
 import { RootState } from "AppTypes";
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useDispatch, useSelector } from "react-redux";
 import { Action } from "redux";
-import { kontrollOperations } from "../../../../ducks/kontroll";
-import MKV from "../../../../melosyskodeverk";
-import LabelMedHjelpetekst from "../../../../felleskomponenter/labelMedHjelpetekst";
-import * as Forms from "../../../../felleskomponenter/forms";
-import { SumArsavregningTabell } from "../vurderingAarsavregning/komponenter/sumArsavregningTabell";
-import { menypanelOperations, menypanelSelectors } from "../../../../ducks/menypanel";
+import { ThunkDispatch } from "redux-thunk";
+import { behandlingerSelectors } from "../../../../ducks/behandlinger";
+import { behandlingsresultatSelectors } from "../../../../ducks/behandlingsresultat";
 import { fagsakSelectors } from "../../../../ducks/fagsaker";
+import { kontrollOperations } from "../../../../ducks/kontroll";
+import { menypanelOperations, menypanelSelectors } from "../../../../ducks/menypanel";
+import { redigerbartSelectors } from "../../../../ducks/redigerbart";
+import { vedtakOperations } from "../../../../ducks/vedtak";
+import Dokumentliste from "../../../../felleskomponenter/dokumentliste";
+import * as Forms from "../../../../felleskomponenter/forms";
 import FullmaktForTrygdeavgiftConfirmationPanel from "../../../../felleskomponenter/fullmaktForTrygdeavgiftConfirmationPanel/fullmaktForTrygdeavgiftConfirmationPanel";
-import { BrevVedleggVisningstabellInterface } from "../../../../services/modules/dokumenter-v2";
+import LabelMedHjelpetekst from "../../../../felleskomponenter/labelMedHjelpetekst";
+import * as Mui from "../../../../felleskomponenter/ui";
 import VedleggTable from "../../../../felleskomponenter/vedleggTable";
+import MKV from "../../../../melosyskodeverk";
+import * as Nav from "../../../../navFrontend";
+import * as Api from "../../../../services/api";
+import { AarsavregningResponse } from "../../../../services/modules/aarsavregning/aarsavregning";
+import { BrevVedleggVisningstabellInterface } from "../../../../services/modules/dokumenter-v2";
+import * as Utils from "../../../../utils";
+import { SumArsavregningTabell } from "../vurderingAarsavregning/komponenter/sumArsavregningTabell";
+import vurdering_vedtak from "./vurderingVedtakSchema";
 
 const { FASTSATT_TRYGDEAVGIFT } = MKV.Koder.behandlinger.behandlingsresultattyper;
 const { FØRSTEGANGSVEDTAK } = MKV.Koder.vedtakstyper;
@@ -37,7 +37,6 @@ const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 interface FormValuesProps {
   innledningFritekst?: string;
   begrunnelseFritekst?: string;
-  behandlingsvalg?: string;
 }
 
 interface Props {
@@ -66,6 +65,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     saksvedlegg: [],
     standardvedlegg: [],
   });
+  const [isFormInitialized, setIsFormInitialized] = useState(false);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as number;
   const erFullmektigEndret = useSelector(menypanelSelectors.MenypanelErFullmektigEndretSelector) as boolean;
@@ -73,95 +73,157 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   const { fattVedtak } = komponentDispatch(dispatch);
 
-  const defaultBegrunnelse = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) as string | undefined;
+  const defaultBegrunnelse = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) as
+    | string
+    | undefined;
   const defaultInnledning = useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) as string | undefined;
 
   const {
     watch,
     control,
     handleSubmit,
-    setValue,
+    reset,
     formState: { isValid: formIsValid },
-  } = useForm({
+  } = useForm<FormValuesProps>({
     resolver: yupResolver(vurdering_vedtak),
-    defaultValues: {
-      begrunnelseFritekst: defaultBegrunnelse || "",
-      innledningFritekst: defaultInnledning || "",
-      behandlingsvalg: undefined,
-    } as FieldValues,
-    mode: 'onSubmit',
-    reValidateMode: 'onChange',
+    context: { behandlingsvalg: lagretAarsavregning?.behandlingsvalg },
+    mode: "onSubmit",
+    reValidateMode: "onChange",
   });
   const formValues = watch();
 
-  const fetchAvregningsData = () => {
-    if (behandlingID === null) return Promise.resolve(undefined);
-    return Api.Aarsavregning.hentAarsavregning(behandlingID).then((response: AarsavregningResponse) => {
+  const fetchAarsavregning = useCallback(async (): Promise<AarsavregningResponse | undefined> => {
+    if (behandlingID === null) return undefined;
+    try {
+      const response = await Api.Aarsavregning.hentAarsavregning(behandlingID);
       setLagretAarsavregning(response);
       return response;
-    }).catch(error => {
+    } catch (error) {
       console.error("Error fetching aarsavregning data: ", error);
       return undefined;
-    });
-  };
+    }
+  }, [behandlingID]);
 
-  const hentMuligeMottakere = async () => {
+  const fetchMuligeMottakere = useCallback(async () => {
     if (behandlingID === null) return;
-    const res = await Api.DokumenterV2.hentMuligeMottakere(behandlingID, {
-      produserbartdokument: AARSAVREGNING_VEDTAKSBREV,
-      orgnr: null,
-    });
-    setMuligeMottakere(res);
-    await hentStandardvedleggForBrev();
-  };
+    try {
+      const res = await Api.DokumenterV2.hentMuligeMottakere(behandlingID, {
+        produserbartdokument: AARSAVREGNING_VEDTAKSBREV,
+        orgnr: null,
+      });
+      setMuligeMottakere(res);
+      await fetchStandardvedleggForBrev();
+    } catch (error) {
+      console.error("Error fetching mulige mottakere: ", error);
+    }
+  }, [behandlingID]);
 
-  const hentStandardvedleggForBrev = async () => {
-    Api.DokumenterV2.hentStandardvedleggForBrev(AARSAVREGNING_VEDTAKSBREV).then((res) => {
+  const fetchStandardvedleggForBrev = useCallback(async () => {
+    try {
+      const res = await Api.DokumenterV2.hentStandardvedleggForBrev(AARSAVREGNING_VEDTAKSBREV);
       setBrevVedlegg({
         saksvedlegg: [],
         standardvedlegg: res,
       });
-    });
-  };
+    } catch (error) {
+      console.error("Error fetching standardvedlegg: ", error);
+    }
+  }, []);
 
-  const hentOgSetHarFullmaktForTrygdeavgift = async () => {
+  const fetchFakturaMottaker = useCallback(async () => {
+    if (behandlingID === null) return;
+    try {
+      const dto = await Api.Trygdeavgift.hentFakturamottaker(behandlingID);
+      setFakturaMottaker(dto.navn);
+    } catch (error) {
+      console.error("Error fetching fakturamottaker: ", error);
+    }
+  }, [behandlingID]);
+
+  const fetchAndSetHarFullmaktForTrygdeavgift = useCallback(async () => {
     if (saksnummer === null || saksnummer === undefined) return;
-    const saksnummerString = typeof saksnummer === 'number' ? saksnummer.toString() : saksnummer;
-    if (typeof saksnummerString !== 'string') return;
+    const saksnummerString = typeof saksnummer === "number" ? saksnummer.toString() : saksnummer;
+    if (typeof saksnummerString !== "string") return;
 
-    await Api.Fagsaker.aktoer.hent(saksnummerString, FULLMEKTIG).then((res) => {
+    try {
+      const res = await Api.Fagsaker.aktoer.hent(saksnummerString, FULLMEKTIG);
       setHarBekreftetFullmaktForTrygdeavgift(false);
       setHarFullmaktForTrygdeavgift(
         res.some((aktoer) => aktoer.fullmakter?.some((fullmakt) => fullmakt === FULLMEKTIG_TRYGDEAVGIFT)),
       );
-    });
-  };
+    } catch (error) {
+      console.error("Error fetching fullmakt info: ", error);
+    }
+  }, [saksnummer]);
 
   useEffect(() => {
     if (aktivtSteg && behandlingID !== null) {
+      setIsFormInitialized(false);
       window.scrollTo(0, 0);
-      fetchAvregningsData().then((response) => {
-        if (response?.behandlingsvalg) {
-          setValue("behandlingsvalg", response.behandlingsvalg, { shouldValidate: false });
-        }
-      });
-      hentMuligeMottakere();
-      Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
-        setFakturaMottaker(dto.navn);
-      });
-      hentOgSetHarFullmaktForTrygdeavgift();
+      Promise.all([
+        fetchAarsavregning(),
+        fetchMuligeMottakere(),
+        fetchFakturaMottaker(),
+        fetchAndSetHarFullmaktForTrygdeavgift(),
+      ]);
     }
-  }, [aktivtSteg, behandlingID, setValue]);
+  }, [
+    aktivtSteg,
+    behandlingID,
+    fetchAarsavregning,
+    fetchMuligeMottakere,
+    fetchFakturaMottaker,
+    fetchAndSetHarFullmaktForTrygdeavgift,
+  ]);
+
+  useEffect(() => {
+    if (aktivtSteg && lagretAarsavregning) {
+      reset({
+        innledningFritekst: defaultInnledning ?? "",
+        begrunnelseFritekst: defaultBegrunnelse ?? "",
+      });
+      setIsFormInitialized(true);
+    }
+  }, [aktivtSteg, lagretAarsavregning, reset, defaultInnledning, defaultBegrunnelse]);
 
   useEffect(() => {
     if (aktivtSteg && erFullmektigEndret && behandlingID !== null) {
-      hentOgSetHarFullmaktForTrygdeavgift();
-      Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
-        setFakturaMottaker(dto.navn);
-      });
+      fetchAndSetHarFullmaktForTrygdeavgift();
+      fetchFakturaMottaker();
       dispatch(menypanelOperations.setErFullmektigEndret(false));
     }
-  }, [aktivtSteg, erFullmektigEndret, behandlingID, dispatch]);
+  }, [
+    aktivtSteg,
+    erFullmektigEndret,
+    behandlingID,
+    dispatch,
+    fetchAndSetHarFullmaktForTrygdeavgift,
+    fetchFakturaMottaker,
+  ]);
+
+  const oppdaterFritekster = useCallback(
+    (values: FormValuesProps) => {
+      if (values && redigerbart && !vedtakPending && behandlingID !== null) {
+        Api.Behandlinger.resultat.oppdaterFritekster(behandlingID, {
+          innledningFritekst: values.innledningFritekst,
+          begrunnelseFritekst: values.begrunnelseFritekst,
+        });
+      }
+    },
+    [behandlingID, redigerbart, vedtakPending],
+  );
+
+  const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), [oppdaterFritekster]);
+
+  useEffect(() => {
+    if (aktivtSteg && behandlingID !== null && lagretAarsavregning && isFormInitialized) {
+      debouncedOppdaterFritekster(formValues);
+    }
+  }, [aktivtSteg, formValues, debouncedOppdaterFritekster, behandlingID, lagretAarsavregning, isFormInitialized]);
+
+  if (!aktivtSteg || !lagretAarsavregning || !isFormInitialized) {
+    return null;
+  }
 
   const lagFattVedtakReqDto = (): Api.Saksflyt.Vedtak.FattVedtakÅrsavregningReqDto => {
     return {
@@ -174,11 +236,12 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   };
 
   const onSubmit = async () => {
-    if (behandlingID === null) {
+    if (behandlingID === null || !lagretAarsavregning) {
       return;
     }
 
-    const stegErGyldig = !harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift;
+    const stegErGyldig =
+      !harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift;
     if (!stegErGyldig) {
       return;
     }
@@ -187,29 +250,15 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     fattVedtak(behandlingID, lagFattVedtakReqDto())
       .then((res) => {
         if (res.data?.data?.error) {
+          console.error("Error during fattVedtak: ", res.data.data.error);
           setVedtakPending(false);
         }
       })
-      .catch(() => {
+      .catch((error) => {
+        console.error("Error submitting vedtak: ", error);
         setVedtakPending(false);
       });
   };
-
-  const oppdaterFritekster = (values: FormValuesProps) => {
-    if (values && redigerbart && !vedtakPending) {
-      Api.Behandlinger.resultat.oppdaterFritekster(behandlingID, {
-        innledningFritekst: values.innledningFritekst,
-        begrunnelseFritekst: values.begrunnelseFritekst,
-      });
-    }
-  };
-  const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), [behandlingID, redigerbart, vedtakPending]);
-
-  useEffect(() => {
-    if (aktivtSteg && behandlingID !== null) {
-      debouncedOppdaterFritekster(formValues);
-    }
-  }, [aktivtSteg, formValues, debouncedOppdaterFritekster, behandlingID]);
 
   const mapMottakerRad = (muligMottaker: Api.DokumenterV2.MuligMottaker) => {
     return {
@@ -226,17 +275,19 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   };
 
   const mapMottakerRader = (mottakere: Api.DokumenterV2.HentMuligeMottakereResDto) => {
-    return [
-      mapMottakerRad(mottakere.hovedMottaker),
-      ...mottakere.kopiMottakere.map((muligMottaker) => mapMottakerRad(muligMottaker)),
-      ...mottakere.fasteMottakere.map((muligMottaker) => mapMottakerRad(muligMottaker)),
-    ];
+    const rader = [];
+    if (mottakere.hovedMottaker) {
+      rader.push(mapMottakerRad(mottakere.hovedMottaker));
+    }
+    rader.push(...mottakere.kopiMottakere.map((muligMottaker) => mapMottakerRad(muligMottaker)));
+    rader.push(...mottakere.fasteMottakere.map((muligMottaker) => mapMottakerRad(muligMottaker)));
+    return rader;
   };
 
   const tidligereTrygdeavgift = lagretAarsavregning?.avregning?.tidligereFakturertBeloep;
   const tidligereTrygdeavgiftAvgiftssystem = lagretAarsavregning?.avregning?.tidligereFakturertBeloepAvgiftssystem;
   const nyTrygdeavgift =
-    formValues?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT
+    lagretAarsavregning?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT
       ? lagretAarsavregning?.avregning?.manueltAvgiftBeloep
       : lagretAarsavregning?.avregning?.nyttTotalbeloep;
 
@@ -246,7 +297,10 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const erNullKroner = trygdeavgiftDiff === 0;
   const skalFaktureres = trygdeavgiftDiff > 0;
 
-  const kanSubmitte = redigerbart && !vedtakPending &&
+  const kanSubmitte =
+    redigerbart &&
+    !vedtakPending &&
+    formIsValid &&
     (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift);
 
   return (
@@ -255,9 +309,10 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         Vedtak årsavregning {lagretAarsavregning ? lagretAarsavregning.aar : ""}
       </Nav.Heading>
 
-      {formValues?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
+      {lagretAarsavregning?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
         <Nav.Alert variant="warning" className="blokk-s">
-          Du har lagt inn "Endelig beregnet trygdeavgift" manuelt og må derfor oppgi en begrunnelse i fritekstfeltet.
+          Du har lagt inn &quot;Endelig beregnet trygdeavgift&quot; manuelt og må derfor oppgi en begrunnelse i
+          fritekstfeltet.
         </Nav.Alert>
       )}
 
@@ -277,8 +332,9 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
               ) : (
                 <>
                   <br />
-                  {`${skalFaktureres ? "Faktura" : "Kreditnota"} på ${Utils.formaterTilNorskBelop(Math.abs(trygdeavgiftDiff)) || "0"
-                    } kr sendes til: `}{" "}
+                  {`${skalFaktureres ? "Faktura" : "Kreditnota"} på ${
+                    Utils.formaterTilNorskBelop(Math.abs(trygdeavgiftDiff)) || "0"
+                  } kr sendes til: `}{" "}
                   <b>{fakturaMottaker}</b>
                 </>
               )}
@@ -314,19 +370,23 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         disabled={!redigerbart}
       />
 
-      {formIsValid && redigerbart && muligeMottakere && behandlingID !== null && (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift) && (
-        <>
-          <Dokumentliste behandlingID={behandlingID} dokumenter={mapMottakerRader(muligeMottakere)} />
-          <VedleggTable
-            valgteVedlegg={brevVedlegg}
-            setValgteVedlegg={() => {
-              /* Readonly */
-            }}
-            label="Vedlegg"
-            redigerbart={false /* Readonly. Ikke vis slett-knapp. */}
-          />
-        </>
-      )}
+      {formIsValid &&
+        redigerbart &&
+        muligeMottakere &&
+        behandlingID !== null &&
+        (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift) && (
+          <>
+            <Dokumentliste behandlingID={behandlingID} dokumenter={mapMottakerRader(muligeMottakere)} />
+            <VedleggTable
+              valgteVedlegg={brevVedlegg}
+              setValgteVedlegg={() => {
+                /* Readonly */
+              }}
+              label="Vedlegg"
+              redigerbart={false /* Readonly. Ikke vis slett-knapp. */}
+            />
+          </>
+        )}
 
       <Mui.StegKnapper
         bekreftKnappProps={{

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -243,7 +243,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), [oppdaterFritekster]);
 
   useEffect(() => {
-    if (aktivtSteg && behandlingID !== null && lagretAarsavregning && isFormInitialized) {
+    if (redigerbart && aktivtSteg && behandlingID !== null && lagretAarsavregning && isFormInitialized) {
       const currentValues = getValues();
       const hasInnledningChanged = (currentValues.innledningFritekst ?? "") !== lagretInnledning;
       const hasBegrunnelseChanged = (currentValues.begrunnelseFritekst ?? "") !== lagretBegrunnelse;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -65,7 +65,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     saksvedlegg: [],
     standardvedlegg: [],
   });
-  const [isFormInitialized, setIsFormInitialized] = useState(false);
+  const [harSkjemaverdier, setHarSkjemaverdier] = useState(false);
   const [fritekstPending, setFritekstPending] = useState(false);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as number;
@@ -162,7 +162,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   useEffect(() => {
     if (aktivtSteg && behandlingID !== null) {
-      setIsFormInitialized(false);
+      setHarSkjemaverdier(false);
       window.scrollTo(0, 0);
       Promise.all([
         fetchAarsavregning(),
@@ -183,23 +183,23 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   useEffect(() => {
     if (aktivtSteg && lagretAarsavregning) {
       const currentValues = getValues();
-      const newInnledning = currentValues.innledningFritekst ?? lagretInnledning ?? "";
-      const newBegrunnelse = currentValues.begrunnelseFritekst ?? lagretBegrunnelse ?? "";
+      const nyInnledningFritekst = currentValues.innledningFritekst ?? lagretInnledning ?? "";
+      const nyBegrunnelseFritekst = currentValues.begrunnelseFritekst ?? lagretBegrunnelse ?? "";
 
-      if (!isFormInitialized) {
+      if (!harSkjemaverdier) {
         reset(
           {
-            innledningFritekst: newInnledning,
-            begrunnelseFritekst: newBegrunnelse,
+            innledningFritekst: nyInnledningFritekst,
+            begrunnelseFritekst: nyBegrunnelseFritekst,
           },
           { keepDirty: false },
         );
-        setLagretInnledning(newInnledning);
-        setLagretBegrunnelse(newBegrunnelse);
-        setIsFormInitialized(true);
+        setLagretInnledning(nyInnledningFritekst);
+        setLagretBegrunnelse(nyBegrunnelseFritekst);
+        setHarSkjemaverdier(true);
       }
     }
-  }, [aktivtSteg, lagretAarsavregning, reset, lagretInnledning, lagretBegrunnelse, getValues, isFormInitialized]);
+  }, [aktivtSteg, lagretAarsavregning, reset, lagretInnledning, lagretBegrunnelse, getValues, harSkjemaverdier]);
 
   useEffect(() => {
     if (aktivtSteg && erFullmektigEndret && behandlingID !== null) {
@@ -243,7 +243,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), [oppdaterFritekster]);
 
   useEffect(() => {
-    if (redigerbart && aktivtSteg && behandlingID !== null && lagretAarsavregning && isFormInitialized) {
+    if (redigerbart && aktivtSteg && behandlingID !== null && lagretAarsavregning && harSkjemaverdier) {
       const currentValues = getValues();
       const hasInnledningChanged = (currentValues.innledningFritekst ?? "") !== lagretInnledning;
       const hasBegrunnelseChanged = (currentValues.begrunnelseFritekst ?? "") !== lagretBegrunnelse;
@@ -259,13 +259,13 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     debouncedOppdaterFritekster,
     behandlingID,
     lagretAarsavregning,
-    isFormInitialized,
+    harSkjemaverdier,
     getValues,
     lagretInnledning,
     lagretBegrunnelse,
   ]);
 
-  if (!aktivtSteg || !lagretAarsavregning || !isFormInitialized) {
+  if (!aktivtSteg || !lagretAarsavregning || !harSkjemaverdier) {
     return null;
   }
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -32,7 +32,7 @@ const { FØRSTEGANGSVEDTAK } = MKV.Koder.vedtakstyper;
 const { AARSAVREGNING_VEDTAKSBREV } = MKV.Koder.brev.produserbaredokumenter;
 const { FULLMEKTIG_TRYGDEAVGIFT } = MKV.Koder.fullmaktstype;
 const { FULLMEKTIG } = MKV.Koder.aktoersroller;
-const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
+const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
 interface FormValuesProps {
   innledningFritekst?: string;
@@ -90,7 +90,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     formState: { isValid: formIsValid },
   } = useForm<FormValuesProps>({
     resolver: yupResolver(vurdering_vedtak),
-    context: { behandlingsvalg: lagretAarsavregning?.behandlingsvalg },
+    context: { endeligAvgiftValg: lagretAarsavregning?.endeligAvgiftValg },
     mode: "onSubmit",
     reValidateMode: "onChange",
   });
@@ -327,7 +327,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const tidligereTrygdeavgift = lagretAarsavregning?.avregning?.tidligereFakturertBeloep;
   const tidligereTrygdeavgiftAvgiftssystem = lagretAarsavregning?.avregning?.tidligereFakturertBeloepAvgiftssystem;
   const nyTrygdeavgift =
-    lagretAarsavregning?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT
+    lagretAarsavregning?.endeligAvgiftValg === MANUELL_ENDELIG_AVGIFT
       ? lagretAarsavregning?.avregning?.manueltAvgiftBeloep
       : lagretAarsavregning?.avregning?.nyttTotalbeloep;
 
@@ -348,7 +348,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         Vedtak årsavregning {lagretAarsavregning ? lagretAarsavregning.aar : ""}
       </Nav.Heading>
 
-      {lagretAarsavregning?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
+      {lagretAarsavregning?.endeligAvgiftValg === MANUELL_ENDELIG_AVGIFT && (
         <Nav.Alert variant="warning" className="blokk-s">
           Du har lagt inn &quot;Endelig beregnet trygdeavgift&quot; manuelt og må derfor oppgi en begrunnelse i
           fritekstfeltet.

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -66,6 +66,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     standardvedlegg: [],
   });
   const [isFormInitialized, setIsFormInitialized] = useState(false);
+  const [fritekstPending, setFritekstPending] = useState(false);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as number;
   const erFullmektigEndret = useSelector(menypanelSelectors.MenypanelErFullmektigEndretSelector) as boolean;
@@ -73,16 +74,19 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   const { fattVedtak } = komponentDispatch(dispatch);
 
-  const defaultBegrunnelse = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) as
-    | string
-    | undefined;
-  const defaultInnledning = useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) as string | undefined;
+  const [lagretInnledning, setLagretInnledning] = useState<string>(
+    useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) ?? "",
+  );
+  const [lagretBegrunnelse, setLagretBegrunnelse] = useState<string>(
+    useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) ?? "",
+  );
 
   const {
     watch,
     control,
     handleSubmit,
     reset,
+    getValues,
     formState: { isValid: formIsValid },
   } = useForm<FormValuesProps>({
     resolver: yupResolver(vurdering_vedtak),
@@ -178,13 +182,24 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   useEffect(() => {
     if (aktivtSteg && lagretAarsavregning) {
-      reset({
-        innledningFritekst: defaultInnledning ?? "",
-        begrunnelseFritekst: defaultBegrunnelse ?? "",
-      });
-      setIsFormInitialized(true);
+      const currentValues = getValues();
+      const newInnledning = currentValues.innledningFritekst ?? lagretInnledning ?? "";
+      const newBegrunnelse = currentValues.begrunnelseFritekst ?? lagretBegrunnelse ?? "";
+
+      if (!isFormInitialized) {
+        reset(
+          {
+            innledningFritekst: newInnledning,
+            begrunnelseFritekst: newBegrunnelse,
+          },
+          { keepDirty: false },
+        );
+        setLagretInnledning(newInnledning);
+        setLagretBegrunnelse(newBegrunnelse);
+        setIsFormInitialized(true);
+      }
     }
-  }, [aktivtSteg, lagretAarsavregning, reset, defaultInnledning, defaultBegrunnelse]);
+  }, [aktivtSteg, lagretAarsavregning, reset, lagretInnledning, lagretBegrunnelse, getValues, isFormInitialized]);
 
   useEffect(() => {
     if (aktivtSteg && erFullmektigEndret && behandlingID !== null) {
@@ -204,10 +219,22 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const oppdaterFritekster = useCallback(
     (values: FormValuesProps) => {
       if (values && redigerbart && !vedtakPending && behandlingID !== null) {
-        Api.Behandlinger.resultat.oppdaterFritekster(behandlingID, {
+        const payload = {
           innledningFritekst: values.innledningFritekst,
           begrunnelseFritekst: values.begrunnelseFritekst,
-        });
+        };
+        Api.Behandlinger.resultat
+          .oppdaterFritekster(behandlingID, payload)
+          .then(() => {
+            setLagretInnledning(values.innledningFritekst ?? "");
+            setLagretBegrunnelse(values.begrunnelseFritekst ?? "");
+          })
+          .catch((error) => {
+            console.error("Feil ved oppdatering av fritekster:", error);
+          })
+          .finally(() => {
+            setFritekstPending(false);
+          });
       }
     },
     [behandlingID, redigerbart, vedtakPending],
@@ -217,9 +244,26 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   useEffect(() => {
     if (aktivtSteg && behandlingID !== null && lagretAarsavregning && isFormInitialized) {
-      debouncedOppdaterFritekster(formValues);
+      const currentValues = getValues();
+      const hasInnledningChanged = (currentValues.innledningFritekst ?? "") !== lagretInnledning;
+      const hasBegrunnelseChanged = (currentValues.begrunnelseFritekst ?? "") !== lagretBegrunnelse;
+
+      if (hasInnledningChanged || hasBegrunnelseChanged) {
+        setFritekstPending(true);
+        debouncedOppdaterFritekster(currentValues);
+      }
     }
-  }, [aktivtSteg, formValues, debouncedOppdaterFritekster, behandlingID, lagretAarsavregning, isFormInitialized]);
+  }, [
+    aktivtSteg,
+    formValues,
+    debouncedOppdaterFritekster,
+    behandlingID,
+    lagretAarsavregning,
+    isFormInitialized,
+    getValues,
+    lagretInnledning,
+    lagretBegrunnelse,
+  ]);
 
   if (!aktivtSteg || !lagretAarsavregning || !isFormInitialized) {
     return null;
@@ -300,7 +344,6 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const kanSubmitte =
     redigerbart &&
     !vedtakPending &&
-    formIsValid &&
     (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift);
 
   return (
@@ -374,24 +417,18 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         redigerbart &&
         muligeMottakere &&
         behandlingID !== null &&
-        (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift) && (
+        (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift) &&
+        !fritekstPending && (
           <>
             <Dokumentliste behandlingID={behandlingID} dokumenter={mapMottakerRader(muligeMottakere)} />
-            <VedleggTable
-              valgteVedlegg={brevVedlegg}
-              setValgteVedlegg={() => {
-                /* Readonly */
-              }}
-              label="Vedlegg"
-              redigerbart={false /* Readonly. Ikke vis slett-knapp. */}
-            />
+            <VedleggTable valgteVedlegg={brevVedlegg} setValgteVedlegg={() => {}} label="Vedlegg" redigerbart={false} />
           </>
         )}
 
       <Mui.StegKnapper
         bekreftKnappProps={{
           disabled: !kanSubmitte,
-          loading: vedtakPending,
+          loading: vedtakPending || fritekstPending,
           type: "submit",
         }}
         bekreftTekst="Fatt vedtak"

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -103,7 +103,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
       setLagretAarsavregning(response);
       return response;
     } catch (error) {
-      console.error("Error fetching aarsavregning data: ", error);
+      console.error("Henting av aarsavregning feilet: ", error);
       return undefined;
     }
   }, [behandlingID]);
@@ -118,7 +118,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
       setMuligeMottakere(res);
       await fetchStandardvedleggForBrev();
     } catch (error) {
-      console.error("Error fetching mulige mottakere: ", error);
+      console.error("Henting av muligeMottakere feilet: ", error);
     }
   }, [behandlingID]);
 
@@ -130,7 +130,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         standardvedlegg: res,
       });
     } catch (error) {
-      console.error("Error fetching standardvedlegg: ", error);
+      console.error("Henting av vedlegg feilet: ", error);
     }
   }, []);
 
@@ -140,7 +140,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
       const dto = await Api.Trygdeavgift.hentFakturamottaker(behandlingID);
       setFakturaMottaker(dto.navn);
     } catch (error) {
-      console.error("Error fetching fakturamottaker: ", error);
+      console.error("Henting av fakturamottaker feilet: ", error);
     }
   }, [behandlingID]);
 
@@ -156,7 +156,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         res.some((aktoer) => aktoer.fullmakter?.some((fullmakt) => fullmakt === FULLMEKTIG_TRYGDEAVGIFT)),
       );
     } catch (error) {
-      console.error("Error fetching fullmakt info: ", error);
+      console.error("Henting av fullmakt feilet: ", error);
     }
   }, [saksnummer]);
 
@@ -230,7 +230,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
             setLagretBegrunnelse(values.begrunnelseFritekst ?? "");
           })
           .catch((error) => {
-            console.error("Feil ved oppdatering av fritekster:", error);
+            console.error("Oppdatering av fritekster feilet: ", error);
           })
           .finally(() => {
             setFritekstPending(false);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -269,16 +269,6 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     return null;
   }
 
-  const lagFattVedtakReqDto = (): Api.Saksflyt.Vedtak.FattVedtakÅrsavregningReqDto => {
-    return {
-      behandlingsresultatTypeKode: FASTSATT_TRYGDEAVGIFT,
-      innledningFritekst: formValues?.innledningFritekst || null,
-      begrunnelseFritekst: formValues?.begrunnelseFritekst || null,
-      vedtakstype: FØRSTEGANGSVEDTAK,
-      kopiMottakere: muligeMottakere.kopiMottakere.map(Api.DokumenterV2.konverterMuligMottakerTilKopiMottaker),
-    };
-  };
-
   const onSubmit = async () => {
     if (behandlingID === null || !lagretAarsavregning) {
       return;
@@ -291,7 +281,13 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     }
 
     setVedtakPending(true);
-    fattVedtak(behandlingID, lagFattVedtakReqDto())
+    fattVedtak(behandlingID, {
+      behandlingsresultatTypeKode: FASTSATT_TRYGDEAVGIFT,
+      innledningFritekst: formValues?.innledningFritekst || null,
+      begrunnelseFritekst: formValues?.begrunnelseFritekst || null,
+      vedtakstype: FØRSTEGANGSVEDTAK,
+      kopiMottakere: muligeMottakere.kopiMottakere.map(Api.DokumenterV2.konverterMuligMottakerTilKopiMottaker),
+    })
       .then((res) => {
         if (res.data?.data?.error) {
           console.error("Error during fattVedtak: ", res.data.data.error);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -32,10 +32,12 @@ const { FØRSTEGANGSVEDTAK } = MKV.Koder.vedtakstyper;
 const { AARSAVREGNING_VEDTAKSBREV } = MKV.Koder.brev.produserbaredokumenter;
 const { FULLMEKTIG_TRYGDEAVGIFT } = MKV.Koder.fullmaktstype;
 const { FULLMEKTIG } = MKV.Koder.aktoersroller;
+const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.aarsavregningBehandlingsvalg;
 
 interface FormValuesProps {
   innledningFritekst?: string;
   begrunnelseFritekst?: string;
+  behandlingsvalg?: string;
 }
 
 interface Props {
@@ -64,34 +66,47 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     saksvedlegg: [],
     standardvedlegg: [],
   });
-  const aarsavregningID = useSelector(behandlingsresultatSelectors.ÅrsavregningIDSelector);
-  const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
-  const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
-  const erFullmektigEndret = useSelector(menypanelSelectors.MenypanelErFullmektigEndretSelector);
-  const saksnummer = useSelector(fagsakSelectors.SaksnummerSelector);
+  const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
+  const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as number;
+  const erFullmektigEndret = useSelector(menypanelSelectors.MenypanelErFullmektigEndretSelector) as boolean;
+  const saksnummer = useSelector(fagsakSelectors.SaksnummerSelector) as string | number | null;
 
   const { fattVedtak } = komponentDispatch(dispatch);
+
+  const defaultBegrunnelse = useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) as string | undefined;
+  const defaultInnledning = useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) as string | undefined;
 
   const {
     watch,
     control,
+    handleSubmit,
+    setValue,
     formState: { isValid: formIsValid },
   } = useForm({
     resolver: yupResolver(vurdering_vedtak),
     defaultValues: {
-      begrunnelseFritekst: useSelector(behandlingsresultatSelectors.BegrunnelseFritekstSelector) || "",
-      innledningFritekst: useSelector(behandlingsresultatSelectors.InnledningFritekstSelector) || "",
+      begrunnelseFritekst: defaultBegrunnelse || "",
+      innledningFritekst: defaultInnledning || "",
+      behandlingsvalg: undefined,
     } as FieldValues,
+    mode: 'onSubmit',
+    reValidateMode: 'onChange',
   });
   const formValues = watch();
 
   const fetchAvregningsData = () => {
+    if (behandlingID === null) return Promise.resolve(undefined);
     return Api.Aarsavregning.hentAarsavregning(behandlingID).then((response: AarsavregningResponse) => {
       setLagretAarsavregning(response);
+      return response;
+    }).catch(error => {
+      console.error("Error fetching aarsavregning data: ", error);
+      return undefined;
     });
   };
 
   const hentMuligeMottakere = async () => {
+    if (behandlingID === null) return;
     const res = await Api.DokumenterV2.hentMuligeMottakere(behandlingID, {
       produserbartdokument: AARSAVREGNING_VEDTAKSBREV,
       orgnr: null,
@@ -110,7 +125,11 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   };
 
   const hentOgSetHarFullmaktForTrygdeavgift = async () => {
-    await Api.Fagsaker.aktoer.hent(saksnummer, FULLMEKTIG).then((res) => {
+    if (saksnummer === null || saksnummer === undefined) return;
+    const saksnummerString = typeof saksnummer === 'number' ? saksnummer.toString() : saksnummer;
+    if (typeof saksnummerString !== 'string') return;
+
+    await Api.Fagsaker.aktoer.hent(saksnummerString, FULLMEKTIG).then((res) => {
       setHarBekreftetFullmaktForTrygdeavgift(false);
       setHarFullmaktForTrygdeavgift(
         res.some((aktoer) => aktoer.fullmakter?.some((fullmakt) => fullmakt === FULLMEKTIG_TRYGDEAVGIFT)),
@@ -119,36 +138,30 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   };
 
   useEffect(() => {
-    if (aktivtSteg) {
-      hentOgSetHarFullmaktForTrygdeavgift();
-    }
-  }, []);
-
-  useEffect(() => {
-    if (aktivtSteg) {
-      if (erFullmektigEndret) {
-        hentOgSetHarFullmaktForTrygdeavgift();
-
-        Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
-          setFakturaMottaker(dto.navn);
-        });
-
-        dispatch(menypanelOperations.setErFullmektigEndret(false));
-      }
-    }
-  }, [erFullmektigEndret]);
-
-  useEffect(() => {
-    if (aktivtSteg) {
+    if (aktivtSteg && behandlingID !== null) {
       window.scrollTo(0, 0);
-      fetchAvregningsData();
+      fetchAvregningsData().then((response) => {
+        if (response?.behandlingsvalg) {
+          setValue("behandlingsvalg", response.behandlingsvalg, { shouldValidate: false });
+        }
+      });
       hentMuligeMottakere();
-
       Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
         setFakturaMottaker(dto.navn);
       });
+      hentOgSetHarFullmaktForTrygdeavgift();
     }
-  }, [aktivtSteg]);
+  }, [aktivtSteg, behandlingID, setValue]);
+
+  useEffect(() => {
+    if (aktivtSteg && erFullmektigEndret && behandlingID !== null) {
+      hentOgSetHarFullmaktForTrygdeavgift();
+      Api.Trygdeavgift.hentFakturamottaker(behandlingID).then((dto) => {
+        setFakturaMottaker(dto.navn);
+      });
+      dispatch(menypanelOperations.setErFullmektigEndret(false));
+    }
+  }, [aktivtSteg, erFullmektigEndret, behandlingID, dispatch]);
 
   const lagFattVedtakReqDto = (): Api.Saksflyt.Vedtak.FattVedtakÅrsavregningReqDto => {
     return {
@@ -160,13 +173,26 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     };
   };
 
-  const fattVedtakOnClick = async () => {
+  const onSubmit = async () => {
+    if (behandlingID === null) {
+      return;
+    }
+
+    const stegErGyldig = !harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift;
+    if (!stegErGyldig) {
+      return;
+    }
+
     setVedtakPending(true);
-    fattVedtak(behandlingID, lagFattVedtakReqDto()).then((res) => {
-      if (res.data?.data?.error) {
+    fattVedtak(behandlingID, lagFattVedtakReqDto())
+      .then((res) => {
+        if (res.data?.data?.error) {
+          setVedtakPending(false);
+        }
+      })
+      .catch(() => {
         setVedtakPending(false);
-      }
-    });
+      });
   };
 
   const oppdaterFritekster = (values: FormValuesProps) => {
@@ -177,13 +203,13 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
       });
     }
   };
-  const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), []);
+  const debouncedOppdaterFritekster = useCallback(Utils._debounce(oppdaterFritekster, 1000), [behandlingID, redigerbart, vedtakPending]);
 
   useEffect(() => {
-    if (aktivtSteg) {
+    if (aktivtSteg && behandlingID !== null) {
       debouncedOppdaterFritekster(formValues);
     }
-  }, [formValues?.innledningFritekst, formValues?.begrunnelseFritekst, formValues?.trygdeavgiftFritekst]);
+  }, [aktivtSteg, formValues, debouncedOppdaterFritekster, behandlingID]);
 
   const mapMottakerRad = (muligMottaker: Api.DokumenterV2.MuligMottaker) => {
     return {
@@ -209,21 +235,31 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
   const tidligereTrygdeavgift = lagretAarsavregning?.avregning?.tidligereFakturertBeloep;
   const tidligereTrygdeavgiftAvgiftssystem = lagretAarsavregning?.avregning?.tidligereFakturertBeloepAvgiftssystem;
-  const nyTrygdeavgift = lagretAarsavregning?.avregning?.nyttTotalbeloep;
+  const nyTrygdeavgift =
+    formValues?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT
+      ? lagretAarsavregning?.avregning?.manueltAvgiftBeloep
+      : lagretAarsavregning?.avregning?.nyttTotalbeloep;
+
   const trygdeavgiftDiff =
     (nyTrygdeavgift ?? 0) - (tidligereTrygdeavgift ?? 0) - (tidligereTrygdeavgiftAvgiftssystem ?? 0);
   const erDifferanseUnderMinstebeløp = Math.abs(trygdeavgiftDiff) < MINSTEBELOP_FAKTURERING_ELLER_REFUSJON;
   const erNullKroner = trygdeavgiftDiff === 0;
   const skalFaktureres = trygdeavgiftDiff > 0;
 
-  const stegErGyldig =
-    formIsValid && (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift);
+  const kanSubmitte = redigerbart && !vedtakPending &&
+    (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift);
 
   return (
-    <div className="vurderingVedtak">
+    <form onSubmit={handleSubmit(onSubmit)} className="vurderingVedtak">
       <Nav.Heading level="1" className="stegvelgertittel">
         Vedtak årsavregning {lagretAarsavregning ? lagretAarsavregning.aar : ""}
       </Nav.Heading>
+
+      {formValues?.behandlingsvalg === MANUELL_ENDELIG_AVGIFT && (
+        <Nav.Alert variant="warning" className="blokk-s">
+          Du har lagt inn "Endelig beregnet trygdeavgift" manuelt og må derfor oppgi en begrunnelse i fritekstfeltet.
+        </Nav.Alert>
+      )}
 
       <SumArsavregningTabell
         nyTrygdeavgift={nyTrygdeavgift}
@@ -241,9 +277,8 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
               ) : (
                 <>
                   <br />
-                  {`${skalFaktureres ? "Faktura" : "Kreditnota"} på ${
-                    Utils.formaterTilNorskBelop(Math.abs(trygdeavgiftDiff)) || "0"
-                  } kr sendes til: `}{" "}
+                  {`${skalFaktureres ? "Faktura" : "Kreditnota"} på ${Utils.formaterTilNorskBelop(Math.abs(trygdeavgiftDiff)) || "0"
+                    } kr sendes til: `}{" "}
                   <b>{fakturaMottaker}</b>
                 </>
               )}
@@ -279,27 +314,29 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         disabled={!redigerbart}
       />
 
-      {stegErGyldig && redigerbart && muligeMottakere && (
-        <Dokumentliste behandlingID={behandlingID} dokumenter={mapMottakerRader(muligeMottakere)} />
+      {formIsValid && redigerbart && muligeMottakere && behandlingID !== null && (!harFullmaktForTrygdeavgift || erDifferanseUnderMinstebeløp || harBekreftetFullmaktForTrygdeavgift) && (
+        <>
+          <Dokumentliste behandlingID={behandlingID} dokumenter={mapMottakerRader(muligeMottakere)} />
+          <VedleggTable
+            valgteVedlegg={brevVedlegg}
+            setValgteVedlegg={() => {
+              /* Readonly */
+            }}
+            label="Vedlegg"
+            redigerbart={false /* Readonly. Ikke vis slett-knapp. */}
+          />
+        </>
       )}
-      <VedleggTable
-        valgteVedlegg={brevVedlegg}
-        setValgteVedlegg={() => {
-          /* Readonly */
-        }}
-        label="Vedlegg"
-        redigerbart={false /* Readonly. Ikke vis slett-knapp. */}
-      />
 
       <Mui.StegKnapper
         bekreftKnappProps={{
-          onClick: fattVedtakOnClick,
-          disabled: !stegErGyldig || !formIsValid || !redigerbart,
+          disabled: !kanSubmitte,
           loading: vedtakPending,
+          type: "submit",
         }}
         bekreftTekst="Fatt vedtak"
-        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart }}
+        tilbakeKnappProps={{ onClick: tilbake, disabled: !redigerbart || vedtakPending, type: "button" }}
       />
-    </div>
+    </form>
   );
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
@@ -5,16 +5,29 @@ import * as KV from "../../../../kodeverk";
 import MKV from "../../../../melosyskodeverk";
 
 const { DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN } = KV.Feilmeldinger;
-export const DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT = { melding: "Du må oppgi en begrunnelse for \"Endelig trygdeavgift\"" };
+export const DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT = {
+  melding: 'Du må oppgi en begrunnelse for "Endelig trygdeavgift"',
+};
 
 const vurdering_vedtak = object().shape({
-  behandlingsvalg: string().nullable(),
+  // behandlingsvalg is no longer part of form values, accessed via context
   begrunnelseFritekst: string()
     .nullable()
     .max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN)
-    .when("behandlingsvalg", {
-      is: MKV.Koder.aarsavregningBehandlingsvalg.MANUELL_ENDELIG_AVGIFT,
-      then: (schema) => schema.required(DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT),
+    .when([], {
+      is: () => true, // Always run the check
+      then: (schema) =>
+        schema.test({
+          name: "begrunnelse-required-manuell",
+          message: DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT,
+          test(value) {
+            const { behandlingsvalg } = this.options.context || {};
+            if (behandlingsvalg === MKV.Koder.aarsavregningBehandlingsvalg.MANUELL_ENDELIG_AVGIFT) {
+              return !!value; // Required if MANUELL_ENDELIG_AVGIFT
+            }
+            return true; // Optional otherwise
+          },
+        }),
       otherwise: (schema) => schema.nullable(),
     }),
   innledningFritekst: string().nullable().max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
@@ -2,11 +2,21 @@
 
 import { object, string } from "yup";
 import * as KV from "../../../../kodeverk";
+import MKV from "../../../../melosyskodeverk";
 
 const { DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN } = KV.Feilmeldinger;
+export const DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT = { melding: "Du må oppgi en begrunnelse for \"Endelig trygdeavgift\"" };
 
 const vurdering_vedtak = object().shape({
-  begrunnelseFritekst: string().nullable().max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN),
+  behandlingsvalg: string().nullable(),
+  begrunnelseFritekst: string()
+    .nullable()
+    .max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN)
+    .when("behandlingsvalg", {
+      is: MKV.Koder.aarsavregningBehandlingsvalg.MANUELL_ENDELIG_AVGIFT,
+      then: (schema) => schema.required(DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT),
+      otherwise: (schema) => schema.nullable(),
+    }),
   innledningFritekst: string().nullable().max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN),
 });
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
@@ -10,12 +10,11 @@ export const DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT = {
 };
 
 const vurdering_vedtak = object().shape({
-  // behandlingsvalg is no longer part of form values, accessed via context
   begrunnelseFritekst: string()
     .nullable()
     .max(4000, DU_KAN_IKKE_SKRIVE_MER_ENN_4000_TEGN)
     .when([], {
-      is: () => true, // Always run the check
+      is: () => true,
       then: (schema) =>
         schema.test({
           name: "begrunnelse-required-manuell",
@@ -25,7 +24,7 @@ const vurdering_vedtak = object().shape({
             if (behandlingsvalg === MKV.Koder.aarsavregningBehandlingsvalg.MANUELL_ENDELIG_AVGIFT) {
               return !!value; // Required if MANUELL_ENDELIG_AVGIFT
             }
-            return true; // Optional otherwise
+            return true;
           },
         }),
       otherwise: (schema) => schema.nullable(),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtakSchema.js
@@ -20,8 +20,8 @@ const vurdering_vedtak = object().shape({
           name: "begrunnelse-required-manuell",
           message: DU_MAA_OPPGI_BEGRUNNELSE_FOR_ENDELIG_TRYGDEAVGIFT,
           test(value) {
-            const { behandlingsvalg } = this.options.context || {};
-            if (behandlingsvalg === MKV.Koder.aarsavregningBehandlingsvalg.MANUELL_ENDELIG_AVGIFT) {
+            const { endeligAvgiftValg } = this.options.context || {};
+            if (endeligAvgiftValg === MKV.Koder.endeligAvgiftValg.MANUELL_ENDELIG_AVGIFT) {
               return !!value; // Required if MANUELL_ENDELIG_AVGIFT
             }
             return true;


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7042
### Implementasjon av MVP 25-prosent regel for årsavregning inngang og vedtakssteg

Opprettet ny komponent BehandlingsvalgRadioGroup som gir saksbehandleren mulighet
  til å velge
  - Endringer i inntekts- og skatteopplysninger
  - Ingen endringer i opplysningene
  - Manuell beregning av endelig trygdeavgift

Ved valg av manuell beregning vises et inputfelt hvor saksbehandleren kan legge inn manuelt beregnet avgift. For uten og delt grunnlag vises i tillegg tidligere fakturert i avgiftssystemet inputfelt.

Opprettet ny komponent ManuellAvgiftFormPart som viser relevante skjemafelter for manuelt beregnet avgift og sum tabellen. Brukes for alle grunnlagstyper.

Refaktorerte også aarsavregning\vurderingVedtak for å støtte 25% regel MVP:
  - La til alert som vises ved manuell avgiftsberegning
  - La til validering som krever begrunnelseFritekst ved manuell
  avgiftsberegning
  - La til fritekstPending flag som viser
  spinner på bekreftknappen ved ulagrede endringer i fritekstfelt