### PR TITLE
7639 feil grunnlag sendes

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.test.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.test.ts
@@ -254,7 +254,7 @@ describe("utils", () => {
             kildetype: "",
             arbAvgBetales: "NEI",
             bruttoInntekt: undefined,
-            erMaanedsbelop: "JA",
+            // erMaanedsbelop ikke satt - UI setter default
           },
         ]);
       });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.test.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.test.ts
@@ -258,6 +258,37 @@ describe("utils", () => {
           },
         ]);
       });
+
+      // MELOSYS-7639: Test for å bevise at erMaanedsbelop ikke skal være hardkodet
+      it("skal ikke sette hardkodet erMaanedsbelop når ingen inntektskilder finnes", () => {
+        const membership = [createMockMedlemskapsperiode()];
+        vi.mocked(Utils._isEmpty).mockReturnValue(false);
+
+        const result = mapTilInntektskilderProps(undefined, membership);
+
+        // erMaanedsbelop skal IKKE være satt (undefined)
+        // UI-komponenten skal sette denne verdien når bruker klikker "Legg til inntekt"
+        expect(result[0].erMaanedsbelop).toBeUndefined();
+      });
+
+      it("mapper erMaanedsbelop korrekt fra backend når inntektskilder finnes", () => {
+        const income = [
+          {
+            fomDato: "2023-01-01",
+            tomDato: "2023-12-31",
+            type: "ARBEID",
+            arbeidsgiversavgiftBetales: false,
+            avgiftspliktigInntekt: 600000,
+            erMaanedsbelop: false, // Backend sender boolean
+          },
+        ];
+        vi.mocked(Utils._isEmpty).mockReturnValue(false);
+
+        const result = mapTilInntektskilderProps(income, []);
+
+        // Frontend skal få string "NEI"
+        expect(result[0].erMaanedsbelop).toBe("NEI");
+      });
     });
   });
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
@@ -169,7 +169,7 @@ export const mapTilInntektskilderProps = (
         arbAvgBetales: Utils.streng.boolTilUppercaseStreng(false),
         bruttoInntekt: undefined,
         kildetype: "",
-        erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(true),
+        // erMaanedsbelop fjernet - UI-komponenten setter default ved "Legg til inntekt"
       },
     ];
   }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
@@ -169,7 +169,6 @@ export const mapTilInntektskilderProps = (
         arbAvgBetales: Utils.streng.boolTilUppercaseStreng(false),
         bruttoInntekt: undefined,
         kildetype: "",
-        // erMaanedsbelop fjernet - UI-komponenten setter default ved "Legg til inntekt"
       },
     ];
   }

