### PR TITLE
7392 Begrenser datovelger datepicker årvalg

### DIFF
--- a/src/felleskomponenter/datovelger/datovelger.tsx
+++ b/src/felleskomponenter/datovelger/datovelger.tsx
@@ -36,8 +36,8 @@ function Datovelger({
 }: DatovelgerProps) {
   const [erUgyldigDato, setErUgyldigDato] = useState<boolean>(false);
   const { datepickerProps, inputProps } = useDatepicker({
-    fromDate: minDate ?? new Date(moment(moment.now()).subtract(50, "years").toDate()),
-    toDate: maxDate ?? new Date(moment(moment.now()).add(50, "years").toDate()),
+    fromDate: minDate ?? moment(moment.now()).subtract(5, "years").startOf("year").toDate(),
+    toDate: maxDate ?? moment(moment.now()).add(5, "years").endOf("year").toDate(),
     locale: "nb",
     defaultSelected: value,
     defaultMonth: minDate ?? value,

--- a/src/felleskomponenter/trygdeavgift/komponenter/meldinger.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/meldinger.tsx
@@ -29,8 +29,8 @@ const SkatteforholdUtenforMedlemskapsperiode = (
 
 const SkattepliktigOgPensjonUforetrygdMedKildeskatt = (
   <Nav.Alert variant="error" className="alertstripe_feilmelding">
-    Inntekstypen &quot;Pensjon/uføretrygd det betales kildeskatt av&quot; kan ikke velges for perioder bruker er
-    skattepliktig til Norge.
+    Inntektstypen &quot;Pensjon/uføretrygd&quot; skal det betales kildeskatt av og kan derfor ikke velges for perioder
+    bruker er skattepliktig til Norge.
   </Nav.Alert>
 );
 


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7392
DatePicker får default begrensning 5 år frem og tilbake i tid. For datofeltene kan man fremdeles skrive perioder lengre bakover i tid. Avklart med Yvonne på kontoret

Fikset også en feilaktig feilmelding i årsavregningen