### PR TITLE
Melosys 7426 endringer i forhåndsvisning og legg til vedlegg

### DIFF
--- a/src/felleskomponenter/dokumentliste/dokumentliste.tsx
+++ b/src/felleskomponenter/dokumentliste/dokumentliste.tsx
@@ -18,7 +18,7 @@ import {
 } from "./dokumentlisteTyper";
 import * as Ikoner from "../../resources/images";
 
-function Dokumentliste({ behandlingID, dokumenter, validateOnClick }: DokumentlisteType) {
+function Dokumentliste({ behandlingID, dokumenter, validateOnClick, label, className }: DokumentlisteType) {
   const [feilmelding, setFeilmelding] = useState<string | null>(null);
 
   const klikk = async (dokument: BrevDokumentMetadataType | SedDokumentMetadataType) => {
@@ -110,11 +110,11 @@ function Dokumentliste({ behandlingID, dokumenter, validateOnClick }: Dokumentli
   };
 
   return (
-    <div className="dokumentliste">
+    <div className={`dokumentliste ${className || ""}`}>
       <Nav.Table size="small">
         <Nav.Table.Header>
           <Nav.Table.Row>
-            <Nav.Table.HeaderCell>Forhåndsvisning av brev</Nav.Table.HeaderCell>
+            <Nav.Table.HeaderCell>{label ? label : "Forhåndsvisning av brev"}</Nav.Table.HeaderCell>
             <Nav.Table.HeaderCell>Mottaker</Nav.Table.HeaderCell>
           </Nav.Table.Row>
         </Nav.Table.Header>

--- a/src/felleskomponenter/dokumentliste/dokumentlisteTyper.ts
+++ b/src/felleskomponenter/dokumentliste/dokumentlisteTyper.ts
@@ -19,6 +19,8 @@ export interface SedDokumentMetadataType extends DokumentMetadataType {
 export interface DokumentlisteType {
   behandlingID: number;
   dokumenter: (BrevDokumentMetadataType | SedDokumentMetadataType)[];
+  label?: string;
+  className?: string;
   validateOnClick?: () => Promise<unknown> | object | boolean;
 }
 

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.less
@@ -1,0 +1,3 @@
+.dokumentliste--no-bottom-margin {
+  margin-bottom: 0;
+}

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.less
@@ -1,3 +1,7 @@
 .dokumentliste--no-bottom-margin {
   margin-bottom: 0;
+
+  .navds-table__row {
+    height: 2.2rem;
+  }
 }

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
@@ -35,14 +35,13 @@ interface BrevMottakereTabellProps {
   muligeMottakere?: Api.DokumenterV2.HentMuligeMottakereResDto;
   muligeMottakereNorskMyndighet?: Api.DokumenterV2.MuligMottaker[];
   formIsValid: boolean;
-  hentBrevRequest: (rolle: string) => Record<string, unknown>;
+  redigerbart: boolean;
   standardvedlegg: Api.DokumenterV2.TilgjengeligStandardvedlegg[];
   fritekstvedlegg: Fritekstvedlegg[];
   setFritekstvedlegg: (fritekstvedlegg: Fritekstvedlegg[]) => void;
   valgteVedlegg: BrevVedleggInterface;
   setValgteVedlegg: (valgteVedlegg: BrevVedleggVisningstabellInterface) => void;
   changeField: (field: string, value: string) => void;
-  redigerbart: boolean;
   dokumenter: FysiskDokument[];
   visFritekstvedleggSkjema: boolean;
   setVisFritekstvedleggSkjema: (value: boolean) => void;
@@ -56,13 +55,12 @@ function BrevMottakereTabell({
   behandlingID,
   formValues,
   formIsValid,
-  hentBrevRequest,
+  redigerbart,
   fritekstvedlegg,
   setFritekstvedlegg,
   valgteVedlegg,
   setValgteVedlegg,
   changeField,
-  redigerbart,
   dokumenter,
   visFritekstvedleggSkjema,
   setVisFritekstvedleggSkjema,
@@ -76,6 +74,62 @@ function BrevMottakereTabell({
   const harStandardVedlegg =
     formValues?.valgtMottaker?.rolle === "BRUKER" && formValues?.felt?.DISTRIBUSJONSTYPE?.valg === "VEDTAK";
   const standardvedleggTilVisning = harStandardVedlegg ? standardvedlegg : [];
+
+  const finnValgAlternativ = (felt: Api.DokumenterV2.Felt) => {
+    return felt?.valg?.valgAlternativer.find((alternativ) => alternativ.kode === formValues?.felt?.[felt.kode]?.valg);
+  };
+
+  const hentFormVerdi = (feltNavn: string, hentValgverdi = false, hentKode = false): string | null => {
+    const feltFraValgtMal = formValues?.valgtBrev?.felter?.find((felt) => felt.kode === feltNavn);
+    if (!feltFraValgtMal) return null;
+    const feltVerdi = formValues.felt?.[feltNavn]?.feltVerdi;
+    if (feltFraValgtMal?.valg) {
+      const valgtAlternativ = finnValgAlternativ(feltFraValgtMal);
+      if (!hentValgverdi) return valgtAlternativ?.visFelt ? feltVerdi : null;
+      if (hentKode) return valgtAlternativ?.kode ?? null;
+      return valgtAlternativ?.visFelt ? feltVerdi : (valgtAlternativ?.beskrivelse ?? null);
+    }
+    return feltVerdi ?? null;
+  };
+
+  const hentKopiMottakere = () => {
+    return formValues?.kopiTilBruker
+      ? muligeMottakere?.kopiMottakere.map(Api.DokumenterV2.konverterMuligMottakerTilKopiMottaker)
+      : [];
+  };
+
+  const hentOrgnr = (mottakerRolle: string) => {
+    switch (mottakerRolle) {
+      case "VIRKSOMHET":
+      case "ARBEIDSGIVER":
+        return formValues?.arbeidsgiver || null;
+      case "ANNEN_ORGANISASJON":
+        return formValues?.organisasjonsnummer || null;
+      default:
+        return null;
+    }
+  };
+
+  const hentBrevRequest = (mottakerRolle: string): Record<string, unknown> => ({
+    produserbardokument: formValues?.type || "",
+    mottaker: mottakerRolle,
+    orgNr: hentOrgnr(mottakerRolle),
+    kontaktpersonNavn: mottakerRolle === "ANNEN_ORGANISASJON" ? formValues?.kontaktperson : null,
+    orgnrNorskMyndighet: formValues?.norskeMyndigheter,
+    innledningFritekst: hentFormVerdi("INNLEDNING_FRITEKST"),
+    manglerFritekst: hentFormVerdi("MANGLER_FRITEKST"),
+    fritekstTittel: hentFormVerdi("BREV_TITTEL", true),
+    fritekst: hentFormVerdi("FRITEKST"),
+    skalViseStandardTekstOmOpplysninger: hentFormVerdi("STANDARDTEKST_INNTEKTSOPPLYSNINGER") === "true",
+    kopiMottakere: hentKopiMottakere() || [],
+    skalViseStandardTekstOmkontaktopplysninger: hentFormVerdi("STANDARDTEKST_KONTAKTINFORMASJON") === "true",
+    saksvedlegg: valgteVedlegg?.saksvedlegg.map((v) => ({ dokumentID: v.dokumentID, journalpostID: v.journalpostID })),
+    standardvedleggType: valgteVedlegg?.standardvedlegg?.type ?? null,
+    fritekstvedlegg,
+    distribusjonstype: hentFormVerdi("DISTRIBUSJONSTYPE", true, true),
+    dokumentTittel: hentFormVerdi("DOKUMENT_TITTEL", true),
+    institusjonID: hentFormVerdi("UTENLANDSK_TRYGDEMYNDIGHET_MOTTAKER", true, true),
+  });
 
   const mapKopiMottakere = (
     muligeBrevMottakere: Api.DokumenterV2.HentMuligeMottakereResDto,

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
@@ -12,6 +12,15 @@ import { formSelectors } from "../../../../ducks/form";
 import { SendBrevFormValues } from "../types";
 import { erBruker } from "./brevMottaker";
 import Dokumentliste, { BrevDokumentMetadataType } from "../../../dokumentliste";
+import BrevVedlegg, { Fritekstvedlegg } from "../brevVedlegg/brevVedlegg";
+import {
+  BrevVedleggInterface,
+  BrevVedleggVisningstabellInterface,
+  FeilmeldingProps,
+  FysiskDokument,
+} from "../../../../services/modules/dokumenter-v2";
+
+import "./brevMottakereTabell.less";
 
 const mapStateToProps = (state: RootState) => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
@@ -26,7 +35,22 @@ interface BrevMottakereTabellProps {
   muligeMottakere?: Api.DokumenterV2.HentMuligeMottakereResDto;
   muligeMottakereNorskMyndighet?: Api.DokumenterV2.MuligMottaker[];
   formIsValid: boolean;
-  hentBrevRequest: any;
+  hentBrevRequest: (rolle: string) => Record<string, unknown>;
+  standardvedlegg: Api.DokumenterV2.TilgjengeligStandardvedlegg[];
+  fritekstvedlegg: Fritekstvedlegg[];
+  setFritekstvedlegg: (fritekstvedlegg: Fritekstvedlegg[]) => void;
+  valgteVedlegg: BrevVedleggInterface;
+  setValgteVedlegg: (valgteVedlegg: BrevVedleggVisningstabellInterface) => void;
+  changeField: (field: string, value: string) => void;
+  redigerbart: boolean;
+  behandlingID2: number;
+  dokumenter: FysiskDokument[];
+  mottakerErNorskMyndighet: boolean;
+  visFritekstvedleggSkjema: boolean;
+  setVisFritekstvedleggSkjema: (value: boolean) => void;
+  redigerFritekstvedleggIndex?: number;
+  setRedigerFritekstvedleggIndex: (value: number | undefined) => void;
+  valgtMottakerHarFeilmelding?: FeilmeldingProps | undefined;
 }
 
 function BrevMottakereTabell({
@@ -36,6 +60,21 @@ function BrevMottakereTabell({
   formValues,
   formIsValid,
   hentBrevRequest,
+  fritekstvedlegg,
+  setFritekstvedlegg,
+  valgteVedlegg,
+  setValgteVedlegg,
+  changeField,
+  redigerbart,
+  behandlingID2,
+  dokumenter,
+  mottakerErNorskMyndighet,
+  visFritekstvedleggSkjema,
+  setVisFritekstvedleggSkjema,
+  redigerFritekstvedleggIndex,
+  setRedigerFritekstvedleggIndex,
+  standardvedlegg,
+  valgtMottakerHarFeilmelding,
 }: BrevMottakereTabellProps & PropsFromRedux) {
   const mapKopiMottakere = (
     muligeBrevMottakere: Api.DokumenterV2.HentMuligeMottakereResDto,
@@ -54,7 +93,9 @@ function BrevMottakereTabell({
       mottakerNavn: muligMottaker.mottakerNavn,
       dokumentNavn: muligMottaker.dokumentNavn,
       dokumentData: {
-        ...hentBrevRequest(rolle),
+        produserbardokument: "true",
+        mottaker: muligMottaker.mottakerNavn,
+        ...(rolle ? hentBrevRequest(rolle) : {}),
         ...(!erBruker(rolle) && muligMottaker.orgnr ? { orgNr: muligMottaker.orgnr } : {}),
       },
     };
@@ -84,13 +125,39 @@ function BrevMottakereTabell({
         <Dokumentliste
           behandlingID={behandlingID}
           dokumenter={mapMottakerRader(muligeMottakere)}
+          label={"Forhåndsvisning av brev og vedlegg"}
+          className="dokumentliste--no-bottom-margin"
           validateOnClick={() => formIsValid}
         />
       )}
+
       {muligeMottakereNorskMyndighet && (
         <Dokumentliste
           behandlingID={behandlingID}
           dokumenter={muligeMottakereNorskMyndighet.map((muligMottaker) => mapDokument(muligMottaker))}
+          label={"Forhåndsvisning av brev og vedlegg"}
+          className="dokumentliste--no-bottom-margin"
+        />
+      )}
+
+      {!valgtMottakerHarFeilmelding && (
+        <BrevVedlegg
+          fritekstvedlegg={fritekstvedlegg}
+          setFritekstvedlegg={setFritekstvedlegg}
+          valgteVedlegg={valgteVedlegg}
+          setValgteVedlegg={setValgteVedlegg}
+          changeField={changeField}
+          formValues={formValues}
+          redigerbart={redigerbart}
+          behandlingID={behandlingID2}
+          dokumenter={dokumenter}
+          mottakerErNorskMyndighet={mottakerErNorskMyndighet}
+          visFritekstvedleggSkjema={visFritekstvedleggSkjema}
+          setVisFritekstvedleggSkjema={setVisFritekstvedleggSkjema}
+          redigerFritekstvedleggIndex={redigerFritekstvedleggIndex}
+          setRedigerFritekstvedleggIndex={setRedigerFritekstvedleggIndex}
+          muligeMottakere={muligeMottakere}
+          standardvedlegg={standardvedlegg}
         />
       )}
     </>

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
@@ -50,7 +50,7 @@ interface BrevMottakereTabellProps {
   muligeMottakereNorskMyndighet?: Api.DokumenterV2.MuligMottaker[];
   formIsValid: boolean;
   redigerbart: boolean;
-  vedlegg: VedleggSubsetProps;
+  brevVedlegg: VedleggSubsetProps;
 }
 
 function BrevMottakereTabell({
@@ -60,14 +60,14 @@ function BrevMottakereTabell({
   formValues,
   formIsValid,
   redigerbart,
-  vedlegg,
+  brevVedlegg,
 }: BrevMottakereTabellProps & PropsFromRedux) {
   const valgtMottakerHarFeilmelding: FeilmeldingProps | undefined = formValues?.valgtMottaker?.feilmelding;
   const mottakerErNorskMyndighet = formValues?.valgtMottaker?.rolle === "NORSK_MYNDIGHET";
 
   const harStandardVedlegg =
     formValues?.valgtMottaker?.rolle === "BRUKER" && formValues?.felt?.DISTRIBUSJONSTYPE?.valg === "VEDTAK";
-  const standardvedleggTilVisning = harStandardVedlegg ? vedlegg.standardvedlegg : [];
+  const standardvedleggTilVisning = harStandardVedlegg ? brevVedlegg.standardvedlegg : [];
 
   const finnValgAlternativ = (felt: Api.DokumenterV2.Felt) => {
     return felt?.valg?.valgAlternativer.find((alternativ) => alternativ.kode === formValues?.felt?.[felt.kode]?.valg);
@@ -117,12 +117,12 @@ function BrevMottakereTabell({
     skalViseStandardTekstOmOpplysninger: hentFormVerdi("STANDARDTEKST_INNTEKTSOPPLYSNINGER") === "true",
     kopiMottakere: hentKopiMottakere() || [],
     skalViseStandardTekstOmkontaktopplysninger: hentFormVerdi("STANDARDTEKST_KONTAKTINFORMASJON") === "true",
-    saksvedlegg: vedlegg.valgteVedlegg?.saksvedlegg.map((v) => ({
+    saksvedlegg: brevVedlegg.valgteVedlegg?.saksvedlegg.map((v) => ({
       dokumentID: v.dokumentID,
       journalpostID: v.journalpostID,
     })),
-    standardvedleggType: vedlegg.valgteVedlegg?.standardvedlegg?.type ?? null,
-    fritekstvedlegg: vedlegg.fritekstvedlegg,
+    standardvedleggType: brevVedlegg.valgteVedlegg?.standardvedlegg?.type ?? null,
+    fritekstvedlegg: brevVedlegg.fritekstvedlegg,
     distribusjonstype: hentFormVerdi("DISTRIBUSJONSTYPE", true, true),
     dokumentTittel: hentFormVerdi("DOKUMENT_TITTEL", true),
     institusjonID: hentFormVerdi("UTENLANDSK_TRYGDEMYNDIGHET_MOTTAKER", true, true),
@@ -197,16 +197,16 @@ function BrevMottakereTabell({
       {kanRendreVedlegg && (
         <BrevVedlegg
           // props som kommer fra subsettet (holdes i sync med BrevVedlegg via ComponentProps)
-          fritekstvedlegg={vedlegg.fritekstvedlegg}
-          setFritekstvedlegg={vedlegg.setFritekstvedlegg}
-          valgteVedlegg={vedlegg.valgteVedlegg}
-          setValgteVedlegg={vedlegg.setValgteVedlegg}
-          changeField={vedlegg.changeField}
-          dokumenter={vedlegg.dokumenter}
-          visFritekstvedleggSkjema={vedlegg.visFritekstvedleggSkjema}
-          setVisFritekstvedleggSkjema={vedlegg.setVisFritekstvedleggSkjema}
-          redigerFritekstvedleggIndex={vedlegg.redigerFritekstvedleggIndex}
-          setRedigerFritekstvedleggIndex={vedlegg.setRedigerFritekstvedleggIndex}
+          fritekstvedlegg={brevVedlegg.fritekstvedlegg}
+          setFritekstvedlegg={brevVedlegg.setFritekstvedlegg}
+          valgteVedlegg={brevVedlegg.valgteVedlegg}
+          setValgteVedlegg={brevVedlegg.setValgteVedlegg}
+          changeField={brevVedlegg.changeField}
+          dokumenter={brevVedlegg.dokumenter}
+          visFritekstvedleggSkjema={brevVedlegg.visFritekstvedleggSkjema}
+          setVisFritekstvedleggSkjema={brevVedlegg.setVisFritekstvedleggSkjema}
+          redigerFritekstvedleggIndex={brevVedlegg.redigerFritekstvedleggIndex}
+          setRedigerFritekstvedleggIndex={brevVedlegg.setRedigerFritekstvedleggIndex}
           // props som tabellen avleder
           formValues={formValues}
           redigerbart={redigerbart}

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
@@ -43,14 +43,11 @@ interface BrevMottakereTabellProps {
   setValgteVedlegg: (valgteVedlegg: BrevVedleggVisningstabellInterface) => void;
   changeField: (field: string, value: string) => void;
   redigerbart: boolean;
-  behandlingID2: number;
   dokumenter: FysiskDokument[];
-  mottakerErNorskMyndighet: boolean;
   visFritekstvedleggSkjema: boolean;
   setVisFritekstvedleggSkjema: (value: boolean) => void;
   redigerFritekstvedleggIndex?: number;
   setRedigerFritekstvedleggIndex: (value: number | undefined) => void;
-  valgtMottakerHarFeilmelding?: FeilmeldingProps | undefined;
 }
 
 function BrevMottakereTabell({
@@ -66,16 +63,20 @@ function BrevMottakereTabell({
   setValgteVedlegg,
   changeField,
   redigerbart,
-  behandlingID2,
   dokumenter,
-  mottakerErNorskMyndighet,
   visFritekstvedleggSkjema,
   setVisFritekstvedleggSkjema,
   redigerFritekstvedleggIndex,
   setRedigerFritekstvedleggIndex,
   standardvedlegg,
-  valgtMottakerHarFeilmelding,
 }: BrevMottakereTabellProps & PropsFromRedux) {
+  const valgtMottakerHarFeilmelding: FeilmeldingProps | undefined = formValues?.valgtMottaker?.feilmelding;
+  const mottakerErNorskMyndighet = formValues?.valgtMottaker?.rolle === "NORSK_MYNDIGHET";
+
+  const harStandardVedlegg =
+    formValues?.valgtMottaker?.rolle === "BRUKER" && formValues?.felt?.DISTRIBUSJONSTYPE?.valg === "VEDTAK";
+  const standardvedleggTilVisning = harStandardVedlegg ? standardvedlegg : [];
+
   const mapKopiMottakere = (
     muligeBrevMottakere: Api.DokumenterV2.HentMuligeMottakereResDto,
   ): BrevDokumentMetadataType[] => {
@@ -149,7 +150,7 @@ function BrevMottakereTabell({
           changeField={changeField}
           formValues={formValues}
           redigerbart={redigerbart}
-          behandlingID={behandlingID2}
+          behandlingID={behandlingID}
           dokumenter={dokumenter}
           mottakerErNorskMyndighet={mottakerErNorskMyndighet}
           visFritekstvedleggSkjema={visFritekstvedleggSkjema}
@@ -157,7 +158,7 @@ function BrevMottakereTabell({
           redigerFritekstvedleggIndex={redigerFritekstvedleggIndex}
           setRedigerFritekstvedleggIndex={setRedigerFritekstvedleggIndex}
           muligeMottakere={muligeMottakere}
-          standardvedlegg={standardvedlegg}
+          standardvedlegg={standardvedleggTilVisning}
         />
       )}
     </>

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { RootState } from "AppTypes";
 import { getFormValues } from "redux-form";
 import { connect, ConnectedProps } from "react-redux";
@@ -12,14 +13,8 @@ import { formSelectors } from "../../../../ducks/form";
 import { SendBrevFormValues } from "../types";
 import { erBruker } from "./brevMottaker";
 import Dokumentliste, { BrevDokumentMetadataType } from "../../../dokumentliste";
-import BrevVedlegg, { Fritekstvedlegg } from "../brevVedlegg/brevVedlegg";
-import {
-  BrevVedleggInterface,
-  BrevVedleggVisningstabellInterface,
-  FeilmeldingProps,
-  FysiskDokument,
-} from "../../../../services/modules/dokumenter-v2";
-
+import BrevVedlegg from "../brevVedlegg/brevVedlegg";
+import { FeilmeldingProps, TilgjengeligStandardvedlegg } from "../../../../services/modules/dokumenter-v2";
 import "./brevMottakereTabell.less";
 
 const mapStateToProps = (state: RootState) => ({
@@ -31,22 +26,31 @@ const mapStateToProps = (state: RootState) => ({
 const connector = connect(mapStateToProps);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
+// Les props-typen direkte fra BrevVedlegg-komponenten og lag et subset som passer som “vedlegg”-prop til tabellen.
+// Legg de til standardvedlegg siden vi vil styre filtrert liste i tabellen
+type BrevVedleggPropsFromComponent = React.ComponentProps<typeof BrevVedlegg>;
+type VedleggSubsetProps = Pick<
+  BrevVedleggPropsFromComponent,
+  | "fritekstvedlegg"
+  | "setFritekstvedlegg"
+  | "valgteVedlegg"
+  | "setValgteVedlegg"
+  | "changeField"
+  | "dokumenter"
+  | "visFritekstvedleggSkjema"
+  | "setVisFritekstvedleggSkjema"
+  | "redigerFritekstvedleggIndex"
+  | "setRedigerFritekstvedleggIndex"
+> & {
+  standardvedlegg: TilgjengeligStandardvedlegg[];
+};
+
 interface BrevMottakereTabellProps {
   muligeMottakere?: Api.DokumenterV2.HentMuligeMottakereResDto;
   muligeMottakereNorskMyndighet?: Api.DokumenterV2.MuligMottaker[];
   formIsValid: boolean;
   redigerbart: boolean;
-  standardvedlegg: Api.DokumenterV2.TilgjengeligStandardvedlegg[];
-  fritekstvedlegg: Fritekstvedlegg[];
-  setFritekstvedlegg: (fritekstvedlegg: Fritekstvedlegg[]) => void;
-  valgteVedlegg: BrevVedleggInterface;
-  setValgteVedlegg: (valgteVedlegg: BrevVedleggVisningstabellInterface) => void;
-  changeField: (field: string, value: string) => void;
-  dokumenter: FysiskDokument[];
-  visFritekstvedleggSkjema: boolean;
-  setVisFritekstvedleggSkjema: (value: boolean) => void;
-  redigerFritekstvedleggIndex?: number;
-  setRedigerFritekstvedleggIndex: (value: number | undefined) => void;
+  vedlegg: VedleggSubsetProps;
 }
 
 function BrevMottakereTabell({
@@ -56,24 +60,14 @@ function BrevMottakereTabell({
   formValues,
   formIsValid,
   redigerbart,
-  fritekstvedlegg,
-  setFritekstvedlegg,
-  valgteVedlegg,
-  setValgteVedlegg,
-  changeField,
-  dokumenter,
-  visFritekstvedleggSkjema,
-  setVisFritekstvedleggSkjema,
-  redigerFritekstvedleggIndex,
-  setRedigerFritekstvedleggIndex,
-  standardvedlegg,
+  vedlegg,
 }: BrevMottakereTabellProps & PropsFromRedux) {
   const valgtMottakerHarFeilmelding: FeilmeldingProps | undefined = formValues?.valgtMottaker?.feilmelding;
   const mottakerErNorskMyndighet = formValues?.valgtMottaker?.rolle === "NORSK_MYNDIGHET";
 
   const harStandardVedlegg =
     formValues?.valgtMottaker?.rolle === "BRUKER" && formValues?.felt?.DISTRIBUSJONSTYPE?.valg === "VEDTAK";
-  const standardvedleggTilVisning = harStandardVedlegg ? standardvedlegg : [];
+  const standardvedleggTilVisning = harStandardVedlegg ? vedlegg.standardvedlegg : [];
 
   const finnValgAlternativ = (felt: Api.DokumenterV2.Felt) => {
     return felt?.valg?.valgAlternativer.find((alternativ) => alternativ.kode === formValues?.felt?.[felt.kode]?.valg);
@@ -123,9 +117,12 @@ function BrevMottakereTabell({
     skalViseStandardTekstOmOpplysninger: hentFormVerdi("STANDARDTEKST_INNTEKTSOPPLYSNINGER") === "true",
     kopiMottakere: hentKopiMottakere() || [],
     skalViseStandardTekstOmkontaktopplysninger: hentFormVerdi("STANDARDTEKST_KONTAKTINFORMASJON") === "true",
-    saksvedlegg: valgteVedlegg?.saksvedlegg.map((v) => ({ dokumentID: v.dokumentID, journalpostID: v.journalpostID })),
-    standardvedleggType: valgteVedlegg?.standardvedlegg?.type ?? null,
-    fritekstvedlegg,
+    saksvedlegg: vedlegg.valgteVedlegg?.saksvedlegg.map((v) => ({
+      dokumentID: v.dokumentID,
+      journalpostID: v.journalpostID,
+    })),
+    standardvedleggType: vedlegg.valgteVedlegg?.standardvedlegg?.type ?? null,
+    fritekstvedlegg: vedlegg.fritekstvedlegg,
     distribusjonstype: hentFormVerdi("DISTRIBUSJONSTYPE", true, true),
     dokumentTittel: hentFormVerdi("DOKUMENT_TITTEL", true),
     institusjonID: hentFormVerdi("UTENLANDSK_TRYGDEMYNDIGHET_MOTTAKER", true, true),
@@ -166,6 +163,8 @@ function BrevMottakereTabell({
     ];
   };
 
+  const kanRendreVedlegg = Boolean(!valgtMottakerHarFeilmelding && redigerbart);
+
   return (
     <>
       {!Utils._isEmpty(muligeMottakere?.kopiMottakere) && (
@@ -195,22 +194,24 @@ function BrevMottakereTabell({
         />
       )}
 
-      {!valgtMottakerHarFeilmelding && (
+      {kanRendreVedlegg && (
         <BrevVedlegg
-          fritekstvedlegg={fritekstvedlegg}
-          setFritekstvedlegg={setFritekstvedlegg}
-          valgteVedlegg={valgteVedlegg}
-          setValgteVedlegg={setValgteVedlegg}
-          changeField={changeField}
+          // props som kommer fra subsettet (holdes i sync med BrevVedlegg via ComponentProps)
+          fritekstvedlegg={vedlegg.fritekstvedlegg}
+          setFritekstvedlegg={vedlegg.setFritekstvedlegg}
+          valgteVedlegg={vedlegg.valgteVedlegg}
+          setValgteVedlegg={vedlegg.setValgteVedlegg}
+          changeField={vedlegg.changeField}
+          dokumenter={vedlegg.dokumenter}
+          visFritekstvedleggSkjema={vedlegg.visFritekstvedleggSkjema}
+          setVisFritekstvedleggSkjema={vedlegg.setVisFritekstvedleggSkjema}
+          redigerFritekstvedleggIndex={vedlegg.redigerFritekstvedleggIndex}
+          setRedigerFritekstvedleggIndex={vedlegg.setRedigerFritekstvedleggIndex}
+          // props som tabellen avleder
           formValues={formValues}
           redigerbart={redigerbart}
           behandlingID={behandlingID}
-          dokumenter={dokumenter}
           mottakerErNorskMyndighet={mottakerErNorskMyndighet}
-          visFritekstvedleggSkjema={visFritekstvedleggSkjema}
-          setVisFritekstvedleggSkjema={setVisFritekstvedleggSkjema}
-          redigerFritekstvedleggIndex={redigerFritekstvedleggIndex}
-          setRedigerFritekstvedleggIndex={setRedigerFritekstvedleggIndex}
           muligeMottakere={muligeMottakere}
           standardvedlegg={standardvedleggTilVisning}
         />

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
@@ -93,7 +93,7 @@ function BrevMottakereTabell({
       mottakerNavn: muligMottaker.mottakerNavn,
       dokumentNavn: muligMottaker.dokumentNavn,
       dokumentData: {
-        produserbardokument: "true",
+        produserbardokument: "",
         mottaker: muligMottaker.mottakerNavn,
         ...(rolle ? hentBrevRequest(rolle) : {}),
         ...(!erBruker(rolle) && muligMottaker.orgnr ? { orgNr: muligMottaker.orgnr } : {}),

--- a/src/felleskomponenter/sideDialog/sendBrev/brevVedlegg/brevVedlegg.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevVedlegg/brevVedlegg.tsx
@@ -161,7 +161,6 @@ function BrevVedlegg({
           slettFritekstvedlegg={slettFritekstvedlegg}
           lagFritekstPdfUrl={lagFritekstPdfUrl}
           setValgteVedlegg={setValgteVedlegg}
-          label="Vedlegg"
           redigerbart={redigerbart}
         />
       )}

--- a/src/felleskomponenter/sideDialog/sendBrev/brevutkast/brevutkast.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevutkast/brevutkast.tsx
@@ -10,9 +10,9 @@ import {
   StandardvedleggType,
   TilgjengeligStandardvedlegg,
 } from "../../../../services/modules/dokumenter-v2";
-import { Fritekstvedlegg } from "../sendBrev";
 import { SendBrevFormValues } from "../types";
 import LagredeUtkast from "./lagredeUtkast";
+import { Fritekstvedlegg } from "../brevVedlegg/brevVedlegg";
 
 const { BRUKER, VIRKSOMHET, ARBEIDSGIVER, ANNEN_ORGANISASJON, NORSK_MYNDIGHET, UTENLANDSK_TRYGDEMYNDIGHET } =
   MKV.Koder.mottakerroller;

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.less
@@ -81,10 +81,6 @@
     margin-top: 0.5rem;
   }
 
-  .navds-table {
-    margin-top: 1rem;
-  }
-
   .skjemaelement__label {
     margin: 0;
   }

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.less
@@ -11,6 +11,10 @@
     margin-bottom: 1rem;
   }
 
+  .knapperad {
+    margin-top: 1rem;
+  }
+
   .alertstripe_feil {
     margin-bottom: 1rem;
 
@@ -53,6 +57,7 @@
 
   .forhåndsvisning {
     margin: 0;
+
     button {
       display: inline-flex;
       text-align: left;

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -524,17 +524,19 @@ function SendBrev({
               muligeMottakere={muligeMottakere}
               muligeMottakereNorskMyndighet={muligeMottakereNorskMyndighet}
               redigerbart={redigerbart}
-              fritekstvedlegg={fritekstvedlegg}
-              setFritekstvedlegg={setFritekstvedlegg}
-              valgteVedlegg={valgteVedlegg}
-              setValgteVedlegg={setValgteVedleggIState}
-              changeField={changeField}
-              dokumenter={dokumenter}
-              visFritekstvedleggSkjema={visFritekstvedleggSkjema}
-              setVisFritekstvedleggSkjema={setVisFritekstvedleggSkjema}
-              redigerFritekstvedleggIndex={redigerFritekstVedleggIndex}
-              setRedigerFritekstvedleggIndex={setRedigerFritekstvedleggIndex}
-              standardvedlegg={standardvedleggListe}
+              vedlegg={{
+                fritekstvedlegg,
+                setFritekstvedlegg,
+                valgteVedlegg,
+                setValgteVedlegg: setValgteVedleggIState,
+                changeField,
+                dokumenter,
+                visFritekstvedleggSkjema,
+                setVisFritekstvedleggSkjema,
+                redigerFritekstvedleggIndex: redigerFritekstVedleggIndex,
+                setRedigerFritekstvedleggIndex: setRedigerFritekstvedleggIndex,
+                standardvedlegg: standardvedleggListe,
+              }}
             />
           </Nav.Column>
         </Nav.Row>

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -36,7 +36,7 @@ import { SendBrevFormValues } from "./types";
 import { lagYupToReduxformErrorMapper } from "../../../yup";
 import sendBrevSchema from "./sendBrevSchema";
 import "./sendBrev.css";
-import BrevVedlegg from "./brevVedlegg/brevVedlegg";
+import { Fritekstvedlegg } from "./brevVedlegg/brevVedlegg";
 import LabelMedHjelpetekst from "../../labelMedHjelpetekst";
 
 const { VIRKSOMHET, ARBEIDSGIVER, ANNEN_ORGANISASJON, NORSK_MYNDIGHET, UTENLANDSK_TRYGDEMYNDIGHET } =
@@ -61,11 +61,6 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<RootState, unknown, Action>)
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export interface Fritekstvedlegg {
-  tittel: string;
-  fritekst: string;
-}
 
 interface Props {
   redigerbart: boolean;
@@ -336,7 +331,7 @@ function SendBrev({
     }
   };
 
-  const hentBrevRequest = (mottakerRolle: string): Api.DokumenterV2.OpprettBrevReqDto => ({
+  const hentBrevRequest = (mottakerRolle: string): Record<string, unknown> => ({
     produserbardokument: formValues.type || "",
     mottaker: mottakerRolle,
     orgNr: hentOrgnr(mottakerRolle),
@@ -366,7 +361,13 @@ function SendBrev({
     setSendBrevSpinner(true);
     setFeil(undefined);
 
-    Api.DokumenterV2.opprettBrev(behandlingID, hentBrevRequest(formValues.valgtMottaker.rolle))
+    const brevRequest: Api.DokumenterV2.OpprettBrevReqDto = {
+      ...hentBrevRequest(formValues.valgtMottaker.rolle),
+      produserbardokument: formValues.type || "",
+      mottaker: formValues.valgtMottaker.rolle,
+    };
+
+    Api.DokumenterV2.opprettBrev(behandlingID, brevRequest)
       .then(() => {
         setVisBrevBestiltAlert(true);
         setTimeout(() => {
@@ -413,7 +414,11 @@ function SendBrev({
     setLagreUtkastSpinner(true);
     setFeil(undefined);
 
-    const requestData = hentBrevRequest(formValues.valgtMottaker.rolle);
+    const requestData: Api.DokumenterV2.OpprettBrevReqDto = {
+      ...hentBrevRequest(formValues.valgtMottaker.rolle),
+      produserbardokument: formValues.type || "",
+      mottaker: formValues.valgtMottaker.rolle,
+    };
 
     (formValues?.aktivtUtkast?.utkastBrevID
       ? Api.Brevutkast.oppdaterBrevutkast(behandlingID, formValues.aktivtUtkast.utkastBrevID, requestData)
@@ -523,6 +528,21 @@ function SendBrev({
               muligeMottakere={muligeMottakere}
               muligeMottakereNorskMyndighet={muligeMottakereNorskMyndighet}
               hentBrevRequest={hentBrevRequest}
+              fritekstvedlegg={fritekstvedlegg}
+              setFritekstvedlegg={setFritekstvedlegg}
+              valgteVedlegg={valgteVedlegg}
+              setValgteVedlegg={setValgteVedleggIState}
+              changeField={changeField}
+              redigerbart={redigerbart}
+              behandlingID2={behandlingID}
+              dokumenter={dokumenter}
+              mottakerErNorskMyndighet={mottakerErNorskMyndighet}
+              visFritekstvedleggSkjema={visFritekstvedleggSkjema}
+              setVisFritekstvedleggSkjema={setVisFritekstvedleggSkjema}
+              redigerFritekstvedleggIndex={redigerFritekstVedleggIndex}
+              setRedigerFritekstvedleggIndex={setRedigerFritekstvedleggIndex}
+              standardvedlegg={harStandardVedlegg() ? standardvedleggListe : []}
+              valgtMottakerHarFeilmelding={valgtMottakerHarFeilmelding}
             />
           </Nav.Column>
         </Nav.Row>
@@ -532,27 +552,6 @@ function SendBrev({
         <Nav.Alert variant="warning" className="varsel">
           {muligeMottakereFeil}
         </Nav.Alert>
-      )}
-
-      {!valgtMottakerHarFeilmelding && (
-        <BrevVedlegg
-          fritekstvedlegg={fritekstvedlegg}
-          setFritekstvedlegg={setFritekstvedlegg}
-          valgteVedlegg={valgteVedlegg}
-          setValgteVedlegg={setValgteVedleggIState}
-          changeField={changeField}
-          formValues={formValues}
-          redigerbart={redigerbart}
-          behandlingID={behandlingID}
-          dokumenter={dokumenter}
-          mottakerErNorskMyndighet={mottakerErNorskMyndighet}
-          visFritekstvedleggSkjema={visFritekstvedleggSkjema}
-          setVisFritekstvedleggSkjema={setVisFritekstvedleggSkjema}
-          redigerFritekstvedleggIndex={redigerFritekstVedleggIndex}
-          setRedigerFritekstvedleggIndex={setRedigerFritekstvedleggIndex}
-          muligeMottakere={muligeMottakere}
-          standardvedlegg={harStandardVedlegg() ? standardvedleggListe : []}
-        />
       )}
 
       <div className="send_brev__knapperad">

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -524,7 +524,7 @@ function SendBrev({
               muligeMottakere={muligeMottakere}
               muligeMottakereNorskMyndighet={muligeMottakereNorskMyndighet}
               redigerbart={redigerbart}
-              vedlegg={{
+              brevVedlegg={{
                 fritekstvedlegg,
                 setFritekstvedlegg,
                 valgteVedlegg,

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -436,10 +436,6 @@ function SendBrev({
     event.preventDefault();
   };
 
-  const harStandardVedlegg = () => {
-    return formValues?.valgtMottaker?.rolle === "BRUKER" && formValues?.felt?.DISTRIBUSJONSTYPE?.valg === "VEDTAK";
-  };
-
   if (!tilgjengeligeMaler || !formValues) return null;
   if (!visInnhold) return null;
 
@@ -534,15 +530,12 @@ function SendBrev({
               setValgteVedlegg={setValgteVedleggIState}
               changeField={changeField}
               redigerbart={redigerbart}
-              behandlingID2={behandlingID}
               dokumenter={dokumenter}
-              mottakerErNorskMyndighet={mottakerErNorskMyndighet}
               visFritekstvedleggSkjema={visFritekstvedleggSkjema}
               setVisFritekstvedleggSkjema={setVisFritekstvedleggSkjema}
               redigerFritekstvedleggIndex={redigerFritekstVedleggIndex}
               setRedigerFritekstvedleggIndex={setRedigerFritekstvedleggIndex}
-              standardvedlegg={harStandardVedlegg() ? standardvedleggListe : []}
-              valgtMottakerHarFeilmelding={valgtMottakerHarFeilmelding}
+              standardvedlegg={standardvedleggListe}
             />
           </Nav.Column>
         </Nav.Row>

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -523,13 +523,12 @@ function SendBrev({
             <BrevMottakereTabell
               muligeMottakere={muligeMottakere}
               muligeMottakereNorskMyndighet={muligeMottakereNorskMyndighet}
-              hentBrevRequest={hentBrevRequest}
+              redigerbart={redigerbart}
               fritekstvedlegg={fritekstvedlegg}
               setFritekstvedlegg={setFritekstvedlegg}
               valgteVedlegg={valgteVedlegg}
               setValgteVedlegg={setValgteVedleggIState}
               changeField={changeField}
-              redigerbart={redigerbart}
               dokumenter={dokumenter}
               visFritekstvedleggSkjema={visFritekstvedleggSkjema}
               setVisFritekstvedleggSkjema={setVisFritekstvedleggSkjema}

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -554,7 +554,7 @@ function SendBrev({
         </Nav.Alert>
       )}
 
-      <div className="send_brev__knapperad">
+      <div className="knapperad">
         <Nav.Button
           variant="primary"
           disabled={knappErDisabled}

--- a/src/felleskomponenter/vedleggTable/__snapshots__/fritekstvedleggRow.test.tsx.snap
+++ b/src/felleskomponenter/vedleggTable/__snapshots__/fritekstvedleggRow.test.tsx.snap
@@ -5,13 +5,47 @@ exports[`fritekstvedleggRow > snapshot test 1`] = `
 <div>
   <table>
     <tbody>
-      <tr class="navds-table__row navds-table__row--shade-on-hover">
+      <tr class="navds-table__row vedlegg-row navds-table__row--shade-on-hover">
         <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewbox="0 0 24 24"
+            class="document-icon"
+          >
+            <path
+              stroke="#0067C5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-miterlimit="10"
+              fill="none"
+              d="M7.717 15.202l8.501-8.5a2 2 0 112.828 2.828L7.563 21.048a4 4 0 01-5.657-5.657l12-12a5.498 5.498 0 017.778 0 5.497 5.497 0 010 7.776l-8.5 8.5"
+            >
+            </path>
+          </svg>
           <a
             href="#"
+            title="Åpnes i ny fane"
+            aria-label="Åpnes i ny fane"
             class="navds-link navds-link--action"
           >
             a
+            <svg
+              width="24"
+              height="24"
+              viewbox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M20.5857 2H14V0H24V10H22V3.41417L10.7071 14.7071L9.29285 13.2929L20.5857 2ZM0 5C0 3.89543 0.895431 3 2 3H10.5V5L2 5V22H19V13.5H21V22C21 23.1046 20.1046 24 19 24H2C0.895429 24 0 23.1046 0 22V5Z"
+                fill="#0067C5"
+              >
+              </path>
+            </svg>
           </a>
         </td>
         <td class="navds-table__data-cell navds-body-short navds-body-short--small">

--- a/src/felleskomponenter/vedleggTable/__snapshots__/vedleggRow.test.tsx.snap
+++ b/src/felleskomponenter/vedleggTable/__snapshots__/vedleggRow.test.tsx.snap
@@ -5,8 +5,26 @@ exports[`vedleggRow > snapshot test 1`] = `
 <div>
   <table>
     <tbody>
-      <tr class="navds-table__row vedlegg navds-table__row--shade-on-hover">
+      <tr class="navds-table__row vedlegg vedlegg-row navds-table__row--shade-on-hover">
         <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewbox="0 0 24 24"
+            class="document-icon"
+            stroke="#0067C5"
+          >
+            <path
+              stroke="#0067C5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-miterlimit="10"
+              fill="none"
+              d="M7.717 15.202l8.501-8.5a2 2 0 112.828 2.828L7.563 21.048a4 4 0 01-5.657-5.657l12-12a5.498 5.498 0 017.778 0 5.497 5.497 0 010 7.776l-8.5 8.5"
+            >
+            </path>
+          </svg>
           <a
             href="#"
             title="Åpnes i ny fane"

--- a/src/felleskomponenter/vedleggTable/__snapshots__/vedleggTable.test.tsx.snap
+++ b/src/felleskomponenter/vedleggTable/__snapshots__/vedleggTable.test.tsx.snap
@@ -4,25 +4,48 @@ exports[`vedleggTable > snapshot test 1`] = `
 
 <div>
   <table class="navds-table navds-table--small vedleggtable">
-    <thead class="navds-table__header">
-      <tr class="navds-table__row navds-table__row--shade-on-hover">
-        <th class="navds-table__header-cell navds-label navds-label--small">
-          a
-        </th>
-        <th class="navds-table__header-cell navds-label navds-label--small">
-        </th>
-        <th class="navds-table__header-cell navds-label navds-label--small">
-        </th>
-      </tr>
-    </thead>
     <tbody class="navds-table__body">
-      <tr class="navds-table__row navds-table__row--shade-on-hover">
+      <tr class="navds-table__row vedlegg-row navds-table__row--shade-on-hover">
         <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewbox="0 0 24 24"
+            class="document-icon"
+          >
+            <path
+              stroke="#0067C5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-miterlimit="10"
+              fill="none"
+              d="M7.717 15.202l8.501-8.5a2 2 0 112.828 2.828L7.563 21.048a4 4 0 01-5.657-5.657l12-12a5.498 5.498 0 017.778 0 5.497 5.497 0 010 7.776l-8.5 8.5"
+            >
+            </path>
+          </svg>
           <a
             href="#"
+            title="Åpnes i ny fane"
+            aria-label="Åpnes i ny fane"
             class="navds-link navds-link--action"
           >
             123
+            <svg
+              width="24"
+              height="24"
+              viewbox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M20.5857 2H14V0H24V10H22V3.41417L10.7071 14.7071L9.29285 13.2929L20.5857 2ZM0 5C0 3.89543 0.895431 3 2 3H10.5V5L2 5V22H19V13.5H21V22C21 23.1046 20.1046 24 19 24H2C0.895429 24 0 23.1046 0 22V5Z"
+                fill="#0067C5"
+              >
+              </path>
+            </svg>
           </a>
         </td>
         <td class="navds-table__data-cell navds-body-short navds-body-short--small">

--- a/src/felleskomponenter/vedleggTable/__snapshots__/vedleggTable.test.tsx.snap
+++ b/src/felleskomponenter/vedleggTable/__snapshots__/vedleggTable.test.tsx.snap
@@ -4,6 +4,17 @@ exports[`vedleggTable > snapshot test 1`] = `
 
 <div>
   <table class="navds-table navds-table--small vedleggtable">
+    <thead class="navds-table__header">
+      <tr class="navds-table__row navds-table__row--shade-on-hover">
+        <th class="navds-table__header-cell navds-label navds-label--small">
+          a
+        </th>
+        <th class="navds-table__header-cell navds-label navds-label--small">
+        </th>
+        <th class="navds-table__header-cell navds-label navds-label--small">
+        </th>
+      </tr>
+    </thead>
     <tbody class="navds-table__body">
       <tr class="navds-table__row vedlegg-row navds-table__row--shade-on-hover">
         <td class="navds-table__data-cell navds-body-short navds-body-short--small">

--- a/src/felleskomponenter/vedleggTable/__snapshots__/vedleggTable.test.tsx.snap
+++ b/src/felleskomponenter/vedleggTable/__snapshots__/vedleggTable.test.tsx.snap
@@ -114,8 +114,26 @@ exports[`vedleggTable > snapshot test 1`] = `
           </button>
         </td>
       </tr>
-      <tr class="navds-table__row vedlegg navds-table__row--shade-on-hover">
+      <tr class="navds-table__row vedlegg vedlegg-row navds-table__row--shade-on-hover">
         <td class="navds-table__data-cell navds-body-short navds-body-short--small">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewbox="0 0 24 24"
+            class="document-icon"
+            stroke="#0067C5"
+          >
+            <path
+              stroke="#0067C5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-miterlimit="10"
+              fill="none"
+              d="M7.717 15.202l8.501-8.5a2 2 0 112.828 2.828L7.563 21.048a4 4 0 01-5.657-5.657l12-12a5.498 5.498 0 017.778 0 5.497 5.497 0 010 7.776l-8.5 8.5"
+            >
+            </path>
+          </svg>
           <a
             href="#"
             title="Åpnes i ny fane"

--- a/src/felleskomponenter/vedleggTable/fritekstvedleggRow.tsx
+++ b/src/felleskomponenter/vedleggTable/fritekstvedleggRow.tsx
@@ -3,9 +3,10 @@ import { MouseEvent, useState } from "react";
 import * as Nav from "../../navFrontend";
 import * as Mui from "../ui";
 import * as Ikoner from "../../resources/images";
-import { Fritekstvedlegg } from "../sideDialog/sendBrev/sendBrev";
 import { apnePdfINyFane } from "../../services/utils";
 import SlettFritekstvedleggModal from "./slettFritekstvedleggModal";
+import { Fritekstvedlegg } from "../sideDialog/sendBrev/brevVedlegg/brevVedlegg";
+import "./vedleggRow.less";
 
 interface FritekstvedleggRowProps {
   fritekstvedlegg: Fritekstvedlegg;
@@ -30,15 +31,17 @@ function FritekstvedleggRow({
     event.preventDefault();
     const url = lagFritekstPdfUrl ? await lagFritekstPdfUrl(index) : null;
     if (url) {
-      apnePdfINyFane(url);
+      await apnePdfINyFane(url);
     }
   };
 
   return (
-    <Nav.Table.Row>
+    <Nav.Table.Row className="vedlegg-row">
       <Nav.Table.DataCell>
-        <Nav.Link href="#" onClick={aapnePdf}>
+        <Ikoner.Binders className="document-icon" />
+        <Nav.Link href="#" title="Åpnes i ny fane" aria-label="Åpnes i ny fane" onClick={aapnePdf}>
           {fritekstvedlegg.tittel}
+          <Ikoner.ExternalLink />
         </Nav.Link>
       </Nav.Table.DataCell>
       <Nav.Table.DataCell />

--- a/src/felleskomponenter/vedleggTable/fritekstvedleggRow.tsx
+++ b/src/felleskomponenter/vedleggTable/fritekstvedleggRow.tsx
@@ -31,7 +31,7 @@ function FritekstvedleggRow({
     event.preventDefault();
     const url = lagFritekstPdfUrl ? await lagFritekstPdfUrl(index) : null;
     if (url) {
-      await apnePdfINyFane(url);
+      apnePdfINyFane(url);
     }
   };
 

--- a/src/felleskomponenter/vedleggTable/vedleggRow.less
+++ b/src/felleskomponenter/vedleggTable/vedleggRow.less
@@ -1,0 +1,8 @@
+.vedlegg-row {
+  .document-icon {
+    height: 18px;
+    width: 18px;
+    vertical-align: middle;
+    margin-right: 8px;
+  }
+}

--- a/src/felleskomponenter/vedleggTable/vedleggRow.less
+++ b/src/felleskomponenter/vedleggTable/vedleggRow.less
@@ -5,4 +5,8 @@
     vertical-align: middle;
     margin-right: 8px;
   }
+
+  .ikon-knapp {
+    min-height: 1rem;
+  }
 }

--- a/src/felleskomponenter/vedleggTable/vedleggRow.tsx
+++ b/src/felleskomponenter/vedleggTable/vedleggRow.tsx
@@ -5,6 +5,7 @@ import * as Ikoner from "../../resources/images";
 import * as Nav from "../../navFrontend";
 import { FysiskDokument, TilgjengeligStandardvedlegg } from "../../services/modules/dokumenter-v2";
 import PdfLinkStandardvedlegg from "../pdfLink/pdfLinkStandardvedlegg";
+import "./vedleggRow.less";
 
 interface VedleggRowProps {
   vedlegg: FysiskDokument | TilgjengeligStandardvedlegg;
@@ -27,8 +28,9 @@ function skalViseEgenFrontendTittel(redigerbart: boolean) {
 function VedleggRow({ vedlegg, slettVedlegg, redigerbart }: VedleggRowProps) {
   if (erTilgjengeligStandardvedlegg(vedlegg)) {
     return (
-      <Nav.Table.Row className="vedlegg">
+      <Nav.Table.Row className="vedlegg vedlegg-row">
         <Nav.Table.DataCell>
+          <Ikoner.Binders className="document-icon" stroke="#0067C5" />
           <PdfLinkStandardvedlegg
             standardvedlegg={vedlegg}
             skalViseEgenFrontendTittel={skalViseEgenFrontendTittel(redigerbart)}

--- a/src/felleskomponenter/vedleggTable/vedleggRow.tsx
+++ b/src/felleskomponenter/vedleggTable/vedleggRow.tsx
@@ -47,8 +47,9 @@ function VedleggRow({ vedlegg, slettVedlegg, redigerbart }: VedleggRowProps) {
   }
 
   return (
-    <Nav.Table.Row className="vedlegg">
+    <Nav.Table.Row className="vedlegg vedlegg-row">
       <Nav.Table.DataCell>
+        <Ikoner.Binders className="document-icon" stroke="#0067C5" />
         <PdfLink journalpostID={vedlegg.journalpostID} dokumentID={vedlegg.dokumentID} tittel={vedlegg.tittel} />
       </Nav.Table.DataCell>
       <Nav.Table.DataCell>

--- a/src/felleskomponenter/vedleggTable/vedleggTable.less
+++ b/src/felleskomponenter/vedleggTable/vedleggTable.less
@@ -3,6 +3,4 @@
     white-space: nowrap;
     text-align: right;
   }
-
-  margin-bottom: 1rem;
 }

--- a/src/felleskomponenter/vedleggTable/vedleggTable.tsx
+++ b/src/felleskomponenter/vedleggTable/vedleggTable.tsx
@@ -1,15 +1,15 @@
 import { BrevVedleggVisningstabellInterface, StandardvedleggType } from "../../services/modules/dokumenter-v2";
 
 import * as Nav from "../../navFrontend";
-import { Fritekstvedlegg } from "../sideDialog/sendBrev/sendBrev";
 import FritekstvedleggRow from "./fritekstvedleggRow";
 import VedleggRow from "./vedleggRow";
 import "./vedleggTable.css";
+import { Fritekstvedlegg } from "../sideDialog/sendBrev/brevVedlegg/brevVedlegg";
 
 interface VedleggTableProps {
   valgteVedlegg: BrevVedleggVisningstabellInterface;
   setValgteVedlegg: (valgteVedlegg: BrevVedleggVisningstabellInterface) => void;
-  label: string;
+  label?: string;
   fritekstvedlegg?: Fritekstvedlegg[];
   redigerFritekstvedlegg?: (index: number) => void;
   slettFritekstvedlegg?: (index: number) => void;
@@ -43,13 +43,15 @@ function VedleggTable({
 
   return (
     <Nav.Table className="vedleggtable" size="small">
-      <Nav.Table.Header>
-        <Nav.Table.Row>
-          <Nav.Table.HeaderCell>{label}</Nav.Table.HeaderCell>
-          <Nav.Table.HeaderCell />
-          <Nav.Table.HeaderCell />
-        </Nav.Table.Row>
-      </Nav.Table.Header>
+      {label && (
+        <Nav.Table.Header>
+          <Nav.Table.Row>
+            <Nav.Table.HeaderCell>{label}</Nav.Table.HeaderCell>
+            <Nav.Table.HeaderCell />
+            <Nav.Table.HeaderCell />
+          </Nav.Table.Row>
+        </Nav.Table.Header>
+      )}
       {(valgteVedlegg.saksvedlegg.length > 0 ||
         (fritekstvedlegg && fritekstvedlegg.length > 0) ||
         valgteVedlegg.standardvedlegg) && (

--- a/src/felleskomponenter/vedleggTable/vedleggTable.tsx
+++ b/src/felleskomponenter/vedleggTable/vedleggTable.tsx
@@ -1,15 +1,14 @@
 import { BrevVedleggVisningstabellInterface, StandardvedleggType } from "../../services/modules/dokumenter-v2";
 
 import * as Nav from "../../navFrontend";
-import { Fritekstvedlegg } from "../sideDialog/sendBrev/sendBrev";
 import FritekstvedleggRow from "./fritekstvedleggRow";
 import VedleggRow from "./vedleggRow";
 import "./vedleggTable.css";
+import { Fritekstvedlegg } from "../sideDialog/sendBrev/brevVedlegg/brevVedlegg";
 
 interface VedleggTableProps {
   valgteVedlegg: BrevVedleggVisningstabellInterface;
   setValgteVedlegg: (valgteVedlegg: BrevVedleggVisningstabellInterface) => void;
-  label: string;
   fritekstvedlegg?: Fritekstvedlegg[];
   redigerFritekstvedlegg?: (index: number) => void;
   slettFritekstvedlegg?: (index: number) => void;
@@ -20,7 +19,6 @@ interface VedleggTableProps {
 function VedleggTable({
   valgteVedlegg,
   setValgteVedlegg,
-  label,
   fritekstvedlegg,
   redigerFritekstvedlegg,
   slettFritekstvedlegg,
@@ -43,13 +41,6 @@ function VedleggTable({
 
   return (
     <Nav.Table className="vedleggtable" size="small">
-      <Nav.Table.Header>
-        <Nav.Table.Row>
-          <Nav.Table.HeaderCell>{label}</Nav.Table.HeaderCell>
-          <Nav.Table.HeaderCell />
-          <Nav.Table.HeaderCell />
-        </Nav.Table.Row>
-      </Nav.Table.Header>
       {(valgteVedlegg.saksvedlegg.length > 0 ||
         (fritekstvedlegg && fritekstvedlegg.length > 0) ||
         valgteVedlegg.standardvedlegg) && (

--- a/src/resources/images/paperclip.svg
+++ b/src/resources/images/paperclip.svg
@@ -1,3 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
-    <path stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M7.717 15.202l8.501-8.5a2 2 0 112.828 2.828L7.563 21.048a4 4 0 01-5.657-5.657l12-12a5.498 5.498 0 017.778 0 5.497 5.497 0 010 7.776l-8.5 8.5" fill="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path stroke="#0067C5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" fill="none"
+          d="M7.717 15.202l8.501-8.5a2 2 0 112.828 2.828L7.563 21.048a4 4 0 01-5.657-5.657l12-12a5.498 5.498 0 017.778 0 5.497 5.497 0 010 7.776l-8.5 8.5"/>
 </svg>

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/__snapshots__/vurderingArtikkel13_x_vedtak.test.jsx.snap
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/__snapshots__/vurderingArtikkel13_x_vedtak.test.jsx.snap
@@ -163,7 +163,7 @@ exports[`VurderingArtikkel13_x_Vedtak > snapshot test 1`] = `
     </div>
     <div class="row">
       <div class="col col-xs-8">
-        <div class="dokumentliste">
+        <div class="dokumentliste ">
           <table class="navds-table navds-table--small">
             <thead class="navds-table__header">
               <tr class="navds-table__row navds-table__row--shade-on-hover">

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/__snapshots__/vurderingArtikkel16Vedtak.test.jsx.snap
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/__snapshots__/vurderingArtikkel16Vedtak.test.jsx.snap
@@ -138,7 +138,7 @@ exports[`VurderingArtikkel16Vedtak > snapshot test 1`] = `
     </div>
     <div class="row">
       <div class="col col-xs-10">
-        <div class="dokumentliste">
+        <div class="dokumentliste ">
           <table class="navds-table navds-table--small">
             <thead class="navds-table__header">
               <tr class="navds-table__row navds-table__row--shade-on-hover">


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7426

1. Flyttet BrevVedlegg fra SendBrev inn i BrevMottakereTabell og gjort label/header optional, slik at den blir en ren liste under  dokumentlista.
2. Justert styling slik at vi får mer lik høyde på rader i de to listene
3. Lag til mer luft over nedre knapperad
4. Lagt til manglende TS typer