--- a/src/sider/journalforing/komponenter/journalforingSchema.test.js
+++ b/src/sider/journalforing/komponenter/journalforingSchema.test.js
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "vitest";
+import journalforingSchema from "./journalforingSchema";
+
+describe("journalforingSchema - validering av dokumenttitler", () => {
+  // Vi tester kun hoveddokument-skjemaet direkte for å isolere testene
+  const getHoveddokumentSchema = () => {
+    // Ekstraher hoveddokument-schemat fra journalforingSchema
+    return journalforingSchema.fields.hoveddokument;
+  };
+
+  test("skal feile når hoveddokument er under redigering og ikke lagret", async () => {
+    // Arrange
+    const values = {
+      tittel: "", // Tomt felt under redigering
+      logiskeVedlegg: [],
+    };
+
+    const context = {
+      registeredFields: {
+        tittel: true, // Feltet er registrert (under redigering) - bruker relativ path
+      },
+      journalforingKnappErTryktPå: true,
+    };
+
+    // Act & Assert
+    try {
+      await getHoveddokumentSchema().validate(values, { context, abortEarly: false });
+      expect.fail("Validering skulle ha feilet");
+    } catch (error) {
+      // Med abortEarly: false får vi alle feil i error.inner
+      const feilmeldinger = error.inner?.map((e) => e.message?.melding || e.message) || [
+        error.message?.melding || error.message,
+      ];
+      const harRiktigFeilmelding = feilmeldinger.some((m) => m.includes("Du må lagre tittel på hoveddokument"));
+      expect(harRiktigFeilmelding).toBe(true);
+    }
+  });
+
+  test("skal feile når vedlegg er under redigering og ikke lagret", async () => {
+    // Arrange
+    const values = {
+      tittel: "Søknad om medlemskap",
+      logiskeVedlegg: [""], // Tomt vedlegg under redigering
+    };
+
+    const context = {
+      registeredFields: {
+        "logiskeVedlegg[0]": true, // Vedlegget er registrert (under redigering) - bruker relativ path
+      },
+      journalforingKnappErTryktPå: true,
+    };
+
+    // Act & Assert
+    try {
+      await getHoveddokumentSchema().validate(values, { context, abortEarly: false });
+      expect.fail("Validering skulle ha feilet");
+    } catch (error) {
+      // Med abortEarly: false får vi alle feil i error.inner
+      const feilmeldinger = error.inner?.map((e) => e.message?.melding || e.message) || [
+        error.message?.melding || error.message,
+      ];
+      const harRiktigFeilmelding = feilmeldinger.some((m) => m.includes("Du må lagre tittel på vedlegg"));
+      expect(harRiktigFeilmelding).toBe(true);
+    }
+  });
+
+  test("skal godta hoveddokument som ikke er under redigering", async () => {
+    // Arrange
+    const values = {
+      tittel: "Søknad om medlemskap",
+      logiskeVedlegg: [],
+    };
+
+    const context = {
+      registeredFields: {}, // Ingen felt under redigering
+      journalforingKnappErTryktPå: true,
+    };
+
+    // Act & Assert (skal ikke kaste feil)
+    await expect(getHoveddokumentSchema().validate(values, { context })).resolves.toBeDefined();
+  });
+
+  test("skal godta vedlegg som ikke er under redigering", async () => {
+    // Arrange
+    const values = {
+      tittel: "Søknad om medlemskap",
+      logiskeVedlegg: ["Vedlegg 1", "Vedlegg 2"],
+    };
+
+    const context = {
+      registeredFields: {}, // Ingen felt under redigering
+      journalforingKnappErTryktPå: true,
+    };
+
+    // Act & Assert (skal ikke kaste feil)
+    await expect(getHoveddokumentSchema().validate(values, { context })).resolves.toBeDefined();
+  });
+
+  test("skal godta tom tittel når journalforingKnappErTryktPå er false", async () => {
+    // Arrange
+    const values = {
+      tittel: "",
+      logiskeVedlegg: [],
+    };
+
+    const context = {
+      registeredFields: {
+        tittel: true, // Bruker relativ path
+      },
+      journalforingKnappErTryktPå: false, // Brukeren har ikke trykt på journalføringsknappen
+    };
+
+    // Act & Assert (skal ikke kaste feil fra erIkkeUnderRedigering)
+    // required() vil fortsatt feile, men det er OK - vi tester bare erIkkeUnderRedigering her
+    try {
+      await getHoveddokumentSchema().validate(values, { context });
+    } catch (error) {
+      // required() feiler med "Velg dokumenttittel...", ikke "Du må lagre..."
+      const melding = error.message?.melding || error.message;
+      expect(melding).not.toContain("Du må lagre");
+    }
+  });
+});

--- a/src/sider/journalforing/komponenter/journalforingSchema.test.ts
+++ b/src/sider/journalforing/komponenter/journalforingSchema.test.ts
@@ -1,122 +1,133 @@
 import { describe, expect, test } from "vitest";
+import type { ObjectSchema, ValidationError } from "yup";
+import { Dokument } from "../../../@types";
 import journalforingSchema from "./journalforingSchema";
