### PR TITLE
7217 Årsavregning - preutfylling av datofelter i skatteforhold og inntektsperiode når medlemskapsperiode er satt

### DIFF
--- a/src/felleskomponenter/trygdeavgift/komponenter/skatteforholdsperioder.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/skatteforholdsperioder.tsx
@@ -9,7 +9,7 @@ import * as Ikoner from "../../../resources/images";
 import { FieldArrayProps, FormValuesProps, Skatteforhold } from "./types";
 import * as Utils from "../../../utils";
 import "./skatteforholdsperioder.css";
-import { Stack } from "@navikt/ds-react";
+import { HGrid, Stack } from "@navikt/ds-react";
 
 interface SkatteforholdsperioderProps {
   formValues: FormValuesProps;
@@ -38,59 +38,58 @@ export function Skatteforholdsperioder({
     <div className="perioder">
       {formValues.skatteforholdsperioder.map((skatteforhold, index) => {
         return (
-          <Nav.Row className="periode__rad" key={fields[index].id}>
-            <Nav.Column className="dato">
-              <Forms.Datovelger
-                label={index === 0 ? "Skatteforhold" : ""}
-                name={`skatteforholdsperioder[${index}].fomDato`}
-                readOnly={!redigerbart}
-                control={control}
-                minDate={minDate}
-                maxDate={maxDate}
-              />
-            </Nav.Column>
+          <HGrid className="periode__rad" key={fields[index].id}>
+            <Forms.Datovelger
+              className="dato"
+              label={index === 0 ? "Skatteforhold" : ""}
+              name={`skatteforholdsperioder[${index}].fomDato`}
+              readOnly={!redigerbart}
+              control={control}
+              minDate={minDate}
+              maxDate={maxDate}
+            />
 
-            <Nav.Column className="dato">
-              <Forms.Datovelger
-                label={index === 0 && <span className="invisible" />}
-                name={`skatteforholdsperioder[${index}].tomDato`}
-                readOnly={!redigerbart}
-                control={control}
-                minDate={Utils.dato.norskStringTilDate(formValues.skatteforholdsperioder[index].fomDato) || minDate}
-                maxDate={maxDate}
-              />
-            </Nav.Column>
+            <Forms.Datovelger
+              className="dato"
+              label={index === 0 && <span className="invisible" />}
+              name={`skatteforholdsperioder[${index}].tomDato`}
+              readOnly={!redigerbart}
+              control={control}
+              minDate={Utils.dato.norskStringTilDate(formValues.skatteforholdsperioder[index].fomDato) || minDate}
+              maxDate={maxDate}
+            />
 
-            <Nav.Column>
-              <Forms.RadioGroup
-                legend={index === 0 ? "Skattepliktig" : ""}
-                hideLegend={index !== 0}
-                name={`skatteforholdsperioder[${index}].skatteplikttype`}
-                readOnly={!redigerbart}
-                control={control}
-                className="skatteforholdsperioder-radio-group"
-              >
-                <Stack gap="6" direction={{ xs: "column", sm: "row" }} wrap={false}>
-                  <Nav.Radio value={MKV.Koder.skatteplikttype.SKATTEPLIKTIG}>Ja</Nav.Radio>
-                  <Nav.Radio value={MKV.Koder.skatteplikttype.IKKE_SKATTEPLIKTIG}>Nei</Nav.Radio>
-                </Stack>
-              </Forms.RadioGroup>
-            </Nav.Column>
+            <Forms.RadioGroup
+              legend={index === 0 ? "Skattepliktig" : ""}
+              hideLegend={index !== 0}
+              name={`skatteforholdsperioder[${index}].skatteplikttype`}
+              readOnly={!redigerbart}
+              control={control}
+              className="skatteforholdsperioder-radio-group"
+            >
+              <Stack gap="6" direction={{ xs: "column", sm: "row" }} wrap={false}>
+                <Nav.Radio value={MKV.Koder.skatteplikttype.SKATTEPLIKTIG}>Ja</Nav.Radio>
+                <Nav.Radio value={MKV.Koder.skatteplikttype.IKKE_SKATTEPLIKTIG}>Nei</Nav.Radio>
+              </Stack>
+            </Forms.RadioGroup>
 
-            <Nav.Column className="slett__knapp">
+            <span className="slett__knapp">
               {redigerbart && formValues.skatteforholdsperioder.length > 1 && (
                 <Mui.IkonKnapp ariaLabel="Slett skatteforhold" ikon={Ikoner.Bin} onClick={() => remove(index)} />
               )}
-            </Nav.Column>
-          </Nav.Row>
+            </span>
+          </HGrid>
         );
       })}
 
-      <Nav.Row className="legg-til__rad">
-        <Mui.Lenkeknapp disabled={!redigerbart} ikon={Ikoner.Add} onClick={() => append(defaultPeriode || {})}>
-          Legg til skatteforhold
-        </Mui.Lenkeknapp>
-      </Nav.Row>
+      <Mui.Lenkeknapp
+        className="legg-til__rad"
+        disabled={!redigerbart}
+        ikon={Ikoner.Add}
+        onClick={() => append(defaultPeriode || {})}
+      >
+        Legg til skatteforhold
+      </Mui.Lenkeknapp>
     </div>
   );
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -42,6 +42,7 @@ import {
 } from "./aarsavregningUtenEllerDeltGrunnlag";
 import aarsavregningUtenEllerDeltGrunnlagSchema from "./aarsavregningUtenEllerDeltGrunnlagSchema";
 import { Feilmelding, finnAktivFeilmelding, finnAktivFeilmeldingForMedlemskapsperioder } from "./valideringsfeil";
+import inntektsperioderTabell from "../komponenter/inntektsperioderTabell";
 
 const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
@@ -194,11 +195,9 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       .sort(Utils.dato.sorterEtterNorskFomDato);
     const medlemskapsperiodeFomTom = hentMedlemskapsFomTomDato(sorterteGyldigePerioder);
 
-    /* eslint-disable no-console */
     consoleLog("[finnMedlemskapsperiode] medlemskapsperiodeFomTom", medlemskapsperiodeFomTom);
     consoleLog("[finnMedlemskapsperiode] sorterteGyldigePerioder", sorterteGyldigePerioder);
     consoleLog("[finnMedlemskapsperiode] perioder", perioder);
-    /* eslint-enable no-console */
 
     return {
       fomDato: Utils.dato.vaskOgFormatterDatoTilNorsk(medlemskapsperiodeFomTom?.fom),
@@ -316,7 +315,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   );
 
   const debouncedBeregning = useCallback(() => {
-    /* eslint-disable-next-line no-console */
     consoleLog("[debouncedBeregning] setter debouncedBeregningPagaar til false");
     setDebouncedBeregningPagaar(false);
     if (
@@ -327,7 +325,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       lagreMedlemskapsperioderPaagar ||
       endeligAvgiftValg !== OPPLYSNINGER_ENDRET
     ) {
-      /* eslint-disable-next-line no-console */
       consoleLog("[debouncedBeregning] return tidlig i debouncedBeregning");
       return;
     }
@@ -343,7 +340,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     );
     const medlemskapsperiodeFomTom = finnMedlemskapsperiode(medlemskapsperioderFormState);
 
-    /* eslint-disable-next-line no-console */
     consoleLog("[debouncedBeregning] medlemskapsperiodeFomTom", medlemskapsperiodeFomTom);
 
     if (!Utils._isEqual(formState, previousFormState)) {
@@ -354,7 +350,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         medlemskapsperioder: medlemskapsperioderFormState as Medlemskapsperiode[],
         medlemskapstypeErPliktig,
       });
-      /* eslint-disable-next-line no-console */
+
       consoleLog("[debouncedBeregning] Aktive feilmeldinger", aktivFeilmelding, {
         skatteforholdsperioder: formState.skatteforholdsperioder,
         inntektskilder: formState.inntektskilder,
@@ -377,7 +373,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       }
     }
 
-    /* eslint-disable-next-line no-console */
     consoleLog("[debouncedBeregning] ferdig");
   }, [
     aarsavregningID,
@@ -426,7 +421,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
           return periode;
         });
 
