### PR TITLE
7542 TOGGLE Sjekk gyldig formvalues før lagring av trygdeavgift, pensjonister eøs

### DIFF
--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -34,7 +34,6 @@ import vurderingTrygdeavgiftSchema from "./vurderingTrygdeavgiftSchema";
 
 import { erBrukerSkattepliktigIHelePerioden } from "../../../../aarsavregning/stegKomponenter/vurderingAarsavregning/utils";
 import { fagsakSelectors } from "../../../../../ducks/fagsaker";
-import { nyVurdering } from "../../../../../services/modules/journalforing";
 const { EU_EOS } = MKV.Koder.sakstyper;
 const { PENSJONIST } = MKV.Koder.behandlinger.behandlingstema;
 interface Props {
@@ -142,7 +141,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
       skatteforholdsperioder.length > 0 &&
       redigerbart
     ) {
-      eøsPensjonistBeregnTrygdeavgiftsperioder(formValues);
+      debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
       setHarBeregnetNyTrygdeavgift(true);
     }
   }, [harBeregnetNyTrygdeavgift, formValues]);


### PR DESCRIPTION
Debounced lagring av trygdeavgift dersom formvalues er valid. Når man starter opp stegvelgeren, sjekker den med engang, men da er ikke alt lastet inn enda. Venter til alt er ferdig og sjekker deretter for å forhindre rød meldingsboks med feilmelding.

https://jira.adeo.no/browse/MELOSYS-7542