+
+type HoveddokumentValues = Pick<Dokument, "tittel" | "logiskeVedlegg">;
+
+interface ValidationContext {
+  registeredFields: Record<string, boolean>;
+  journalforingKnappErTryktPå: boolean;
+}
 
 describe("journalforingSchema - validering av dokumenttitler", () => {
   // Vi tester kun hoveddokument-skjemaet direkte for å isolere testene
-  const getHoveddokumentSchema = () => {
+  const getHoveddokumentSchema = (): ObjectSchema<HoveddokumentValues> => {
     // Ekstraher hoveddokument-schemat fra journalforingSchema
-    return journalforingSchema.fields.hoveddokument;
+    return journalforingSchema.fields.hoveddokument as ObjectSchema<HoveddokumentValues>;
   };
 
   test("skal feile når hoveddokument er under redigering og ikke lagret", async () => {
-    // Arrange
-    const values = {
+    const values: HoveddokumentValues = {
       tittel: "", // Tomt felt under redigering
       logiskeVedlegg: [],
     };
 
-    const context = {
+    const context: ValidationContext = {
       registeredFields: {
         tittel: true, // Feltet er registrert (under redigering) - bruker relativ path
       },
       journalforingKnappErTryktPå: true,
     };
-
-    // Act & Assert
     try {
       await getHoveddokumentSchema().validate(values, { context, abortEarly: false });
       expect.fail("Validering skulle ha feilet");
     } catch (error) {
       // Med abortEarly: false får vi alle feil i error.inner
-      const feilmeldinger = error.inner?.map((e) => e.message?.melding || e.message) || [
-        error.message?.melding || error.message,
+      const validationError = error as ValidationError;
+      const feilmeldinger = validationError.inner?.map((e) => {
+        const msg = (e as any).message;
+        return typeof msg === "object" ? msg.melding : msg;
+      }) || [
+        typeof (validationError as any).message === "object"
+          ? (validationError as any).message.melding
+          : validationError.message,
       ];
-      const harRiktigFeilmelding = feilmeldinger.some((m) => m.includes("Du må lagre tittel på hoveddokument"));
+      const harRiktigFeilmelding = feilmeldinger.some((m) => m?.includes("Du må lagre tittel på hoveddokument"));
       expect(harRiktigFeilmelding).toBe(true);
     }
   });
 
   test("skal feile når vedlegg er under redigering og ikke lagret", async () => {
-    // Arrange
-    const values = {
+    const values: HoveddokumentValues = {
       tittel: "Søknad om medlemskap",
       logiskeVedlegg: [""], // Tomt vedlegg under redigering
     };
 
-    const context = {
+    const context: ValidationContext = {
       registeredFields: {
         "logiskeVedlegg[0]": true, // Vedlegget er registrert (under redigering) - bruker relativ path
       },
       journalforingKnappErTryktPå: true,
     };
-
-    // Act & Assert
     try {
       await getHoveddokumentSchema().validate(values, { context, abortEarly: false });
       expect.fail("Validering skulle ha feilet");
     } catch (error) {
       // Med abortEarly: false får vi alle feil i error.inner
-      const feilmeldinger = error.inner?.map((e) => e.message?.melding || e.message) || [
-        error.message?.melding || error.message,
+      const validationError = error as ValidationError;
+      const feilmeldinger = validationError.inner?.map((e) => {
+        const msg = (e as any).message;
+        return typeof msg === "object" ? msg.melding : msg;
+      }) || [
+        typeof (validationError as any).message === "object"
+          ? (validationError as any).message.melding
+          : validationError.message,
       ];
-      const harRiktigFeilmelding = feilmeldinger.some((m) => m.includes("Du må lagre tittel på vedlegg"));
+      const harRiktigFeilmelding = feilmeldinger.some((m) => m?.includes("Du må lagre tittel på vedlegg"));
       expect(harRiktigFeilmelding).toBe(true);
     }
   });
 
   test("skal godta hoveddokument som ikke er under redigering", async () => {
-    // Arrange
-    const values = {
+    const values: HoveddokumentValues = {
       tittel: "Søknad om medlemskap",
       logiskeVedlegg: [],
     };
 
-    const context = {
+    const context: ValidationContext = {
       registeredFields: {}, // Ingen felt under redigering
       journalforingKnappErTryktPå: true,
     };
 
-    // Act & Assert (skal ikke kaste feil)
     await expect(getHoveddokumentSchema().validate(values, { context })).resolves.toBeDefined();
   });
 
   test("skal godta vedlegg som ikke er under redigering", async () => {
-    // Arrange
-    const values = {
+    const values: HoveddokumentValues = {
       tittel: "Søknad om medlemskap",
       logiskeVedlegg: ["Vedlegg 1", "Vedlegg 2"],
     };
 
-    const context = {
+    const context: ValidationContext = {
       registeredFields: {}, // Ingen felt under redigering
       journalforingKnappErTryktPå: true,
     };
 
-    // Act & Assert (skal ikke kaste feil)
     await expect(getHoveddokumentSchema().validate(values, { context })).resolves.toBeDefined();
   });
 
   test("skal godta tom tittel når journalforingKnappErTryktPå er false", async () => {
-    // Arrange
-    const values = {
+    const values: HoveddokumentValues = {
       tittel: "",
       logiskeVedlegg: [],
     };
 
-    const context = {
+    const context: ValidationContext = {
       registeredFields: {
         tittel: true, // Bruker relativ path
       },
       journalforingKnappErTryktPå: false, // Brukeren har ikke trykt på journalføringsknappen
     };
 
-    // Act & Assert (skal ikke kaste feil fra erIkkeUnderRedigering)
     // required() vil fortsatt feile, men det er OK - vi tester bare erIkkeUnderRedigering her
     try {
       await getHoveddokumentSchema().validate(values, { context });
     } catch (error) {
       // required() feiler med "Velg dokumenttittel...", ikke "Du må lagre..."
-      const melding = error.message?.melding || error.message;
+      const validationError = error as ValidationError;
+      const msg = (validationError as any).message;
+      const melding = typeof msg === "object" ? msg.melding : msg;
       expect(melding).not.toContain("Du må lagre");
     }
   });


### PR DESCRIPTION
Fikser årsavregning periodetype-bug (MELOSYS-7639)

  JIRA: https://jira.adeo.no/browse/MELOSYS-7639

  Problem

  Når bruker legger til inntektskilder i årsavregning uten grunnlag, blir periodetype lagret feil:
  - Bruker velger "Md." (månedlig) i dropdown
  - Etter refresh vises "Total" i stedet
  - Feilen oppstår kun første gang i ny behandling, og kun for perioder som IKKE dekker et helt kalenderår

  Rot-årsak:mapTilInntektskilderProps i utils.ts satte hardkodet erMaanedsbelop: "JA" når ingen inntektskilder fantes. Dette overskrev brukerens valg når data ble sendt til backend.

  Løsning

  Fjernet hardkodet verdi for erMaanedsbelop når tom inntektskilde opprettes:

  Før:
  {
    // ...andre felter
    erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(true), // ❌ Hardkodet "JA"
  }

  Etter:
  {
    // ...andre felter
    // erMaanedsbelop ikke satt - UI setter default basert på brukerens valg ✅
  }

  TDD-tilnærming

  Fulgte TDD RED → GREEN:
  1. RED: La til tester som beviser buggen (commit afc1986)
  2. GREEN: Fikset buggen - fjernet hardkodet verdi (commit e7960ce)

  Test-dekning

  ✅ 2 nye enhetstester i utils.test.ts:
  - Verifiserer at erMaanedsbelop ikke er hardkodet når ingen inntektskilder finnes
  - Verifiserer at erMaanedsbelop mappes korrekt fra backend når inntektskilder finnes

  Bonus

  Konverterte journalforingSchema.test.js til TypeScript og forbedret type-bruken (commits 760eea0, 35eb49e)

  Testing

  - ✅ Alle enhetstester passerer (1566 tester)
  - ⚠️ Manuell testing anbefales i q1/q2 for å verifisere fix

  Sjekkliste

  - TDD RED-fase: Tester opprettet som beviser buggen
  - TDD GREEN-fase: Bug fikset, tester passerer
  - Ingen hardkodede verdier i mapping-laget
  - Eksisterende funksjonalitet bevart
