### PR TITLE
7347: Bruk nginxinc/nginx-unprivileged igjen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,32 @@
-FROM nginxinc/nginx-unprivileged:alpine
+FROM nginxinc/nginx-unprivileged
 
-# Fjern unødvendige pakker som lager CVE-er
+# Remove the specific packages causing CVEs
 USER root
-RUN apk del --no-cache curl wget ca-certificates && \
-    apk upgrade --available && \
-    rm -rf /var/cache/apk/* /usr/bin/wget /usr/bin/curl
+RUN apt-get update && \
+    apt-get remove -y curl && \
+    apt-get upgrade -y && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
+# Your original working setup (unchanged)
 COPY ./build /usr/share/nginx/html
 COPY ./nais/proxy.nginx /etc/nginx/templates/default.conf.template
-COPY generate-config.sh /tmp/generate-config.sh
-COPY .prod.env .q1.env .q2.env .local.env /app/
+COPY generate-config.sh /docker-entrypoint.d/generate-config.sh
 
-# Generer ALLE miljøkonfigurasjoner under BUILD (eliminerer permission-problemer)
-RUN chmod +x /tmp/generate-config.sh
-
-# Generer konfigurasjon for hvert miljø som root (ingen permission-problemer)
-RUN ENVIRONMENT_NAME=prod /tmp/generate-config.sh && \
-    mv /usr/share/nginx/html/env-config.js /usr/share/nginx/html/env-config-prod.js
-
-RUN ENVIRONMENT_NAME=q1 /tmp/generate-config.sh && \
-    mv /usr/share/nginx/html/env-config.js /usr/share/nginx/html/env-config-q1.js
-
-RUN ENVIRONMENT_NAME=q2 /tmp/generate-config.sh && \
-    mv /usr/share/nginx/html/env-config.js /usr/share/nginx/html/env-config-q2.js
-
-RUN ENVIRONMENT_NAME=local /tmp/generate-config.sh && \
-    mv /usr/share/nginx/html/env-config.js /usr/share/nginx/html/env-config-local.js
-
-# Lag et enkelt runtime-script som bare kopierer riktig fil (alltid fungerer)
-RUN cat > /docker-entrypoint.d/select-config.sh << 'EOF'
-#!/bin/sh
-ENV_NAME=${ENVIRONMENT_NAME:-prod}
-echo "Velger konfigurasjon for miljø: $ENV_NAME"
-cp /usr/share/nginx/html/env-config-${ENV_NAME}.js /usr/share/nginx/html/env-config.js 2>/dev/null || {
-    echo "Miljø $ENV_NAME ikke funnet, bruker prod som fallback"
-    cp /usr/share/nginx/html/env-config-prod.js /usr/share/nginx/html/env-config.js
-}
-echo "env-config.js oppdatert for miljø: $ENV_NAME"
-EOF
-
-# Sett tillatelser og fjern gamle script
-RUN chmod +x /docker-entrypoint.d/select-config.sh && \
-    chown -R 101:101 /etc/nginx/conf.d/ && \
-    chown -R 101:101 /etc/nginx/templates/ && \
-    chown -R 101:101 /usr/share/nginx/html/ && \
-    rm /tmp/generate-config.sh
+COPY .prod.env /app/.prod.env
+COPY .q1.env /app/.q1.env
+COPY .q2.env /app/.q2.env
+COPY .local.env /app/.local.env
 
 ENV ENVIRONMENT_NAME=prod
-USER 101
+
+# Your original permissions (that worked before)
+USER root
+RUN chown -R 1069:1069 /etc/nginx/conf.d/
+RUN chown -R 1069:1069 /etc/nginx/templates/
+RUN chown -R 1069:1069 /usr/share/nginx/html/
+RUN chmod +x /docker-entrypoint.d/generate-config.sh
+USER 1069
+
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginxinc/nginx-unprivileged
 
-# Remove the specific packages causing CVEs
+# Fjern avhenigheter som ikke er nødvendige for å kjøre nginx, og som skaper CVEs.
 USER root
 RUN apt-get update && \
     apt-get remove -y curl && \
@@ -9,7 +9,6 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Your original working setup (unchanged)
 COPY ./build /usr/share/nginx/html
 COPY ./nais/proxy.nginx /etc/nginx/templates/default.conf.template
 COPY generate-config.sh /docker-entrypoint.d/generate-config.sh
@@ -21,7 +20,6 @@ COPY .local.env /app/.local.env
 
 ENV ENVIRONMENT_NAME=prod
 
-# Your original permissions (that worked before)
 USER root
 RUN chown -R 1069:1069 /etc/nginx/conf.d/
 RUN chown -R 1069:1069 /etc/nginx/templates/

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -16,14 +16,6 @@ spec:
     min: 2
     max: 2
     cpuThresholdPercentage: 50
-  liveness:
-    path: melosys/health/is-alive
-    initialDelay: 30
-    timeout: 10
-  readiness:
-    path: melosys/health/is-ready
-    initialDelay: 30
-    timeout: 10
   resources:
     limits:
       cpu: 500m

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -16,6 +16,14 @@ spec:
     min: 2
     max: 2
     cpuThresholdPercentage: 50
+  liveness:
+    path: melosys/health/is-alive
+    initialDelay: 30
+    timeout: 10
+  readiness:
+    path: melosys/health/is-ready
+    initialDelay: 30
+    timeout: 10
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
Alpine-versjon lot seg ikke lett kjøre. Bruker derfor gamle nginx-unpriv, men fjerner de sårbare pakkene manuelt.