### PR TITLE
MELOSYS-7427 brev endringer i fritekstvedlegg

### DIFF
--- a/src/felleskomponenter/htmlEditor/htmlEditor.less
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.less
@@ -1,3 +1,5 @@
+@import "../../constants.less";
+
 @borderRadiusBase: 4px;
 @redError: #ba3a26;
 
@@ -7,7 +9,7 @@
     padding-bottom: 0.5rem;
   }
   .editor-wrapper {
-    background-color: #ffffff;
+    background-color: @white;
     max-width: calc(210mm - 7rem);
   }
 

--- a/src/felleskomponenter/htmlEditor/htmlEditor.less
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.less
@@ -7,6 +7,7 @@
     padding-bottom: 0.5rem;
   }
   .editor-wrapper {
+    background-color: #ffffff;
     max-width: calc(210mm - 7rem);
   }
 

--- a/src/felleskomponenter/sideDialog/sendBrev/brevVedlegg/fritekstvedleggSkjema.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevVedlegg/fritekstvedleggSkjema.less
@@ -19,7 +19,7 @@
 
   &__skjema {
     border-radius: 4px;
-    background-color: #f8f8f8;
+    background-color: #f2f3f5;
   }
 
   .row {

--- a/src/felleskomponenter/sideDialog/sendBrev/brevVedlegg/fritekstvedleggSkjema.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevVedlegg/fritekstvedleggSkjema.less
@@ -1,3 +1,5 @@
+@import "../../../../constants.less";
+
 .fritekstvedleggSkjema {
   padding-left: 8px;
 
@@ -31,6 +33,6 @@
   }
 
   .wrapper {
-    background-color: #ffffff;
+    background-color: @white;
   }
 }

--- a/src/felleskomponenter/sideDialog/sendBrev/brevVedlegg/fritekstvedleggSkjema.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevVedlegg/fritekstvedleggSkjema.less
@@ -1,5 +1,3 @@
-@import "../../../../constants.less";
-
 .fritekstvedleggSkjema {
   padding-left: 8px;
 
@@ -33,6 +31,6 @@
   }
 
   .wrapper {
-    background-color: @white;
+    background-color: #ffffff;
   }
 }

--- a/src/felleskomponenter/sideDialog/sendBrev/brevVedlegg/fritekstvedleggSkjema.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevVedlegg/fritekstvedleggSkjema.tsx
@@ -30,7 +30,6 @@ function FritekstvedleggSkjema({
   width,
 }: FritekstvedleggSkjemaProps) {
   const cls = bem("fritekstvedleggSkjema");
-  const placeholder = `Skriv inn tittel, maks ${TEGNBEGRENSNING} tegn`;
 
   return (
     <Nav.Row className={cls.block}>
@@ -43,9 +42,8 @@ function FritekstvedleggSkjema({
           <Nav.Column xs={width}>
             <Skjema.Input
               feltNavn={`felt.${felt.kode}_TITTEL.feltVerdi`}
-              label="Tittel"
+              label="Tittel (maks 60 tegn)"
               normalize={begrensAntallTegn(TEGNBEGRENSNING)}
-              placeholder={placeholder}
             />
           </Nav.Column>
         </Nav.Row>
@@ -55,7 +53,7 @@ function FritekstvedleggSkjema({
             bekreft={leggTilFritekstvedlegg}
             avbryt={resetFritekstvedlegg}
             avbrytTekst="Avbryt"
-            bekreftTekst="Lagre"
+            bekreftTekst="Lagre fritekstvedlegg"
             redigerbart
             size="small"
           />


### PR DESCRIPTION
Et par-tre ting:

- Usikker på fargen til "den grå boksen", jeg ser ikke noen eksakt farge spec i ticket eller Figma. Jeg måler #f2f3f5 på skjermdunpene og har brukt det, men ser at felter andre steder har bakgrunn #e9e9e9 og det ser mer fornuftig ut for meg
- Designet ser ut til å ønske editor-feltet med 100% bredde. Det er ikke default og de andre, tilsvarende feltene er heller ikke strekt helt ut. Antar at det skal være konsistent og da kan vi heller evt ta det på egen sak dersom det ønskes full bredde
- Designet ser ut til å ønske header på editoren med grå bakgrunn.  Det er ikke default og de andre, tilsvarende feltene har heller ikke det, så det har jeg droppet

https://jira.adeo.no/browse/MELOSYS-7427