-        /* eslint-disable-next-line no-console */
         consoleLog("[lagreMedlemskapsperioder] oppdaterteMedlemskapsperioder", oppdaterteMedlemskapsperioder);
 
         setLagredeMedlemskapsperioder(oppdaterteMedlemskapsperioder);
@@ -608,14 +602,14 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   useEffect(() => {
     setDebouncedBeregningPagaar(false);
     debouncedBeregningRef.current = Utils._debounce(debouncedBeregning, 350);
-    /* eslint-disable-next-line no-console */
+
     consoleLog("[useEffect debouncedBeregning] Lager en ny debounce funksjon når beregning callback endres");
 
     // Cancel på unmount
     return () => {
       if (debouncedBeregningRef.current?.cancel) {
         setDebouncedBeregningPagaar(false);
-        /* eslint-disable-next-line no-console */
+
         consoleLog(
           "[useEffect debouncedBeregning] Avbryter eventuelt eksisterende beregning for å sette opp ny debounce funksjon.",
         );
@@ -658,7 +652,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     // Avbryter hvis vi allerede har en beregning som venter
     if (debouncedBeregningRef.current?.cancel && Object.keys(changedDependencies).length > 0) {
       setDebouncedBeregningPagaar(false);
-      /* eslint-disable-next-line no-console */
+
       consoleLog("[useEffect hovedberegning] Avbryter eventuelt eksisterende beregning.", {
         beregningPaagar,
         lagreMedlemskapsperioderPaagar,
@@ -668,7 +662,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     }
 
     if (medlemskapsperiodeEndret || Object.keys(changedDependencies).length === 0 || lagreMedlemskapsperioderPaagar) {
-      /* eslint-disable-next-line no-console */
       consoleLog("[useEffect hovedberegning] Avbryter useEffect uten å gjøre noe.", {
         medlemskapsperiodeEndret,
         changedDependencies,
@@ -688,7 +681,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       );
 
       if (!redigerbart || !aarsavregningID || endrerBestemmelse || beregningPaagar || lagreMedlemskapsperioderPaagar) {
-        /* eslint-disable-next-line no-console */
         consoleLog(
           "[useEffect hovedberegning] return tidlig i fordi redigerbart, aarsavregningID, endrerBestemmelse, lagreMedlemskapsperioderPaagar",
           {
@@ -719,14 +711,13 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         });
       } else {
         setArrayValideringsfeil(undefined);
-        /* eslint-disable-next-line no-console */
+
         consoleLog("[useEffect hovedberegning] Clear arrayValideringsfeil", {
           currentFormState,
           previousFormState,
         });
       }
     } else {
-      /* eslint-disable-next-line no-console */
       consoleLog("[useEffect hovedberegning] debouncedBeregningRef.current er undefined");
     }
   }, [
@@ -763,6 +754,24 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   useEffect(() => {
     oppdaterStatus(stegErGyldig);
   }, [stegErGyldig, oppdaterStatus]);
+
+  // Hack for at første/initielle element i skatteforhold og inntektsperiode ferdigutfylles med medlemskapsperiode når medlemskapsperiode er satt
+  useEffect(() => {
+    if (medlemskapsperiode.fomDato && medlemskapsperiode.tomDato) {
+      const initialSkatteforholdElement = skatteforholdsperioder[0];
+      const initialInntektsPeriode = inntektskilder[0];
+
+      if (!(initialSkatteforholdElement.fomDato && initialSkatteforholdElement.tomDato)) {
+        skattRemove(0);
+        skattAppend(medlemskapsperiode);
+      }
+
+      if (!(initialInntektsPeriode.fomDato && initialInntektsPeriode.tomDato)) {
+        inntektRemove(0);
+        inntektAppend(medlemskapsperiode);
+      }
+    }
+  }, [medlemskapsperiode]);
 
   const handleEndeligAvgiftValgChange = useCallback(
     (value: string) => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -42,7 +42,6 @@ import {
 } from "./aarsavregningUtenEllerDeltGrunnlag";
 import aarsavregningUtenEllerDeltGrunnlagSchema from "./aarsavregningUtenEllerDeltGrunnlagSchema";
 import { Feilmelding, finnAktivFeilmelding, finnAktivFeilmeldingForMedlemskapsperioder } from "./valideringsfeil";
-import inntektsperioderTabell from "../komponenter/inntektsperioderTabell";
 
 const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
@@ -755,7 +754,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     oppdaterStatus(stegErGyldig);
   }, [stegErGyldig, oppdaterStatus]);
 
-  // Hack for at første/initielle element i skatteforhold og inntektsperiode ferdigutfylles med medlemskapsperiode når medlemskapsperiode er satt
+  // Denne gjør at første/initielle element i skatteforhold og inntektsperiode ferdigutfylles med medlemskapsperiode når medlemskapsperiode er satt
   useEffect(() => {
     if (medlemskapsperiode.fomDato && medlemskapsperiode.tomDato) {
       const initialSkatteforholdElement = skatteforholdsperioder[0];


### PR DESCRIPTION
Diskuterte med Cathrin. Siden det i de aller fleste tilfeller kun er én medlemskapsperiode så holder det med denne løsningen hvor det, i korte trekk, kun preutfylles verdier første gang man fyller ut datofeltene for medlemskapsperiode.

Intellij sin "Run eslint --fix on save" fjernet en del linjer ala `/* eslint-disable no-console */` etc. Så ble litt urelatert støy der.