### PR TITLE
5203: Gjør "Legg til periode"-knappen synlig for delt grunnlag.

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -188,6 +188,10 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       .every((periode: Medlemskapsperiode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG);
   }, [medlemskapsperioder]);
 
+  const erDeltGrunnlag =
+    harTrygdeavgiftFraAvgiftssystemet &&
+    !!initiellData.aarsavregningResponse?.tidligereTrygdeavgiftsGrunnlagsopplysninger;
+
   const finnMedlemskapsperiode = useCallback((perioder: Medlemskapsperiode[]) => {
     const sorterteGyldigePerioder = perioder
       .filter((periode: Medlemskapsperiode) => periode.fomDato && periode.tomDato)
@@ -892,6 +896,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
                 minDate={minDate}
                 trygdedekninger={trygdedekninger}
                 setValue={setValue}
+                erDeltGrunnlag={erDeltGrunnlag}
               />
             ))}
           </div>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
@@ -63,6 +63,7 @@ export interface PeriodeElementerProps {
   minDate?: Date;
   trygdedekninger?: string[];
   setValue: (name: string, value: any, options?: any) => void;
+  erDeltGrunnlag?: boolean;
 }
 
 export function MedlemskapsperiodeSkjema({
@@ -78,6 +79,7 @@ export function MedlemskapsperiodeSkjema({
   minDate,
   trygdedekninger = [],
   setValue,
+  erDeltGrunnlag = false,
 }: PeriodeElementerProps) {
   const pliktigeBestemmelser = usePliktigeBestemmelser();
   const erPliktigBestemmelse = formValues.bestemmelse && pliktigeBestemmelser.includes(formValues.bestemmelse);
@@ -167,7 +169,7 @@ export function MedlemskapsperiodeSkjema({
           </Nav.Column>
         )}
       </Nav.Row>
-      {medlemskapsperioder.length === index + 1 && !erPliktigBestemmelse && (
+      {medlemskapsperioder.length === index + 1 && (!erPliktigBestemmelse || erDeltGrunnlag) && (
         <div className="legg-til__rad">
           <Mui.Lenkeknapp onClick={handleLeggTil} ikon={Ikoner.Add} disabled={!redigerbart || !visLeggTil}>
             Legg til periode


### PR DESCRIPTION
Fikser bug skapt i #2829 hvor "Legg til periode"-knappen ble skjult for delt og uten grunnlag dersom bestemmelsen var pliktig. Dette er OK for uten grunnlag, men _ikke_ for delt grunnlag.