### PR TITLE
7544 Legg til støtte for dobbeltsignatur i forhåndsvisning av fritekstbrev

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottakereTabell.tsx
@@ -51,6 +51,7 @@ interface BrevMottakereTabellProps {
   formIsValid: boolean;
   redigerbart: boolean;
   brevVedlegg: VedleggSubsetProps;
+  saksbehandlerNrToIdent?: string | null;
 }
 
 function BrevMottakereTabell({
@@ -61,6 +62,7 @@ function BrevMottakereTabell({
   formIsValid,
   redigerbart,
   brevVedlegg,
+  saksbehandlerNrToIdent,
 }: BrevMottakereTabellProps & PropsFromRedux) {
   const valgtMottakerHarFeilmelding: FeilmeldingProps | undefined = formValues?.valgtMottaker?.feilmelding;
   const mottakerErNorskMyndighet = formValues?.valgtMottaker?.rolle === "NORSK_MYNDIGHET";
@@ -125,6 +127,7 @@ function BrevMottakereTabell({
     fritekstvedlegg: brevVedlegg.fritekstvedlegg,
     distribusjonstype: hentFormVerdi("DISTRIBUSJONSTYPE", true, true),
     dokumentTittel: hentFormVerdi("DOKUMENT_TITTEL", true),
+    saksbehandlerNrToIdent: saksbehandlerNrToIdent,
     institusjonID: hentFormVerdi("UTENLANDSK_TRYGDEMYNDIGHET_MOTTAKER", true, true),
   });
 

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -640,6 +640,7 @@ function SendBrev({
               muligeMottakere={muligeMottakere}
               muligeMottakereNorskMyndighet={muligeMottakereNorskMyndighet}
               redigerbart={redigerbart}
+              saksbehandlerNrToIdent={finnSaksbehandlerIdentForDobbelSignatur()}
               brevVedlegg={{
                 fritekstvedlegg,
                 setFritekstvedlegg,


### PR DESCRIPTION
- Legger til saksbehandlerNrToIdent som prop til BrevMottakereTabell
- Sender dobbeltsignatur-data fra sendBrev.tsx ned til forhåndsvisning
- Fikser manglende dobbeltsignatur i brevforhåndsvisning som var glemt i opprinnelig MELOSYS-5319 implementasjon


https://jira.adeo.no/browse/MELOSYS-7544
