### PR TITLE
7378 DAPI Uten grunnlag avgift fra avgiftssystemet

### DIFF
--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -7,10 +7,9 @@ export interface AarsavregningResponse {
   aarsavregningID: number;
   aar: number;
   tidligereGrunnlagsopplysninger?: Grunnlagsopplysninger;
-  harAvvik?: boolean;
   nyttGrunnlag?: Grunnlagsopplysninger;
   avregning?: Avregning;
-  harDeltGrunnlag?: boolean;
+  harTrygdeavgiftFraAvgiftssystemet?: boolean;
   endeligAvgiftValg?: string;
 }
 
@@ -18,14 +17,14 @@ export interface AarsavregningRequest {
   avregning: Omit<Avregning, "tidligereFakturertBeloep">;
 }
 
-export interface OppdaterHarDeltGrunnlagRequest {
-  harDeltGrunnlag: boolean;
+export interface OppdaterHarTrygdeavgiftFraAvgiftssystemetRequest {
+  harTrygdeavgiftFraAvgiftssystemet: boolean;
 }
 
 export interface Grunnlagsopplysninger {
   trygdeavgiftsgrunnlag: Trygdeavgiftsgrunnlag;
   avgift: Avgift;
-  tidligereÅrsavregningFakturertBeloepAvgiftssystem?: number;
+  tidligereTrygdeavgiftFraAvgiftssystemet?: number;
   tidligereÅrsavregningManueltAvgiftBeloep?: number;
 }
 
@@ -55,7 +54,7 @@ export interface Avregning {
   beregnetAvgiftBelop?: number;
   tidligereFakturertBeloep?: number;
   tilFaktureringBeloep?: number;
-  tidligereFakturertBeloepAvgiftssystem?: number;
+  trygdeavgiftFraAvgiftssystemet?: number;
   manueltAvgiftBeloep?: number;
 }
 
@@ -82,9 +81,9 @@ export const lagAarsavregning = (
 ): Promise<AarsavregningResponse> =>
   postAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}`, request);
 
-export const oppdaterHarDeltGrunnlag = (
+export const oppdaterHarTrygdeavgiftFraAvgiftssystemet = (
   behandlingID: number,
-  request: OppdaterHarDeltGrunnlagRequest,
+  request: OppdaterHarTrygdeavgiftFraAvgiftssystemetRequest,
 ): Promise<AarsavregningResponse> =>
   postAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${AARSAVREGNING}/grunnlagstype`, request);
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlag.tsx
@@ -31,10 +31,13 @@ const mapInnvilgetMedlemskapsPeriode = (medlemskapsperioder: Medlemskapsperiode[
   };
 };
 
