### PR TITLE
 7401 Vis tidligere beregnet trygdeavgift selv når verdien er 0

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -955,7 +955,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         !feilmelding &&
         endeligAvgiftValg === OPPLYSNINGER_ENDRET && (
           <SumArsavregningTabell
-            harGrunnlagIMelosys={harTrygdeavgiftFraAvgiftssystemet}
+            harGrunnlagIMelosys={harGrunnlag}
             nyTrygdeavgift={aarsavregningResponse?.avregning?.beregnetAvgiftBelop}
             tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
             tidligereTrygdeavgiftAvgiftssystem={aarsavregningResponse?.avregning?.trygdeavgiftFraAvgiftssystemet}
@@ -980,7 +980,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         manueltAvgiftBeloep !== null &&
         manueltAvgiftBeloep !== "" && (
           <SumArsavregningTabell
-            harGrunnlagIMelosys={harTrygdeavgiftFraAvgiftssystemet}
+            harGrunnlagIMelosys={harGrunnlag}
             nyTrygdeavgift={Number(manueltAvgiftBeloep)}
             tidligereTrygdeavgift={aarsavregningResponse?.avregning?.tidligereFakturertBeloep}
             tidligereTrygdeavgiftAvgiftssystem={

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.test.tsx
@@ -23,14 +23,16 @@ describe("SumArsavregningTabell", () => {
     expect(screen.getByText("Differanse")).toBeInTheDocument();
   });
 
-  it("shows Melosys row only when harGrunnlagIMelosys is true", () => {
+  it("shows Melosys row when harGrunnlagIMelosys is true or tidligereTrygdeavgift is defined", () => {
     const { rerender } = render(<SumArsavregningTabell harGrunnlagIMelosys={true} />);
 
     expect(screen.getByText("Tidligere beregnet trygdeavgift")).toBeInTheDocument();
 
     rerender(<SumArsavregningTabell harGrunnlagIMelosys={false} />);
-
     expect(screen.queryByText("Tidligere beregnet trygdeavgift")).not.toBeInTheDocument();
+
+    rerender(<SumArsavregningTabell harGrunnlagIMelosys={false} tidligereTrygdeavgift={0} />);
+    expect(screen.getByText("Tidligere beregnet trygdeavgift")).toBeInTheDocument();
   });
 
   it("shows current year Avgiftssystem row with correct label when value is provided", () => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
@@ -37,7 +37,7 @@ export function SumArsavregningTabell({
               {formaterTilNorskBelop(nyTrygdeavgift || 0)} kr
             </Nav.Table.DataCell>
           </Nav.Table.Row>
-          {harGrunnlagIMelosys && (
+          {(harGrunnlagIMelosys || tidligereTrygdeavgift !== undefined) && (
             <Nav.Table.Row>
               <Nav.Table.DataCell scope="col">-</Nav.Table.DataCell>
               <Nav.Table.DataCell scope="col">Tidligere beregnet trygdeavgift</Nav.Table.DataCell>


### PR DESCRIPTION
  Fikser bug hvor "Tidligere beregnet trygdeavgift" ikke ble vist når det ikke var grunnlag i Melosys og trygdeavgift fra Avgiftssystemet var NEI.

  Endringene inkluderer:
  - Oppdatert visningslogikk i SumArsavregningTabell for å vise raden når tidligereTrygdeavgift er definert
  - Fikset props-sending i aarsavregningUtenEllerDeltGrunnlagForm
  - Oppdatert tilhørende test

https://jira.adeo.no/browse/MELOSYS-7401