### PR TITLE
MELOSYS-7421 Korrigert margin-bottom

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.less
@@ -9,3 +9,33 @@
 .kontaktperson {
   margin-bottom: 0;
 }
+
+.arbeidsgiver .navds-radio-buttons {
+  margin-bottom: 0;
+}
+
+.arbeidsgiver {
+  &__adresse {
+    margin: 0 0 0 2rem;
+  }
+}
+
+.alertstripe_feil {
+  margin-bottom: 1rem;
+
+  ul {
+    margin: 0 0 0 -1rem;
+  }
+}
+
+.brukeradresse {
+  margin-left: 0.5rem;
+}
+
+.organisasjonsAdresse {
+  margin-bottom: 0.5rem;
+
+  .registeradresse {
+    margin-top: 0;
+  }
+}

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.less
@@ -20,6 +20,12 @@
   }
 }
 
+.norskmyndighet {
+  .navds-checkboxes {
+    margin-bottom: 0;
+  }
+}
+
 .alertstripe_feil {
   margin-bottom: 1rem;
 

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakerNorskMyndighet.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakerNorskMyndighet.tsx
@@ -7,6 +7,7 @@ import * as KV from "../../../../kodeverk";
 import * as Nav from "../../../../navFrontend";
 import * as Api from "../../../../services/api";
 import { SendBrevFormValues } from "../types";
+import "./brevMottaker.less";
 
 function BrevMottakerNorskMyndighet() {
   const formValues = useSelector((state: any) => getFormValues(KV.Form.SEND_BREV)(state) as SendBrevFormValues);
@@ -35,7 +36,11 @@ function BrevMottakerNorskMyndighet() {
   };
 
   return (
-    <Nav.CheckboxGroup legend="Hvilke etater skal brevet sendes til?" defaultValue={valgteNorskeMyndigheter}>
+    <Nav.CheckboxGroup
+      className="norskmyndighet"
+      legend="Hvilke etater skal brevet sendes til?"
+      defaultValue={valgteNorskeMyndigheter}
+    >
       {tilgjengeligeNorskeMyndigheter?.map((norskMyndighet) => (
         <Nav.Checkbox
           key={norskMyndighet.orgnr}

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.less
@@ -50,6 +50,10 @@
     margin-bottom: 1rem;
   }
 
+  .brevmottaker__wrapper {
+    margin-bottom: 1.5rem;
+  }
+
   .fritekstvedlegg__knapp {
     margin-top: 0.5rem;
   }

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.less
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.less
@@ -11,35 +11,8 @@
     margin-bottom: 1rem;
   }
 
-  .alertstripe_feil {
-    margin-bottom: 1rem;
-
-    ul {
-      margin: 0;
-      margin-left: -1rem;
-    }
-  }
-
   .brevknapp {
     margin: 1rem 1rem 0 0;
-  }
-
-  .brukeradresse {
-    margin-left: 0.5rem;
-  }
-
-  .arbeidsgiver {
-    &__adresse {
-      margin: 0 0 0.5rem 2rem;
-    }
-  }
-
-  .organisasjonsAdresse {
-    margin-bottom: 0.5rem;
-
-    .registeradresse {
-      margin-top: 0;
-    }
   }
 
   .normal_font_weight {

--- a/src/sider/sendbrev/sendbrev.less
+++ b/src/sider/sendbrev/sendbrev.less
@@ -1,8 +1,4 @@
 .send_brev {
   width: 100%;
   padding-top: 1em;
-
-  .brevmottaker__wrapper {
-    margin-bottom: 1.5rem;
-  }
 }


### PR DESCRIPTION
NB: I JIRA saken nevnes det at brevmottaker__wrapper legger på 1.5rem (24px) bottom og at det kan være problemet. Men denne er jo i effekt uansett hvilken mottaker som velges så det forklarer ikke problemet med forskjellig bottom margin avhengig av valgt mottaker.

Jeg har i stedet korrigert bottom-margins på navds-radio-buttons og arbeidsgiver_adresse.

Ser også at samme problem oppstår ved valg av mottaker "Norsk myndighet" og har korrigeret bottom margin for check-boxer der, på tilsvarende måte.

I tillegg er en del CSS flyttet dit de brukes - klasser som hører til brevmottaker ned fra sendBrev.less til brevMottaker.less og brevmottaker__wrapper fra sendbrev.less til sendBrev.less.

https://jira.adeo.no/browse/MELOSYS-7421