### PR TITLE
7326 Mangler behandlingstyper ved eksisterende aktiv behandling

### DIFF
--- a/src/sider/journalforing/komponenter/knyttTilSak.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.jsx
@@ -96,7 +96,7 @@ export function KnyttTilSak(props) {
   }, [journalforingGjelder, sakstype.kode, sakstema.kode, sisteBehandling?.behandlingstema?.kode]);
 
   useEffect(() => {
-    if (sakstype.kode && sakstema.kode && behandlingstema) {
+    if (sakstype.kode && sakstema.kode) {
       Api.LovligeKombinasjoner.hentBehandlingstyperForKnyttTilSak(
         journalforingGjelder,
         sak.saksnummer,

--- a/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
@@ -15,6 +15,7 @@ vi.mock("../../../services/modules/anmodningsperioder", () => ({
 }));
 vi.mock("../../../services/modules/lovligekombinasjoner", () => ({
   hentBehandlingstemaer: () => Promise.resolve([]),
+  hentBehandlingstyperForKnyttTilSak: () => Promise.resolve([]),
 }));
 describe("KnyttTilSak", () => {
   let props = null;
@@ -49,7 +50,7 @@ describe("KnyttTilSak", () => {
       journalforingGjelder: MKV.Koder.aktoersroller.BRUKER,
       behandlingstyper: [],
       opprettBehandling: false,
-      behandlingstema: "",
+      behandlingstema: undefined,
       behandlingstype: "",
       changeField: vi.fn(),
       erJournalføring: true,

--- a/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
@@ -142,4 +142,14 @@ describe("KnyttTilSak", () => {
     expect(screen.queryByText(/Hvis du har mottatt svar på anmodning om unntak skal du/i)).toBeNull();
     expect(screen.getByText("Tidligere behandling er avsluttet.")).toBeInTheDocument();
   });
+
+  it("viser behandlingstypevalg når behandlingstema er undefined", async () => {
+    props.behandlingstema = undefined;
+    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+
+    const radiogruppe = screen.getByRole("group");
+    expect(radiogruppe).toBeInTheDocument();
+    expect(within(radiogruppe).queryAllByRole("radio")).toHaveLength(2);
+    expect(within(radiogruppe).getByLabelText("Opprett ny behandling")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Vi henter ikke behandlingstyper for knytt til sak dersom behandlings tema er null. Dette forårsaker problemer når vi prøver å hente for flere aktive behandlinger.
https://jira.adeo.no/browse/MELOSYS-7326