### PR TITLE
7294: Fiks valideringsfeil på grunn inkonsistent datokonvertering

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -137,7 +137,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       const aktivFeilmelding = finnAktivFeilmelding({
         skatteforholdsperioder: formState.skatteforholdsperioder,
         inntektskilder: formState.inntektskilder,
-        medlemskapsperiode: innvilgetMedlemskapsperiode,
+        medlemskapsperiodeFomTom: innvilgetMedlemskapsperiode!,
         medlemskapstypeErPliktig,
       });
       if (!aktivFeilmelding) {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
@@ -121,7 +121,10 @@ const ikkeAlleSammeSkatteforholdstyper = (perioder: any[]): boolean => {
 interface AarsavregningValidationParams {
   skatteforholdsperioder: Skatteforhold[];
   inntektskilder: Inntektskilde[];
-  medlemskapsperiode: any;
+  medlemskapsperiodeFomTom: {
+    fomDato: string;
+    tomDato: string;
+  };
   medlemskapstypeErPliktig: boolean;
 }
 
@@ -131,18 +134,18 @@ interface AarsavregningValidationParams {
 export function finnAktivFeilmelding({
   skatteforholdsperioder,
   inntektskilder,
-  medlemskapsperiode,
+  medlemskapsperiodeFomTom,
   medlemskapstypeErPliktig,
 }: AarsavregningValidationParams): string | undefined {
   const vaskedeSkatteforholdsperioder = Utils.dato.vaskOgFormaterDatoerTilIso(skatteforholdsperioder);
   const vaskedeInntektskilder = Utils.dato.vaskOgFormaterDatoerTilIso(inntektskilder);
-  const medlemskapsperiodeIsoFormat = {
-    fomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.fomDato),
-    tomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.tomDato),
+  const medlemskapsperiodeFomTomIsoFormat = {
+    fomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiodeFomTom.fomDato)!,
+    tomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiodeFomTom.tomDato)!,
   };
 
   if (vaskedeSkatteforholdsperioder && vaskedeSkatteforholdsperioder.length > 0) {
-    if (!dekkerHeleMedlemskapsperiode(vaskedeSkatteforholdsperioder, medlemskapsperiodeIsoFormat)) {
+    if (!dekkerHeleMedlemskapsperiode(vaskedeSkatteforholdsperioder, medlemskapsperiodeFomTomIsoFormat)) {
       return TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
     }
 
@@ -164,7 +167,7 @@ export function finnAktivFeilmelding({
     vaskedeInntektskilder.length > 0 &&
     (!medlemskapstypeErPliktig || !erBrukerSkattepliktigIHelePerioden(vaskedeSkatteforholdsperioder))
   ) {
-    if (!dekkerHeleMedlemskapsperiode(vaskedeInntektskilder, medlemskapsperiodeIsoFormat)) {
+    if (!dekkerHeleMedlemskapsperiode(vaskedeInntektskilder, medlemskapsperiodeFomTomIsoFormat)) {
       return TypeFeilmelding.INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
     }
   }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
@@ -14,19 +14,19 @@ export enum TypeFeilmelding {
 const dekkerHeleMedlemskapsperiode = (perioder: any[], medlemskapsperiode: any): boolean => {
   if (!perioder || perioder.length === 0) return true;
 
-  const medlemskapsperiodeFom = Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.fomDato);
-  const medlemskapsperiodeTom = Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.tomDato);
+  const medlemskapsperiodeFom = medlemskapsperiode.fomDato;
+  const medlemskapsperiodeTom = medlemskapsperiode.tomDato;
 
   const minFomDato = perioder
     .map((periode) => {
-      const date = Utils.dato.isoStringTilDate(Utils.dato.vaskOgFormatterTilISO(periode.fomDato));
+      const date = Utils.dato.isoStringTilDate(periode.fomDato);
       return date ? date.getTime() : Infinity;
     })
     .reduce((min, current) => Math.min(min, current), Infinity);
 
   const maxTomDato = perioder
     .map((periode) => {
-      const date = Utils.dato.isoStringTilDate(Utils.dato.vaskOgFormatterTilISO(periode.tomDato));
+      const date = Utils.dato.isoStringTilDate(periode.tomDato);
       return date ? date.getTime() : -Infinity;
     })
     .reduce((max, current) => Math.max(max, current), -Infinity);
@@ -57,13 +57,12 @@ const harOppholdsperioder = (perioder: any) => {
     return false;
   }
 
-  const sortedPerioder = perioder.sort(Utils.dato.sorterEtterNorskFomDato);
-  console.log("[harOppholdsperioder] sortedPerioder", sortedPerioder);
+  const sortedPerioder = perioder.sort(Utils.dato.sorterEtterISOFomDato);
 
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < sortedPerioder.length - 1; i++) {
-    const currentTom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i].tomDato);
-    const nextFom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i + 1].fomDato);
+    const currentTom = sortedPerioder[i].tomDato;
+    const nextFom = sortedPerioder[i + 1].fomDato;
 
     // Convert to Date objects
     const currentTomDate = Utils.dato.isoStringTilDate(currentTom);
@@ -86,16 +85,12 @@ const ingenOverlappendePerioder = (perioder: any[]): boolean => {
   if (!perioder || perioder.length <= 1) return true;
 
   try {
-    // Sort periods by start date
-    const sortedPerioder = perioder.sort(Utils.dato.sorterEtterNorskFomDato);
-    console.log("[ingenOverlappendePerioder] sortedPerioder", sortedPerioder);
+    const sortedPerioder = perioder.sort(Utils.dato.sorterEtterISOFomDato);
 
-    // Check for overlapping periods
     for (let i = 0; i < sortedPerioder.length - 1; i++) {
-      const currentTom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i].tomDato);
-      const nextFom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i + 1].fomDato);
+      const currentTom = sortedPerioder[i].tomDato;
+      const nextFom = sortedPerioder[i + 1].fomDato;
 
