### PR TITLE
7326: Fiks feil i journalføring

### DIFF
--- a/src/ducks/sok/selectors.ts
+++ b/src/ducks/sok/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from "reselect";
 import { RootState } from "AppTypes";
 import { FagsakOppsummering } from "../../services/modules/types";
+import { STATUS } from "../../services/utils";
 
 /**
  * Selectors
@@ -12,4 +13,9 @@ import { FagsakOppsummering } from "../../services/modules/types";
 export const FagsakSokSelector = createSelector(
   (state: RootState) => (state.sok.data.fagsakListe ? state.sok.data.fagsakListe : []),
   (sokResultat: FagsakOppsummering[]) => sokResultat || [],
+);
+
+export const SokPendingSelector = createSelector(
+  (state: RootState) => state.sok.status,
+  (status) => status === STATUS.PENDING,
 );

--- a/src/sider/journalforing/komponenter/behandlingerListe.tsx
+++ b/src/sider/journalforing/komponenter/behandlingerListe.tsx
@@ -32,7 +32,7 @@ function BehandlingerListe({ behandlingerForFagsak }: BehandlingerListeProps) {
     <VStack>
       <div className="behandlinger-liste">
         {behandlingerToShow.map((behandling) => (
-          <HStack justify="space-between" paddingInline="3 3" paddingBlock="2 1">
+          <HStack key={behandling.behandlingID} justify="space-between" paddingInline="3 3" paddingBlock="2 1">
             <div className="behandling-tittel">{behandling.behandlingstype.term}</div>
             <BehandlingsstatusMedSvarfrist
               behandlingsstatus={behandling.behandlingsstatus}

--- a/src/sider/journalforing/komponenter/fagsakVelger.jsx
+++ b/src/sider/journalforing/komponenter/fagsakVelger.jsx
@@ -17,6 +17,7 @@ import KnyttTilSak from "./knyttTilSak";
 import "./fagsakVelger.css";
 import { HStack } from "@navikt/ds-react";
 import { EnkelNavBox } from "../../../felleskomponenter/enkelNavBox";
+import { Spinner } from "../../../felleskomponenter/spinner";
 
 const EKSISTERENDE = "Eksisterende sak";
 const OPPRETT = "Opprett ny sak";
@@ -31,11 +32,12 @@ function FagsakVelger(props) {
     formValues,
     erJournalføring,
     nullstillFormVerdier = undefined,
+    fagsakerHentes = false,
   } = props;
   const [valgtVisning, setValgtVisning] = useState(EKSISTERENDE);
   const feltNavn = erJournalføring ? FormValuesJournalforing : FormValuesOpprettNySak;
   const dispatch = useDispatch();
-  const ingenSakerFinnes = fagsakListe.length === 0;
+  const ingenSakerFinnes = fagsakListe.length === 0 && !fagsakerHentes;
 
   useEffect(() => {
     if (nullstillFormVerdier) {
@@ -72,6 +74,7 @@ function FagsakVelger(props) {
 
   return (
     <div className="fagsakVelger">
+      {fagsakerHentes && <Spinner />}
       {ingenSakerFinnes ? (
         <>
           <Nav.Alert variant="info">Ingen eksisterende saker funnet. Du må opprette en ny sak.</Nav.Alert>
@@ -99,7 +102,7 @@ function FagsakVelger(props) {
         </Nav.RadioGroup>
       )}
 
-      {valgtVisning === EKSISTERENDE && (
+      {!fagsakerHentes && valgtVisning === EKSISTERENDE && (
         <Skjema.CustomRadioPanelGruppe
           feltNavn="saksnummer"
           radios={radioValg}
@@ -109,7 +112,7 @@ function FagsakVelger(props) {
           className="marginMellomCustomRadioPaneler"
         />
       )}
-      {valgtVisning === OPPRETT && <OpprettSak formValues={formValues} feltNavn={feltNavn} />}
+      {!fagsakerHentes && valgtVisning === OPPRETT && <OpprettSak formValues={formValues} feltNavn={feltNavn} />}
     </div>
   );
 }
@@ -121,6 +124,7 @@ FagsakVelger.propTypes = {
   formValues: PT.object.isRequired,
   erJournalføring: PT.bool.isRequired,
   nullstillFormVerdier: PT.func,
+  fagsakerHentes: PT.bool,
 };
 
 export default FagsakVelger;

--- a/src/sider/journalforing/komponenter/journalforingform/journalforingform.jsx
+++ b/src/sider/journalforing/komponenter/journalforingform/journalforingform.jsx
@@ -84,6 +84,7 @@ function JournalforingForm({
   avsenderIDFraJournalpost = "",
   avsenderNavnFraJournalpost = "",
   mottaksKanalErElektronisk,
+  fagsakerHentes,
 }) {
   const visForvaltningsmelding = skalViseForvaltningsmelding(formValues, fagsakListe);
   const visFagsakVelger = formValues?.brukerNavn || formValues?.virksomhetNavn;
@@ -167,6 +168,7 @@ function JournalforingForm({
               settJournalforingHensikt={settJournalforingHensikt}
               landkoder={landkoder}
               formValues={formValues}
+              fagsakerHentes={fagsakerHentes}
             />
           }
         />
@@ -222,6 +224,7 @@ JournalforingForm.propTypes = {
   avsenderNavnFraJournalpost: PT.string,
   mottaksKanalErEessi: PT.bool.isRequired,
   mottaksKanalErElektronisk: PT.bool.isRequired,
+  fagsakerHentes: PT.bool,
 };
 
 const toVedleggMedProps = (vedlegg) =>
@@ -261,6 +264,7 @@ const mapStateToProps = (state) => ({
     forvaltningsmeldingMottaker: null,
   },
   fagsakListe: sokSelectors.FagsakSokSelector(state),
+  fagsakerHentes: sokSelectors.SokPendingSelector(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/sider/journalforing/komponenter/knyttTilSak.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.jsx
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { change } from "redux-form";
 import PT from "prop-types";
 
-import MKV, { MKVUtils } from "../../../melosyskodeverk";
+import { MKVUtils } from "../../../melosyskodeverk";
 import * as MPT from "../../../proptypes";
 import * as Skjema from "../../../felleskomponenter/skjema";
 import * as Nav from "../../../navFrontend";
@@ -13,8 +13,6 @@ import * as Utils from "../../../utils";
 import "./knyttTilSak.css";
 import { useAsyncCallbackState } from "../../../hooks";
 import { harFlerePågåendeBehandlinger } from "../../../melosyskodeverk/utils";
-
-const { VIRKSOMHET } = MKV.Koder.aktoersroller;
 
 export function KnyttTilSak(props) {
   const { sak, erJournalføring, changeField, feltNavn, formValues } = props;
@@ -98,29 +96,64 @@ export function KnyttTilSak(props) {
   }, [journalforingGjelder, sakstype.kode, sakstema.kode, sisteBehandling?.behandlingstema?.kode]);
 
   useEffect(() => {
-    // Behandlingstema er obligatorisk for virksomhet
-    if (sakstype.kode && sakstema.kode && !(journalforingGjelder === VIRKSOMHET && !behandlingstema)) {
-      Api.LovligeKombinasjoner.hentBehandlingstyperForKnyttTilSak(
-        journalforingGjelder,
-        sak.saksnummer,
-        behandlingstema,
-      ).then((alleMuligeBehandlingstyper) => {
-        setMuligeBehandlingstyper(alleMuligeBehandlingstyper);
-      });
+    if (sakstype.kode && sakstema.kode && behandlingstema) {
+      Api.LovligeKombinasjoner.hentBehandlingstyperForKnyttTilSak(journalforingGjelder, sak.saksnummer, behandlingstema)
+        .then((alleMuligeBehandlingstyper) => {
+          setMuligeBehandlingstyper(alleMuligeBehandlingstyper);
+        })
+        .catch((error) => {
+          console.error("Kunne ikke hente behandlingstyper:", error);
+          setMuligeBehandlingstyper([]);
+        });
+    } else {
+      setMuligeBehandlingstyper([]);
     }
   }, [journalforingGjelder, sakstype.kode, sakstema.kode, behandlingstema, sisteBehandling?.behandlingID]);
 
+  // Håndterer setting av behandlingstema basert på opprettBehandling tilstand
   useEffect(() => {
     if (opprettBehandling && Utils._isEmpty(behandlingstema)) {
       changeField(feltNavn.formNavn, feltNavn.behandlingstema, sisteBehandling.behandlingstema.kode);
     }
-    if (!opprettBehandling && !Utils._isEmpty(behandlingstema)) {
+    // Setter behandlingstema når opprettBehandling er undefined (visse journalføringsscenarier)
+    else if (
+      opprettBehandling === undefined &&
+      Utils._isEmpty(behandlingstema) &&
+      sisteBehandlingKanOpprettesAndregangsbehandlingPå &&
+      !sakKanIkkeViderebehandles
+    ) {
+      changeField(feltNavn.formNavn, feltNavn.behandlingstema, sisteBehandling.behandlingstema.kode);
+    }
+    // Setter behandlingstema i journalføring selv når opprettBehandling er false
+    else if (
+      erJournalføring &&
+      Utils._isEmpty(behandlingstema) &&
+      sisteBehandling?.behandlingstema?.kode &&
+      !sakKanIkkeViderebehandles
+    ) {
+      changeField(feltNavn.formNavn, feltNavn.behandlingstema, sisteBehandling.behandlingstema.kode);
+    }
+    // Nullstiller behandlingstema kun når det ikke trengs for journalføring
+    else if (
+      !opprettBehandling &&
+      !Utils._isEmpty(behandlingstema) &&
+      opprettBehandling !== undefined &&
+      !(erJournalføring && !sakKanIkkeViderebehandles)
+    ) {
       changeField(feltNavn.formNavn, feltNavn.behandlingstema, "");
     }
     if (!opprettBehandling && !Utils._isEmpty(behandlingstype)) {
       changeField(feltNavn.formNavn, feltNavn.behandlingstype, "");
     }
-  }, [opprettBehandling, behandlingstema, behandlingstype, sisteBehandling?.behandlingstema?.kode]);
+  }, [
+    opprettBehandling,
+    behandlingstema,
+    behandlingstype,
+    sisteBehandling?.behandlingstema?.kode,
+    sisteBehandlingKanOpprettesAndregangsbehandlingPå,
+    sakKanIkkeViderebehandles,
+    erJournalføring,
+  ]);
 
   function VurderDokumentCheckbox() {
     return <Skjema.Checkbox feltNavn="vurderDokument" label={`Oppdater behandlingsstatus til "Vurder dokument"`} />;

--- a/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
@@ -33,11 +33,13 @@ describe("KnyttTilSak", () => {
         saksstatus: {
           kode: MKV.Koder.saksstatuser.UNDER_BEHANDLING,
         },
+        saksnummer: "123",
         behandlingOversikter: [
           {
             behandlingsstatus: { kode: MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET },
             behandlingstype: { kode: MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG },
             behandlingstema: { kode: MKV.Koder.behandlinger.behandlingstema.YRKESAKTIV },
+            behandlingID: 1,
           },
         ],
       },
@@ -45,14 +47,9 @@ describe("KnyttTilSak", () => {
         opprettBehandling: null,
         behandlingstema: null,
         behandlingstype: null,
-        journalforingGjelder: null,
+        journalforingGjelder: MKV.Koder.aktoersroller.BRUKER,
       },
       feltNavn: JournalforingValues,
-      journalforingGjelder: MKV.Koder.aktoersroller.BRUKER,
-      behandlingstyper: [],
-      opprettBehandling: false,
-      behandlingstema: undefined,
-      behandlingstype: "",
       changeField: vi.fn(),
       erJournalføring: true,
     };
@@ -144,9 +141,8 @@ describe("KnyttTilSak", () => {
     expect(screen.getByText("Tidligere behandling er avsluttet.")).toBeInTheDocument();
   });
 
-  it("viser behandlingstypevalg når behandlingstema er undefined", async () => {
-    props.behandlingstema = undefined;
-    props.formValues.behandlingstema = undefined;
+  it("viser behandlingstypevalg når behandlingstema er valgt", async () => {
+    props.formValues.behandlingstema = "YRKESAKTIV";
     props.formValues.opprettBehandling = true;
 
     renderWithProviders(<WrappedKnyttTilSak {...props} />);
@@ -158,5 +154,21 @@ describe("KnyttTilSak", () => {
     const radioButtons = within(behandlingstypeGroup).getAllByRole("radio");
     expect(radioButtons).toHaveLength(1);
     expect(within(behandlingstypeGroup).getByLabelText("Årsavregning")).toBeInTheDocument();
+  });
+
+  it("håndterer feil ved henting av behandlingstyper", async () => {
+    mocks.hentBehandlingstyperForKnyttTilSak.mockRejectedValueOnce(new Error("API Error"));
+    props.formValues.behandlingstema = "YRKESAKTIV";
+    props.formValues.opprettBehandling = true;
+
+    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+
+    await waitFor(() => {
+      expect(mocks.hentBehandlingstyperForKnyttTilSak).toHaveBeenCalled();
+      const behandlingstypeGroup = screen.queryByRole("group", { name: "Behandlingstype" });
+      if (behandlingstypeGroup) {
+        expect(within(behandlingstypeGroup).queryAllByRole("radio")).toHaveLength(0);
+      }
+    });
   });
 });


### PR DESCRIPTION
Originale løsning #2730 var litt hacky. Grunnen til at behandlingstema ikke er satt i visse tilfeller er pga rendering og endring av state.

- Behandlingstema er krav for å hente kombinasjoner. Det å ikke kreve behandlingstema ga mye problemer med statehåndtering pga asynce dobbeltkall. Fant ingen tilfeller hvor behandlingstema etterhvert ikke ble tilgjengelig
- Fikser spinner i journalføring, som ikke var der før.
- Fikser error der tags i liste ikke hadde key