### PR TITLE
7297 TOGGLE Fikser visning av validering radiogruppe årsavregning

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -43,7 +43,7 @@ const mapMedlemskapsperiodeBestemmelse = (harDeltGrunnlag: boolean, medlemskapsp
 };
 
 export interface AarsavregningMedGrunnlagFormValues extends FormValuesProps {
-  endeligAvgiftValg?: string;
+  endeligAvgiftValg: string;
   manueltAvgiftBeloep?: number;
 }
 
@@ -67,7 +67,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
     formDefaultValues: {
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
-      endeligAvgiftValg: undefined,
+      endeligAvgiftValg: "",
       manueltAvgiftBeloep: undefined,
     },
     medlemskapstypeErPliktig: false,
@@ -86,7 +86,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
       return {
         skatteforholdsperioder: [{}],
         inntektskilder: [{}],
-        endeligAvgiftValg: undefined,
+        endeligAvgiftValg: "",
         manueltAvgiftBeloep: undefined,
       };
     const { inntektskperioder, skatteforholdsperioder } = trygdeavgiftsgrunnlag;
@@ -94,7 +94,7 @@ export function AarsavregningMedGrunnlag({ bekreft, oppdaterStatus }: Props) {
     const sorterteSkatteforhold = [...skatteforholdsperioder].sort(Utils.dato.sorterEtterISOFomDato);
 
     return {
-      endeligAvgiftValg,
+      endeligAvgiftValg: endeligAvgiftValg || "",
       manueltAvgiftBeloep,
       skatteforholdsperioder: !Utils._isEmpty(sorterteSkatteforhold)
         ? mapTilSkatteforholdProps(sorterteSkatteforhold)

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -74,7 +74,7 @@ export interface AarsavregningFormValuesProps extends FormValuesProps {
   totaltForskuddsvisFakturert?: number | string;
   bestemmelse?: string;
   endeligAvgiftValg: string;
-  manueltAvgiftBeloep?: number;
+  manueltAvgiftBeloep?: number | string;
 }
 
 export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, harDeltGrunnlag }: Props) {
@@ -94,7 +94,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       inntektskilder: [{}],
       totaltForskuddsvisFakturert: "",
       endeligAvgiftValg: "",
-      manueltAvgiftBeloep: undefined,
+      manueltAvgiftBeloep: "",
     },
   });
 
@@ -232,7 +232,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
           bestemmelse,
           totaltForskuddsvisFakturert: aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem || "",
           endeligAvgiftValg: aarsavregningRes?.endeligAvgiftValg || "",
-          manueltAvgiftBeloep: aarsavregningRes?.avregning?.manueltAvgiftBeloep,
+          manueltAvgiftBeloep: aarsavregningRes?.avregning?.manueltAvgiftBeloep || "",
           skatteforholdsperioder: mapTilSkatteforholdProps(
             deltGrunnlagAarsavregningHarIkkeNyttGrunnlag
               ? aarsavregningRes?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -20,7 +20,6 @@ import {
 import { AarsavregningUtenEllerDeltGrunnlagForm } from "./aarsavregningUtenEllerDeltGrunnlagForm";
 
 const { DELVIS_INNVILGET, INNVILGET } = MKV.Koder.innvilgelsesResultat;
-const { OPPLYSNINGER_ENDRET } = MKV.Koder.endeligAvgiftValg;
 
 export const ULAGRET_MEDLEMSKAPSPERIODE_ID = -1;
 
@@ -74,7 +73,7 @@ export interface MedlemskapTomFomDatoer {
 export interface AarsavregningFormValuesProps extends FormValuesProps {
   totaltForskuddsvisFakturert?: number | string;
   bestemmelse?: string;
-  endeligAvgiftValg?: string;
+  endeligAvgiftValg: string;
   manueltAvgiftBeloep?: number;
 }
 
@@ -94,7 +93,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
       totaltForskuddsvisFakturert: "",
-      endeligAvgiftValg: undefined,
+      endeligAvgiftValg: "",
       manueltAvgiftBeloep: undefined,
     },
   });
@@ -232,7 +231,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
             : [DEFAULT_MEDLEMSKAPSPERIODE],
           bestemmelse,
           totaltForskuddsvisFakturert: aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem || "",
-          endeligAvgiftValg: aarsavregningRes?.endeligAvgiftValg,
+          endeligAvgiftValg: aarsavregningRes?.endeligAvgiftValg || "",
           manueltAvgiftBeloep: aarsavregningRes?.avregning?.manueltAvgiftBeloep,
           skatteforholdsperioder: mapTilSkatteforholdProps(
             deltGrunnlagAarsavregningHarIkkeNyttGrunnlag

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.tsx
@@ -43,22 +43,23 @@ export function EndeligAvgiftValgRadioGroup({
     : radioOptions.filter((option) => option.value !== OPPLYSNINGER_UENDRET);
 
   return (
-    <Forms.RadioGroup
-      name="endeligAvgiftValg"
-      control={control}
-      legend="Hva ønsker du å gjøre?"
-      readOnly={!redigerbart}
-      onChange={(value) => {
-        handleEndeligAvgiftValgChange(value);
-      }}
-      className="endeligAvgiftValg_radio_group"
-    >
-      {filteredOptions.map((option) => (
-        <Nav.Radio key={option.value} value={option.value}>
-          {option.label}
-          {option.description}
-        </Nav.Radio>
-      ))}
-    </Forms.RadioGroup>
+    <div className="endeligAvgiftValg_radio_group">
+      <Forms.RadioGroup
+        name="endeligAvgiftValg"
+        control={control}
+        legend="Hva ønsker du å gjøre?"
+        readOnly={!redigerbart}
+        onChange={(value) => {
+          handleEndeligAvgiftValgChange(value);
+        }}
+      >
+        {filteredOptions.map((option) => (
+          <Nav.Radio key={option.value} value={option.value}>
+            {option.label}
+            {option.description}
+          </Nav.Radio>
+        ))}
+      </Forms.RadioGroup>
+    </div>
   );
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
@@ -77,7 +77,8 @@
 
   .endeligAvgiftValg_radio_group {
     .navds-radio-buttons {
-      margin-top: 0.5rem;
+      margin-bottom: 0;
     }
+    margin-bottom: 1.5rem;
   }
 }


### PR DESCRIPTION
Setter default endeligAvgiftValg skjemaverdi til empty string for å vise valideringsfeil på endeligAvgiftValg radiogroup (yup liker ikke undefined på en string som ikke er nullable)