-const mapMedlemskapsperiodeBestemmelse = (harDeltGrunnlag: boolean, medlemskapsperioder?: Medlemskapsperiode[]) => {
+const mapMedlemskapsperiodeBestemmelse = (
+  harTrygdeavgiftFraAvgiftssystemet: boolean,
+  medlemskapsperioder?: Medlemskapsperiode[],
+) => {
   if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
     const sortertePerioder = [...medlemskapsperioder]
-      .filter((periode) => (harDeltGrunnlag ? !periode.redigerbar : true))
+      .filter((periode) => (harTrygdeavgiftFraAvgiftssystemet ? !periode.redigerbar : true))
       .filter((periode) => periode.id !== ULAGRET_MEDLEMSKAPSPERIODE_ID)
       .sort(sorterEtterISOFomDato);
     return sortertePerioder?.[0]?.bestemmelse;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -62,7 +62,7 @@ interface Props {
   bekreft: () => void;
   aktivtSteg: boolean;
   oppdaterStatus: (isValid: boolean) => void;
-  harDeltGrunnlag: boolean;
+  harTrygdeavgiftFraAvgiftssystemet: boolean;
 }
 
 export interface MedlemskapTomFomDatoer {
@@ -77,7 +77,11 @@ export interface AarsavregningFormValuesProps extends FormValuesProps {
   manueltAvgiftBeloep?: number | string;
 }
 
-export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, harDeltGrunnlag }: Props) {
+export function AarsavregningUtenEllerDeltGrunnlag({
+  bekreft,
+  oppdaterStatus,
+  harTrygdeavgiftFraAvgiftssystemet,
+}: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const [initiellData, setInitiellData] = useState<{
     valgtÅr?: number;
@@ -133,7 +137,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
 
     if (
       redigerbart &&
-      harDeltGrunnlag &&
+      harTrygdeavgiftFraAvgiftssystemet &&
       innvilgedeMedlemskapsperioder.length === 0 &&
       aarsavregningRes?.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag
     ) {
@@ -219,16 +223,16 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
         }
 
         const deltGrunnlagAarsavregningHarIkkeNyttGrunnlag =
-          harDeltGrunnlag && aarsavregningRes && !aarsavregningRes.nyttGrunnlag;
+          harTrygdeavgiftFraAvgiftssystemet && aarsavregningRes && !aarsavregningRes.nyttGrunnlag;
 
         const mappedMedlemskapsperioder = await getMappedMedlemskapsperioder(aarsavregningRes!);
         const bestemmelse = getBestemmelse(mappedMedlemskapsperioder);
         const trygdedekninger = await getTrygdedekninger(bestemmelse);
 
         const totaltForskuddsvisFakturert =
-          aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem !== undefined &&
-          aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem !== null
-            ? aarsavregningRes?.avregning?.tidligereFakturertBeloepAvgiftssystem
+          aarsavregningRes?.avregning?.trygdeavgiftFraAvgiftssystemet !== undefined &&
+          aarsavregningRes?.avregning?.trygdeavgiftFraAvgiftssystemet !== null
+            ? aarsavregningRes?.avregning?.trygdeavgiftFraAvgiftssystemet
             : "";
         const manueltAvgiftBeloep =
           aarsavregningRes?.avregning?.manueltAvgiftBeloep !== undefined &&
@@ -275,7 +279,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
     };
 
     lastInitiellData();
-  }, [behandlingID, harDeltGrunnlag]);
+  }, [behandlingID, harTrygdeavgiftFraAvgiftssystemet]);
 
   const memoizedOppdaterStatus = useCallback((erGyldig: boolean) => {
     oppdaterStatus(erGyldig);
@@ -290,7 +294,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({ bekreft, oppdaterStatus, ha
       initiellData={initiellData}
       bekreft={bekreft}
       oppdaterStatus={memoizedOppdaterStatus}
-      harDeltGrunnlag={harDeltGrunnlag}
+      harTrygdeavgiftFraAvgiftssystemet={harTrygdeavgiftFraAvgiftssystemet}
     />
   );
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -63,6 +63,7 @@ interface Props {
   aktivtSteg: boolean;
   oppdaterStatus: (isValid: boolean) => void;
   harTrygdeavgiftFraAvgiftssystemet: boolean;
+  harGrunnlag: boolean;
 }
 
 export interface MedlemskapTomFomDatoer {
@@ -71,7 +72,7 @@ export interface MedlemskapTomFomDatoer {
 }
 
 export interface AarsavregningFormValuesProps extends FormValuesProps {
-  totaltForskuddsvisFakturert?: number | string;
+  trygdeavgiftFraAvgiftssystemet?: number | string;
   bestemmelse?: string;
   endeligAvgiftValg: string;
   manueltAvgiftBeloep?: number | string;
@@ -81,6 +82,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({
   bekreft,
   oppdaterStatus,
   harTrygdeavgiftFraAvgiftssystemet,
+  harGrunnlag,
 }: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const [initiellData, setInitiellData] = useState<{
@@ -96,7 +98,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({
       medlemskapsperioder: [DEFAULT_MEDLEMSKAPSPERIODE],
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
-      totaltForskuddsvisFakturert: "",
+      trygdeavgiftFraAvgiftssystemet: "",
       endeligAvgiftValg: "",
       manueltAvgiftBeloep: "",
     },
@@ -229,7 +231,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({
         const bestemmelse = getBestemmelse(mappedMedlemskapsperioder);
         const trygdedekninger = await getTrygdedekninger(bestemmelse);
 
-        const totaltForskuddsvisFakturert =
+        const trygdeavgiftFraAvgiftssystemet =
           aarsavregningRes?.avregning?.trygdeavgiftFraAvgiftssystemet !== undefined &&
           aarsavregningRes?.avregning?.trygdeavgiftFraAvgiftssystemet !== null
             ? aarsavregningRes?.avregning?.trygdeavgiftFraAvgiftssystemet
@@ -245,7 +247,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({
             ? mappedMedlemskapsperioder
             : [DEFAULT_MEDLEMSKAPSPERIODE],
           bestemmelse,
-          totaltForskuddsvisFakturert,
+          trygdeavgiftFraAvgiftssystemet,
           endeligAvgiftValg: aarsavregningRes?.endeligAvgiftValg || "",
           manueltAvgiftBeloep,
           skatteforholdsperioder: mapTilSkatteforholdProps(
@@ -295,6 +297,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({
       bekreft={bekreft}
       oppdaterStatus={memoizedOppdaterStatus}
       harTrygdeavgiftFraAvgiftssystemet={harTrygdeavgiftFraAvgiftssystemet}
+      harGrunnlag={harGrunnlag}
     />
   );
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -74,7 +74,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   initiellData,
   bekreft,
   oppdaterStatus,
-  harDeltGrunnlag,
+  harTrygdeavgiftFraAvgiftssystemet,
 }: {
   initiellData: {
     valgtÅr?: number;
@@ -85,7 +85,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   };
   bekreft: () => void;
   oppdaterStatus: (isValid: boolean) => void;
-  harDeltGrunnlag: boolean;
+  harTrygdeavgiftFraAvgiftssystemet: boolean;
 }) {
   const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
   const [beregningPaagar, setBeregningPaagar] = useState(false);
@@ -537,11 +537,11 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     if (
       redigerbart &&
       forrigeTotaltForskuddsvisFakturert.current !== totaltForskuddsvisFakturert &&
-      totaltForskuddsvisFakturert !== aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem
+      totaltForskuddsvisFakturert !== aarsavregningResponse?.avregning?.trygdeavgiftFraAvgiftssystemet
     ) {
       debouncedOppdaterTotaltForskuddsvisFakturert({
         avregning: {
-          tidligereFakturertBeloepAvgiftssystem: totaltForskuddsvisFakturert,
+          trygdeavgiftFraAvgiftssystemet: totaltForskuddsvisFakturert,
         },
       });
     }
@@ -753,8 +753,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const skjemaErRedigerbart = redigerbart && !endrerBestemmelse;
 
   const tidligereAarsavregningTrygdeavgiftFraAvgiftssystem =
-    initiellData.aarsavregningResponse?.tidligereGrunnlagsopplysninger
-      ?.tidligereÅrsavregningFakturertBeloepAvgiftssystem;
+    initiellData.aarsavregningResponse?.tidligereGrunnlagsopplysninger?.tidligereTrygdeavgiftFraAvgiftssystemet;
 
   const tidligereAarsavregningErManueltBeregnet = Boolean(
     initiellData.aarsavregningResponse?.tidligereGrunnlagsopplysninger?.tidligereÅrsavregningManueltAvgiftBeloep,
@@ -785,7 +784,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
             control={control}
             setValue={setValue}
             bestemmelser={initiellData.bestemmelser}
-            harDeltGrunnlag={harDeltGrunnlag}
+            harTrygdeavgiftFraAvgiftssystemet={harTrygdeavgiftFraAvgiftssystemet}
             behandlingID={behandlingID}
             redigerbart={skjemaErRedigerbart}
             setTrygdedekninger={setTrygdedekninger}
@@ -882,10 +881,10 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         !feilmelding &&
         endeligAvgiftValg === OPPLYSNINGER_ENDRET && (
           <SumArsavregningTabell
-            harGrunnlagIMelosys={harDeltGrunnlag}
+            harGrunnlagIMelosys={harTrygdeavgiftFraAvgiftssystemet}
             nyTrygdeavgift={aarsavregningResponse?.avregning?.beregnetAvgiftBelop}
             tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
-            tidligereTrygdeavgiftAvgiftssystem={aarsavregningResponse?.avregning?.tidligereFakturertBeloepAvgiftssystem}
+            tidligereTrygdeavgiftAvgiftssystem={aarsavregningResponse?.avregning?.trygdeavgiftFraAvgiftssystemet}
             tidligereAarsavregningTrygdeavgiftFraAvgiftssystem={tidligereAarsavregningTrygdeavgiftFraAvgiftssystem}
           />
         )}
@@ -907,7 +906,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         manueltAvgiftBeloep !== null &&
         manueltAvgiftBeloep !== "" && (
           <SumArsavregningTabell
-            harGrunnlagIMelosys={harDeltGrunnlag}
+            harGrunnlagIMelosys={harTrygdeavgiftFraAvgiftssystemet}
             nyTrygdeavgift={Number(manueltAvgiftBeloep)}
             tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
             tidligereTrygdeavgiftAvgiftssystem={

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -25,7 +25,7 @@ import { BeregnetTrygdeavgiftDetaljer } from "../komponenter/beregnetTrygdeavgif
 import BestemmelseSelect from "../komponenter/bestemmelseSelect";
 import { BorderedFormContainer } from "../komponenter/borderedFormContainer";
 import { EndeligAvgiftValgRadioGroup } from "../komponenter/endeligAvgiftValgRadioGroup";
-import { InnbetaltFraAvgiftssystemetInput } from "../komponenter/innbetaltFraAvgiftssystemetInput";
+import { TrygdeavgiftFraAvgiftssystemetInput } from "../komponenter/trygdeavgiftFraAvgiftssystemetInput";
 import { ManuellAvgiftFormPart } from "../komponenter/manuellAvgiftFormPart";
 import { MedlemskapsperiodeSkjema } from "../komponenter/medlemskapsperiodeSkjema";
 import { SumArsavregningTabell } from "../komponenter/sumArsavregningTabell";
@@ -75,6 +75,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   bekreft,
   oppdaterStatus,
   harTrygdeavgiftFraAvgiftssystemet,
+  harGrunnlag,
 }: {
   initiellData: {
     valgtÅr?: number;
@@ -86,6 +87,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   bekreft: () => void;
   oppdaterStatus: (isValid: boolean) => void;
   harTrygdeavgiftFraAvgiftssystemet: boolean;
+  harGrunnlag: boolean;
 }) {
   const [feilmelding, setFeilmelding] = useState<undefined | string>(undefined);
   const [beregningPaagar, setBeregningPaagar] = useState(false);
@@ -120,6 +122,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     resolver: yupResolver(aarsavregningUtenEllerDeltGrunnlagSchema),
     context: {
       aar: initiellData.valgtÅr,
+      harTrygdeavgiftFraAvgiftssystemet,
     },
     mode: "onChange",
     defaultValues: initiellData.formDefaultValues,
@@ -148,14 +151,14 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const bestemmelse = useWatch({ control, name: "bestemmelse" });
   const medlemskapsperioder = useWatch({ control, name: "medlemskapsperioder" });
   const medlemskapsperioderForrigeAntall = useRef(medlemskapsperioder.length);
-  const totaltForskuddsvisFakturert = useWatch({ control, name: "totaltForskuddsvisFakturert" });
+  const trygdeavgiftFraAvgiftssystemet = useWatch({ control, name: "trygdeavgiftFraAvgiftssystemet" });
   const skatteforholdsperioder = useWatch({ control, name: "skatteforholdsperioder" });
   const inntektskilder = useWatch({ control, name: "inntektskilder" });
   const endeligAvgiftValg = useWatch({ control, name: "endeligAvgiftValg" });
   const manueltAvgiftBeloep = useWatch({ control, name: "manueltAvgiftBeloep" });
 
   const debouncedBeregningRef = useRef<any>(null);
-  const forrigeTotaltForskuddsvisFakturert = useRef(totaltForskuddsvisFakturert);
+  const forrigetrygdeavgiftFraAvgiftssystemet = useRef(trygdeavgiftFraAvgiftssystemet);
   const previousDepsRef = useRef<any>(null);
 
   const medlemskapstypeErPliktig = useMemo(() => {
@@ -188,7 +191,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     skatteforholdsperioderFormState: Skatteforhold[],
     inntektskilderFormState: Inntektskilde[],
     medlemskapsperioderFormState: Medlemskapsperiode[],
-    totaltForskuddsvisFakturertParam: number | undefined,
+    trygdeavgiftFraAvgiftssystemetParam: number | undefined,
   ) => ({
     skatteforholdsperioder: skatteforholdsperioderFormState.map((skatteforhold: Skatteforhold) => ({
       fomDato: skatteforhold.fomDato,
@@ -209,7 +212,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       trygdedekning: periode.trygdedekning,
       medlemskapstype: periode.medlemskapstype,
     })),
-    totaltForskuddsvisFakturert: totaltForskuddsvisFakturertParam,
+    trygdeavgiftFraAvgiftssystemet: trygdeavgiftFraAvgiftssystemetParam,
   });
 
   useEffect(() => {
@@ -304,7 +307,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       getValues("skatteforholdsperioder"),
       getValues("inntektskilder"),
       medlemskapsperioderFormState,
-      getValues("totaltForskuddsvisFakturert"),
+      getValues("trygdeavgiftFraAvgiftssystemet"),
     );
     const medlemskapsperiodeFomTom = finnMedlemskapsperiode(medlemskapsperioderFormState);
 
@@ -510,7 +513,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     }
   };
 
-  const handleOppdaterTotaltForskuddsvisFakturert = async (
+  const handleOppdatertrygdeavgiftFraAvgiftssystemet = async (
     behandlingid: number,
     request: Api.Aarsavregning.AarsavregningRequest,
     aarsavregningid?: number,
@@ -523,10 +526,10 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       });
   };
 
-  const debouncedOppdaterTotaltForskuddsvisFakturert = useCallback(
+  const debouncedOppdatertrygdeavgiftFraAvgiftssystemet = useCallback(
     Utils._debounce(
       (request: Api.Aarsavregning.AarsavregningRequest) =>
-        handleOppdaterTotaltForskuddsvisFakturert(behandlingID, request, aarsavregningID),
+        handleOppdatertrygdeavgiftFraAvgiftssystemet(behandlingID, request, aarsavregningID),
       350,
     ),
     [aarsavregningID],
@@ -536,18 +539,18 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   useEffect(() => {
     if (
       redigerbart &&
-      forrigeTotaltForskuddsvisFakturert.current !== totaltForskuddsvisFakturert &&
-      totaltForskuddsvisFakturert !== aarsavregningResponse?.avregning?.trygdeavgiftFraAvgiftssystemet
+      forrigetrygdeavgiftFraAvgiftssystemet.current !== trygdeavgiftFraAvgiftssystemet &&
+      trygdeavgiftFraAvgiftssystemet !== aarsavregningResponse?.avregning?.trygdeavgiftFraAvgiftssystemet
     ) {
-      debouncedOppdaterTotaltForskuddsvisFakturert({
+      debouncedOppdatertrygdeavgiftFraAvgiftssystemet({
         avregning: {
-          trygdeavgiftFraAvgiftssystemet: totaltForskuddsvisFakturert,
+          trygdeavgiftFraAvgiftssystemet,
         },
       });
     }
 
-    forrigeTotaltForskuddsvisFakturert.current = totaltForskuddsvisFakturert;
-  }, [totaltForskuddsvisFakturert]);
+    forrigetrygdeavgiftFraAvgiftssystemet.current = trygdeavgiftFraAvgiftssystemet;
+  }, [trygdeavgiftFraAvgiftssystemet]);
 
   // Lager en ny debounce funksjon når beregning callback endres
   useEffect(() => {
@@ -584,7 +587,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       formIsValid,
       lagreMedlemskapsperioderPaagar,
       endrerBestemmelse,
-      totaltForskuddsvisFakturert,
+      trygdeavgiftFraAvgiftssystemet,
       endeligAvgiftValg,
       aarsavregningID,
       redigerbart,
@@ -624,7 +627,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         getValues("skatteforholdsperioder"),
         getValues("inntektskilder"),
         getValues("medlemskapsperioder"),
-        getValues("totaltForskuddsvisFakturert"),
+        getValues("trygdeavgiftFraAvgiftssystemet"),
       );
 
       if (!redigerbart || !aarsavregningID || endrerBestemmelse || beregningPaagar || lagreMedlemskapsperioderPaagar) {
@@ -674,7 +677,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     formIsValid,
     lagreMedlemskapsperioderPaagar,
     endrerBestemmelse,
-    totaltForskuddsvisFakturert,
+    trygdeavgiftFraAvgiftssystemet,
     endeligAvgiftValg,
     aarsavregningID,
     redigerbart,
@@ -761,11 +764,13 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
   return (
     <div className="vurderingAarsavregning">
-      <InnbetaltFraAvgiftssystemetInput
-        control={control}
-        redigerbart={skjemaErRedigerbart}
-        erNyAarsavregning={Boolean(tidligereAarsavregningTrygdeavgiftFraAvgiftssystem)}
-      />
+      {harTrygdeavgiftFraAvgiftssystemet && (
+        <TrygdeavgiftFraAvgiftssystemetInput
+          control={control}
+          redigerbart={skjemaErRedigerbart}
+          erNyAarsavregning={Boolean(tidligereAarsavregningTrygdeavgiftFraAvgiftssystem)}
+        />
+      )}
 
       <EndeligAvgiftValgRadioGroup
         control={control}
@@ -784,7 +789,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
             control={control}
             setValue={setValue}
             bestemmelser={initiellData.bestemmelser}
-            harTrygdeavgiftFraAvgiftssystemet={harTrygdeavgiftFraAvgiftssystemet}
+            harGrunnlag={harGrunnlag}
             behandlingID={behandlingID}
             redigerbart={skjemaErRedigerbart}
             setTrygdedekninger={setTrygdedekninger}
@@ -910,7 +915,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
             nyTrygdeavgift={Number(manueltAvgiftBeloep)}
             tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
             tidligereTrygdeavgiftAvgiftssystem={
-              totaltForskuddsvisFakturert ? Number(totaltForskuddsvisFakturert) : undefined
+              trygdeavgiftFraAvgiftssystemet ? Number(trygdeavgiftFraAvgiftssystemet) : undefined
             }
             tidligereAarsavregningTrygdeavgiftFraAvgiftssystem={tidligereAarsavregningTrygdeavgiftFraAvgiftssystem}
           />

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
@@ -165,7 +165,11 @@ const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
     then: (schema) => schema.min(1, "Minst en medlemskapsperiode").of(medlemskapsperiodeSchema),
     otherwise: (schema) => schema,
   }),
-  totaltForskuddsvisFakturert: string().nullable().required(MAA_FYLLES_UT),
+  trygdeavgiftFraAvgiftssystemet: string().when(["$harTrygdeavgiftFraAvgiftssystemet"], {
+    is: true,
+    then: (schema) => schema.required(MAA_FYLLES_UT),
+    otherwise: (schema) => schema.nullable(),
+  }),
   skatteforholdsperioder: array().when(["endeligAvgiftValg"], {
     is: (endeligAvgiftValg) => endeligAvgiftValg === OPPLYSNINGER_ENDRET,
     then: (schema) => schema.min(1, "Minst en skatteforholdsperiode").of(skatteforholdsperiodeSchema),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/__snapshots__/tidligereGrunnlag.test.tsx.snap
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/__snapshots__/tidligereGrunnlag.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`TidligereGrunnlagAccordion > beregning med grunnlag snapshot test 1`] = `
+exports[`TidligereGrunnlag > beregning med grunnlag snapshot test 1`] = `
 
 <div>
   <div
@@ -281,7 +281,7 @@ exports[`TidligereGrunnlagAccordion > beregning med grunnlag snapshot test 1`] =
 
 `;
 
-exports[`TidligereGrunnlagAccordion > manuell beregning snapshot test 1`] = `
+exports[`TidligereGrunnlag > manuell beregning snapshot test 1`] = `
 
 <div>
   <div
@@ -297,65 +297,6 @@ exports[`TidligereGrunnlagAccordion > manuell beregning snapshot test 1`] = `
         15&nbsp;000 kr
       </strong>
     </p>
-  </div>
-</div>
-
-`;
-
-exports[`TidligereGrunnlagAccordion > uten grunnlag snapshot test 1`] = `
-
-<div>
-  <div
-    style="--__ac-box-background: var(--a-surface-subtle);"
-    class="navds-box tidligereGrunnlag navds-box-bg"
-  >
-    <h3 class="navds-heading navds-heading--small">
-      Tidligere grunnlag
-    </h3>
-    <div
-      data-color="info"
-      data-variant="info"
-      class="navds-alert navds-alert--info navds-alert--small"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-labelledby="333"
-        class="navds-alert__icon"
-      >
-        <title id="333">
-          Informasjon
-        </title>
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M3.25 4A.75.75 0 0 1 4 3.25h16a.75.75 0 0 1 .75.75v16a.75.75 0 0 1-.75.75H4a.75.75 0 0 1-.75-.75zM11 7.75a1 1 0 1 1 2 0 1 1 0 0 1-2 0m-1.25 3a.75.75 0 0 1 .75-.75H12a.75.75 0 0 1 .75.75v4.75h.75a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5h.75v-4h-.75a.75.75 0 0 1-.75-.75"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
-      <div class="navds-alert__wrapper navds-alert__wrapper--maxwidth navds-body-long navds-body-long--small">
-        <p class="navds-body-long navds-body-long--small">
-          Det er ingen informasjon om perioder med medlemskap og forskuddsvis fakturert trygdeavgift i Melosys.
-        </p>
-        <ul>
-          <li>
-            Hvis trygdeavgiften er forskuddsvis fakturert fra avgiftssystemet, oppgi totalbeløpet som er fakturert.
-          </li>
-          <li>
-            Hvis trygdeavgiften tidligere har vært årsavregnet i avgiftssystemet, oppgi totalbeløpet for endelig beregnet trygdeavgift.
-          </li>
-          <li>
-            Hvis trygdeavgiften ikke er forskuddsvis fakturert, la det være tomt.
-          </li>
-        </ul>
-      </div>
-    </div>
   </div>
 </div>
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
@@ -13,7 +13,7 @@ interface BestemmelseSelectProps {
   control: Control<any>;
   setValue: (name: string, value: any) => void;
   bestemmelser: string[];
-  harTrygdeavgiftFraAvgiftssystemet: boolean;
+  harGrunnlag: boolean;
   behandlingID?: number;
   redigerbart: boolean;
   setTrygdedekninger: (trygdedekninger: string[]) => void;
@@ -27,7 +27,7 @@ function BestemmelseSelect({
   setValue,
   bestemmelser,
   behandlingID,
-  harTrygdeavgiftFraAvgiftssystemet,
+  harGrunnlag,
   redigerbart,
   setTrygdedekninger,
   setFeilmelding,
@@ -98,7 +98,7 @@ function BestemmelseSelect({
       label="Bestemmelse"
       aria-label="Bestemmelse"
       control={control}
-      readOnly={!redigerbart || harTrygdeavgiftFraAvgiftssystemet}
+      readOnly={!redigerbart || harGrunnlag}
       emptyFieldDisabled
       onChange={(valgtBestemmelse) => {
         handleBestemmelseChange(valgtBestemmelse);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
@@ -13,7 +13,7 @@ interface BestemmelseSelectProps {
   control: Control<any>;
   setValue: (name: string, value: any) => void;
   bestemmelser: string[];
-  harDeltGrunnlag: boolean;
+  harTrygdeavgiftFraAvgiftssystemet: boolean;
   behandlingID?: number;
   redigerbart: boolean;
   setTrygdedekninger: (trygdedekninger: string[]) => void;
@@ -26,8 +26,8 @@ function BestemmelseSelect({
   control,
   setValue,
   bestemmelser,
-  harDeltGrunnlag,
   behandlingID,
+  harTrygdeavgiftFraAvgiftssystemet,
   redigerbart,
   setTrygdedekninger,
   setFeilmelding,
@@ -82,13 +82,13 @@ function BestemmelseSelect({
       }
     },
     [
-      harDeltGrunnlag,
       medlemskapsperioder,
       inntektskilder,
       setValue,
       setTrygdedekninger,
       setFeilmelding,
       setEndrerBestemmelse,
+      lagreMedlemskapsperioderHvisGyldig,
     ],
   );
 
@@ -98,7 +98,7 @@ function BestemmelseSelect({
       label="Bestemmelse"
       aria-label="Bestemmelse"
       control={control}
-      readOnly={!redigerbart || harDeltGrunnlag}
+      readOnly={!redigerbart || harTrygdeavgiftFraAvgiftssystemet}
       emptyFieldDisabled
       onChange={(valgtBestemmelse) => {
         handleBestemmelseChange(valgtBestemmelse);
@@ -116,5 +116,4 @@ function BestemmelseSelect({
     </Forms.Select>
   );
 }
-
 export default BestemmelseSelect;

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereGrunnlag.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereGrunnlag.test.tsx
@@ -3,9 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import MKV from "../../../../../melosyskodeverk";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
-import { TidligereGrunnlagAccordion } from "./tidligereGrunnlag";
+import { TidligereGrunnlag } from "./tidligereGrunnlag";
 
-describe("TidligereGrunnlagAccordion", () => {
+describe("TidligereGrunnlag", () => {
   const createMockResponse = (overrides: Partial<AarsavregningResponse> = {}): AarsavregningResponse => ({
     aarsavregningID: 1,
     aar: 2023,
@@ -62,12 +62,6 @@ describe("TidligereGrunnlagAccordion", () => {
     ...overrides,
   });
 
-  const createNoDataResponse = (): AarsavregningResponse => ({
-    aarsavregningID: 1,
-    aar: 2023,
-    tidligereGrunnlagsopplysninger: undefined,
-  });
-
   const createManuellBeregningResponse = (): AarsavregningResponse =>
     createMockResponse({
       tidligereGrunnlagsopplysninger: {
@@ -101,7 +95,7 @@ describe("TidligereGrunnlagAccordion", () => {
     const user = userEvent.setup();
     const mockResponse = createMockResponse();
 
-    const { container } = render(<TidligereGrunnlagAccordion aarsavregningResponse={mockResponse} />);
+    const { container } = render(<TidligereGrunnlag aarsavregningResponse={mockResponse} />);
 
     await user.click(screen.getByRole("button"));
 
@@ -111,15 +105,7 @@ describe("TidligereGrunnlagAccordion", () => {
   it("manuell beregning snapshot test", async () => {
     const manuellResponse = createManuellBeregningResponse();
 
-    const { container } = render(<TidligereGrunnlagAccordion aarsavregningResponse={manuellResponse} />);
-
-    expect(container).toMatchSnapshot();
-  });
-
-  it("uten grunnlag snapshot test", async () => {
-    const noDataResponse = createNoDataResponse();
-
-    const { container } = render(<TidligereGrunnlagAccordion aarsavregningResponse={noDataResponse} />);
+    const { container } = render(<TidligereGrunnlag aarsavregningResponse={manuellResponse} />);
 
     expect(container).toMatchSnapshot();
   });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereGrunnlag.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereGrunnlag.test.tsx
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { TidligereGrunnlagAccordion } from "./tidligereGrunnlag";
-import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
+import { describe, expect, it } from "vitest";
 import MKV from "../../../../../melosyskodeverk";
+import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
+import { TidligereGrunnlagAccordion } from "./tidligereGrunnlag";
 
 describe("TidligereGrunnlagAccordion", () => {
   const createMockResponse = (overrides: Partial<AarsavregningResponse> = {}): AarsavregningResponse => ({
@@ -56,7 +56,7 @@ describe("TidligereGrunnlagAccordion", () => {
         totalInntekt: 500000,
         totalAvgift: 25500,
       },
-      tidligereÅrsavregningFakturertBeloepAvgiftssystem: undefined,
+      tidligereTrygdeavgiftFraAvgiftssystemet: undefined,
       tidligereÅrsavregningManueltAvgiftBeloep: undefined,
     },
     ...overrides,
@@ -92,7 +92,7 @@ describe("TidligereGrunnlagAccordion", () => {
           totalInntekt: 0,
           totalAvgift: 0,
         },
-        tidligereÅrsavregningFakturertBeloepAvgiftssystem: undefined,
+        tidligereTrygdeavgiftFraAvgiftssystemet: undefined,
         tidligereÅrsavregningManueltAvgiftBeloep: 15000,
       },
     });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/tidligereGrunnlag.tsx
@@ -7,13 +7,11 @@ import { Aarsavregningsmeldinger } from "./aarsavregningsmeldinger";
 import GrunnlagTabeller from "./grunnlagTabeller";
 import MedlemskapsPerioderTabell from "./medlemskapsPerioderTabell";
 
-interface TidligereGrunnlagAccordionProps {
+interface TidligereGrunnlagProps {
   aarsavregningResponse: AarsavregningResponse;
 }
 
-export function TidligereGrunnlagAccordion({ aarsavregningResponse }: TidligereGrunnlagAccordionProps) {
-  const harTidligereGrunnlag = Boolean(aarsavregningResponse.tidligereGrunnlagsopplysninger);
-
+export function TidligereGrunnlag({ aarsavregningResponse }: TidligereGrunnlagProps) {
   const erManueltBeregnet = Boolean(
     aarsavregningResponse.tidligereGrunnlagsopplysninger?.tidligereÅrsavregningManueltAvgiftBeloep !== null &&
       aarsavregningResponse.tidligereGrunnlagsopplysninger?.tidligereÅrsavregningManueltAvgiftBeloep !== undefined,
@@ -28,7 +26,7 @@ export function TidligereGrunnlagAccordion({ aarsavregningResponse }: TidligereG
         Tidligere grunnlag
       </Nav.Heading>
 
-      {harTidligereGrunnlag && !erManueltBeregnet && (
+      {!erManueltBeregnet && (
         <>
           <Nav.BodyLong size="small">
             Brutto årsinntekt:{" "}
@@ -88,24 +86,6 @@ export function TidligereGrunnlagAccordion({ aarsavregningResponse }: TidligereG
             kr
           </strong>
         </Nav.BodyLong>
-      )}
-
-      {!harTidligereGrunnlag && (
-        <Nav.Alert variant="info" size="small">
-          <Nav.BodyLong size="small">
-            Det er ingen informasjon om perioder med medlemskap og forskuddsvis fakturert trygdeavgift i Melosys.
-          </Nav.BodyLong>
-          <ul>
-            <li>
-              Hvis trygdeavgiften er forskuddsvis fakturert fra avgiftssystemet, oppgi totalbeløpet som er fakturert.
-            </li>
-            <li>
-              Hvis trygdeavgiften tidligere har vært årsavregnet i avgiftssystemet, oppgi totalbeløpet for endelig
-              beregnet trygdeavgift.
-            </li>
-            <li>Hvis trygdeavgiften ikke er forskuddsvis fakturert, la det være tomt.</li>
-          </ul>
-        </Nav.Alert>
       )}
     </Nav.Box>
   );

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/trygdeavgiftFraAvgiftssystemetInput.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/trygdeavgiftFraAvgiftssystemetInput.tsx
@@ -2,18 +2,22 @@ import "../vurderingAarsavregningInngang.css";
 import { Control } from "react-hook-form";
 import * as Forms from "../../../../../felleskomponenter/forms";
 
-interface TidligereGrunnlagProps {
+interface TrygdeavgiftFraAvgiftssystemetInputProps {
   control: Control;
   redigerbart: boolean;
   erNyAarsavregning: boolean;
 }
 
-export function InnbetaltFraAvgiftssystemetInput({ control, redigerbart, erNyAarsavregning }: TidligereGrunnlagProps) {
+export function TrygdeavgiftFraAvgiftssystemetInput({
+  control,
+  redigerbart,
+  erNyAarsavregning,
+}: TrygdeavgiftFraAvgiftssystemetInputProps) {
   return (
     <Forms.Input
       label="Trygdeavgift fra Avgiftssystemet"
       description={erNyAarsavregning ? "Du skal kun endre hvis tidligere oppgitte beløp er feil" : ""}
-      name="totaltForskuddsvisFakturert"
+      name="trygdeavgiftFraAvgiftssystemet"
       control={control}
       readOnly={!redigerbart}
       className="avgift_input"

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -19,7 +19,7 @@ import { behandlingsresultatOperations } from "../../../../ducks/behandlingsresu
 import LabelMedHjelpetekst from "../../../../felleskomponenter/labelMedHjelpetekst";
 import { AarsavregningMedGrunnlag } from "./aarsavregningMedGrunnlag/aarsavregningMedGrunnlag";
 import { AarsavregningUtenEllerDeltGrunnlag } from "./aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
-import { TidligereGrunnlagAccordion } from "./komponenter/tidligereGrunnlag";
+import { TidligereGrunnlag } from "./komponenter/tidligereGrunnlag";
 import * as Utils from "../../../../utils";
 
 const { FASTSATT_TRYGDEAVGIFT, IKKE_FASTSATT } = MKV.Koder.behandlinger.behandlingsresultattyper;
@@ -78,7 +78,8 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   const [harTrygdeavgiftFraAvgiftssystemet, setHarTrygdeavgiftFraAvgiftssystemet] = useState<boolean | undefined>(
     undefined,
   );
-  const [visDeltGrunnlagRadioGroup, setVisDeltGrunnlagRadioGroup] = useState(false);
+  const [endrerHarTrygdeavgiftFraAvgiftssystemet, setEndrerHarTrygdeavgiftFraAvgiftssystemet] =
+    useState<boolean>(false);
   const [erNyVurdering, setErNyVurdering] = useState<boolean>(false);
   const [harAktivÅrsavregning, setHarAktivÅrsavregning] = useState<boolean>(false);
   const [harManglendeInnbetalingBehandling, setHarManglendeInnbetalingBehandling] = useState<boolean>(false);
@@ -91,22 +92,14 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   const dispatch = useDispatch();
 
   const utledGrunnlagstypeForÅrsavregning = (res: AarsavregningResponse) => {
-    if (res.harTrygdeavgiftFraAvgiftssystemet || res.aar === 2023 || res.aar === 2024) {
-      setVisDeltGrunnlagRadioGroup(true);
-      setHarTrygdeavgiftFraAvgiftssystemet(res.harTrygdeavgiftFraAvgiftssystemet);
-    } else {
-      setVisDeltGrunnlagRadioGroup(false);
-      setHarTrygdeavgiftFraAvgiftssystemet(false);
-    }
+    setHarTrygdeavgiftFraAvgiftssystemet(res.harTrygdeavgiftFraAvgiftssystemet);
 
-    if (
-      res.tidligereGrunnlagsopplysninger === null ||
-      Utils._isEmpty(res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder)
-    ) {
-      setHarGrunnlag(false);
-    } else {
-      setHarGrunnlag(true);
-    }
+    setHarGrunnlag(
+      !(
+        res.tidligereGrunnlagsopplysninger === null ||
+        Utils._isEmpty(res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder)
+      ),
+    );
   };
 
   useEffect(() => {
@@ -132,7 +125,6 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
     setLagÅrsavregningFeil(undefined);
     setErNyVurdering(false);
     setHarAktivÅrsavregning(false);
-    setVisDeltGrunnlagRadioGroup(false);
     setHarGrunnlag(undefined);
     setHarTrygdeavgiftFraAvgiftssystemet(undefined);
     setAarsavregningResponse(undefined);
@@ -167,9 +159,13 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   };
 
   const håndterHarTrygdeavgiftFraAvgiftssystemet = async (value: boolean) => {
+    setEndrerHarTrygdeavgiftFraAvgiftssystemet(true);
     Api.Aarsavregning.oppdaterHarTrygdeavgiftFraAvgiftssystemet(behandlingID, {
       harTrygdeavgiftFraAvgiftssystemet: value,
-    }).then((res) => setHarTrygdeavgiftFraAvgiftssystemet(res.harTrygdeavgiftFraAvgiftssystemet));
+    }).then((res) => {
+      setHarTrygdeavgiftFraAvgiftssystemet(res.harTrygdeavgiftFraAvgiftssystemet);
+      setEndrerHarTrygdeavgiftFraAvgiftssystemet(false);
+    });
   };
 
   const forrigeÅrsavregningErManueltBeregnet = Boolean(
@@ -249,10 +245,17 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
             </Nav.Alert>
           )}
 
-          {/* Tidligere grunnlag accordion - vises når år/aarsavregningResponse er satt  */}
-          {aarsavregningResponse && <TidligereGrunnlagAccordion aarsavregningResponse={aarsavregningResponse} />}
+          {aarsavregningResponse && harGrunnlag && <TidligereGrunnlag aarsavregningResponse={aarsavregningResponse} />}
 
-          {visDeltGrunnlagRadioGroup && (
+          {aarsavregningResponse && harGrunnlag === false && (
+            <Nav.Alert variant="info" className="alertstripe_feilmelding">
+              <Nav.BodyLong size="small">
+                Det er ingen informasjon om perioder med medlemskap og forskuddsvis fakturert trygdeavgift i Melosys.
+              </Nav.BodyLong>
+            </Nav.Alert>
+          )}
+
+          {(valgtÅr || initieltÅr) && (
             <Nav.Row>
               <Nav.Column xs="12">
                 <Nav.RadioGroup
@@ -260,7 +263,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
                   legend={
                     <LabelMedHjelpetekst
                       label="Skal du legge til trygdeavgift fra Avgiftssystemet til denne årsavregningen?"
-                      hjelpetekst={DELT_GRUNNLAG_HJELPETEKST}
+                      hjelpetekst={harGrunnlag ? DELT_GRUNNLAG_HJELPETEKST : ""}
                     />
                   }
                   value={harTrygdeavgiftFraAvgiftssystemet}
@@ -275,17 +278,22 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
             </Nav.Row>
           )}
 
-          {harGrunnlag === true && harTrygdeavgiftFraAvgiftssystemet === false && (
-            <AarsavregningMedGrunnlag bekreft={bekreft} aktivtSteg={aktivtSteg} oppdaterStatus={oppdaterStatus} />
-          )}
-          {(harGrunnlag === false || harTrygdeavgiftFraAvgiftssystemet) && (
-            <AarsavregningUtenEllerDeltGrunnlag
-              bekreft={bekreft}
-              aktivtSteg={aktivtSteg}
-              oppdaterStatus={oppdaterStatus}
-              harTrygdeavgiftFraAvgiftssystemet={Boolean(harTrygdeavgiftFraAvgiftssystemet)}
-            />
-          )}
+          {!endrerHarTrygdeavgiftFraAvgiftssystemet &&
+            harGrunnlag === true &&
+            harTrygdeavgiftFraAvgiftssystemet === false && (
+              <AarsavregningMedGrunnlag bekreft={bekreft} aktivtSteg={aktivtSteg} oppdaterStatus={oppdaterStatus} />
+            )}
+          {!endrerHarTrygdeavgiftFraAvgiftssystemet &&
+            (harGrunnlag === false || harTrygdeavgiftFraAvgiftssystemet) &&
+            harTrygdeavgiftFraAvgiftssystemet !== null && (
+              <AarsavregningUtenEllerDeltGrunnlag
+                bekreft={bekreft}
+                aktivtSteg={aktivtSteg}
+                oppdaterStatus={oppdaterStatus}
+                harTrygdeavgiftFraAvgiftssystemet={Boolean(harTrygdeavgiftFraAvgiftssystemet)}
+                harGrunnlag={Boolean(harGrunnlag)}
+              />
+            )}
         </>
       )}
     </div>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -20,6 +20,7 @@ import LabelMedHjelpetekst from "../../../../felleskomponenter/labelMedHjelpetek
 import { AarsavregningMedGrunnlag } from "./aarsavregningMedGrunnlag/aarsavregningMedGrunnlag";
 import { AarsavregningUtenEllerDeltGrunnlag } from "./aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
 import { TidligereGrunnlagAccordion } from "./komponenter/tidligereGrunnlag";
+import * as Utils from "../../../../utils";
 
 const { FASTSATT_TRYGDEAVGIFT, IKKE_FASTSATT } = MKV.Koder.behandlinger.behandlingsresultattyper;
 const { MANGLENDE_INNBETALING_TRYGDEAVGIFT } = MKV.Koder.behandlinger.behandlingstyper;
@@ -74,7 +75,9 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   const [initieltÅr, setInitieltÅr] = useState<number | undefined>(undefined);
   const [lagÅrsavregningFeil, setLagÅrsavregningFeil] = useState<string | undefined>(undefined);
   const [harGrunnlag, setHarGrunnlag] = useState<boolean | undefined>(undefined);
-  const [harDeltGrunnlag, setHarDeltGrunnlag] = useState<boolean | undefined>(undefined);
+  const [harTrygdeavgiftFraAvgiftssystemet, setHarTrygdeavgiftFraAvgiftssystemet] = useState<boolean | undefined>(
+    undefined,
+  );
   const [visDeltGrunnlagRadioGroup, setVisDeltGrunnlagRadioGroup] = useState(false);
   const [erNyVurdering, setErNyVurdering] = useState<boolean>(false);
   const [harAktivÅrsavregning, setHarAktivÅrsavregning] = useState<boolean>(false);
@@ -88,17 +91,21 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   const dispatch = useDispatch();
 
   const utledGrunnlagstypeForÅrsavregning = (res: AarsavregningResponse) => {
-    if (res.tidligereGrunnlagsopplysninger === null) {
+    if (res.harTrygdeavgiftFraAvgiftssystemet || res.aar === 2023 || res.aar === 2024) {
+      setVisDeltGrunnlagRadioGroup(true);
+      setHarTrygdeavgiftFraAvgiftssystemet(res.harTrygdeavgiftFraAvgiftssystemet);
+    } else {
+      setVisDeltGrunnlagRadioGroup(false);
+      setHarTrygdeavgiftFraAvgiftssystemet(false);
+    }
+
+    if (
+      res.tidligereGrunnlagsopplysninger === null ||
+      Utils._isEmpty(res.tidligereGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.medlemskapsperioder)
+    ) {
       setHarGrunnlag(false);
     } else {
       setHarGrunnlag(true);
-      if (res.harDeltGrunnlag || res.aar === 2023 || res.aar === 2024) {
-        setVisDeltGrunnlagRadioGroup(true);
-        setHarDeltGrunnlag(res.harDeltGrunnlag);
-      } else {
-        setVisDeltGrunnlagRadioGroup(false);
-        setHarDeltGrunnlag(false);
-      }
     }
   };
 
@@ -127,7 +134,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
     setHarAktivÅrsavregning(false);
     setVisDeltGrunnlagRadioGroup(false);
     setHarGrunnlag(undefined);
-    setHarDeltGrunnlag(undefined);
+    setHarTrygdeavgiftFraAvgiftssystemet(undefined);
     setAarsavregningResponse(undefined);
 
     const år = Number(event.target.value);
@@ -159,10 +166,10 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
     });
   };
 
-  const håndterDeltGrunnlag = async (value: boolean) => {
-    Api.Aarsavregning.oppdaterHarDeltGrunnlag(behandlingID, { harDeltGrunnlag: value }).then((res) =>
-      setHarDeltGrunnlag(res.harDeltGrunnlag),
-    );
+  const håndterHarTrygdeavgiftFraAvgiftssystemet = async (value: boolean) => {
+    Api.Aarsavregning.oppdaterHarTrygdeavgiftFraAvgiftssystemet(behandlingID, {
+      harTrygdeavgiftFraAvgiftssystemet: value,
+    }).then((res) => setHarTrygdeavgiftFraAvgiftssystemet(res.harTrygdeavgiftFraAvgiftssystemet));
   };
 
   const forrigeÅrsavregningErManueltBeregnet = Boolean(
@@ -170,9 +177,8 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
       aarsavregningResponse?.tidligereGrunnlagsopplysninger?.tidligereÅrsavregningManueltAvgiftBeloep !== undefined,
   );
   const forrigeÅrsavregningHarInnbetaltFraAvgiftssystem = Boolean(
-    aarsavregningResponse?.tidligereGrunnlagsopplysninger?.tidligereÅrsavregningFakturertBeloepAvgiftssystem !== null &&
-      aarsavregningResponse?.tidligereGrunnlagsopplysninger?.tidligereÅrsavregningFakturertBeloepAvgiftssystem !==
-        undefined,
+    aarsavregningResponse?.tidligereGrunnlagsopplysninger?.tidligereTrygdeavgiftFraAvgiftssystemet !== null &&
+      aarsavregningResponse?.tidligereGrunnlagsopplysninger?.tidligereTrygdeavgiftFraAvgiftssystemet !== undefined,
   );
 
   const sisteMuligeÅr = new Date().getFullYear() - 1;
@@ -250,14 +256,14 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
             <Nav.Row>
               <Nav.Column xs="12">
                 <Nav.RadioGroup
-                  onChange={håndterDeltGrunnlag}
+                  onChange={håndterHarTrygdeavgiftFraAvgiftssystemet}
                   legend={
                     <LabelMedHjelpetekst
                       label="Skal du legge til trygdeavgift fra Avgiftssystemet til denne årsavregningen?"
                       hjelpetekst={DELT_GRUNNLAG_HJELPETEKST}
                     />
                   }
-                  value={harDeltGrunnlag}
+                  value={harTrygdeavgiftFraAvgiftssystemet}
                   readOnly={!redigerbart || harAktivÅrsavregning || forrigeÅrsavregningHarInnbetaltFraAvgiftssystem}
                 >
                   <Nav.HStack gap="6">
@@ -269,15 +275,15 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
             </Nav.Row>
           )}
 
-          {harGrunnlag === true && harDeltGrunnlag === false && (
+          {harGrunnlag === true && harTrygdeavgiftFraAvgiftssystemet === false && (
             <AarsavregningMedGrunnlag bekreft={bekreft} aktivtSteg={aktivtSteg} oppdaterStatus={oppdaterStatus} />
           )}
-          {(harGrunnlag === false || harDeltGrunnlag) && (
+          {(harGrunnlag === false || harTrygdeavgiftFraAvgiftssystemet) && (
             <AarsavregningUtenEllerDeltGrunnlag
               bekreft={bekreft}
               aktivtSteg={aktivtSteg}
               oppdaterStatus={oppdaterStatus}
-              harDeltGrunnlag={Boolean(harDeltGrunnlag)}
+              harTrygdeavgiftFraAvgiftssystemet={Boolean(harTrygdeavgiftFraAvgiftssystemet)}
             />
           )}
         </>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -78,7 +78,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   const [harTrygdeavgiftFraAvgiftssystemet, setHarTrygdeavgiftFraAvgiftssystemet] = useState<boolean | undefined>(
     undefined,
   );
-  const [endrerHarTrygdeavgiftFraAvgiftssystemet, setEndrerHarTrygdeavgiftFraAvgiftssystemet] =
+  const [harTrygdeavgiftFraAvgiftssystemetIsPending, setHarTrygdeavgiftFraAvgiftssystemetIsPending] =
     useState<boolean>(false);
   const [erNyVurdering, setErNyVurdering] = useState<boolean>(false);
   const [harAktivÅrsavregning, setHarAktivÅrsavregning] = useState<boolean>(false);
@@ -159,12 +159,12 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   };
 
   const håndterHarTrygdeavgiftFraAvgiftssystemet = async (value: boolean) => {
-    setEndrerHarTrygdeavgiftFraAvgiftssystemet(true);
+    setHarTrygdeavgiftFraAvgiftssystemetIsPending(true);
     Api.Aarsavregning.oppdaterHarTrygdeavgiftFraAvgiftssystemet(behandlingID, {
       harTrygdeavgiftFraAvgiftssystemet: value,
     }).then((res) => {
       setHarTrygdeavgiftFraAvgiftssystemet(res.harTrygdeavgiftFraAvgiftssystemet);
-      setEndrerHarTrygdeavgiftFraAvgiftssystemet(false);
+      setHarTrygdeavgiftFraAvgiftssystemetIsPending(false);
     });
   };
 
@@ -278,12 +278,12 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
             </Nav.Row>
           )}
 
-          {!endrerHarTrygdeavgiftFraAvgiftssystemet &&
+          {!harTrygdeavgiftFraAvgiftssystemetIsPending &&
             harGrunnlag === true &&
             harTrygdeavgiftFraAvgiftssystemet === false && (
               <AarsavregningMedGrunnlag bekreft={bekreft} aktivtSteg={aktivtSteg} oppdaterStatus={oppdaterStatus} />
             )}
-          {!endrerHarTrygdeavgiftFraAvgiftssystemet &&
+          {!harTrygdeavgiftFraAvgiftssystemetIsPending &&
             (harGrunnlag === false || harTrygdeavgiftFraAvgiftssystemet) &&
             harTrygdeavgiftFraAvgiftssystemet !== null && (
               <AarsavregningUtenEllerDeltGrunnlag

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.less
@@ -2,4 +2,9 @@
   .navds-alert {
     margin-bottom: 1rem;
   }
+
+  .editor_label {
+    font-size: 1rem;
+    font-weight: 600;
+  }
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -3,7 +3,6 @@ import { RootState } from "AppTypes";
 import { useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useSelector } from "react-redux";
-import { useDispatch } from "../../../../hooks";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
 import { behandlingerSelectors } from "../../../../ducks/behandlinger";
@@ -16,9 +15,9 @@ import { vedtakOperations } from "../../../../ducks/vedtak";
 import Dokumentliste from "../../../../felleskomponenter/dokumentliste";
 import * as Forms from "../../../../felleskomponenter/forms";
 import FullmaktForTrygdeavgiftConfirmationPanel from "../../../../felleskomponenter/fullmaktForTrygdeavgiftConfirmationPanel/fullmaktForTrygdeavgiftConfirmationPanel";
-import LabelMedHjelpetekst from "../../../../felleskomponenter/labelMedHjelpetekst";
 import * as Mui from "../../../../felleskomponenter/ui";
 import VedleggTable from "../../../../felleskomponenter/vedleggTable";
+import { useDispatch } from "../../../../hooks";
 import MKV from "../../../../melosyskodeverk";
 import * as Nav from "../../../../navFrontend";
 import * as Api from "../../../../services/api";
@@ -27,8 +26,8 @@ import { BrevVedleggVisningstabellInterface } from "../../../../services/modules
 import * as Utils from "../../../../utils";
 import { SumArsavregningTabell } from "../vurderingAarsavregning/komponenter/sumArsavregningTabell";
 import { beregnSumTilFakturaEllerRefusjon } from "../vurderingAarsavregning/utils";
-import vurdering_vedtak from "./vurderingVedtakSchema";
 import "./vurderingVedtak.css";
+import vurdering_vedtak from "./vurderingVedtakSchema";
 
 const { FASTSATT_TRYGDEAVGIFT } = MKV.Koder.behandlinger.behandlingsresultattyper;
 const { FØRSTEGANGSVEDTAK } = MKV.Koder.vedtakstyper;
@@ -328,20 +327,20 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   };
 
   const tidligereTrygdeavgift = lagretAarsavregning?.avregning?.tidligereFakturertBeloep;
-  const tidligereTrygdeavgiftAvgiftssystem = lagretAarsavregning?.avregning?.tidligereFakturertBeloepAvgiftssystem;
+  const trygdeavgiftFraAvgiftssystemet = lagretAarsavregning?.avregning?.trygdeavgiftFraAvgiftssystemet;
   const nyTrygdeavgift =
     lagretAarsavregning?.endeligAvgiftValg === MANUELL_ENDELIG_AVGIFT
       ? lagretAarsavregning?.avregning?.manueltAvgiftBeloep
       : lagretAarsavregning?.avregning?.beregnetAvgiftBelop;
 
-  const tidligereAarsavregningTrygdeavgiftFraAvgiftssystem =
-    lagretAarsavregning?.tidligereGrunnlagsopplysninger?.tidligereÅrsavregningFakturertBeloepAvgiftssystem;
+  const tidligereTrygdeavgiftFraAvgiftssystemet =
+    lagretAarsavregning?.tidligereGrunnlagsopplysninger?.tidligereTrygdeavgiftFraAvgiftssystemet;
 
   const sumTilFakturaEllerRefusjon = beregnSumTilFakturaEllerRefusjon(
     nyTrygdeavgift,
     tidligereTrygdeavgift,
-    tidligereTrygdeavgiftAvgiftssystem,
-    tidligereAarsavregningTrygdeavgiftFraAvgiftssystem,
+    trygdeavgiftFraAvgiftssystemet,
+    tidligereTrygdeavgiftFraAvgiftssystemet,
   );
   const erDifferanseUnderMinstebeløp = Math.abs(sumTilFakturaEllerRefusjon) < MINSTEBELOP_FAKTURERING_ELLER_REFUSJON;
   const erNullKroner = sumTilFakturaEllerRefusjon === 0;
@@ -368,9 +367,11 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
       <SumArsavregningTabell
         nyTrygdeavgift={nyTrygdeavgift}
         tidligereTrygdeavgift={tidligereTrygdeavgift}
-        tidligereTrygdeavgiftAvgiftssystem={tidligereTrygdeavgiftAvgiftssystem}
-        harGrunnlagIMelosys={tidligereTrygdeavgift !== null || lagretAarsavregning?.harDeltGrunnlag === true}
-        tidligereAarsavregningTrygdeavgiftFraAvgiftssystem={tidligereAarsavregningTrygdeavgiftFraAvgiftssystem}
+        tidligereTrygdeavgiftAvgiftssystem={trygdeavgiftFraAvgiftssystemet}
+        harGrunnlagIMelosys={
+          tidligereTrygdeavgift !== null || lagretAarsavregning?.harTrygdeavgiftFraAvgiftssystemet === true
+        }
+        tidligereAarsavregningTrygdeavgiftFraAvgiftssystem={tidligereTrygdeavgiftFraAvgiftssystemet}
       />
 
       {fakturaMottaker ? (
@@ -400,24 +401,20 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         />
       ) : null}
 
-      <Nav.BodyLong weight="semibold" size="small" className="fritekst_overskrift">
-        <LabelMedHjelpetekst label="Fritekst til innledning" hjelpetekst="" />
-      </Nav.BodyLong>
       <Forms.HtmlEditor
         name="innledningFritekst"
         control={control}
         className="fritekst_editor"
         disabled={!redigerbart}
+        label="Fritekst til innledning"
       />
 
-      <Nav.BodyLong weight="semibold" size="small" className="fritekst_overskrift">
-        <LabelMedHjelpetekst label="Fritekst til begrunnelse" hjelpetekst="" />
-      </Nav.BodyLong>
       <Forms.HtmlEditor
         name="begrunnelseFritekst"
         control={control}
         className="fritekst_editor"
         disabled={!redigerbart}
+        label="Fritekst til begrunnelse"
       />
 
       {formIsValid &&


### PR DESCRIPTION
api: https://github.com/navikt/melosys-api/pull/2851
- Renamer en rekke variabler i aarsavregning dtoer
- Spørsmålet om årsavregningen har avgift fra avgiftssystemet vises nå for alle behandlinger.
- totaltForskuddsvisFakturert (form variabel) renamet til trygdeavgiftFraAvgiftssystemet
- BestemmelseSelect disables nå basert på om behandlingen har grunnlag i melosys (eksisterende medlemskapsperiode(r))
- MELOSYS-7376, ny varseltekst for uten grunnlag