-      // Convert to Date objects
       const currentTomDate = Utils.dato.isoStringTilDate(currentTom);
       const nextFomDate = Utils.dato.isoStringTilDate(nextFom);
 
@@ -139,30 +134,37 @@ export function finnAktivFeilmelding({
   medlemskapsperiode,
   medlemskapstypeErPliktig,
 }: AarsavregningValidationParams): string | undefined {
-  if (skatteforholdsperioder && skatteforholdsperioder.length > 0) {
-    if (!dekkerHeleMedlemskapsperiode(skatteforholdsperioder, medlemskapsperiode)) {
+  const vaskedeSkatteforholdsperioder = Utils.dato.vaskOgFormaterDatoerTilIso(skatteforholdsperioder);
+  const vaskedeInntektskilder = Utils.dato.vaskOgFormaterDatoerTilIso(inntektskilder);
+  const medlemskapsperiodeIsoFormat = {
+    fomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.fomDato),
+    tomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.tomDato),
+  };
+
+  if (vaskedeSkatteforholdsperioder && vaskedeSkatteforholdsperioder.length > 0) {
+    if (!dekkerHeleMedlemskapsperiode(vaskedeSkatteforholdsperioder, medlemskapsperiodeIsoFormat)) {
       return TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
     }
 
-    if (!ingenOverlappendePerioder(skatteforholdsperioder)) {
+    if (!ingenOverlappendePerioder(vaskedeSkatteforholdsperioder)) {
       return TypeFeilmelding.OVERLAPPENDE_SKATTEFORHOLDSPERIODER;
     }
 
-    if (harOppholdsperioder(skatteforholdsperioder)) {
+    if (harOppholdsperioder(vaskedeSkatteforholdsperioder)) {
       return TypeFeilmelding.HAR_OPPHOLDSPERIODER_SKATTEFORHOLD;
     }
 
-    if (!ikkeAlleSammeSkatteforholdstyper(skatteforholdsperioder)) {
+    if (!ikkeAlleSammeSkatteforholdstyper(vaskedeSkatteforholdsperioder)) {
       return TypeFeilmelding.LIKE_SKATTEPLIKTTYPER;
     }
   }
 
   if (
-    inntektskilder &&
-    inntektskilder.length > 0 &&
-    (!medlemskapstypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder))
+    vaskedeInntektskilder &&
+    vaskedeInntektskilder.length > 0 &&
+    (!medlemskapstypeErPliktig || !erBrukerSkattepliktigIHelePerioden(vaskedeSkatteforholdsperioder))
   ) {
-    if (!dekkerHeleMedlemskapsperiode(inntektskilder, medlemskapsperiode)) {
+    if (!dekkerHeleMedlemskapsperiode(vaskedeInntektskilder, medlemskapsperiodeIsoFormat)) {
       return TypeFeilmelding.INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
     }
   }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -304,14 +304,14 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       const aktivFeilmelding = finnAktivFeilmelding({
         skatteforholdsperioder: formState.skatteforholdsperioder,
         inntektskilder: formState.inntektskilder,
-        medlemskapsperiode: medlemskapsperiodeFomTom,
+        medlemskapsperiodeFomTom,
         medlemskapsperioder: medlemskapsperioderFormState as Medlemskapsperiode[],
         medlemskapstypeErPliktig,
       });
       console.log("[debouncedBeregning] Aktive feilmeldinger", aktivFeilmelding, {
         skatteforholdsperioder: formState.skatteforholdsperioder,
         inntektskilder: formState.inntektskilder,
-        medlemskapsperiode: medlemskapsperiodeFomTom,
+        medlemskapsperiodeFomTom,
         medlemskapsperioder: medlemskapsperioderFormState as Medlemskapsperiode[],
         medlemskapstypeErPliktig,
       });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
@@ -13,29 +13,27 @@ export enum TypeFeilmelding {
   HAR_OPPHOLDSPERIODER_MEDLEMSKAPSPERIODER = "HAR_OPPHOLDSPERIODER_MEDLEMSKAPSPERIODER",
 }
 
-const harOppholdsperioder = (perioder: any) => {
+const harOppholdsperioder = (perioder: any[]) => {
   if (!perioder || perioder.length <= 1) {
     return false;
   }
 
-  const sortedPerioder = perioder.sort(Utils.dato.sorterEtterNorskFomDato);
+  const sortedPerioder = perioder.sort(Utils.dato.sorterEtterISOFomDato);
   console.log("[harOppholdsperioder] sortedPerioder", sortedPerioder);
 
-  // eslint-disable-next-line no-plusplus
   for (let i = 0; i < sortedPerioder.length - 1; i++) {
-    const currentTom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i].tomDato);
-    const nextFom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i + 1].fomDato);
+    const currentTom = sortedPerioder[i].tomDato;
+    const nextFom = sortedPerioder[i + 1].fomDato;
 
-    // Convert to Date objects
     const currentTomDate = Utils.dato.isoStringTilDate(currentTom);
     const nextFomDate = Utils.dato.isoStringTilDate(nextFom);
 
     if (currentTomDate && nextFomDate) {
-      // Add 1 day to the end date
+      // Legg til 1 dag til sluttdatoen
       const tomDateForComparison = new Date(currentTomDate);
       tomDateForComparison.setDate(tomDateForComparison.getDate() + 1);
 
-      // Check if the next period starts more than one day after this period ends
+      // Sjekk om neste periode starter mer enn 1 dag etter denne perioden slutter
       if (tomDateForComparison.getTime() < nextFomDate.getTime()) return true;
     }
   }
@@ -51,16 +49,10 @@ const dekkerHeleMedlemskapsperiode = (
   if (!perioder || perioder.length === 0) return true;
 
   try {
-    const medlemskapsperiodeFom = Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.fomDato);
-    const medlemskapsperiodeTom = Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.tomDato);
+    const medlemskapsperiodeFom = medlemskapsperiode.fomDato;
+    const medlemskapsperiodeTom = medlemskapsperiode.tomDato;
 
-    const vasketPerioder = perioder.map((periode) => {
-      return {
-        fomDato: Utils.dato.vaskOgFormatterTilISO(periode.fomDato),
-        tomDato: Utils.dato.vaskOgFormatterTilISO(periode.tomDato),
-      };
-    });
-    const minFomDato = vasketPerioder.reduce(
+    const minFomDato = perioder.reduce(
       (min, periode) => {
         if (periode.fomDato != null && (min === null || periode.fomDato < min)) {
           return periode.fomDato;
@@ -70,7 +62,7 @@ const dekkerHeleMedlemskapsperiode = (
       null as string | null,
     );
 
-    const maxTomDato = vasketPerioder.reduce(
+    const maxTomDato = perioder.reduce(
       (max, periode) => {
         if (periode.tomDato != null && (max === null || periode.tomDato > max)) {
           return periode.tomDato;
@@ -81,12 +73,13 @@ const dekkerHeleMedlemskapsperiode = (
     );
 
     if (!minFomDato || minFomDato !== medlemskapsperiodeFom || !maxTomDato || maxTomDato !== medlemskapsperiodeTom) {
-      console.log(`[dekkerHeleMedlemskapsperiode, ${type}] minFomDato`, minFomDato);
-      console.log(`[dekkerHeleMedlemskapsperiode, ${type}] maxTomDato`, maxTomDato);
+      console.log(
+        `[dekkerHeleMedlemskapsperiode, ${type}] Datoer dekker ikke. MinFom: ${minFomDato} (Skal være: ${medlemskapsperiodeFom}), MaxTom: ${maxTomDato} (Skal være: ${medlemskapsperiodeTom})`,
+      );
       return false;
     }
 
-    return !harOppholdsperioder(vasketPerioder);
+    return !harOppholdsperioder(perioder);
   } catch (error) {
     return true;
   }
@@ -96,14 +89,13 @@ const ingenOverlappendePerioder = (perioder: any[]): boolean => {
   if (!perioder || perioder.length <= 1) return true;
 
   try {
-    // Sort periods by start date
-    const sortedPerioder = perioder.sort(Utils.dato.sorterEtterNorskFomDato);
+    const sortedPerioder = perioder.sort(Utils.dato.sorterEtterISOFomDato);
     console.log("[ingenOverlappendePerioder] sortedPerioder", sortedPerioder);
 
     // Check for overlapping periods
     for (let i = 0; i < sortedPerioder.length - 1; i++) {
-      const currentTom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i].tomDato);
-      const nextFom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[i + 1].fomDato);
+      const currentTom = sortedPerioder[i].tomDato;
+      const nextFom = sortedPerioder[i + 1].fomDato;
 
       // Convert to Date objects
       const currentTomDate = Utils.dato.isoStringTilDate(currentTom);
@@ -145,10 +137,12 @@ interface AarsavregningValidationParams {
 }
 
 export function finnAktivFeilmeldingForMedlemskapsperioder(medlemskapsperioder: Medlemskapsperiode[]) {
-  if (!ingenOverlappendePerioder(medlemskapsperioder)) {
+  const vaskedeMedlemskapsperioder = Utils.dato.vaskOgFormaterDatoerTilIso(medlemskapsperioder);
+
+  if (!ingenOverlappendePerioder(vaskedeMedlemskapsperioder)) {
     return TypeFeilmelding.OVERLAPPENDE_MEDLEMSKAPSPERIODER;
   }
-  if (harOppholdsperioder(medlemskapsperioder)) {
+  if (harOppholdsperioder(vaskedeMedlemskapsperioder)) {
     return TypeFeilmelding.HAR_OPPHOLDSPERIODER_MEDLEMSKAPSPERIODER;
   }
   return undefined;
@@ -169,29 +163,40 @@ export function finnAktivFeilmelding({
     return medlemskapsperioderFeilmelding;
   }
 
-  if (skatteforholdsperioder && skatteforholdsperioder.length > 0) {
-    if (!dekkerHeleMedlemskapsperiode(skatteforholdsperioder, medlemskapsperiode, "skatteforhold")) {
-      console.log("[finnAktivFeilmelding] dekkerHeleMedlemskapsperiode", skatteforholdsperioder, medlemskapsperiode);
-      return TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
-    }
+  const vaskedeMedlemskapsperioder = Utils.dato.vaskOgFormaterDatoerTilIso(medlemskapsperioder);
+  const vaskedeSkatteforholdsperioder = Utils.dato.vaskOgFormaterDatoerTilIso(skatteforholdsperioder);
+  const vaskedeInntektskilder = Utils.dato.vaskOgFormaterDatoerTilIso(inntektskilder);
 
-    if (!ingenOverlappendePerioder(skatteforholdsperioder)) {
-      console.log("[finnAktivFeilmelding] ingenOverlappendePerioder", skatteforholdsperioder);
-      return TypeFeilmelding.OVERLAPPENDE_SKATTEFORHOLDSPERIODER;
-    }
+  const medlemskapsperiodeIsoFormat = {
+    fomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.fomDato),
+    tomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.tomDato),
+  };
 
-    if (!ikkeAlleSammeSkatteforholdstyper(skatteforholdsperioder)) {
-      console.log("[finnAktivFeilmelding] ikkeAlleSammeSkatteforholdstyper", skatteforholdsperioder);
-      return TypeFeilmelding.LIKE_SKATTEPLIKTTYPER;
-    }
+  if (!dekkerHeleMedlemskapsperiode(vaskedeSkatteforholdsperioder, medlemskapsperiodeIsoFormat, "skatteforhold")) {
+    console.log(
+      "[finnAktivFeilmelding] dekkerHeleMedlemskapsperiode",
+      vaskedeSkatteforholdsperioder,
+      vaskedeMedlemskapsperioder,
+    );
+    return TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
+  }
+
+  if (!ingenOverlappendePerioder(vaskedeSkatteforholdsperioder)) {
+    console.log("[finnAktivFeilmelding] ingenOverlappendePerioder", vaskedeSkatteforholdsperioder);
+    return TypeFeilmelding.OVERLAPPENDE_SKATTEFORHOLDSPERIODER;
+  }
+
+  if (!ikkeAlleSammeSkatteforholdstyper(vaskedeSkatteforholdsperioder)) {
+    console.log("[finnAktivFeilmelding] ikkeAlleSammeSkatteforholdstyper", vaskedeSkatteforholdsperioder);
+    return TypeFeilmelding.LIKE_SKATTEPLIKTTYPER;
   }
 
   if (
-    inntektskilder &&
-    inntektskilder.length > 0 &&
-    (!medlemskapstypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder))
+    vaskedeInntektskilder &&
+    vaskedeInntektskilder.length > 0 &&
+    (!medlemskapstypeErPliktig || !erBrukerSkattepliktigIHelePerioden(vaskedeSkatteforholdsperioder))
   ) {
-    if (!dekkerHeleMedlemskapsperiode(inntektskilder, medlemskapsperiode, "inntektskilde")) {
+    if (!dekkerHeleMedlemskapsperiode(vaskedeInntektskilder, medlemskapsperiodeIsoFormat, "inntektskilde")) {
       return TypeFeilmelding.INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
     }
   }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
@@ -43,14 +43,17 @@ const harOppholdsperioder = (perioder: any[]) => {
 
 const dekkerHeleMedlemskapsperiode = (
   perioder: any[],
-  medlemskapsperiode: any,
+  medlemskapsperiodeFomTom: {
+    fomDato: string;
+    tomDato: string;
+  },
   type: "skatteforhold" | "inntektskilde",
 ): boolean => {
   if (!perioder || perioder.length === 0) return true;
 
   try {
-    const medlemskapsperiodeFom = medlemskapsperiode.fomDato;
-    const medlemskapsperiodeTom = medlemskapsperiode.tomDato;
+    const medlemskapsperiodeFom = medlemskapsperiodeFomTom.fomDato;
+    const medlemskapsperiodeTom = medlemskapsperiodeFomTom.tomDato;
 
     const minFomDato = perioder.reduce(
       (min, periode) => {
@@ -128,7 +131,7 @@ const ikkeAlleSammeSkatteforholdstyper = (perioder: any[]): boolean => {
 interface AarsavregningValidationParams {
   skatteforholdsperioder: Skatteforhold[];
   inntektskilder: Inntektskilde[];
-  medlemskapsperiode: {
+  medlemskapsperiodeFomTom: {
     fomDato: string;
     tomDato: string;
   };
@@ -154,7 +157,7 @@ export function finnAktivFeilmeldingForMedlemskapsperioder(medlemskapsperioder: 
 export function finnAktivFeilmelding({
   skatteforholdsperioder,
   inntektskilder,
-  medlemskapsperiode,
+  medlemskapsperiodeFomTom,
   medlemskapstypeErPliktig,
   medlemskapsperioder,
 }: AarsavregningValidationParams): string | undefined {
@@ -167,12 +170,14 @@ export function finnAktivFeilmelding({
   const vaskedeSkatteforholdsperioder = Utils.dato.vaskOgFormaterDatoerTilIso(skatteforholdsperioder);
   const vaskedeInntektskilder = Utils.dato.vaskOgFormaterDatoerTilIso(inntektskilder);
 
-  const medlemskapsperiodeIsoFormat = {
-    fomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.fomDato),
-    tomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.tomDato),
+  const medlemskapsperiodeFomTomIsoFormat = {
+    fomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiodeFomTom.fomDato)!,
+    tomDato: Utils.dato.vaskOgFormatterTilISO(medlemskapsperiodeFomTom.tomDato)!,
   };
 
-  if (!dekkerHeleMedlemskapsperiode(vaskedeSkatteforholdsperioder, medlemskapsperiodeIsoFormat, "skatteforhold")) {
+  if (
+    !dekkerHeleMedlemskapsperiode(vaskedeSkatteforholdsperioder, medlemskapsperiodeFomTomIsoFormat, "skatteforhold")
+  ) {
     console.log(
       "[finnAktivFeilmelding] dekkerHeleMedlemskapsperiode",
       vaskedeSkatteforholdsperioder,
@@ -196,7 +201,7 @@ export function finnAktivFeilmelding({
     vaskedeInntektskilder.length > 0 &&
     (!medlemskapstypeErPliktig || !erBrukerSkattepliktigIHelePerioden(vaskedeSkatteforholdsperioder))
   ) {
-    if (!dekkerHeleMedlemskapsperiode(vaskedeInntektskilder, medlemskapsperiodeIsoFormat, "inntektskilde")) {
+    if (!dekkerHeleMedlemskapsperiode(vaskedeInntektskilder, medlemskapsperiodeFomTomIsoFormat, "inntektskilde")) {
       return TypeFeilmelding.INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
     }
   }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
@@ -43,30 +43,50 @@ const harOppholdsperioder = (perioder: any) => {
   return false;
 };
 
-const dekkerHeleMedlemskapsperiode = (perioder: any[], medlemskapsperiode: any): boolean => {
+const dekkerHeleMedlemskapsperiode = (
+  perioder: any[],
+  medlemskapsperiode: any,
+  type: "skatteforhold" | "inntektskilde",
+): boolean => {
   if (!perioder || perioder.length === 0) return true;
 
   try {
     const medlemskapsperiodeFom = Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.fomDato);
     const medlemskapsperiodeTom = Utils.dato.vaskOgFormatterTilISO(medlemskapsperiode.tomDato);
 
-    // Sort periods by start date
-    const sortedPerioder = perioder.sort(Utils.dato.sorterEtterNorskFomDato);
-    console.log("[dekkerHeleMedlemskapsperiode] sortedPerioder", sortedPerioder);
+    const vasketPerioder = perioder.map((periode) => {
+      return {
+        fomDato: Utils.dato.vaskOgFormatterTilISO(periode.fomDato),
+        tomDato: Utils.dato.vaskOgFormatterTilISO(periode.tomDato),
+      };
+    });
+    const minFomDato = vasketPerioder.reduce(
+      (min, periode) => {
+        if (periode.fomDato != null && (min === null || periode.fomDato < min)) {
+          return periode.fomDato;
+        }
+        return min;
+      },
+      null as string | null,
+    );
 
-    console.log("[dekkerHeleMedlemskapsperiode] medlemskapsperiodeFom", medlemskapsperiodeFom);
-    console.log("[dekkerHeleMedlemskapsperiode] medlemskapsperiodeTom", medlemskapsperiodeTom);
-    // Dekning
-    const firstFom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[0].fomDato);
-    console.log("[dekkerHeleMedlemskapsperiode] firstFom", firstFom);
-    if (!firstFom || firstFom !== medlemskapsperiodeFom) return false;
+    const maxTomDato = vasketPerioder.reduce(
+      (max, periode) => {
+        if (periode.tomDato != null && (max === null || periode.tomDato > max)) {
+          return periode.tomDato;
+        }
+        return max;
+      },
+      null as string | null,
+    );
 
-    const lastTom = Utils.dato.vaskOgFormatterTilISO(sortedPerioder[sortedPerioder.length - 1].tomDato);
-    console.log("[dekkerHeleMedlemskapsperiode] lastTom", lastTom);
-    if (!lastTom || lastTom !== medlemskapsperiodeTom) return false;
+    if (!minFomDato || minFomDato !== medlemskapsperiodeFom || !maxTomDato || maxTomDato !== medlemskapsperiodeTom) {
+      console.log(`[dekkerHeleMedlemskapsperiode, ${type}] minFomDato`, minFomDato);
+      console.log(`[dekkerHeleMedlemskapsperiode, ${type}] maxTomDato`, maxTomDato);
+      return false;
+    }
 
-    // Opphold
-    return !harOppholdsperioder(sortedPerioder);
+    return !harOppholdsperioder(vasketPerioder);
   } catch (error) {
     return true;
   }
@@ -150,7 +170,7 @@ export function finnAktivFeilmelding({
   }
 
   if (skatteforholdsperioder && skatteforholdsperioder.length > 0) {
-    if (!dekkerHeleMedlemskapsperiode(skatteforholdsperioder, medlemskapsperiode)) {
+    if (!dekkerHeleMedlemskapsperiode(skatteforholdsperioder, medlemskapsperiode, "skatteforhold")) {
       console.log("[finnAktivFeilmelding] dekkerHeleMedlemskapsperiode", skatteforholdsperioder, medlemskapsperiode);
       return TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
     }
@@ -171,7 +191,7 @@ export function finnAktivFeilmelding({
     inntektskilder.length > 0 &&
     (!medlemskapstypeErPliktig || !erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder))
   ) {
-    if (!dekkerHeleMedlemskapsperiode(inntektskilder, medlemskapsperiode)) {
+    if (!dekkerHeleMedlemskapsperiode(inntektskilder, medlemskapsperiode, "inntektskilde")) {
       return TypeFeilmelding.INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
     }
   }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
@@ -99,6 +99,7 @@ function BestemmelseSelect({
       aria-label="Bestemmelse"
       control={control}
       readOnly={!redigerbart || harDeltGrunnlag}
+      emptyFieldDisabled
       onChange={(valgtBestemmelse) => {
         handleBestemmelseChange(valgtBestemmelse);
       }}

--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -90,6 +90,24 @@ function vaskOgFormatterDatoTilNorsk(dato, defaultValue = "") {
   return formatterDatoTilNorsk(dato, defaultValue);
 }
 
+/**
+ * Vasker og formaterer dato-array til ISO format. Må være en array av objekter med fomDato og tomDato.
+ *
+ * @param {Array} perioder - Array av objekter med fomDato og tomDato.
+ * @param {string} [defaultValue] - Standardverdi hvis dato er ugyldig.
+ * @returns {Array}
+ */
+const vaskOgFormaterDatoerTilIso = (perioder, defaultValue = undefined) => {
+  if (!Array.isArray(perioder)) {
+    return [];
+  }
+  return perioder.map((periode) => ({
+    ...periode,
+    fomDato: periode.fomDato ? vaskOgFormatterTilISO(periode.fomDato, defaultValue) : defaultValue,
+    tomDato: periode.tomDato ? vaskOgFormatterTilISO(periode.tomDato, defaultValue) : defaultValue,
+  }));
+};
+
 /** Forutsatt at datoen er validert korrekt norsk (DD.MM.YYYY HH:mm), formatter den til det maskinlesbare
  * formatet "YYYY-MM-DD
  *
@@ -284,4 +302,5 @@ export {
   vaskInputDato,
   vaskOgFormatterDatoTilNorsk,
   vaskOgFormatterTilISO,
+  vaskOgFormaterDatoerTilIso,
 };


### PR DESCRIPTION
- Gjør om til allerede ISO fra public-metodene istf de underliggende metodene
- Bruker nå min og max-dato for å sjekke at inntektsperiode dekker medlemskapsperiode, siden vi tillatter overlappende perioder her
- Fiks liten fel med bestemmelse