### PR TITLE
Melosys 7637 skal ikke kunne velge behandlingstema

### DIFF
--- a/src/sider/journalforing/komponenter/knyttTilSak.test.tsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => {
   return {
     hent: vi.fn(),
     hentBehandlingstyperForKnyttTilSak: vi.fn(() => Promise.resolve([{ kode: "AARSAVREGNING", term: "Årsavregning" }])),
+    hentTrygdeavgiftOppsummering: vi.fn(() => Promise.resolve({ harBehandlingMedTrygdeavgift: false })),
   };
 });
 vi.mock("../../../services/modules/anmodningsperioder", () => ({
@@ -19,6 +20,9 @@ vi.mock("../../../services/modules/anmodningsperioder", () => ({
 vi.mock("../../../services/modules/lovligekombinasjoner", () => ({
   hentBehandlingstemaer: () => Promise.resolve([]),
   hentBehandlingstyperForKnyttTilSak: () => mocks.hentBehandlingstyperForKnyttTilSak(),
+}));
+vi.mock("../../../services/modules/fagsaker/fagsak", () => ({
+  hentTrygdeavgiftOppsummering: () => mocks.hentTrygdeavgiftOppsummering(),
 }));
 
 describe("KnyttTilSak", () => {
@@ -66,6 +70,8 @@ describe("KnyttTilSak", () => {
       erJournalføring: true,
     };
     mocks.hent.mockReset();
+    mocks.hentTrygdeavgiftOppsummering.mockReset();
+    mocks.hentTrygdeavgiftOppsummering.mockReturnValue(Promise.resolve({ harBehandlingMedTrygdeavgift: false }));
   });
 
   const WrappedKnyttTilSak = reduxForm({ form: "test" })(KnyttTilSak as any);
@@ -368,6 +374,66 @@ describe("KnyttTilSak", () => {
       await waitFor(() => {
         expect(screen.queryByText(/Du kan ikke opprette en ny behandling/i)).toBeNull();
         expect(screen.getByText("Tidligere behandling er avsluttet.")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Behandlingstema disabled ved andregangsbehandling", () => {
+    it("behandlingstema-dropdown er disabled når saken har eksisterende behandlinger", async () => {
+      props.formValues.opprettBehandling = true;
+      props.formValues.behandlingstema = "YRKESAKTIV";
+      props.sak.behandlingOversikter[0].behandlingsstatus = {
+        kode: MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET,
+        term: "Avsluttet",
+      };
+
+      await renderWithProvidersAsync(<WrappedKnyttTilSak {...(props as any)} />);
+
+      await waitFor(() => {
+        const behandlingstemaSelect = screen.getByLabelText("Behandlingstema");
+        expect(behandlingstemaSelect).toBeDisabled();
+      });
+    });
+
+    it("viser riktig hjelpetekst når behandlingstema er disabled pga andregangsbehandling", async () => {
+      props.formValues.opprettBehandling = true;
+      props.formValues.behandlingstema = "YRKESAKTIV";
+      props.sak.behandlingOversikter[0].behandlingsstatus = {
+        kode: MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET,
+        term: "Avsluttet",
+      };
+
+      await renderWithProvidersAsync(<WrappedKnyttTilSak {...(props as any)} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Du kan ikke endre behandlingstema når saken har en tilknyttet fakturaserie eller en eksisterende behandling.",
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("viser samme melding og disabled dropdown når saken har trygdeavgift", async () => {
+      mocks.hentTrygdeavgiftOppsummering.mockReturnValueOnce(Promise.resolve({ harBehandlingMedTrygdeavgift: true }));
+
+      props.formValues.opprettBehandling = true;
+      props.formValues.behandlingstema = "YRKESAKTIV";
+      props.sak.behandlingOversikter[0].behandlingsstatus = {
+        kode: MKV.Koder.behandlinger.behandlingsstatus.AVSLUTTET,
+        term: "Avsluttet",
+      };
+
+      await renderWithProvidersAsync(<WrappedKnyttTilSak {...(props as any)} />);
+
+      await waitFor(() => {
+        const behandlingstemaSelect = screen.getByLabelText("Behandlingstema");
+        expect(behandlingstemaSelect).toBeDisabled();
+        expect(
+          screen.getByText(
+            "Du kan ikke endre behandlingstema når saken har en tilknyttet fakturaserie eller en eksisterende behandling.",
+          ),
+        ).toBeInTheDocument();
       });
     });
   });

--- a/src/sider/journalforing/komponenter/knyttTilSak.tsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.tsx
@@ -53,6 +53,9 @@ export function KnyttTilSak(props: KnyttTilSakProps) {
   const sisteBehandling = behandlingOversikter[0];
   const dispatch = useDispatch();
 
+  // Sjekk om det er andregangsbehandling (saken har eksisterende behandlinger)
+  const erAndregangsbehandling = behandlingOversikter.length > 0;
+
   // State for data fra operasjonen
   const [state, setState] = useState<KnyttTilSakState>({
     muligeBehandlingstemaer: [],
@@ -189,16 +192,17 @@ export function KnyttTilSak(props: KnyttTilSakProps) {
               feltNavn={feltNavn.behandlingstema}
               label="Behandlingstema"
               emptyFieldDisabled={!!(behandlingstema as { kode?: string })?.kode}
-              disabled={state.harBehandlingMedTrygdeavgift}
-              className={state.harBehandlingMedTrygdeavgift ? "select__slim" : undefined}
+              disabled={state.harBehandlingMedTrygdeavgift || erAndregangsbehandling}
+              className={state.harBehandlingMedTrygdeavgift || erAndregangsbehandling ? "select__slim" : undefined}
             >
               {state.muligeBehandlingstemaer?.map((elem) => (
                 <option key={elem.kode} value={elem.kode} label={elem.term ?? undefined} />
               ))}
             </Skjema.Select>
-            {state.harBehandlingMedTrygdeavgift && (
+            {(state.harBehandlingMedTrygdeavgift || erAndregangsbehandling) && (
               <Nav.Detail className="behandlingstema__label">
-                Du kan ikke endre behandlingstema når saken har en tilknyttet fakturaserie.
+                Du kan ikke endre behandlingstema når saken har en tilknyttet fakturaserie eller en eksisterende
+                behandling.
               </Nav.Detail>
             )}
             <Skjema.RadioGroup legend="Behandlingstype" name={feltNavn.behandlingstype}>

--- a/src/sider/journalforing/komponenter/knyttTilSak.tsx
+++ b/src/sider/journalforing/komponenter/knyttTilSak.tsx
@@ -54,7 +54,7 @@ export function KnyttTilSak(props: KnyttTilSakProps) {
   const dispatch = useDispatch();
 
   // Sjekk om det er andregangsbehandling (saken har eksisterende behandlinger)
-  const erAndregangsbehandling = behandlingOversikter.length > 0;
+  const erAndregangsbehandling = (behandlingOversikter?.length ?? 0) > 0;
 
   // State for data fra operasjonen
   const [state, setState] = useState<KnyttTilSakState>({
@@ -109,7 +109,7 @@ export function KnyttTilSak(props: KnyttTilSakProps) {
 
   // Håndterer brukerinteraksjoner: Oppdatering av behandlingstema
   useEffect(() => {
-    if (opprettBehandling && Utils._isEmpty(behandlingstema)) {
+    if (opprettBehandling && Utils._isEmpty(behandlingstema) && sisteBehandling?.behandlingstema?.kode) {
       changeField(feltNavn.formNavn, feltNavn.behandlingstema, sisteBehandling.behandlingstema.kode);
     }
     // Nullstill behandlingstype når opprettBehandling er false


### PR DESCRIPTION
 ## MELOSYS-7637: Disable behandlingstema ved andregangsbehandling

  **JIRA:** https://jira.adeo.no/browse/MELOSYS-7637

  ### Hva gjør denne PR-en?
  Disabler behandlingstema-dropdown når saken har eksisterende behandlinger, slik at andregangsbehandlinger arver behandlingstema fra førstegangsbehandlingen.

  ### Hvorfor?
  Forhindrer inkonsistente behandlingstemaer i samme sak.

  ### Endringer
  - Sjekk for andregangsbehandling: `erAndregangsbehandling = (behandlingOversikter?.length ?? 0) > 0`
  - Disabled felt: `disabled={state.harBehandlingMedTrygdeavgift || erAndregangsbehandling}`
  - Oppdatert hjelpetekst
  - Bug-fix: Optional chaining for `sisteBehandling`

  ### Testing
  - ✅ 3 nye tester lagt til
  - ✅ 16/16 tester passerer for knyttTilSak
  - ✅ 34/34 tester passerer for journalforing
  - ✅ Ingen regresjoner

  ### Manuell testing
  Verifiser at behandlingstema-felt er:
  - ✅ Disabled når sak har eksisterende behandlinger
  - ✅ Enabled når det er en ny sak
