### PR TITLE
7538 Validering av manglende valg for etater + skjematest

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
@@ -261,7 +261,7 @@ function BrevMottaker({
         </Nav.Row>
       )}
 
-      {mottakerErNorskMyndighet && <BrevMottakerNorskMyndighet />}
+      {mottakerErNorskMyndighet && <BrevMottakerNorskMyndighet changeField={changeField} />}
 
       {mottakerErUtenlandskTrygdemyndighet && feil && (
         <Nav.Row>

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakerNorskMyndighet.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakerNorskMyndighet.tsx
@@ -1,21 +1,29 @@
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
-import { change, getFormValues } from "redux-form";
-import { useDispatch } from "../../../../hooks";
+import { getFormValues, getFormSyncErrors } from "redux-form";
+import { RootState } from "AppTypes";
 
 import * as KV from "../../../../kodeverk";
 import * as Nav from "../../../../navFrontend";
 import * as Api from "../../../../services/api";
-import { SendBrevFormValues } from "../types";
+import { SendBrevFormValues, SyncErrors } from "../types";
+import { unwrapMelding } from "../../../skjema/utils";
 import "./brevMottaker.less";
 
-function BrevMottakerNorskMyndighet() {
-  const formValues = useSelector((state: any) => getFormValues(KV.Form.SEND_BREV)(state) as SendBrevFormValues);
+interface BrevMottakerNorskMyndighetProps {
+  changeField: (felt: string, data: string[] | undefined) => void;
+}
+
+function BrevMottakerNorskMyndighet({ changeField }: BrevMottakerNorskMyndighetProps) {
+  const formValues = useSelector((state: RootState) => getFormValues(KV.Form.SEND_BREV)(state) as SendBrevFormValues);
+  const syncErrors = useSelector((state: RootState) => getFormSyncErrors(KV.Form.SEND_BREV)(state)) as SyncErrors;
   const [tilgjengeligeNorskeMyndigheter, setTilgjengeligeNorskeMyndigheter] =
     useState<Api.DokumenterV2.TilgjengeligeNorskeMyndigheterResDto>();
   const [valgteNorskeMyndigheter, setValgteNorskeMyndigheter] = useState<string[]>(formValues?.norskeMyndigheter || []);
 
-  const dispatch = useDispatch();
+  const norskeMyndighetError = syncErrors?.norskeMyndigheter;
+  const skalViseFeil = Boolean(formValues?.showFieldErrors) && Boolean(norskeMyndighetError);
+  const errorMessage = skalViseFeil ? unwrapMelding(norskeMyndighetError) : undefined;
 
   useEffect(() => {
     Api.DokumenterV2.hentTilgjengeligeNorskeMyndigheter().then((response) =>
@@ -23,15 +31,22 @@ function BrevMottakerNorskMyndighet() {
     );
   }, []);
 
+  // Sync local state with form when external changes happen
   useEffect(() => {
-    dispatch(change(KV.Form.SEND_BREV, "norskeMyndigheter", valgteNorskeMyndigheter));
-  }, [valgteNorskeMyndigheter]);
+    if (formValues?.norskeMyndigheter !== valgteNorskeMyndigheter) {
+      setValgteNorskeMyndigheter(formValues?.norskeMyndigheter || []);
+    }
+  }, [formValues?.norskeMyndigheter]);
 
-  const handleCheckboxChange = (item: string) => {
-    if (valgteNorskeMyndigheter.includes(item)) {
-      setValgteNorskeMyndigheter(valgteNorskeMyndigheter.filter((i) => i !== item));
+  useEffect(() => {
+    changeField("norskeMyndigheter", valgteNorskeMyndigheter);
+  }, [valgteNorskeMyndigheter, changeField]);
+
+  const handleCheckboxChange = (orgnr: string) => {
+    if (valgteNorskeMyndigheter.includes(orgnr)) {
+      setValgteNorskeMyndigheter(valgteNorskeMyndigheter.filter((item) => item !== orgnr));
     } else {
-      setValgteNorskeMyndigheter([...valgteNorskeMyndigheter, item]);
+      setValgteNorskeMyndigheter([...valgteNorskeMyndigheter, orgnr]);
     }
   };
 
@@ -39,12 +54,14 @@ function BrevMottakerNorskMyndighet() {
     <Nav.CheckboxGroup
       className="norskmyndighet"
       legend="Hvilke etater skal brevet sendes til?"
-      defaultValue={valgteNorskeMyndigheter}
+      name="norskeMyndigheter"
+      error={errorMessage}
     >
       {tilgjengeligeNorskeMyndigheter?.map((norskMyndighet) => (
         <Nav.Checkbox
           key={norskMyndighet.orgnr}
           value={norskMyndighet.orgnr}
+          checked={valgteNorskeMyndigheter.includes(norskMyndighet.orgnr)}
           onChange={() => handleCheckboxChange(norskMyndighet.orgnr)}
         >
           {norskMyndighet.navn}

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrevSchema.test.ts
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrevSchema.test.ts
@@ -188,7 +188,7 @@ describe("sendBrevSchema - felles krav for alle brevmaler", () => {
   });
 });
 
-describe("alle kombinasjoner av mottaker og brevmal – korrekte feltfeil og de matcher oppsummering", () => {
+describe("kombinasjoner av mottaker og brevmal – korrekte feltfeil og de matcher oppsummering", () => {
   // Små hjelpere for å redusere duplisering i like testløp
   async function runGenereltFritekstFlow(
     initialValues: Partial<SendBrevFormValues>,
@@ -743,6 +743,82 @@ describe("alle kombinasjoner av mottaker og brevmal – korrekte feltfeil og de 
     };
 
     // 6) Nå skal validering være OK
+    err = await validate(values);
+    expect(err).toBeNull();
+  });
+
+  it("NORSK_MYNDIGHET + GENERELT_FRITEKSTBREV_BRUKER -> krever minst én etat valgt", async () => {
+    // Test for Norske myndigheter som mottaker med Fritekstbrev
+    const fritekstbrevBrev = {
+      felter: [
+        {
+          kode: "BREV_TITTEL",
+          paakrevd: true,
+          valg: {
+            valgAlternativer: [{ kode: "FRITEKST_BRUKER_OG_VIRKSOMHET", beskrivelse: "Fritekstittel", visFelt: true }],
+          },
+        },
+        { kode: "FRITEKST", paakrevd: true },
+        {
+          kode: "DISTRIBUSJONSTYPE",
+          paakrevd: true,
+          valg: {
+            valgAlternativer: [
+              { kode: "DIGITAL", beskrivelse: "Digital", visFelt: true },
+              { kode: "POST", beskrivelse: "Post", visFelt: true },
+            ],
+          },
+        },
+      ],
+    } as any;
+
+    // Start: Norsk myndighet valgt men ingen etater valgt, samt tomme påkrevde felter
+    let values: Partial<SendBrevFormValues> = {
+      type: "GENERELT_FRITEKSTBREV_BRUKER",
+      valgtMottaker: makeMottaker("NORSK_MYNDIGHET"),
+      norskeMyndigheter: [], // Tom array - ingen etater valgt
+      valgtBrev: fritekstbrevBrev,
+      felt: {
+        BREV_TITTEL: {},
+        FRITEKST: {},
+        DISTRIBUSJONSTYPE: {},
+      } as any,
+    };
+
+    // Forvent feil på norskeMyndigheter og påkrevde felter
+    let err = await validate(values);
+    expect(err).toBeTruthy();
+    expect(hasPath(err, "norskeMyndigheter")).toBe(true);
+
+    // Sjekk at feilmeldingen er korrekt - feilmeldingen er i første error som objekt
+    const norskeMyndighetError = err?.errors?.[0] as any;
+    expect(norskeMyndighetError?.melding).toBe("Du må velge minst én etat");
+
+    // Sjekk også at brevfeltene har feil
+    const feltErrors = extractFeltErrors(err);
+    expect(feltErrors?.BREV_TITTEL?.valg?.melding).toBe("Du må velge overskrift til brevet");
+    expect(feltErrors?.FRITEKST?.feltVerdi?.melding).toBe("Du må skrive inn hovedtekst til brevet");
+    expect(feltErrors?.DISTRIBUSJONSTYPE?.valg?.melding).toBe("Du må velge type brev");
+
+    // Fyll norskeMyndigheter og alle påkrevde felter -> forvent success
+    values = {
+      ...values,
+      norskeMyndigheter: ["974760673"],
+      felt: {
+        BREV_TITTEL: { valg: "FRITEKST_BRUKER_OG_VIRKSOMHET", feltVerdi: "Test tittel" },
+        FRITEKST: { feltVerdi: "Test innhold" },
+        DISTRIBUSJONSTYPE: { valg: "DIGITAL" },
+      } as any,
+    };
+    err = await validate(values);
+    expect(err).toBeNull();
+
+    // Test også at det fungerer med undefined norskeMyndigheter når mottaker ikke er NORSK_MYNDIGHET
+    values = {
+      ...values,
+      valgtMottaker: makeMottaker("BRUKER"),
+      norskeMyndigheter: undefined,
+    };
     err = await validate(values);
     expect(err).toBeNull();
   });

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrevSchema.ts
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrevSchema.ts
@@ -1,7 +1,7 @@
 import type { AnyObject, StringSchema, TestContext } from "yup";
 import { array, object, string } from "yup";
 import * as StringUtils from "../../../utils/streng";
-import { erAnnenOrganisasjon, erArbeidsgiver, erVirksomhet } from "./brevMottaker/brevMottaker";
+import { erAnnenOrganisasjon, erArbeidsgiver, erVirksomhet, erNorskMyndighet } from "./brevMottaker/brevMottaker";
 import { BrevFelt, ErrorsMap, Felt, Melding, SendBrevFormValues, ValgtMottakerType } from "./types";
 import { ValgAlternativ } from "../../../services/modules/dokumenter-v2";
 
@@ -11,6 +11,7 @@ const BREVMAL_MANGLER: Melding = { melding: "Velg brevmal" };
 const ARBEIDSGIVER_MANGLER: Melding = { melding: "Velg arbeidsgiver" };
 const ORGNUMMER_FELT_MANGLER: Melding = { melding: "Fyll ut organisasjonsnummer" };
 const ORGNUMMER_UGYLDIG: Melding = { melding: "Ugyldig organisasjonsnummer" };
+const NORSKE_MYNDIGHETER_MANGLER: Melding = { melding: "Du må velge minst én etat" };
 
 // Ikke-feltbundne feilmeldinger (kontekst-/regel-baserte), avhengig av valgt brevmal
 const STANDARDTEKST_ELLER_FRITEKST_MANGLER = { melding: "Du må velge minst én av standardtekst eller fritekst" };
@@ -120,7 +121,13 @@ const send_brev = object({
     then: (schema) => (schema as CustomSchema).erOrgnr(ORGNUMMER_UGYLDIG).required(ORGNUMMER_FELT_MANGLER),
     otherwise: (schema) => schema.nullable(),
   }),
-  norskeMyndigheter: array().of((string() as unknown as CustomSchema).erOrgnr(ORGNUMMER_UGYLDIG)),
+  norskeMyndigheter: array()
+    .of((string() as unknown as CustomSchema).erOrgnr(ORGNUMMER_UGYLDIG))
+    .when("valgtMottaker", {
+      is: (valgtMottaker: ValgtMottakerType | null) => erNorskMyndighet(valgtMottaker?.rolle),
+      then: (schema) => schema.min(1, NORSKE_MYNDIGHETER_MANGLER),
+      otherwise: (schema) => schema.nullable(),
+    }),
   kontaktperson: string().nullable(),
   arbeidsgiver: string()
     .when("valgtMottaker", {


### PR DESCRIPTION

- Lagt til validering av påkrevd felt "Hvilke etater skal brevet sendes til?"  i sendBrevSchema.ts, med feilmelding "Du må velge minst én etat" dersom det ikke er fylt inn.
- Gjort nødvendige tilpasninger for feilhåndtering i brevMottaker.ts og brevMottakerNorskMyndighet.ts (tilsvarende som for Nav.Checkbox i valgAlternativer.ts)
- Lagt til test for dette valget i sendBrevSchema.test.ts

https://jira.adeo.no/browse/MELOSYS-7538