### PR TITLE
7327 La til ekstra validering for visning av feilmelding

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/feilmeldinger.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/feilmeldinger.tsx
@@ -9,6 +9,7 @@ const { FTRL_KAP2_2_1, FTRL_KAP2_2_7_FJERDE_LEDD, FTRL_KAP2_2_8_FJERDE_LEDD } =
 const { MIDLERTIDIG_2_1_FJERDE_LEDD } = MKV.Koder.ikkeyrkesaktivoppholdtype;
 const { MIDLERTIDIG_ARBEID_2_1_FJERDE_LEDD } = MKV.Koder.arbeidssituasjontype;
 const { AVSLAATT, INNVILGET, OPPHØRT } = MKV.Koder.innvilgelsesResultat;
+const { PENSJONIST } = MKV.Koder.behandlinger.behandlingstema;
 
 const IngenMedlemskapsperioder = (
   <Nav.Alert variant="error" className="alertstripe_feilmelding">
@@ -249,7 +250,7 @@ enum TypeFeilmelding {
 export function finnAktivFeilmelding(
   medlemskapsperioder: MedlemskapsperiodeProp[],
   behandlingstype: string,
-  land: string[],
+  behandlingstema: string,
   begrensePeriodeVedtakToggleEnabled: boolean | undefined,
   søknadsperiodeFomDato: string,
   søknadsperiodeTomDato?: string,
@@ -304,7 +305,10 @@ export function finnAktivFeilmelding(
   }
 
   const { bestemmelse } = medlemskapsperioder[0];
-  if (bestemmelse === FTRL_KAP2_2_7_FJERDE_LEDD || bestemmelse === FTRL_KAP2_2_8_FJERDE_LEDD) {
+  if (
+    (bestemmelse === FTRL_KAP2_2_7_FJERDE_LEDD || bestemmelse === FTRL_KAP2_2_8_FJERDE_LEDD) &&
+    behandlingstema !== PENSJONIST
+  ) {
     return TypeFeilmelding.BESTEMMELSE_FOR_FAMILIEMEDLEMMER;
   }
 

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
@@ -120,7 +120,7 @@ export function VurderingPerioder({ bekreft, tilbake, aktivtSteg, oppdaterStatus
   const aktivFeilmeldingType = finnAktivFeilmelding(
     formValues?.medlemskapsperioder,
     behandlingstype,
-    soknadsland,
+    behandlingstema,
     begrensePeriodeVedtakToggleEnabled,
     soknadsperiode.fom,
     soknadsperiode.tom,


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7327

La til ekstra validering for feilmelding "BESTEMMELSE_FOR_FAMILIEMEDLEMMER" slik at det ikke dukker opp i Pensjonist flyten. 

Endret parameteren for Feilmelding klassen fra "land" til "behandlingstema" siden "land" blir aldri brukt. 