### PR TITLE
7347: Bruk nginx-unprivileged:alpine og fjern curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM nginxinc/nginx-unprivileged
+FROM nginxinc/nginx-unprivileged:alpine
+
+# Fjern unødvendige pakker som lager CVEs
+USER root
+RUN apk del --no-cache curl wget ca-certificates && \
+    apk upgrade --available && \
+    rm -rf /var/cache/apk/* /usr/bin/wget /usr/bin/curl \
 
 COPY ./build /usr/share/nginx/html
 COPY ./nais/proxy.nginx /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
Fikser følgende CVEs:
CVE-2024-5535
CVE-2023-38545