### PR TITLE
7256 TOGGLE Lagring av ukjentsluttdato kun når formIsValid

### DIFF
--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/komponenter/periodeVelger/periodeVelger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/komponenter/periodeVelger/periodeVelger.tsx
@@ -10,7 +10,6 @@ export interface PeriodeVelgerProps {
   control: Control;
   formValues: any;
   ukjentSluttdato?: boolean;
-  handleChange: () => void;
   ukjentSluttdatoKey: string;
 }
 
@@ -19,7 +18,6 @@ export function PeriodeOgLandVelger({
   control,
   formValues,
   ukjentSluttdato,
-  handleChange,
   ukjentSluttdatoKey,
 }: PeriodeVelgerProps) {
   return (
@@ -37,7 +35,6 @@ export function PeriodeOgLandVelger({
               name="fomDato"
               aria-label="Fra og med"
               readOnly={!redigerbart}
-              onChange={handleChange}
             />
           </Nav.Column>
           <Nav.Column className="dato">
@@ -49,7 +46,6 @@ export function PeriodeOgLandVelger({
               name="tomDato"
               aria-label="Til og med"
               readOnly={!redigerbart || ukjentSluttdato}
-              onChange={handleChange}
             />
           </Nav.Column>
           <Nav.Column className="brederefelt">
@@ -58,7 +54,7 @@ export function PeriodeOgLandVelger({
               control={control}
               name="bostedLandkode"
               disabled={!redigerbart}
-              onChange={handleChange}
+              emptyFieldDisabled={!!formValues?.bostedLandkode}
             >
               {MKV.KTObjects.landkoder.map((item: any) => (
                 <option key={item.kode} value={item.kode} label={Utils.land.landTekstFormat(item)} />

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/komponenter/periodeVelger/periodeVelger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/komponenter/periodeVelger/periodeVelger.tsx
@@ -10,6 +10,7 @@ export interface PeriodeVelgerProps {
   control: Control;
   formValues: any;
   ukjentSluttdato?: boolean;
+  handleChange: () => void;
   ukjentSluttdatoKey: string;
 }
 
@@ -18,6 +19,7 @@ export function PeriodeOgLandVelger({
   control,
   formValues,
   ukjentSluttdato,
+  handleChange,
   ukjentSluttdatoKey,
 }: PeriodeVelgerProps) {
   return (
@@ -35,6 +37,7 @@ export function PeriodeOgLandVelger({
               name="fomDato"
               aria-label="Fra og med"
               readOnly={!redigerbart}
+              onChange={handleChange}
             />
           </Nav.Column>
           <Nav.Column className="dato">
@@ -46,6 +49,7 @@ export function PeriodeOgLandVelger({
               name="tomDato"
               aria-label="Til og med"
               readOnly={!redigerbart || ukjentSluttdato}
+              onChange={handleChange}
             />
           </Nav.Column>
           <Nav.Column className="brederefelt">
@@ -54,7 +58,7 @@ export function PeriodeOgLandVelger({
               control={control}
               name="bostedLandkode"
               disabled={!redigerbart}
-              emptyFieldDisabled={!!formValues?.bostedLandkode}
+              onChange={handleChange}
             >
               {MKV.KTObjects.landkoder.map((item: any) => (
                 <option key={item.kode} value={item.kode} label={Utils.land.landTekstFormat(item)} />

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/komponenter/periodeVelger/periodeVelger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/komponenter/periodeVelger/periodeVelger.tsx
@@ -59,6 +59,7 @@ export function PeriodeOgLandVelger({
               name="bostedLandkode"
               disabled={!redigerbart}
               onChange={handleChange}
+              emptyFieldDisabled={formValues?.bostedLandkode}
             >
               {MKV.KTObjects.landkoder.map((item: any) => (
                 <option key={item.kode} value={item.kode} label={Utils.land.landTekstFormat(item)} />

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -35,8 +35,10 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const { fomDato, tomDato, bostedLandkode } = helseutgiftDekkesPeriode;
   const [ukjentSluttdatoKey, setUkjentSluttdatoKey] = useState("");
 
-  const ukjentSluttdatoMedlemskapsperiode = useSelector(
-    oppsummertfaktaSelectors.UkjentSluttdatoMedlemskapsperiodeSelector,
+  const lagretUkjentSluttdato = useSelector(oppsummertfaktaSelectors.UkjentSluttdatoMedlemskapsperiodeSelector);
+
+  const [ukjentSluttdatoMedlemskapsperiode, setUkjentSluttdatoMedlemskapsperiode] = useState(
+    lagretUkjentSluttdato || false,
   );
 
   const initialValues = useMemo(
@@ -51,7 +53,6 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const {
     control,
     watch,
-    trigger,
     reset,
     formState: { isValid: formIsValid, isDirty },
   } = useForm({
@@ -61,19 +62,9 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
   });
 
   const formValues = watch();
-  const debouncedLagreHelseutgiftPeriode = useMemo(
-    () =>
-      Utils._debounce(async () => {
-        const latestValues = watch();
-        const isValid = await trigger();
-        if (isValid) {
-          await oppdaterEllerOpprettHelseutgiftDekkesPeriode(latestValues);
-        }
-      }, 500),
-    [watch(), trigger],
-  );
 
   const oppdaterSluttdato = async (ukjentSluttdato: boolean) => {
+    setUkjentSluttdatoMedlemskapsperiode(ukjentSluttdato);
     if (ukjentSluttdato) {
       const fomISODate = Utils.dato.formatterDatoTilISO(formValues.fomDato, "");
       if (fomISODate) {
@@ -86,19 +77,23 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
           tomDato: newTomDato,
         });
 
-        await debouncedLagreHelseutgiftPeriode();
         setUkjentSluttdatoKey(newTomDato);
       }
     } else {
       setUkjentSluttdatoKey("");
     }
-    await dispatch(oppsummertfaktaOperations.lagreUkjentSluttdatoMedlemskapsperiode(behandlingID, ukjentSluttdato));
   };
 
   const bekreftOgFortsett = async () => {
     if (formIsValid && isDirty) {
       oppdaterEllerOpprettHelseutgiftDekkesPeriode(formValues);
       dispatch(helseutgiftDekkesPeriodeOperations.hentHelseutgiftDekkesPeriode(behandlingID));
+      dispatch(
+        oppsummertfaktaOperations.lagreUkjentSluttdatoMedlemskapsperiode(
+          behandlingID,
+          ukjentSluttdatoMedlemskapsperiode,
+        ),
+      );
     }
     bekreft();
   };
@@ -128,14 +123,11 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
         redigerbart={redigerbart}
         formValues={formValues}
         ukjentSluttdato={ukjentSluttdatoMedlemskapsperiode}
-        handleChange={async () => {
-          await debouncedLagreHelseutgiftPeriode();
-        }}
         ukjentSluttdatoKey={ukjentSluttdatoKey}
       />
 
       <UkjentSluttdatoMedlemskapsperiode
-        ukjentSluttdatoMedlemskapsperiode={ukjentSluttdatoMedlemskapsperiode || false}
+        ukjentSluttdatoMedlemskapsperiode={ukjentSluttdatoMedlemskapsperiode}
         onUkjentSluttdatoChange={oppdaterSluttdato}
         erEøsPensjonist={true}
       />

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -35,8 +35,10 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const { fomDato, tomDato, bostedLandkode } = helseutgiftDekkesPeriode;
   const [ukjentSluttdatoKey, setUkjentSluttdatoKey] = useState("");
 
-  const ukjentSluttdatoMedlemskapsperiode = useSelector(
-    oppsummertfaktaSelectors.UkjentSluttdatoMedlemskapsperiodeSelector,
+  const lagretUkjentSluttdato = useSelector(oppsummertfaktaSelectors.UkjentSluttdatoMedlemskapsperiodeSelector);
+
+  const [ukjentSluttdatoMedlemskapsperiode, setUkjentSluttdatoMedlemskapsperiode] = useState(
+    lagretUkjentSluttdato || false,
   );
 
   const initialValues = useMemo(
@@ -63,17 +65,22 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const formValues = watch();
   const debouncedLagreHelseutgiftPeriode = useMemo(
     () =>
-      Utils._debounce(async () => {
+      Utils._debounce(async (ukjentSluttdato?: boolean) => {
         const latestValues = watch();
         const isValid = await trigger();
         if (isValid) {
+          const currentUkjentSluttdato = ukjentSluttdato ?? ukjentSluttdatoMedlemskapsperiode;
           await oppdaterEllerOpprettHelseutgiftDekkesPeriode(latestValues);
+          await dispatch(
+            oppsummertfaktaOperations.lagreUkjentSluttdatoMedlemskapsperiode(behandlingID, currentUkjentSluttdato),
+          );
         }
       }, 500),
     [watch(), trigger],
   );
 
   const oppdaterSluttdato = async (ukjentSluttdato: boolean) => {
+    setUkjentSluttdatoMedlemskapsperiode(ukjentSluttdato);
     if (ukjentSluttdato) {
       const fomISODate = Utils.dato.formatterDatoTilISO(formValues.fomDato, "");
       if (fomISODate) {
@@ -86,18 +93,19 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
           tomDato: newTomDato,
         });
 
-        await debouncedLagreHelseutgiftPeriode();
+        await debouncedLagreHelseutgiftPeriode(ukjentSluttdato);
         setUkjentSluttdatoKey(newTomDato);
       }
     } else {
       setUkjentSluttdatoKey("");
+      if (formIsValid) {
+        await dispatch(oppsummertfaktaOperations.lagreUkjentSluttdatoMedlemskapsperiode(behandlingID, ukjentSluttdato));
+      }
     }
-    await dispatch(oppsummertfaktaOperations.lagreUkjentSluttdatoMedlemskapsperiode(behandlingID, ukjentSluttdato));
   };
 
   const bekreftOgFortsett = async () => {
     if (formIsValid && isDirty) {
-      oppdaterEllerOpprettHelseutgiftDekkesPeriode(formValues);
       dispatch(helseutgiftDekkesPeriodeOperations.hentHelseutgiftDekkesPeriode(behandlingID));
     }
     bekreft();
@@ -135,7 +143,7 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
       />
 
       <UkjentSluttdatoMedlemskapsperiode
-        ukjentSluttdatoMedlemskapsperiode={ukjentSluttdatoMedlemskapsperiode || false}
+        ukjentSluttdatoMedlemskapsperiode={ukjentSluttdatoMedlemskapsperiode}
         onUkjentSluttdatoChange={oppdaterSluttdato}
         erEøsPensjonist={true}
       />

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -35,10 +35,8 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const { fomDato, tomDato, bostedLandkode } = helseutgiftDekkesPeriode;
   const [ukjentSluttdatoKey, setUkjentSluttdatoKey] = useState("");
 
-  const lagretUkjentSluttdato = useSelector(oppsummertfaktaSelectors.UkjentSluttdatoMedlemskapsperiodeSelector);
-
-  const [ukjentSluttdatoMedlemskapsperiode, setUkjentSluttdatoMedlemskapsperiode] = useState(
-    lagretUkjentSluttdato || false,
+  const ukjentSluttdatoMedlemskapsperiode = useSelector(
+    oppsummertfaktaSelectors.UkjentSluttdatoMedlemskapsperiodeSelector,
   );
 
   const initialValues = useMemo(
@@ -53,6 +51,7 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const {
     control,
     watch,
+    trigger,
     reset,
     formState: { isValid: formIsValid, isDirty },
   } = useForm({
@@ -62,9 +61,19 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
   });
 
   const formValues = watch();
+  const debouncedLagreHelseutgiftPeriode = useMemo(
+    () =>
+      Utils._debounce(async () => {
+        const latestValues = watch();
+        const isValid = await trigger();
+        if (isValid) {
+          await oppdaterEllerOpprettHelseutgiftDekkesPeriode(latestValues);
+        }
+      }, 500),
+    [watch(), trigger],
+  );
 
   const oppdaterSluttdato = async (ukjentSluttdato: boolean) => {
-    setUkjentSluttdatoMedlemskapsperiode(ukjentSluttdato);
     if (ukjentSluttdato) {
       const fomISODate = Utils.dato.formatterDatoTilISO(formValues.fomDato, "");
       if (fomISODate) {
@@ -77,23 +86,19 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
           tomDato: newTomDato,
         });
 
+        await debouncedLagreHelseutgiftPeriode();
         setUkjentSluttdatoKey(newTomDato);
       }
     } else {
       setUkjentSluttdatoKey("");
     }
+    await dispatch(oppsummertfaktaOperations.lagreUkjentSluttdatoMedlemskapsperiode(behandlingID, ukjentSluttdato));
   };
 
   const bekreftOgFortsett = async () => {
     if (formIsValid && isDirty) {
       oppdaterEllerOpprettHelseutgiftDekkesPeriode(formValues);
       dispatch(helseutgiftDekkesPeriodeOperations.hentHelseutgiftDekkesPeriode(behandlingID));
-      dispatch(
-        oppsummertfaktaOperations.lagreUkjentSluttdatoMedlemskapsperiode(
-          behandlingID,
-          ukjentSluttdatoMedlemskapsperiode,
-        ),
-      );
     }
     bekreft();
   };
@@ -123,11 +128,14 @@ export function VurderingOpplysninger({ bekreft, tilbake, aktivtSteg, oppdaterSt
         redigerbart={redigerbart}
         formValues={formValues}
         ukjentSluttdato={ukjentSluttdatoMedlemskapsperiode}
+        handleChange={async () => {
+          await debouncedLagreHelseutgiftPeriode();
+        }}
         ukjentSluttdatoKey={ukjentSluttdatoKey}
       />
 
       <UkjentSluttdatoMedlemskapsperiode
-        ukjentSluttdatoMedlemskapsperiode={ukjentSluttdatoMedlemskapsperiode}
+        ukjentSluttdatoMedlemskapsperiode={ukjentSluttdatoMedlemskapsperiode || false}
         onUkjentSluttdatoChange={oppdaterSluttdato}
         erEøsPensjonist={true}
       />


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7256

~~Har fjernet lagring underveis for både periode og land, og ukjent sluttdato.
Dataene lagres bare ved trykk av bekreft og fortsett~~

Etter avklaring med fag vil vi likevel beholde muligheten å lagre underveis, har derfor endret på lagrings logikk for ukjentsluttdato der verdien lagres kun ved formIsValid. 

Har også endret på bostedsland der man ikke kan velge "Velg..." igjen etter man har valgt et land. 