### PR TITLE
NOJIRA G4P Deprecater nav-frontend-grid komponenter

### DIFF
--- a/src/navFrontend/grid/column.tsx
+++ b/src/navFrontend/grid/column.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prefer-stateless-function */
 import classNames from "classnames";
 import { Component, ComponentClass, HTMLAttributes } from "react";
 
@@ -23,7 +24,9 @@ export interface ColumnProps extends HTMLAttributes<HTMLDivElement> {
   lg?: "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12";
 }
 
-// eslint-disable-next-line react/prefer-stateless-function
+/**
+ * @deprecated Bruk aksel primitives (HGrid, HStack, VStack, Box) i stedet.
+ */
 class Column extends Component<ColumnProps> {
   render() {
     const { children, className, xs, sm, md, lg, ...props } = this.props;

--- a/src/navFrontend/grid/container.tsx
+++ b/src/navFrontend/grid/container.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prefer-stateless-function */
 import classNames from "classnames";
 import { Component, ComponentClass, HTMLAttributes } from "react";
 
@@ -12,7 +13,9 @@ export interface ContainerProps extends HTMLAttributes<HTMLDivElement> {
   fluid?: boolean;
 }
 
-// eslint-disable-next-line react/prefer-stateless-function
+/**
+ * @deprecated Bruk aksel primitives (HGrid, HStack, VStack, Box) i stedet.
+ */
 class Container extends Component<ContainerProps> {
   render() {
     const { children, className, fluid, ...props } = this.props;

--- a/src/navFrontend/grid/row.tsx
+++ b/src/navFrontend/grid/row.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prefer-stateless-function */
 import classNames from "classnames";
 import { Component, ComponentClass, HTMLAttributes } from "react";
 
@@ -7,7 +8,9 @@ export interface RowProps extends HTMLAttributes<HTMLDivElement> {
   className?: string;
 }
 
-// eslint-disable-next-line react/prefer-stateless-function
+/**
+ * @deprecated Bruk aksel primitives (HGrid, HStack, VStack, Box) i stedet.
+ */
 class Row extends Component<RowProps> {
   render() {
     const { children, className, ...props } = this.props;


### PR DESCRIPTION
Deprecater row, column og container. Dette er gamle layout primitives fra nav-frontend-grid pakken som ble importert til prosjektet ifm. migrering til react 18