### PR TITLE
NOJIRA G4P forbedring i testkode

### DIFF
--- a/src/ducks/test-utils/renderWithProviders.tsx
+++ b/src/ducks/test-utils/renderWithProviders.tsx
@@ -1,12 +1,10 @@
 import React, { PropsWithChildren, ReactElement } from "react";
-import { act, RenderOptions } from "@testing-library/react";
-import { render } from "@testing-library/react";
+import { render, RenderOptions, act } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { RootState } from "AppTypes";
 import { createTestStore } from "./createTestStore";
 
-interface ExtendedRenderOptions extends Omit<RenderOptions, "queries"> {
-  preloadedState?: Partial<RootState>;
+interface ExtendedRenderOptions extends Omit<RenderOptions, "wrapper"> {
+  preloadedState?: object | undefined;
   store?: any;
 }
 

--- a/src/ducks/test-utils/renderWithProviders.tsx
+++ b/src/ducks/test-utils/renderWithProviders.tsx
@@ -1,5 +1,5 @@
-import { PropsWithChildren, ReactElement } from "react";
-import type { RenderOptions } from "@testing-library/react";
+import React, { PropsWithChildren, ReactElement } from "react";
+import { act, RenderOptions } from "@testing-library/react";
 import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { RootState } from "AppTypes";
@@ -19,3 +19,13 @@ export function renderWithProviders(
   }
   return { store, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
 }
+
+/**
+ * Async version of renderWithProviders that wraps in act()
+ * Use this for components that perform async operations during render
+ */
+export const renderWithProvidersAsync = async (ui: ReactElement, options: ExtendedRenderOptions = {}) => {
+  return act(async () => {
+    return renderWithProviders(ui, options);
+  });
+};

--- a/src/felleskomponenter/dialogboks/avslagSoknad/dialogboksAvslagSoknad.test.tsx
+++ b/src/felleskomponenter/dialogboks/avslagSoknad/dialogboksAvslagSoknad.test.tsx
@@ -1,5 +1,6 @@
 import { renderWithProviders } from "../../../ducks/test-utils/renderWithProviders";
 import { DialogboksAvslagSoknad } from "./dialogboksAvslagSoknad";
+import { waitFor } from "@testing-library/react";
 
 // Mock react-redux useDispatch hook
 vi.mock("react-redux", async () => {
@@ -23,9 +24,11 @@ describe("DialogboksAvslagSoknad", () => {
     kontrollfeil: [],
   };
 
-  it("viser en Nav Modal", () => {
+  it("viser en Nav Modal", async () => {
     const { getByRole } = renderWithProviders(<DialogboksAvslagSoknad {...props} />);
-    expect(getByRole("dialog")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getByRole("dialog")).toBeInTheDocument();
+    });
   });
 
   it("viser forhåndsvisning når ingen feilmeldinger finnes", async () => {
@@ -43,6 +46,9 @@ describe("DialogboksAvslagSoknad", () => {
     const { queryByText } = renderWithProviders(<DialogboksAvslagSoknad {...props} />, {
       preloadedState: initialState,
     });
-    expect(queryByText("Forhåndsvisning av brev")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(queryByText("Forhåndsvisning av brev")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/avsluttsak.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import MKV from "../../../melosyskodeverk";
-import { renderWithProviders } from "../../../ducks/test-utils/renderWithProviders";
+import { renderWithProviders, renderWithProvidersAsync } from "../../../ducks/test-utils/renderWithProviders";
 import AvsluttSak from "./avsluttsak";
 
 const {
@@ -63,7 +63,7 @@ describe("AvsluttSak", () => {
   it("viser riktige valg for sakstype FTRL og behandlingstype FØRSTEGANG ", async () => {
     props.sakstype = FTRL;
     props.behandlingstema = YRKESAKTIV;
-    renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+    await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
     const knapper = await screen.findAllByRole("button");
     expect(knapper).toHaveLength(6);
@@ -79,7 +79,7 @@ describe("AvsluttSak", () => {
     props.sakstype = FTRL;
     props.behandlingstema = YRKESAKTIV;
     props.behandlingstype = NY_VURDERING;
-    renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+    await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
     const knapper = await screen.findAllByRole("button");
     expect(knapper).toHaveLength(8);
@@ -102,7 +102,7 @@ describe("AvsluttSak", () => {
 
   describe("Behandlingen er bortfalt", () => {
     it("viser Behandlingen er bortfalt når behandling er redigerbart", async () => {
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Behandlingen er bortfalt")).toBeInTheDocument();
     });
@@ -111,49 +111,49 @@ describe("AvsluttSak", () => {
   describe("Ferdigbehandlet", () => {
     it(`viser 'Ferdigbehandlet' dersom behandlingstema er blant de tillatte og behandlingstype er ${NY_VURDERING}`, async () => {
       props.behandlingstype = NY_VURDERING;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Ferdigbehandlet")).toBeInTheDocument();
     });
 
     it(`viser 'Ferdigbehandlet' dersom behandlingstema er blant de tillatte og behandlingstype er ${HENVENDELSE}`, async () => {
       props.behandlingstype = HENVENDELSE;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Ferdigbehandlet")).toBeInTheDocument();
     });
 
     it(`viser 'Ferdigbehandlet' dersom behandlingstema ikke er blant de tillatte så lenge behandling er redigerbart`, async () => {
       props.behandlingstema = YRKESAKTIV;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Ferdigbehandlet")).toBeInTheDocument();
     });
 
     it(`viser 'Ferdigbehandlet' dersom behandlingstema er ARBEID_FLERE_LAND, sakstype er EU_SØS, behandlingstype er FØRSTEGANG og det er redigerbart`, async () => {
       props.behandlingstema = ARBEID_FLERE_LAND;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Ferdigbehandlet")).toBeInTheDocument();
     });
 
     it(`viser ikke 'Ferdigbehandlet' dersom behandlingstema er annet enn ARBEID_FLERE_LAND, behandlingstype er FØRSTEGANG og det er redigerbart`, async () => {
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
-      expect(await screen.queryByText("Ferdigbehandlet")).toBeNull();
+      expect(screen.queryByText("Ferdigbehandlet")).toBeNull();
     });
   });
 
   describe("Søknaden er avslått", () => {
     it(`viser 'Søknaden er avslått' dersom behandlingstype og behandlingstema er blant de tillatte`, async () => {
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Søknaden er avslått")).toBeInTheDocument();
     });
 
     it(`viser ikke 'Søknaden er avslått' dersom behandlingstype er ${HENVENDELSE}`, async () => {
       props.behandlingstype = HENVENDELSE;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Søknaden er avslått")).toBeFalsy();
@@ -161,7 +161,7 @@ describe("AvsluttSak", () => {
 
     it(`viser ikke 'Søknaden er avslått' dersom sakstema er ${UNNTAK}`, async () => {
       props.sakstema = UNNTAK;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Søknaden er avslått")).toBeFalsy();
@@ -170,7 +170,7 @@ describe("AvsluttSak", () => {
 
   describe("Søknaden er innvilget", () => {
     it(`viser 'Søknaden er innvilget' dersom sakstype er ${EU_EOS} og behandlingstype er ${FØRSTEGANG} og behandlingstema er ${UTSENDT_ARBEIDSTAKER}`, async () => {
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Søknaden er innvilget")).toBeInTheDocument();
     });
@@ -179,7 +179,7 @@ describe("AvsluttSak", () => {
       props.sakstype = FTRL;
       props.behandlingstype = FØRSTEGANG;
       props.behandlingstema = YRKESAKTIV;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Søknaden er innvilget")).toBeInTheDocument();
     });
@@ -188,7 +188,7 @@ describe("AvsluttSak", () => {
       props.sakstype = TRYGDEAVTALE;
       props.behandlingstype = FØRSTEGANG;
       props.behandlingstema = YRKESAKTIV;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Søknaden er innvilget")).toBeInTheDocument();
     });
@@ -197,7 +197,7 @@ describe("AvsluttSak", () => {
       props.sakstype = TRYGDEAVTALE;
       props.behandlingstype = HENVENDELSE;
       props.behandlingstema = YRKESAKTIV;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Søknaden er innvilget")).toBeFalsy();
@@ -205,7 +205,7 @@ describe("AvsluttSak", () => {
 
     it(`viser ikke 'Søknaden er innvilget' dersom sakstema er ${UNNTAK}`, async () => {
       props.sakstema = UNNTAK;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Søknaden er innvilget")).toBeFalsy();
@@ -214,7 +214,7 @@ describe("AvsluttSak", () => {
 
   describe("Søknaden/klagen er trukket", () => {
     it(`viser 'Søknaden/klagen er trukket' dersom sakstype er ${EU_EOS} og behandlingstype er ${FØRSTEGANG} og behandlingstema er ${UTSENDT_ARBEIDSTAKER}`, async () => {
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Søknaden/klagen er trukket")).toBeInTheDocument();
     });
@@ -223,7 +223,7 @@ describe("AvsluttSak", () => {
       props.sakstype = FTRL;
       props.behandlingstype = FØRSTEGANG;
       props.behandlingstema = YRKESAKTIV;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Søknaden/klagen er trukket")).toBeInTheDocument();
     });
@@ -232,7 +232,7 @@ describe("AvsluttSak", () => {
       props.sakstype = TRYGDEAVTALE;
       props.behandlingstype = FØRSTEGANG;
       props.behandlingstema = YRKESAKTIV;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Søknaden/klagen er trukket")).toBeInTheDocument();
     });
@@ -241,7 +241,7 @@ describe("AvsluttSak", () => {
       props.sakstype = TRYGDEAVTALE;
       props.behandlingstype = HENVENDELSE;
       props.behandlingstema = YRKESAKTIV;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Søknaden/klagen er trukket")).toBeFalsy();
@@ -249,7 +249,7 @@ describe("AvsluttSak", () => {
 
     it(`viser ikke 'Søknaden/klagen er trukket' dersom sakstema er ${UNNTAK}`, async () => {
       props.sakstema = UNNTAK;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Søknaden/klagen er trukket")).toBeFalsy();
@@ -258,7 +258,7 @@ describe("AvsluttSak", () => {
 
   describe("Avslå søknad pga. manglende opplysninger", () => {
     it(`viser 'Avslå søknad pga. manglende opplysninger' dersom sakstype er ${EU_EOS} og behandlingstype er ${FØRSTEGANG} og behandlingstema er ${UTSENDT_ARBEIDSTAKER}`, async () => {
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Avslå søknad pga. manglende opplysninger")).toBeInTheDocument();
     });
@@ -267,7 +267,7 @@ describe("AvsluttSak", () => {
       props.sakstype = FTRL;
       props.behandlingstype = FØRSTEGANG;
       props.behandlingstema = YRKESAKTIV;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Avslå søknad pga. manglende opplysninger")).toBeInTheDocument();
     });
@@ -276,7 +276,7 @@ describe("AvsluttSak", () => {
       props.sakstype = TRYGDEAVTALE;
       props.behandlingstype = FØRSTEGANG;
       props.behandlingstema = YRKESAKTIV;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Avslå søknad pga. manglende opplysninger")).toBeInTheDocument();
     });
@@ -285,7 +285,7 @@ describe("AvsluttSak", () => {
       props.sakstype = TRYGDEAVTALE;
       props.behandlingstype = HENVENDELSE;
       props.behandlingstema = YRKESAKTIV;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Avslå søknad pga. manglende opplysninger")).toBeFalsy();
@@ -293,7 +293,7 @@ describe("AvsluttSak", () => {
 
     it(`viser ikke 'Avslå søknad pga. manglende opplysninger' dersom sakstema er ${UNNTAK}`, async () => {
       props.sakstema = UNNTAK;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Avslå søknad pga. manglende opplysninger")).toBeFalsy();
@@ -303,7 +303,7 @@ describe("AvsluttSak", () => {
   describe("Klage-handlinger", () => {
     it(`viser Klage-handlinger dersom behandlingstype er ${KLAGE}`, async () => {
       props.behandlingstype = KLAGE;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Medhold på klage")).toBeTruthy();
@@ -315,7 +315,7 @@ describe("AvsluttSak", () => {
 
     it(`viser ikke Klage-handlinger dersom behandlingstype er ${FØRSTEGANG}`, async () => {
       props.behandlingstype = FØRSTEGANG;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Medhold på klage")).toBeFalsy();
@@ -329,14 +329,14 @@ describe("AvsluttSak", () => {
   describe("Vedtaket er omgjort (fvl § 35)", () => {
     it(`viser 'Vedtaket er omgjort (fvl § 35)' dersom behandlingstype er ${NY_VURDERING}`, async () => {
       props.behandlingstype = NY_VURDERING;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       expect(await screen.findByText("Vedtaket er omgjort (fvl § 35)")).toBeInTheDocument();
     });
 
     it(`viser ikke 'Vedtaket er omgjort (fvl § 35)' dersom behandlingstype er ${FØRSTEGANG}`, async () => {
       props.behandlingstype = FØRSTEGANG;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Vedtaket er omgjort (fvl § 35)")).toBeFalsy();
@@ -348,7 +348,7 @@ describe("AvsluttSak", () => {
       props.behandlingstema = ANMODNING_OM_UNNTAK_HOVEDREGEL;
       props.sakstype = TRYGDEAVTALE;
       props.sakstema = UNNTAK;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Perioden er godkjent")).toBeTruthy();
@@ -360,7 +360,7 @@ describe("AvsluttSak", () => {
       props.behandlingstema = REGISTRERING_UNNTAK;
       props.sakstype = TRYGDEAVTALE;
       props.sakstema = UNNTAK;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Perioden er godkjent")).toBeTruthy();
@@ -372,7 +372,7 @@ describe("AvsluttSak", () => {
       props.behandlingstema = A1_ANMODNING_OM_UNNTAK_PAPIR;
       props.sakstype = EU_EOS;
       props.sakstema = UNNTAK;
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Perioden er godkjent")).toBeTruthy();
@@ -381,7 +381,7 @@ describe("AvsluttSak", () => {
     });
 
     it(`viser ikke Unntak-handlinger for andre tilfeller enn de ovenfor`, async () => {
-      renderWithProviders(<AvsluttSak />, { preloadedState: initialState() });
+      await renderWithProvidersAsync(<AvsluttSak />, { preloadedState: initialState() });
 
       const knapper = await screen.findAllByRole("button");
       expect(knapper.some((knapp) => knapp.textContent === "Perioden er godkjent")).toBeFalsy();

--- a/src/felleskomponenter/informasjonlinje/behandlingsmeny/leggbehandlingtilbake.test.tsx
+++ b/src/felleskomponenter/informasjonlinje/behandlingsmeny/leggbehandlingtilbake.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react";
-import { renderWithProviders } from "../../../ducks/test-utils/renderWithProviders";
+import { renderWithProvidersAsync } from "../../../ducks/test-utils/renderWithProviders";
 import LeggBehandlingTilbake from "./leggbehandlingtilbake";
 
 describe("LeggBehandlingTilbake", () => {
@@ -13,7 +13,7 @@ describe("LeggBehandlingTilbake", () => {
   });
 
   it("viser begge valg som knapper om redigerbart", async () => {
-    renderWithProviders(<LeggBehandlingTilbake />, { preloadedState: initialState(true) });
+    await renderWithProvidersAsync(<LeggBehandlingTilbake />, { preloadedState: initialState(true) });
 
     const knapper = await screen.findAllByRole("button");
     expect(knapper).toHaveLength(2);
@@ -22,7 +22,7 @@ describe("LeggBehandlingTilbake", () => {
   });
 
   it("viser bare Til felles oppgaveliste som er en tekst om ikke redigerbart", async () => {
-    renderWithProviders(<LeggBehandlingTilbake />, { preloadedState: initialState(false) });
+    await renderWithProvidersAsync(<LeggBehandlingTilbake />, { preloadedState: initialState(false) });
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
     expect(screen.getByText("Til felles oppgaveliste")).toBeInTheDocument();

--- a/src/felleskomponenter/menypanel/menypunkter/fakturainformasjon/__snapshots__/faktura.test.jsx.snap
+++ b/src/felleskomponenter/menypanel/menypunkter/fakturainformasjon/__snapshots__/faktura.test.jsx.snap
@@ -3,176 +3,180 @@
 exports[`Faktura > snapshot test 1`] = `
 
 <div>
-  <tr class="navds-table__row navds-table__expandable-row navds-table__row--shade-on-hover">
-    <td class="navds-table__data-cell navds-table__toggle-expand-cell navds-body-short navds-body-short--medium">
-      <button
-        class="navds-table__toggle-expand-button"
-        type="button"
-        aria-controls="«r0»"
-        aria-expanded="false"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-labelledby="333"
-          class="navds-table__expandable-icon"
-        >
-          <title id="333">
-            Vis mer
-          </title>
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-            clip-rule="evenodd"
+  <table>
+    <tbody>
+      <tr class="navds-table__row navds-table__expandable-row navds-table__row--shade-on-hover">
+        <td class="navds-table__data-cell navds-table__toggle-expand-cell navds-body-short navds-body-short--medium">
+          <button
+            class="navds-table__toggle-expand-button"
+            type="button"
+            aria-controls="«r0»"
+            aria-expanded="false"
           >
-          </path>
-        </svg>
-      </button>
-    </td>
-    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-    </td>
-    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-      Q2 - Q3 2023
-    </td>
-    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-      <div class="faktura_status_wrapper">
-        <div class="dott green">
-        </div>
-        Bestilt
-      </div>
-    </td>
-    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-      -
-    </td>
-  </tr>
-  <tr
-    data-state="closed"
-    class="navds-table__expanded-row"
-    aria-hidden="true"
-    id="333"
-  >
-    <td
-      colspan="999"
-      class="navds-table__expanded-row-cell"
-    >
-      <div
-        class="navds-table__expanded-row-collapse"
-        style="height: 0px; overflow: hidden;"
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-labelledby="333"
+              class="navds-table__expandable-icon"
+            >
+              <title id="333">
+                Vis mer
+              </title>
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </button>
+        </td>
+        <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+        </td>
+        <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+          Q2 - Q3 2023
+        </td>
+        <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+          <div class="faktura_status_wrapper">
+            <div class="dott green">
+            </div>
+            Bestilt
+          </div>
+        </td>
+        <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+          -
+        </td>
+      </tr>
+      <tr
+        data-state="closed"
+        class="navds-table__expanded-row"
+        aria-hidden="true"
+        id="333"
       >
-        <div
-          aria-hidden="true"
-          class="navds-table__expanded-row-content navds-table__expanded-row-content--gutter-left"
-          style="display: none;"
+        <td
+          colspan="999"
+          class="navds-table__expanded-row-cell"
         >
-          <div class="fakturalinje">
-            <div class="fakturanr_wrapper">
-              Fakturanr:&nbsp;
-              <span class="kopierbar-tekst">
-                <span class="kopierbar-tekst__container">
-                  <button type="button">
-                    -
+          <div
+            class="navds-table__expanded-row-collapse"
+            style="height: 0px; overflow: hidden;"
+          >
+            <div
+              aria-hidden="true"
+              class="navds-table__expanded-row-content navds-table__expanded-row-content--gutter-left"
+              style="display: none;"
+            >
+              <div class="fakturalinje">
+                <div class="fakturanr_wrapper">
+                  Fakturanr:&nbsp;
+                  <span class="kopierbar-tekst">
+                    <span class="kopierbar-tekst__container">
+                      <button type="button">
+                        -
+                        <svg
+                          width="18"
+                          height="21"
+                          viewbox="0 0 18 21"
+                          fill="none"
+                          xmlns="http://www.w3.org/2000/svg"
+                          class="kopierbar-tekst__kopier-ikon"
+                        >
+                          <path
+                            fill-rule="evenodd"
+                            clip-rule="evenodd"
+                            d="M1 20.1729V5.51123H11.1504V20.1729H1Z"
+                            stroke="#3E3832"
+                            stroke-width="1.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                          </path>
+                          <path
+                            d="M6.63904 3.19925V1H16.7894V15.6617H14.2518"
+                            stroke="#3E3832"
+                            stroke-width="1.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                          </path>
+                        </svg>
+                      </button>
+                    </span>
+                  </span>
+                </div>
+                <div class="fakturalinje">
+                  <div class="navds-alert navds-alert--info navds-alert--small">
                     <svg
-                      width="18"
-                      height="21"
-                      viewbox="0 0 18 21"
-                      fill="none"
                       xmlns="http://www.w3.org/2000/svg"
-                      class="kopierbar-tekst__kopier-ikon"
+                      width="1em"
+                      height="1em"
+                      fill="none"
+                      viewbox="0 0 24 24"
+                      focusable="false"
+                      role="img"
+                      aria-labelledby="333"
+                      class="navds-alert__icon"
                     >
+                      <title id="333">
+                        Informasjon
+                      </title>
                       <path
+                        fill="currentColor"
                         fill-rule="evenodd"
+                        d="M3.25 4A.75.75 0 0 1 4 3.25h16a.75.75 0 0 1 .75.75v16a.75.75 0 0 1-.75.75H4a.75.75 0 0 1-.75-.75zM11 7.75a1 1 0 1 1 2 0 1 1 0 0 1-2 0m-1.25 3a.75.75 0 0 1 .75-.75H12a.75.75 0 0 1 .75.75v4.75h.75a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5h.75v-4h-.75a.75.75 0 0 1-.75-.75"
                         clip-rule="evenodd"
-                        d="M1 20.1729V5.51123H11.1504V20.1729H1Z"
-                        stroke="#3E3832"
-                        stroke-width="1.5"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      >
-                      </path>
-                      <path
-                        d="M6.63904 3.19925V1H16.7894V15.6617H14.2518"
-                        stroke="#3E3832"
-                        stroke-width="1.5"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
                       >
                       </path>
                     </svg>
-                  </button>
-                </span>
-              </span>
-            </div>
-            <div class="fakturalinje">
-              <div class="navds-alert navds-alert--info navds-alert--small">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="1em"
-                  height="1em"
-                  fill="none"
-                  viewbox="0 0 24 24"
-                  focusable="false"
-                  role="img"
-                  aria-labelledby="333"
-                  class="navds-alert__icon"
-                >
-                  <title id="333">
-                    Informasjon
-                  </title>
-                  <path
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                    d="M3.25 4A.75.75 0 0 1 4 3.25h16a.75.75 0 0 1 .75.75v16a.75.75 0 0 1-.75.75H4a.75.75 0 0 1-.75-.75zM11 7.75a1 1 0 1 1 2 0 1 1 0 0 1-2 0m-1.25 3a.75.75 0 0 1 .75-.75H12a.75.75 0 0 1 .75.75v4.75h.75a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5h.75v-4h-.75a.75.75 0 0 1-.75-.75"
-                    clip-rule="evenodd"
-                  >
-                  </path>
-                </svg>
-                <div class="navds-alert__wrapper navds-alert__wrapper--maxwidth navds-body-long navds-body-long--small">
-                  Fakturanummer er bare kjent i Melosys når det gjelder en manglende innbetaling, du kan likevel finne faktura i OeBS ved å søke på bruker
+                    <div class="navds-alert__wrapper navds-alert__wrapper--maxwidth navds-body-long navds-body-long--small">
+                      Fakturanummer er bare kjent i Melosys når det gjelder en manglende innbetaling, du kan likevel finne faktura i OeBS ved å søke på bruker
+                    </div>
+                  </div>
                 </div>
+                <table class="navds-table navds-table--small">
+                  <thead class="navds-table__header">
+                    <tr class="navds-table__row">
+                      <th
+                        class="navds-table__header-cell navds-label navds-label--small"
+                        scope="col"
+                      >
+                      </th>
+                      <th
+                        class="navds-table__header-cell navds-label navds-label--small"
+                        scope="col"
+                      >
+                        Antall
+                      </th>
+                      <th
+                        class="navds-table__header-cell navds-label navds-label--small"
+                        scope="col"
+                      >
+                        Enhetspris
+                      </th>
+                      <th
+                        class="navds-table__header-cell navds-label navds-label--small"
+                        scope="col"
+                      >
+                        Beløp
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody class="navds-table__body">
+                  </tbody>
+                </table>
               </div>
             </div>
-            <table class="navds-table navds-table--small">
-              <thead class="navds-table__header">
-                <tr class="navds-table__row">
-                  <th
-                    class="navds-table__header-cell navds-label navds-label--small"
-                    scope="col"
-                  >
-                  </th>
-                  <th
-                    class="navds-table__header-cell navds-label navds-label--small"
-                    scope="col"
-                  >
-                    Antall
-                  </th>
-                  <th
-                    class="navds-table__header-cell navds-label navds-label--small"
-                    scope="col"
-                  >
-                    Enhetspris
-                  </th>
-                  <th
-                    class="navds-table__header-cell navds-label navds-label--small"
-                    scope="col"
-                  >
-                    Beløp
-                  </th>
-                </tr>
-              </thead>
-              <tbody class="navds-table__body">
-              </tbody>
-            </table>
           </div>
-        </div>
-      </div>
-    </td>
-  </tr>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 
 `;

--- a/src/felleskomponenter/menypanel/menypunkter/fakturainformasjon/faktura.test.jsx
+++ b/src/felleskomponenter/menypanel/menypunkter/fakturainformasjon/faktura.test.jsx
@@ -18,7 +18,13 @@ describe("Faktura", () => {
   });
 
   it("snapshot test", () => {
-    const { container } = renderWithProviders(<Faktura {...props} />);
+    const { container } = renderWithProviders(
+      <table>
+        <tbody>
+          <Faktura {...props} />
+        </tbody>
+      </table>,
+    );
 
     expect(container).toMatchSnapshot();
   });

--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personinfo.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personinfo.test.tsx
@@ -19,7 +19,7 @@ describe("Personinfo", () => {
       };
     };
 
-  const initialState = { landkoder: { status: "OK", data: [{ kode: "NO", term: "Norge" }] } };
+  const preloadedState = { landkoder: { status: "OK", data: [{ kode: "NO", term: "Norge" }] } };
 
   let props: ComponentProps<typeof Personinfo>;
 
@@ -80,63 +80,109 @@ describe("Personinfo", () => {
     },
   ];
 
-  const requestResultMock = {
-    mocks: [
+  const createMocks = (shouldError = false) => {
+    const personinfoData = {
+      folkeregisterpersonstatuser: personstatus,
+      foedsel: {
+        foedeland: "NO",
+        foedested: "Aker sykehus",
+        foedselsaar: 1995,
+        foedselsdato: "1995-09-23",
+      },
+      sivilstand,
+    };
+
+    const personopplysningerData = {
+      navn: {
+        fornavn: "Kent",
+        mellomnavn: "C",
+        etternavn: "Dodds",
+      },
+      kjoenn: "",
+      folkeregisterpersonstatuser: [],
+      folkeregisteridentifikator: "123",
+      statsborgerskap: [],
+      sivilstand: [],
+    };
+
+    const mocks = [
       {
         request: {
           query: HentPersoninfoDocument,
-          variables: {
-            behandlingID: 1,
-          },
+          variables: { behandlingID: 1 },
         },
-        result: {
-          data: {
-            hentSaksopplysninger: {
-              persondata: {
-                folkeregisterpersonstatuser: personstatus,
-                foedested: [{ foedested: "Aker sykehus", foedeland: "NO" }],
-                foedselsdato: [{ foedselsaar: 1995, foedselsdato: "1995-23-09" }],
-                sivilstand,
+        ...(shouldError
+          ? { error: new Error("feil") }
+          : {
+              result: {
+                data: {
+                  hentSaksopplysninger: {
+                    persondata: personinfoData,
+                  },
+                },
               },
-            },
-          },
-        },
+            }),
       },
       {
         request: {
           query: HentPersonopplysningerDocument,
-          variables: {
-            behandlingID: 1,
-          },
+          variables: { behandlingID: 1 },
         },
-        result: {
-          data: {
-            hentSaksopplysninger: {
-              persondata: {
-                navn: {
-                  fornavn: "Kent",
-                  mellomnavn: "C",
-                  etternavn: "Dodds",
+        ...(shouldError
+          ? { error: new Error("feil") }
+          : {
+              result: {
+                data: {
+                  hentSaksopplysninger: {
+                    persondata: personopplysningerData,
+                  },
                 },
-                kjoenn: "",
-                folkeregisterpersonstatuser: [],
-                folkeregisteridentifikator: "123",
-                statsborgerskap: [],
-                sivilstand: [],
+              },
+            }),
+      },
+    ];
+
+    // Legg til flere kopier for å håndtere multiple kall
+    if (!shouldError) {
+      mocks.push(
+        {
+          request: {
+            query: HentPersonopplysningerDocument,
+            variables: { behandlingID: 1 },
+          },
+          result: {
+            data: {
+              hentSaksopplysninger: {
+                persondata: personopplysningerData,
               },
             },
           },
         },
-      },
-    ],
+        {
+          request: {
+            query: HentPersoninfoDocument,
+            variables: { behandlingID: 1 },
+          },
+          result: {
+            data: {
+              hentSaksopplysninger: {
+                persondata: personinfoData,
+              },
+            },
+          },
+        },
+      );
+    }
+
+    return mocks;
   };
 
   it("viser melding ved henting av personinfo", () => {
     renderWithProviders(
-      <MockedProvider {...requestResultMock}>
+      <MockedProvider mocks={createMocks()} addTypename={false}>
         <Personinfo {...props} />
       </MockedProvider>,
-      { preloadedState: { initialState } },
+      { preloadedState },
     );
 
     expect(screen.getByText("Henter personinfo...")).toBeInTheDocument();
@@ -144,31 +190,10 @@ describe("Personinfo", () => {
 
   it("viser melding ved nettverkserror under henting av personinfo", async () => {
     await renderWithProvidersAsync(
-      <MockedProvider
-        mocks={[
-          {
-            request: {
-              query: HentPersoninfoDocument,
-              variables: {
-                behandlingID: 1,
-              },
-            },
-            error: new Error("feil"),
-          },
-          {
-            request: {
-              query: HentPersonopplysningerDocument,
-              variables: {
-                behandlingID: 1,
-              },
-            },
-            error: new Error("feil"),
-          },
-        ]}
-      >
+      <MockedProvider mocks={createMocks(true)} addTypename={false}>
         <Personinfo {...props} />
       </MockedProvider>,
-      { preloadedState: { initialState } },
+      { preloadedState },
     );
 
     await waitFor(() => {
@@ -178,10 +203,10 @@ describe("Personinfo", () => {
 
   it("sender sivilstand-data til sivilstandModal etter dataen er hentet", async () => {
     renderWithProviders(
-      <MockedProvider {...requestResultMock}>
+      <MockedProvider mocks={createMocks()} addTypename={false}>
         <Personinfo {...props} />
       </MockedProvider>,
-      { preloadedState: { initialState } },
+      { preloadedState },
     );
 
     const user = userEvent.setup();
@@ -200,10 +225,10 @@ describe("Personinfo", () => {
 
   it("sender personstatus-data til personstatusModal etter dataen er hentet", async () => {
     await renderWithProvidersAsync(
-      <MockedProvider {...requestResultMock}>
+      <MockedProvider mocks={createMocks()} addTypename={false}>
         <Personinfo {...props} />
       </MockedProvider>,
-      { preloadedState: { initialState } },
+      { preloadedState },
     );
 
     const user = userEvent.setup();

--- a/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personinfo.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/person/personinfo/personinfo.test.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 import { HentPersoninfoDocument } from "./hentPersoninfo.generated";
 import Personinfo from "./personinfo";
 import { HentPersonopplysningerDocument } from "../../../../informasjonlinje/hentpersonopplysninger.generated";
-import { renderWithProviders } from "../../../../../ducks/test-utils/renderWithProviders";
+import { renderWithProviders, renderWithProvidersAsync } from "../../../../../ducks/test-utils/renderWithProviders";
 
 describe("Personinfo", () => {
   window.matchMedia =
@@ -143,7 +143,7 @@ describe("Personinfo", () => {
   });
 
   it("viser melding ved nettverkserror under henting av personinfo", async () => {
-    renderWithProviders(
+    await renderWithProvidersAsync(
       <MockedProvider
         mocks={[
           {
@@ -199,7 +199,7 @@ describe("Personinfo", () => {
   });
 
   it("sender personstatus-data til personstatusModal etter dataen er hentet", async () => {
-    renderWithProviders(
+    await renderWithProvidersAsync(
       <MockedProvider {...requestResultMock}>
         <Personinfo {...props} />
       </MockedProvider>,

--- a/src/felleskomponenter/multiSelect/multiSelect.test.tsx
+++ b/src/felleskomponenter/multiSelect/multiSelect.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react";
 import MultiSelect from "./multiSelect";
-import { renderWithProviders } from "../../ducks/test-utils/renderWithProviders";
+import { renderWithProviders, renderWithProvidersAsync } from "../../ducks/test-utils/renderWithProviders";
 
 const props = {
   label: "Label",
@@ -15,7 +15,7 @@ const props = {
 
 describe("MultiSelect", () => {
   it("Props er satt", async () => {
-    renderWithProviders(<MultiSelect {...props} />);
+    await renderWithProvidersAsync(<MultiSelect {...props} />);
 
     const select = screen.getByRole("combobox");
     fireEvent.mouseDown(select);

--- a/src/felleskomponenter/skjema/input/__snapshots__/input.test.jsx.snap
+++ b/src/felleskomponenter/skjema/input/__snapshots__/input.test.jsx.snap
@@ -12,8 +12,6 @@ exports[`Input > snapshot test 1`] = `
     </label>
     <input
       meta="[object Object]"
-      array="[object Object]"
-      form="test"
       navn="Test"
       id="333"
       class="navds-text-field__input navds-body-short navds-body-short--small"

--- a/src/felleskomponenter/skjema/input/input.test.jsx
+++ b/src/felleskomponenter/skjema/input/input.test.jsx
@@ -1,37 +1,19 @@
 import Input from "./input";
-import { reduxForm } from "redux-form";
+import { reduxForm, Field } from "redux-form";
 import { renderWithProviders } from "../../../ducks/test-utils/renderWithProviders";
 
-const WrappedInput = reduxForm({ form: "test" })(Input);
+const TestForm = reduxForm({ form: "test" })(() => (
+  <Field name="testField" component={Input} label="test" feltNavn="Test" navn="Test" />
+));
 
 describe("Input", () => {
-  let props = null;
-
-  beforeEach(() => {
-    props = {
-      label: "test",
-      meta: {
-        error: "",
-        touched: false,
-        active: true,
-      },
-      feltNavn: "Test",
-      navn: "Test",
-    };
-  });
-
   it("snapshot test", () => {
-    const { container } = renderWithProviders(<WrappedInput {...props} />);
+    const { container } = renderWithProviders(<TestForm />);
     expect(container).toMatchSnapshot();
   });
 
   it("viser ikke feilmelding", () => {
-    props.meta = {
-      error: "",
-      touched: true,
-      active: false,
-    };
-    const { queryByText } = renderWithProviders(<WrappedInput {...props} />);
+    const { queryByText } = renderWithProviders(<TestForm />);
     expect(queryByText("feilmelding")).not.toBeInTheDocument();
   });
 });

--- a/src/felleskomponenter/vedleggTable/__snapshots__/fritekstvedleggRow.test.tsx.snap
+++ b/src/felleskomponenter/vedleggTable/__snapshots__/fritekstvedleggRow.test.tsx.snap
@@ -3,105 +3,74 @@
 exports[`fritekstvedleggRow > snapshot test 1`] = `
 
 <div>
-  <tr class="navds-table__row navds-table__row--shade-on-hover">
-    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-      <a
-        href="#"
-        class="navds-link navds-link--action"
-      >
-        a
-      </a>
-    </td>
-    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-    </td>
-    <td class="navds-table__data-cell icon__cell navds-body-short navds-body-short--small">
-      <button
-        type="button"
-        aria-label="Rediger vedlegg"
-        title="Rediger vedlegg"
-        class="ikon-knapp navds-button navds-button--tertiary navds-button--small navds-button--icon-only"
-      >
-        <span class="navds-button__icon">
-          <svg
-            width="24"
-            height="24"
-            viewbox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            class="ikon"
+  <table>
+    <tbody>
+      <tr class="navds-table__row navds-table__row--shade-on-hover">
+        <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+          <a
+            href="#"
+            class="navds-link navds-link--action"
           >
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M22.8353 1.16464C24.3882 2.7175 24.3882 5.23518 22.8353 6.78804L8.07288 21.5494L0.682007 24L0 23.318L2.44911 15.926L17.2115 1.16464C18.7645 -0.388214 21.2823 -0.388214 22.8353 1.16464ZM18.6175 8.19388L15.8056 5.38219L4.18826 16.9987L2.79497 21.2036L7.00155 19.809L18.6175 8.19388ZM21.4293 2.57049C20.6882 1.82935 19.5074 1.79567 18.7262 2.46943L18.6175 2.57049L17.2115 3.97634L20.0234 6.78804L21.4293 5.38219C22.1705 4.64105 22.2042 3.46036 21.5304 2.67927L21.4293 2.57049Z"
-              fill="#0067C5"
-            >
-            </path>
-          </svg>
-        </span>
-      </button>
-      <button
-        type="button"
-        aria-label="Slett vedlegg"
-        title="Slett vedlegg"
-        class="ikon-knapp navds-button navds-button--tertiary navds-button--small navds-button--icon-only"
-      >
-        <span class="navds-button__icon">
-          <svg
-            width="22"
-            height="24"
-            viewbox="0 0 22 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            class="ikon"
+            a
+          </a>
+        </td>
+        <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+        </td>
+        <td class="navds-table__data-cell icon__cell navds-body-short navds-body-short--small">
+          <button
+            type="button"
+            aria-label="Rediger vedlegg"
+            title="Rediger vedlegg"
+            class="ikon-knapp navds-button navds-button--tertiary navds-button--small navds-button--icon-only"
           >
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M11 0C13.4189 0 15.4366 1.71767 15.8999 3.99981L22 4V6H20V20C20 22.2091 18.2091 24 16 24H6C3.79086 24 2 22.2091 2 20V6H0V4L6.10006 3.99981C6.5634 1.71767 8.58111 0 11 0ZM8.17004 4H8.66856H8.70601H9.26735H12.7327H13.2598H13.3079H13.829L13.7533 3.80669C13.6245 3.50979 13.449 3.23782 13.2362 3C12.7661 2.47481 12.1137 2.11621 11.3786 2.02365L11.1763 2.00509L11 2C10.1115 2 9.31326 2.38625 8.76394 3C8.54865 3.24054 8.3716 3.51603 8.24235 3.8169L8.17004 4ZM4 6H18V20L17.9945 20.1493C17.9182 21.1841 17.0544 22 16 22H6L5.85074 21.9945C4.81588 21.9182 4 21.0544 4 20V6ZM9 9V19H7V9H9ZM15 9V19H13V9H15Z"
-              fill="#0067C5"
-            >
-            </path>
-          </svg>
-        </span>
-      </button>
-    </td>
-    <dialog
-      class="navds-modal navds-modal--polyfilled navds-modal--autowidth"
-      aria-labelledby="333"
-      role="dialog"
-    >
-      <div class="navds-modal__header">
-        <h1
-          id="333"
-          class="navds-heading navds-heading--medium"
-        >
-          Slett fritekstvedlegg?
-        </h1>
-      </div>
-      <div class="navds-modal__body">
-        <p class="navds-body-long navds-body-long--small">
-          Er du sikker på at du vil slette fritekstvedlegget?
-          <br>
-          Dokumentet vil bli permanent slettet fra Melosys
-        </p>
-      </div>
-      <div class="navds-modal__footer">
-        <div class="container__knapperad">
-          <button class="navds-button navds-button--primary navds-button--small">
-            <span class="navds-label navds-label--small">
-              Ja, slett
+            <span class="navds-button__icon">
+              <svg
+                width="24"
+                height="24"
+                viewbox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="ikon"
+              >
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M22.8353 1.16464C24.3882 2.7175 24.3882 5.23518 22.8353 6.78804L8.07288 21.5494L0.682007 24L0 23.318L2.44911 15.926L17.2115 1.16464C18.7645 -0.388214 21.2823 -0.388214 22.8353 1.16464ZM18.6175 8.19388L15.8056 5.38219L4.18826 16.9987L2.79497 21.2036L7.00155 19.809L18.6175 8.19388ZM21.4293 2.57049C20.6882 1.82935 19.5074 1.79567 18.7262 2.46943L18.6175 2.57049L17.2115 3.97634L20.0234 6.78804L21.4293 5.38219C22.1705 4.64105 22.2042 3.46036 21.5304 2.67927L21.4293 2.57049Z"
+                  fill="#0067C5"
+                >
+                </path>
+              </svg>
             </span>
           </button>
-          <button class="navds-button navds-button--tertiary navds-button--small">
-            <span class="navds-label navds-label--small">
-              Avbryt
+          <button
+            type="button"
+            aria-label="Slett vedlegg"
+            title="Slett vedlegg"
+            class="ikon-knapp navds-button navds-button--tertiary navds-button--small navds-button--icon-only"
+          >
+            <span class="navds-button__icon">
+              <svg
+                width="22"
+                height="24"
+                viewbox="0 0 22 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="ikon"
+              >
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M11 0C13.4189 0 15.4366 1.71767 15.8999 3.99981L22 4V6H20V20C20 22.2091 18.2091 24 16 24H6C3.79086 24 2 22.2091 2 20V6H0V4L6.10006 3.99981C6.5634 1.71767 8.58111 0 11 0ZM8.17004 4H8.66856H8.70601H9.26735H12.7327H13.2598H13.3079H13.829L13.7533 3.80669C13.6245 3.50979 13.449 3.23782 13.2362 3C12.7661 2.47481 12.1137 2.11621 11.3786 2.02365L11.1763 2.00509L11 2C10.1115 2 9.31326 2.38625 8.76394 3C8.54865 3.24054 8.3716 3.51603 8.24235 3.8169L8.17004 4ZM4 6H18V20L17.9945 20.1493C17.9182 21.1841 17.0544 22 16 22H6L5.85074 21.9945C4.81588 21.9182 4 21.0544 4 20V6ZM9 9V19H7V9H9ZM15 9V19H13V9H15Z"
+                  fill="#0067C5"
+                >
+                </path>
+              </svg>
             </span>
           </button>
-        </div>
-      </div>
-    </dialog>
-  </tr>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 
 `;

--- a/src/felleskomponenter/vedleggTable/__snapshots__/vedleggRow.test.tsx.snap
+++ b/src/felleskomponenter/vedleggTable/__snapshots__/vedleggRow.test.tsx.snap
@@ -3,47 +3,51 @@
 exports[`vedleggRow > snapshot test 1`] = `
 
 <div>
-  <tr class="navds-table__row vedlegg navds-table__row--shade-on-hover">
-    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-      <a
-        href="#"
-        class="navds-link navds-link--action"
-      >
-        test (åpnes i ny fane)
-      </a>
-    </td>
-    <td class="navds-table__data-cell navds-body-short navds-body-short--small">
-      <span>
-      </span>
-    </td>
-    <td class="navds-table__data-cell icon__cell navds-body-short navds-body-short--small">
-      <button
-        type="button"
-        aria-label="Fjern vedlegg"
-        title="Fjern vedlegg"
-        class="ikon-knapp navds-button navds-button--tertiary navds-button--small navds-button--icon-only"
-      >
-        <span class="navds-button__icon">
-          <svg
-            width="22"
-            height="24"
-            viewbox="0 0 22 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            class="ikon"
+  <table>
+    <tbody>
+      <tr class="navds-table__row vedlegg navds-table__row--shade-on-hover">
+        <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+          <a
+            href="#"
+            class="navds-link navds-link--action"
           >
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M11 0C13.4189 0 15.4366 1.71767 15.8999 3.99981L22 4V6H20V20C20 22.2091 18.2091 24 16 24H6C3.79086 24 2 22.2091 2 20V6H0V4L6.10006 3.99981C6.5634 1.71767 8.58111 0 11 0ZM8.17004 4H8.66856H8.70601H9.26735H12.7327H13.2598H13.3079H13.829L13.7533 3.80669C13.6245 3.50979 13.449 3.23782 13.2362 3C12.7661 2.47481 12.1137 2.11621 11.3786 2.02365L11.1763 2.00509L11 2C10.1115 2 9.31326 2.38625 8.76394 3C8.54865 3.24054 8.3716 3.51603 8.24235 3.8169L8.17004 4ZM4 6H18V20L17.9945 20.1493C17.9182 21.1841 17.0544 22 16 22H6L5.85074 21.9945C4.81588 21.9182 4 21.0544 4 20V6ZM9 9V19H7V9H9ZM15 9V19H13V9H15Z"
-              fill="#0067C5"
-            >
-            </path>
-          </svg>
-        </span>
-      </button>
-    </td>
-  </tr>
+            test (åpnes i ny fane)
+          </a>
+        </td>
+        <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+          <span>
+          </span>
+        </td>
+        <td class="navds-table__data-cell icon__cell navds-body-short navds-body-short--small">
+          <button
+            type="button"
+            aria-label="Fjern vedlegg"
+            title="Fjern vedlegg"
+            class="ikon-knapp navds-button navds-button--tertiary navds-button--small navds-button--icon-only"
+          >
+            <span class="navds-button__icon">
+              <svg
+                width="22"
+                height="24"
+                viewbox="0 0 22 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="ikon"
+              >
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M11 0C13.4189 0 15.4366 1.71767 15.8999 3.99981L22 4V6H20V20C20 22.2091 18.2091 24 16 24H6C3.79086 24 2 22.2091 2 20V6H0V4L6.10006 3.99981C6.5634 1.71767 8.58111 0 11 0ZM8.17004 4H8.66856H8.70601H9.26735H12.7327H13.2598H13.3079H13.829L13.7533 3.80669C13.6245 3.50979 13.449 3.23782 13.2362 3C12.7661 2.47481 12.1137 2.11621 11.3786 2.02365L11.1763 2.00509L11 2C10.1115 2 9.31326 2.38625 8.76394 3C8.54865 3.24054 8.3716 3.51603 8.24235 3.8169L8.17004 4ZM4 6H18V20L17.9945 20.1493C17.9182 21.1841 17.0544 22 16 22H6L5.85074 21.9945C4.81588 21.9182 4 21.0544 4 20V6ZM9 9V19H7V9H9ZM15 9V19H13V9H15Z"
+                  fill="#0067C5"
+                >
+                </path>
+              </svg>
+            </span>
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 
 `;

--- a/src/felleskomponenter/vedleggTable/__snapshots__/vedleggTable.test.tsx.snap
+++ b/src/felleskomponenter/vedleggTable/__snapshots__/vedleggTable.test.tsx.snap
@@ -79,41 +79,6 @@ exports[`vedleggTable > snapshot test 1`] = `
             </span>
           </button>
         </td>
-        <dialog
-          class="navds-modal navds-modal--polyfilled navds-modal--autowidth"
-          aria-labelledby="333"
-          role="dialog"
-        >
-          <div class="navds-modal__header">
-            <h1
-              id="333"
-              class="navds-heading navds-heading--medium"
-            >
-              Slett fritekstvedlegg?
-            </h1>
-          </div>
-          <div class="navds-modal__body">
-            <p class="navds-body-long navds-body-long--small">
-              Er du sikker på at du vil slette fritekstvedlegget?
-              <br>
-              Dokumentet vil bli permanent slettet fra Melosys
-            </p>
-          </div>
-          <div class="navds-modal__footer">
-            <div class="container__knapperad">
-              <button class="navds-button navds-button--primary navds-button--small">
-                <span class="navds-label navds-label--small">
-                  Ja, slett
-                </span>
-              </button>
-              <button class="navds-button navds-button--tertiary navds-button--small">
-                <span class="navds-label navds-label--small">
-                  Avbryt
-                </span>
-              </button>
-            </div>
-          </div>
-        </dialog>
       </tr>
       <tr class="navds-table__row vedlegg navds-table__row--shade-on-hover">
         <td class="navds-table__data-cell navds-body-short navds-body-short--small">

--- a/src/felleskomponenter/vedleggTable/fritekstvedleggRow.test.tsx
+++ b/src/felleskomponenter/vedleggTable/fritekstvedleggRow.test.tsx
@@ -1,17 +1,28 @@
 import FritekstvedleggRow from "./fritekstvedleggRow";
 import { render } from "@testing-library/react";
+import React from "react";
+
+// Mock the modal component to avoid HTML structure issues in tests
+vi.mock("./slettFritekstvedleggModal", () => ({
+  default: ({ open, children }: { open: boolean; children?: React.ReactNode }) =>
+    open ? <div data-testid="mocked-modal">{children}</div> : null,
+}));
 
 describe("fritekstvedleggRow", () => {
   it("snapshot test", () => {
     const { container } = render(
-      <FritekstvedleggRow
-        fritekstvedlegg={{ tittel: "a", fritekst: "b" }}
-        slettFritekstvedlegg={vi.fn()}
-        redigerFritekstvedlegg={vi.fn()}
-        index={1}
-        lagFritekstPdfUrl={vi.fn()}
-        redigerbart
-      />,
+      <table>
+        <tbody>
+          <FritekstvedleggRow
+            fritekstvedlegg={{ tittel: "a", fritekst: "b" }}
+            slettFritekstvedlegg={vi.fn()}
+            redigerFritekstvedlegg={vi.fn()}
+            index={1}
+            lagFritekstPdfUrl={vi.fn()}
+            redigerbart
+          />
+        </tbody>
+      </table>,
     );
     expect(container).toMatchSnapshot();
   });

--- a/src/felleskomponenter/vedleggTable/vedleggRow.test.tsx
+++ b/src/felleskomponenter/vedleggTable/vedleggRow.test.tsx
@@ -13,7 +13,13 @@ const dokument = {
 
 describe("vedleggRow", () => {
   it("snapshot test", () => {
-    const { container } = render(<VedleggRow slettVedlegg={vi.fn()} vedlegg={dokument} redigerbart />);
+    const { container } = render(
+      <table>
+        <tbody>
+          <VedleggRow slettVedlegg={vi.fn()} vedlegg={dokument} redigerbart />
+        </tbody>
+      </table>,
+    );
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/felleskomponenter/vedleggTable/vedleggTable.test.tsx
+++ b/src/felleskomponenter/vedleggTable/vedleggTable.test.tsx
@@ -1,6 +1,12 @@
 import VedleggTable from "./vedleggTable";
 import { render } from "@testing-library/react";
 
+// Mock the modal component to avoid HTML structure issues in tests
+vi.mock("./slettFritekstvedleggModal", () => ({
+  default: ({ open, children }: { open: boolean; children?: React.ReactNode }) =>
+    open ? <div data-testid="mocked-modal">{children}</div> : null,
+}));
+
 const dokument = {
   dokumentID: "1",
   tittel: "test",

--- a/src/felleskomponenter/vedleggvelger/vedleggVelger.test.tsx
+++ b/src/felleskomponenter/vedleggvelger/vedleggVelger.test.tsx
@@ -4,6 +4,11 @@ import VedleggVelger from "./vedleggVelger";
 import VedleggVelgerModal from "./vedleggVelgerModal";
 import { render, screen } from "@testing-library/react";
 
+// Mock the table component to avoid HTML structure issues in tests
+vi.mock("./vedleggVelgerTable", () => ({
+  default: () => <div data-testid="mocked-vedlegg-velger-table">Mocked VedleggVelgerTable</div>,
+}));
+
 describe("VedleggVelger", () => {
   let props: ComponentProps<typeof VedleggVelger>;
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,7 +1,9 @@
 import createFetchMock from "vitest-fetch-mock";
 import * as matchers from "@testing-library/jest-dom";
-import { vi, expect } from "vitest";
+import { expect, vi } from "vitest";
 import toDiffableHtml from "diffable-html";
+// Oppsettfilen for Yup kjøres ikke uten videre av vi. Derfor er det nødvendig å importere den manuelt her.
+import "./setupYup";
 
 expect.extend(matchers);
 
@@ -15,12 +17,23 @@ expect.addSnapshotSerializer({
   },
 });
 
-// Oppsettfilen for Yup kjøres ikke uten videre av vi. Derfor er det nødvendig å importere den manuelt her.
-import "./setupYup";
-
 const fetchMocker = createFetchMock(vi);
 // sets globalThis.fetch and globalThis.fetchMock to our mocked version
 fetchMocker.enableMocks();
+// Standard fallback for alle unmocked requests
+fetchMocker.mockResponse((req) => {
+  // eslint-disable-next-line no-console
+  console.warn(`🔍 Unmocked fetch request:
+    🧪 Test: ${expect.getState().currentTestName || "Unknown test"}
+    🌐 URL: ${req.url}
+    📋 Method: ${req.method}`);
+
+  return Promise.resolve({
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+});
 
 global.window.env = {
   APP_NAME: "IKKE_VIKTIG",

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { VurderingVedtak } from "./vurderingVedtak";
-import { renderWithProviders } from "../../../../ducks/test-utils/renderWithProviders";
+import { renderWithProvidersAsync } from "../../../../ducks/test-utils/renderWithProviders";
 import MKV from "../../../../melosyskodeverk";
 import * as Api from "../../../../services/api";
 
@@ -146,7 +146,7 @@ describe("VurderingVedtak", () => {
       },
     };
 
-    const { container } = renderWithProviders(<VurderingVedtak {...mockProps} />, {
+    const { container } = await renderWithProvidersAsync(<VurderingVedtak {...mockProps} />, {
       preloadedState: initialReduxState,
     });
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.test.tsx
@@ -4,6 +4,11 @@ import { renderWithProvidersAsync } from "../../../../ducks/test-utils/renderWit
 import MKV from "../../../../melosyskodeverk";
 import * as Api from "../../../../services/api";
 
+Object.defineProperty(window, "scrollTo", {
+  value: vi.fn(),
+  writable: true,
+});
+
 // Mock only the API calls to prevent network requests
 vi.mock("../../../../services/api", () => ({
   Aarsavregning: {

--- a/src/sider/journalforing/komponenter/journalforingform/journalforingform.test.jsx
+++ b/src/sider/journalforing/komponenter/journalforingform/journalforingform.test.jsx
@@ -1,7 +1,7 @@
 import MKV from "../../../../melosyskodeverk";
 
 import Journalforingform from "./journalforingform";
-import { renderWithProviders } from "../../../../ducks/test-utils/renderWithProviders";
+import { renderWithProviders, renderWithProvidersAsync } from "../../../../ducks/test-utils/renderWithProviders";
 import { testReduxState } from "./testReduxState";
 import userEvent from "@testing-library/user-event";
 import { fireEvent, queryByAttribute } from "@testing-library/react";
@@ -198,7 +198,7 @@ describe("JournalforingForm", () => {
   });
 
   it("skalTilordnes vises før vi velger sak", async () => {
-    const { getByLabelText } = renderWithProviders(<Journalforingform {...props} />, {
+    const { getByLabelText } = await renderWithProvidersAsync(<Journalforingform {...props} />, {
       preloadedState: testReduxState,
     });
 

--- a/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
@@ -157,6 +157,9 @@ describe("KnyttTilSak", () => {
   });
 
   it("håndterer feil ved henting av behandlingstyper", async () => {
+    // Suppress console.error for denne spesifikke testen, siden det er feilhåndtering som testes
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
     mocks.hentBehandlingstyperForKnyttTilSak.mockRejectedValueOnce(new Error("API Error"));
     props.formValues.behandlingstema = "YRKESAKTIV";
     props.formValues.opprettBehandling = true;
@@ -170,5 +173,8 @@ describe("KnyttTilSak", () => {
         expect(within(behandlingstypeGroup).queryAllByRole("radio")).toHaveLength(0);
       }
     });
+
+    // Restore console.error
+    consoleSpy.mockRestore();
   });
 });

--- a/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.test.jsx
@@ -1,7 +1,7 @@
 import { JournalforingValues } from "../../../kodeverk/form";
 import MKV from "../../../melosyskodeverk";
 import { KnyttTilSak } from "./knyttTilSak";
-import { renderWithProviders } from "../../../ducks/test-utils/renderWithProviders";
+import { renderWithProvidersAsync } from "../../../ducks/test-utils/renderWithProviders";
 import { screen, waitFor, within } from "@testing-library/react";
 import { reduxForm } from "redux-form";
 
@@ -58,10 +58,10 @@ describe("KnyttTilSak", () => {
 
   const WrappedKnyttTilSak = reduxForm({ form: "test" })(KnyttTilSak);
 
-  it(`Vis komponent for knytte til eksisterende sak komponent og knapper for å opprette ny behandling dersom siste behandling er inaktiv`, () => {
+  it(`Vis komponent for knytte til eksisterende sak komponent og knapper for å opprette ny behandling dersom siste behandling er inaktiv`, async () => {
     props.sak.behandlingOversikter[0].behandlingsstatus = { kode: MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET };
 
-    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+    await renderWithProvidersAsync(<WrappedKnyttTilSak {...props} />);
 
     expect(screen.getByText("Tidligere behandling er avsluttet.")).toBeInTheDocument();
     expect(screen.getByText("Velg hva du vil gjøre med dokumentet")).toBeInTheDocument();
@@ -76,42 +76,42 @@ describe("KnyttTilSak", () => {
       kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
     };
 
-    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+    renderWithProvidersAsync(<WrappedKnyttTilSak {...props} />);
 
     expect(screen.queryByText("Velg hva du vil gjøre med dokumentet")).toBeNull();
     expect(screen.queryByRole("group")).toBeNull();
   });
 
-  it(`Ikke vis knytt til eksisterende sak komponent dersom status er henlagt`, () => {
+  it(`Ikke vis knytt til eksisterende sak komponent dersom status er henlagt`, async () => {
     props.sak.saksstatus.kode = MKV.Koder.saksstatuser.HENLAGT;
     props.erJournalføring = false;
 
-    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+    await renderWithProvidersAsync(<WrappedKnyttTilSak {...props} />);
 
     expect(screen.queryByText("Velg hva du vil gjøre med dokumentet")).toBeNull();
     expect(screen.queryByRole("group")).toBeNull();
     expect(screen.getByText(/Du kan ikke opprette en ny behandling/i)).toBeInTheDocument();
   });
 
-  it(`Vis vurder dokument dersom man er i journalføring-kontekst`, () => {
+  it(`Vis vurder dokument dersom man er i journalføring-kontekst`, async () => {
     props.sak.behandlingOversikter[0].behandlingsstatus = {
       kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
     };
     props.erJournalføring = true;
 
-    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+    await renderWithProvidersAsync(<WrappedKnyttTilSak {...props} />);
 
     expect(screen.getByRole("checkbox")).toBeInTheDocument();
     expect(screen.getByText(`Oppdater behandlingsstatus til "Vurder dokument"`)).toBeInTheDocument();
   });
 
-  it(`Ikke vis vurder dokument dersom man er i opprett ny sak/behandling-kontekst`, () => {
+  it(`Ikke vis vurder dokument dersom man er i opprett ny sak/behandling-kontekst`, async () => {
     props.sak.behandlingOversikter[0].behandlingsstatus = {
       kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
     };
     props.erJournalføring = false;
 
-    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+    await renderWithProvidersAsync(<WrappedKnyttTilSak {...props} />);
 
     expect(screen.queryByRole("checkbox")).toBeNull();
     expect(screen.queryByText(`Oppdater behandlingsstatus til "Vurder dokument"`)).toBeNull();
@@ -124,7 +124,7 @@ describe("KnyttTilSak", () => {
       kode: MKV.Koder.behandlinger.behandlingsstatus.UNDER_BEHANDLING,
     };
 
-    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+    await renderWithProvidersAsync(<WrappedKnyttTilSak {...props} />);
 
     await waitFor(() => expect(mocks.hent).toHaveBeenCalledOnce());
     expect(screen.getByText(/Hvis du har mottatt svar på anmodning om unntak skal du/i)).toBeInTheDocument();
@@ -134,7 +134,7 @@ describe("KnyttTilSak", () => {
     mocks.hent.mockReturnValueOnce({ anmodningsperioder: [{ sendtUtland: true }] });
     props.sak.behandlingOversikter[0].behandlingsstatus = { kode: MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET };
 
-    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+    await renderWithProvidersAsync(<WrappedKnyttTilSak {...props} />);
 
     await waitFor(() => expect(mocks.hent).toHaveBeenCalledOnce());
     expect(screen.queryByText(/Hvis du har mottatt svar på anmodning om unntak skal du/i)).toBeNull();
@@ -145,7 +145,7 @@ describe("KnyttTilSak", () => {
     props.formValues.behandlingstema = "YRKESAKTIV";
     props.formValues.opprettBehandling = true;
 
-    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+    await renderWithProvidersAsync(<WrappedKnyttTilSak {...props} />);
 
     await waitFor(() => expect(mocks.hentBehandlingstyperForKnyttTilSak).toHaveBeenCalled());
     expect(screen.getByText("Behandlingstype")).toBeInTheDocument();
@@ -161,7 +161,7 @@ describe("KnyttTilSak", () => {
     props.formValues.behandlingstema = "YRKESAKTIV";
     props.formValues.opprettBehandling = true;
 
-    renderWithProviders(<WrappedKnyttTilSak {...props} />);
+    await renderWithProvidersAsync(<WrappedKnyttTilSak {...props} />);
 
     await waitFor(() => {
       expect(mocks.hentBehandlingstyperForKnyttTilSak).toHaveBeenCalled();

--- a/src/sider/journalforing/komponenter/opprettSak.test.jsx
+++ b/src/sider/journalforing/komponenter/opprettSak.test.jsx
@@ -1,6 +1,6 @@
 import OpprettSak from "./opprettSak";
 import MKV from "../../../melosyskodeverk";
-import { renderWithProviders } from "../../../ducks/test-utils/renderWithProviders";
+import { renderWithProviders, renderWithProvidersAsync } from "../../../ducks/test-utils/renderWithProviders";
 import { reduxForm } from "redux-form";
 import { cleanup } from "@testing-library/react";
 
@@ -121,7 +121,7 @@ describe("OpprettSak - journalføring", () => {
     });
   });
 
-  it("Opprett sak. Skal ha fra/til dato, valg av land, radio knapper", () => {
+  it("Opprett sak. Skal ha fra/til dato, valg av land, radio knapper", async () => {
     props.formValues.opprettnysak_behandlingstema = ARBEID_FLERE_LAND;
     props.formValues.opprettnysak_behandlingstype = MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG;
     props.formValues.journalforingSoknadsland = ARBEID_FLERE_LAND;
@@ -129,7 +129,9 @@ describe("OpprettSak - journalføring", () => {
     props.formValues.sakstype = MKV.Koder.sakstyper.EU_EOS;
     props.formValues.journalforingGjelder = MKV.Koder.aktoersroller.BRUKER;
 
-    const { getByLabelText, getAllByRole, getByRole } = renderWithProviders(<WrappedOpprettSak {...props} />);
+    const { getByLabelText, getAllByRole, getByRole } = await renderWithProvidersAsync(
+      <WrappedOpprettSak {...props} />,
+    );
 
     expect(getByLabelText("Fra")).toBeInTheDocument();
     expect(getByLabelText("Til")).toBeInTheDocument();
@@ -222,7 +224,7 @@ describe("OpprettSak - opprett ny sak", () => {
     });
   });
 
-  it("Opprett sak. Skal ha fra/til dato, valg av land, radio knapper", () => {
+  it("Opprett sak. Skal ha fra/til dato, valg av land, radio knapper", async () => {
     props.formValues.behandlingstema = ARBEID_FLERE_LAND;
     props.formValues.behandlingstype = MKV.Koder.behandlinger.behandlingstyper.FØRSTEGANG;
     props.formValues.journalforingSoknadsland = ARBEID_FLERE_LAND;
@@ -230,7 +232,9 @@ describe("OpprettSak - opprett ny sak", () => {
     props.formValues.sakstype = MKV.Koder.sakstyper.EU_EOS;
     props.formValues.journalforingGjelder = MKV.Koder.aktoersroller.BRUKER;
 
-    const { getByLabelText, getAllByRole, getByRole } = renderWithProviders(<WrappedOpprettSak {...props} />);
+    const { getByLabelText, getAllByRole, getByRole } = await renderWithProvidersAsync(
+      <WrappedOpprettSak {...props} />,
+    );
 
     expect(getByLabelText("Fra")).toBeInTheDocument();
     expect(getByLabelText("Til")).toBeInTheDocument();


### PR DESCRIPTION
Vi har mye console output ved kjøring av enhetstester (ca 1400 linjer). Selv om testene kjører ok indikerer output enten problemer med test(config) eller problemer i runtime kode.

Denne PR'en inneholder forbedringer for å redusere konsollmeldinger pga feil konfig i tester.

Output er nå ca 200 linjer og peker på feil relatert til runtime kode (NAV komponenter, Redux forms, moment JS, yup etc)
