### PR TITLE
7527 Forbedring av valideringsmeldinger

### DIFF
--- a/src/felleskomponenter/htmlEditor/htmlEditor.less
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.less
@@ -76,8 +76,14 @@
     }
 
     &--error {
+      .ql-toolbar {
+        border-color: @redError;
+        border-width: 2px 2px 2px 2px;
+      }
+
       .ql-container {
         border-color: @redError;
+        border-width: 0 2px 2px 2px;
       }
     }
 
@@ -111,11 +117,21 @@
   }
 
   .feilmelding {
-    color: @redError;
+    color: var(--a-text-danger, @redError);
     font-family: Arial, sans-serif;
     font-size: 0.875rem;
     font-weight: 600;
     line-height: 1.375rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+
+  .feilmelding__ikon {
+    flex-shrink: 0;
+    width: 1rem;
+    height: 1rem;
   }
 
   .ql-snow .ql-picker.ql-header .ql-picker-item[data-value="2"]::before {

--- a/src/felleskomponenter/htmlEditor/htmlEditor.tsx
+++ b/src/felleskomponenter/htmlEditor/htmlEditor.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import { useEffect, useMemo, useRef, useState } from "react";
 import ReactQuill, { Quill } from "react-quill-new";
 import "react-quill-new/dist/quill.snow.css";
-import "./htmlEditor.css";
+import "./htmlEditor.less";
 
 // Registrerer egendefinert blot for tekst i klammer
 const Inline = Quill.import("blots/inline") as any;
@@ -249,7 +249,31 @@ function HtmlEditor({ value, onChange, disabled, label, feil, className, placeho
           placeholder={placeholder}
         />
       </div>
-      {feil && <div className="feilmelding">{typeof feil === "string" ? feil : feil.melding}</div>}
+      {feil && (
+        // TODO Bruk av ExclamationmarkTriangleFillIcon from "@navikt/aksel-icons" ser ikke bra ut her, trolig pga
+        //  versjonsforskjell på komponentene fra @navikt/ds-react og vår aksel-icons versjon.
+        // Aligning av versjoner kan løse dette, men bør testes som en egen sak. I mellomtiden brukes inline SVG som er
+        // lik ExclamationmarkTriangleFillIcon fra vår versjon av @navikt/ds-react her
+        <div className="navds-form-field__error" aria-relevant="additions removals" aria-live="polite">
+          <p className="navds-error-message navds-label navds-label--small navds-error-message--show-icon">
+            <svg
+              viewBox="0 0 17 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              focusable={false}
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M3.49209 11.534L8.11398 2.7594C8.48895 2.04752 9.50833 2.04743 9.88343 2.75924L14.5073 11.5339C14.8582 12.1998 14.3753 13 13.6226 13H4.37685C3.6242 13 3.14132 12.1999 3.49209 11.534ZM9.74855 10.495C9.74855 10.9092 9.41276 11.245 8.99855 11.245C8.58433 11.245 8.24855 10.9092 8.24855 10.495C8.24855 10.0808 8.58433 9.74497 8.99855 9.74497C9.41276 9.74497 9.74855 10.0808 9.74855 10.495ZM9.49988 5.49997C9.49988 5.22383 9.27602 4.99997 8.99988 4.99997C8.72373 4.99997 8.49988 5.22383 8.49988 5.49997V7.99997C8.49988 8.27611 8.72373 8.49997 8.99988 8.49997C9.27602 8.49997 9.49988 8.27611 9.49988 7.99997V5.49997Z"
+                fill="currentColor"
+              />
+            </svg>
+            {typeof feil === "string" ? feil : feil.melding}
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/utils/feilmelding.tsx
+++ b/src/utils/feilmelding.tsx
@@ -26,8 +26,8 @@ export function syncErrorsTilFeilmelding(
 
   return (
     <>
-      <p>{tittel}</p>
-      <ul>
+      <span>{tittel}</span>
+      <ul style={{ margin: 0, paddingLeft: "1rem" }}>
         {Object.keys(syncErrors).map((key) => {
           const syncError = syncErrors[key];
           return finnFeilmelding(syncError);


### PR DESCRIPTION
- Lagt på rød trekant ikon for HTML editor, så feilmeldingen ser likt ut som de fra Aksel-komponentene
- Endret farge på feilmeldingstekst for HTML editor til samme som for Aksel-komponentene
- Endret syncErrorsTilFeilmelding slik at vi ikke får margin mellom tittel og første element
- Rød kant på hele HTML komponenten når den mangler

https://jira.adeo.no/browse/MELOSYS-7527
