### PR TITLE
Revert "7392 Begrenser datovelger datepicker årvalg"

### DIFF
--- a/src/felleskomponenter/datovelger/datovelger.tsx
+++ b/src/felleskomponenter/datovelger/datovelger.tsx
@@ -36,8 +36,8 @@ function Datovelger({
 }: DatovelgerProps) {
   const [erUgyldigDato, setErUgyldigDato] = useState<boolean>(false);
   const { datepickerProps, inputProps } = useDatepicker({
-    fromDate: minDate ?? moment(moment.now()).subtract(5, "years").startOf("year").toDate(),
-    toDate: maxDate ?? moment(moment.now()).add(5, "years").endOf("year").toDate(),
+    fromDate: minDate ?? new Date(moment(moment.now()).subtract(50, "years").toDate()),
+    toDate: maxDate ?? new Date(moment(moment.now()).add(50, "years").toDate()),
     locale: "nb",
     defaultSelected: value,
     defaultMonth: minDate ?? value,

--- a/src/felleskomponenter/trygdeavgift/komponenter/meldinger.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/meldinger.tsx
@@ -29,8 +29,8 @@ const SkatteforholdUtenforMedlemskapsperiode = (
 
 const SkattepliktigOgPensjonUforetrygdMedKildeskatt = (
   <Nav.Alert variant="error" className="alertstripe_feilmelding">
-    Inntektstypen &quot;Pensjon/uføretrygd&quot; skal det betales kildeskatt av og kan derfor ikke velges for perioder
-    bruker er skattepliktig til Norge.
+    Inntekstypen &quot;Pensjon/uføretrygd det betales kildeskatt av&quot; kan ikke velges for perioder bruker er
+    skattepliktig til Norge.
   </Nav.Alert>
 );
 


### PR DESCRIPTION
Reverts navikt/melosys-web#2790

Skapte issues når man skriver format som vaskes/konverteres, og som er utenfor årene i lista. Reverter denne da denne kan ta noe tid å undersøke og fikse, så kan Ragnar se på det når han kommer tilbake fra ferie.