### PR TITLE
NOJIRA G4P Fikser nullstilling av bruttoInntekt

### DIFF
--- a/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.tsx
@@ -108,7 +108,8 @@ export function Inntektskilder({
   };
 
   const handleEndreArbAvgBetales = (index: number, arbAvgBetales: string) => {
-    update(index, { ...formValues.inntektskilder[index], arbAvgBetales, bruttoInntekt: undefined });
+    // @ts-expect-error - "" er nødvendig for å nullstille feltet
+    update(index, { ...formValues.inntektskilder[index], arbAvgBetales, bruttoInntekt: "" });
   };
 
   const erHoyInntekt = (inntekt: any) => {

--- a/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/inntektskilder.tsx
@@ -130,7 +130,8 @@ export function Inntektskilder({
           inntektskilde.arbAvgBetales,
         );
         if (!skalFylleInnBruttoInntekt && inntektskilde.bruttoInntekt) {
-          update(index, { ...inntektskilde, bruttoInntekt: undefined });
+          // @ts-expect-error - "" er nødvendig for å nullstille feltet
+          update(index, { ...inntektskilde, bruttoInntekt: "" });
         }
 
         return (


### PR DESCRIPTION
Undefined funker ikke for å tømme verdien av en controlled input.