### PR TITLE
7625 Tillat endelig beregnet trygdeavgift 0 kr i en årsavregning

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.test.tsx
@@ -1,0 +1,48 @@
+import { yupResolver } from "@hookform/resolvers/yup";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useForm } from "react-hook-form";
+import aarsavregningMedGrunnlagSchema from "./aarsavregningMedGrunnlagSchema";
+import MKV from "../../../../../melosyskodeverk";
+
+const { MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
+
+describe("aarsavregningMedGrunnlagForm validering", () => {
+  it("skal tillate 0 kr som endelig beregnet trygdeavgift", async () => {
+    const { result } = renderHook(() =>
+      useForm({
+        resolver: yupResolver(aarsavregningMedGrunnlagSchema),
+        mode: "all",
+        defaultValues: {
+          endeligAvgiftValg: MANUELL_ENDELIG_AVGIFT,
+          manueltAvgiftBeloep: "0",
+          skatteforholdsperioder: [],
+          inntektskilder: [],
+        },
+      }),
+    );
+
+    const isValid = await result.current.trigger();
+
+    expect(isValid).toBe(true);
+  });
+
+  it("skal kreve at feltet fylles ut når MANUELL_ENDELIG_AVGIFT er valgt", async () => {
+    const { result } = renderHook(() =>
+      useForm({
+        resolver: yupResolver(aarsavregningMedGrunnlagSchema),
+        mode: "all",
+        defaultValues: {
+          endeligAvgiftValg: MANUELL_ENDELIG_AVGIFT,
+          manueltAvgiftBeloep: "",
+          skatteforholdsperioder: [],
+          inntektskilder: [],
+        },
+      }),
+    );
+
+    const isValid = await result.current.trigger("manueltAvgiftBeloep");
+
+    expect(isValid).toBe(false);
+  });
+});

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -234,7 +234,9 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
       ) ||
       Boolean(
         endeligAvgiftValg === MANUELL_ENDELIG_AVGIFT &&
-          aarsavregningResponse?.avregning?.manueltAvgiftBeloep &&
+          aarsavregningResponse?.avregning?.manueltAvgiftBeloep !== undefined &&
+          aarsavregningResponse?.avregning?.manueltAvgiftBeloep !== null &&
+          formIsValid &&
           !feilmelding,
       ),
     [endeligAvgiftValg, formIsValid, aarsavregningResponse, feilmelding, arrayValideringsfeil],


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7625

Når saksbehandler legger inn 0 kr, lagres verdien korrekt til backend, men når den sjekkes for å aktivere "Bekreft og fortsett"-knappen, evalueres tallet 0 som falsy, noe som gjorde at valideringen feilet.
