### PR TITLE
6760 bugfix, spesialregel for validering av STANDARDTEKST_INNTEKTSOPPLYSNINGER

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrevSchema.test.ts
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrevSchema.test.ts
@@ -87,14 +87,14 @@ function expectMangelbrevBrukerErrors(err: ValidationError | null) {
     innledningFritekstValg === "Du må velge minst én av standardtekst eller fritekst";
   expect(innledningOK).toBe(true);
 
-  expect(manglerFritekstMsg).toBe("Du må skrive inn i hva mottaker skal sende inn");
+  expect(manglerFritekstMsg).toBe("Du må skrive inn hva mottaker skal sende inn");
 
   // Nøklene skal fortsatt være de samme
   expect(Object.keys(feltErrors as ErrorsMap).sort()).toEqual(["INNLEDNING_FRITEKST", "MANGLER_FRITEKST"].sort());
 
   // Oppsummering: må inneholde melding for MANGLER_FRITEKST og minst én av de to mulige for INNLEDNING_FRITEKST
   const summary = buildValidationSummary(feltErrors);
-  expect(summary).toContain("Du må skrive inn i hva mottaker skal sende inn");
+  expect(summary).toContain("Du må skrive inn hva mottaker skal sende inn");
   expect(
     summary.includes("Du må skrive inn innledningstekst i fritekstfeltet") ||
       summary.includes("Du må velge minst én av standardtekst eller fritekst"),
@@ -428,10 +428,10 @@ describe("alle kombinasjoner av mottaker og brevmal – korrekte feltfeil og de 
     const feilEtterFørsteUtfylling = extractFeltErrors(err);
     expect(unwrapMelding(feilEtterFørsteUtfylling?.INNLEDNING_FRITEKST?.feltVerdi)).toBeUndefined();
     expect(unwrapMelding(feilEtterFørsteUtfylling?.MANGLER_FRITEKST?.feltVerdi)).toBe(
-      "Du må skrive inn i hva mottaker skal sende inn",
+      "Du må skrive inn hva mottaker skal sende inn",
     );
     const summary = buildValidationSummary(feilEtterFørsteUtfylling);
-    expect(summary).toContain("Du må skrive inn i hva mottaker skal sende inn");
+    expect(summary).toContain("Du må skrive inn hva mottaker skal sende inn");
 
     // Hvis schema fortsatt krever valg for INNLEDNING_FRITEKST, sett et lovlig valg før siste validering
     const innledningValgMangler =
@@ -492,11 +492,9 @@ describe("alle kombinasjoner av mottaker og brevmal – korrekte feltfeil og de 
     expect(err).toBeTruthy();
     const feilEtter = extractFeltErrors(err);
     expect(unwrapMelding(feilEtter?.INNLEDNING_FRITEKST?.feltVerdi)).toBeUndefined();
-    expect(unwrapMelding(feilEtter?.MANGLER_FRITEKST?.feltVerdi)).toBe(
-      "Du må skrive inn i hva mottaker skal sende inn",
-    );
+    expect(unwrapMelding(feilEtter?.MANGLER_FRITEKST?.feltVerdi)).toBe("Du må skrive inn hva mottaker skal sende inn");
     const summary = buildValidationSummary(feilEtter);
-    expect(summary).toContain("Du må skrive inn i hva mottaker skal sende inn");
+    expect(summary).toContain("Du må skrive inn hva mottaker skal sende inn");
 
     // 3) Fyll inn MANGLER_FRITEKST -> ingen feil igjen
     values = {
@@ -539,11 +537,9 @@ describe("alle kombinasjoner av mottaker og brevmal – korrekte feltfeil og de 
     expect(err).toBeTruthy();
     const feilEtter = extractFeltErrors(err);
     expect(unwrapMelding(feilEtter?.INNLEDNING_FRITEKST?.feltVerdi)).toBeUndefined();
-    expect(unwrapMelding(feilEtter?.MANGLER_FRITEKST?.feltVerdi)).toBe(
-      "Du må skrive inn i hva mottaker skal sende inn",
-    );
+    expect(unwrapMelding(feilEtter?.MANGLER_FRITEKST?.feltVerdi)).toBe("Du må skrive inn hva mottaker skal sende inn");
     const summary = buildValidationSummary(feilEtter);
-    expect(summary).toContain("Du må skrive inn i hva mottaker skal sende inn");
+    expect(summary).toContain("Du må skrive inn hva mottaker skal sende inn");
 
     const innledningValgMangler =
       unwrapMelding(feilEtter?.INNLEDNING_FRITEKST?.valg) === "Du må velge minst én av standardtekst eller fritekst";

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrevSchema.ts
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrevSchema.ts
@@ -14,7 +14,7 @@ const ORGNUMMER_UGYLDIG: Melding = { melding: "Ugyldig organisasjonsnummer" };
 
 // Ikke-feltbundne feilmeldinger (kontekst-/regel-baserte), avhengig av valgt brevmal
 const STANDARDTEKST_ELLER_FRITEKST_MANGLER = { melding: "Du må velge minst én av standardtekst eller fritekst" };
-const FRITEKST_HVA_MOTTAKER_SKAL_SENDE_INN_MANGLER = { melding: "Du må skrive inn i hva mottaker skal sende inn" };
+const FRITEKST_HVA_MOTTAKER_SKAL_SENDE_INN_MANGLER = { melding: "Du må skrive inn hva mottaker skal sende inn" };
 const OVERSKRIFT_FRITEKSTBREV_BRUKER_MANGLER = { melding: "Du må skrive inn overskrift til brevet" };
 const INNLEDNINGSTEKST_MANGLERBREV_BRUKER_MANGLER = { melding: "Du må skrive inn innledningstekst i fritekstfeltet" };
 

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrevSchema.ts
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrevSchema.ts
@@ -14,7 +14,7 @@ const ORGNUMMER_UGYLDIG: Melding = { melding: "Ugyldig organisasjonsnummer" };
 
 // Ikke-feltbundne feilmeldinger (kontekst-/regel-baserte), avhengig av valgt brevmal
 const STANDARDTEKST_ELLER_FRITEKST_MANGLER = { melding: "Du må velge minst én av standardtekst eller fritekst" };
-const FRITEKST_MANGLERBREV_MANGLER = { melding: "Du må skrive inn i hva mottaker skal sende inn" };
+const FRITEKST_HVA_MOTTAKER_SKAL_SENDE_INN_MANGLER = { melding: "Du må skrive inn i hva mottaker skal sende inn" };
 const OVERSKRIFT_FRITEKSTBREV_BRUKER_MANGLER = { melding: "Du må skrive inn overskrift til brevet" };
 const INNLEDNINGSTEKST_MANGLERBREV_BRUKER_MANGLER = { melding: "Du må skrive inn innledningstekst i fritekstfeltet" };
 
@@ -165,6 +165,12 @@ const send_brev = object({
           errors["FRITEKST"].valg = STANDARDTEKST_ELLER_FRITEKST_MANGLER;
           harFeil = true;
         }
+
+        if (valgtFritekst && !StringUtils.harStrengInnhold(value?.FRITEKST?.feltVerdi)) {
+          if (!errors["FRITEKST"]) errors["FRITEKST"] = {};
+          errors["FRITEKST"].feltVerdi = FRITEKST_HVA_MOTTAKER_SKAL_SENDE_INN_MANGLER;
+          harFeil = true;
+        }
       }
 
       valgtBrev.felter.forEach((brevFelt) => {
@@ -281,7 +287,7 @@ const send_brev = object({
         }
 
         if ((erMangelbrevBruker || erMangelbrevArbeidsgiver) && manglerFritekst) {
-          errors[brevFelt.kode].feltVerdi = FRITEKST_MANGLERBREV_MANGLER;
+          errors[brevFelt.kode].feltVerdi = FRITEKST_HVA_MOTTAKER_SKAL_SENDE_INN_MANGLER;
           harFeil = true;
         }
 


### PR DESCRIPTION

Lagt inn validering av manglende utfylling av "Fritekst" for brevmal STANDARDTEKST_INNTEKTSOPPLYSNINGER.
Korrigering av navn på feilmelding

https://jira.adeo.no/browse/MELOSYS-6760