### PR TITLE
NOJIRA Fjernet årsak til dobbel slash i URL'er.

### DIFF
--- a/src/services/modules/adresser.ts
+++ b/src/services/modules/adresser.ts
@@ -3,7 +3,7 @@ import { API_BASE_URL } from "../api-constants";
 import { BrevAdresse } from "./dokumenter-v2";
 
 export const hentPersonAdresse = (personIdent: string): Promise<BrevAdresse> =>
-  getAsJson(`${API_BASE_URL}/adresser?personIdent=${personIdent}`);
+  getAsJson(`${API_BASE_URL}adresser?personIdent=${personIdent}`);
 
 export const hentOrganisasjonAdresse = (orgnr: string): Promise<BrevAdresse> =>
-  getAsJson(`${API_BASE_URL}/adresser?orgnr=${orgnr}`);
+  getAsJson(`${API_BASE_URL}adresser?orgnr=${orgnr}`);

--- a/src/services/modules/trygdeavgift.ts
+++ b/src/services/modules/trygdeavgift.ts
@@ -45,34 +45,34 @@ export interface Fakturamottaker {
 }
 
 export const hentTrygdeavgiftMottaker = (behandlingID: number): Promise<TrygdeavgiftMottakerDto> =>
-  getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/mottaker`);
+  getAsJson(`${API_BASE_URL}behandlinger/${behandlingID}/${TRYGDEAVGIFT}/mottaker`);
 
 export const beregnTrygdeavgiftsperioder = (
   behandlingID: number,
   trygdeavgiftsgrunnlag: TrygdeavgiftsgrunnlagDto,
 ): Promise<BeregnetTrygdeavgift> =>
-  putAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/beregning`, trygdeavgiftsgrunnlag);
+  putAsJson(`${API_BASE_URL}behandlinger/${behandlingID}/${TRYGDEAVGIFT}/beregning`, trygdeavgiftsgrunnlag);
 
 export const eøsPensjonistBeregnTrygdeavgiftsperioder = (
   behandlingID: number,
   trygdeavgiftsgrunnlag: TrygdeavgiftsgrunnlagDto,
 ): Promise<BeregnetTrygdeavgift> =>
   putAsJson(
-    `${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/${EØS_PENSJONIST}/beregning`,
+    `${API_BASE_URL}behandlinger/${behandlingID}/${TRYGDEAVGIFT}/${EØS_PENSJONIST}/beregning`,
     trygdeavgiftsgrunnlag,
   );
 
 export const hentBeregnetTrygdeavgift = (behandlingID: number): Promise<BeregnetTrygdeavgift> =>
-  getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/beregning`);
+  getAsJson(`${API_BASE_URL}behandlinger/${behandlingID}/${TRYGDEAVGIFT}/beregning`);
 
 export const hentBeregnetTrygdeavgiftEosPensjonist = (behandlingID: number): Promise<BeregnetTrygdeavgift> =>
-  getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/eos-pensjonist/beregning`);
+  getAsJson(`${API_BASE_URL}behandlinger/${behandlingID}/${TRYGDEAVGIFT}/eos-pensjonist/beregning`);
 
 export const hentOpprinneligTrygdeavgiftsgrunnlag = (behandlingID: number): Promise<TrygdeavgiftsgrunnlagDto> =>
-  getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/grunnlag/opprinnelig`);
+  getAsJson(`${API_BASE_URL}behandlinger/${behandlingID}/${TRYGDEAVGIFT}/grunnlag/opprinnelig`);
 
 export const hentFakturamottaker = (behandlingID: number): Promise<Fakturamottaker> =>
-  getAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}/fakturamottaker`);
+  getAsJson(`${API_BASE_URL}behandlinger/${behandlingID}/${TRYGDEAVGIFT}/fakturamottaker`);
 
 export const slettTrygdeavgiftsperioder = (behandlingID: number): Promise<null> =>
-  deleteAsJson(`${API_BASE_URL}/behandlinger/${behandlingID}/${TRYGDEAVGIFT}`);
+  deleteAsJson(`${API_BASE_URL}behandlinger/${behandlingID}/${TRYGDEAVGIFT}`);


### PR DESCRIPTION
Fjernet årsak til dobbel slash i URL'er.
Dette er et problem kun på local dev på Mac'er etter siste OS oppgradering (Tahoe 26).