### PR TITLE
7370 Fikser bug med manglende vedtakssteg innsynsmodus

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -225,14 +225,25 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         const bestemmelse = getBestemmelse(mappedMedlemskapsperioder);
         const trygdedekninger = await getTrygdedekninger(bestemmelse);
 
+        const totaltForskuddsvisFakturert =
+          aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem !== undefined &&
+          aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem !== null
+            ? aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem
+            : "";
+        const manueltAvgiftBeloep =
+          aarsavregningRes?.avregning?.manueltAvgiftBeloep !== undefined &&
+          aarsavregningRes?.avregning?.manueltAvgiftBeloep !== null
+            ? aarsavregningRes?.avregning?.manueltAvgiftBeloep
+            : "";
+
         const formDefaultValues: FieldValue<AarsavregningFormValuesProps> = {
           medlemskapsperioder: mappedMedlemskapsperioder.length
             ? mappedMedlemskapsperioder
             : [DEFAULT_MEDLEMSKAPSPERIODE],
           bestemmelse,
-          totaltForskuddsvisFakturert: aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem || "",
+          totaltForskuddsvisFakturert,
           endeligAvgiftValg: aarsavregningRes?.endeligAvgiftValg || "",
-          manueltAvgiftBeloep: aarsavregningRes?.avregning?.manueltAvgiftBeloep || "",
+          manueltAvgiftBeloep,
           skatteforholdsperioder: mapTilSkatteforholdProps(
             deltGrunnlagAarsavregningHarIkkeNyttGrunnlag
               ? aarsavregningRes?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.skatteforholdsperioder

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.less
@@ -100,6 +100,10 @@
         &:hover {
           border-color: @blue-nav;
         }
+
+        &.navds-radio--readonly {
+          border-color: @gray-dark !important;
+        }
       }
     }
   }


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7370
Feilen oppstår fordi 0 evaluerer til falsy. Når vi da mapper skjemaverdier setter vi formValue til tom string som er ugyldig skjema state. I de tilfeller anses ikke steg 1 som gyldig og derfor blir ikke vedtakssteget rendret i innsynsmodus