### PR TITLE
7639 Årsavregning - Periodetype bevares

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: "http://localhost:3333",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -80,9 +80,9 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run start",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
+    command: "node generate-local-config.mjs .local.env && npx vite --port 3333",
+    url: "http://localhost:3333",
+    reuseExistingServer: false, // Alltid start en ny server for e2e-tester
     timeout: 120 * 1000, // 2 minutes to allow for slow startup
   },
 });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
@@ -36,7 +36,7 @@ export function BeregnetTrygdeavgiftDetaljer({
           (m) => new Date(m.fomDato) <= new Date(period.tom) && new Date(m.tomDato) >= new Date(period.fom),
         );
 
-        const overlappingSkatteforhold = data.trygdeavgiftsgrunnlag.skatteforholdsperioder?.find(
+        const overlappingSkatteforhold = data.trygdeavgiftsgrunnlag.skatteforholdsperioder.find(
           (s) => new Date(s.fomDato) <= new Date(period.tom) && new Date(s.tomDato) >= new Date(period.fom),
         );
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
@@ -32,11 +32,11 @@ export function BeregnetTrygdeavgiftDetaljer({
   const hentDetaljer = (data: Grunnlagsopplysninger): DetaljerInterface[] => {
     return data.avgift.trygdeavgiftsperioder
       .map((period) => {
-        const overlappingMedlemskap = data.trygdeavgiftsgrunnlag.medlemskapsperioder.find(
+        const overlappingMedlemskap = data.trygdeavgiftsgrunnlag.medlemskapsperioder?.find(
           (m) => new Date(m.fomDato) <= new Date(period.tom) && new Date(m.tomDato) >= new Date(period.fom),
         );
 
-        const overlappingSkatteforhold = data.trygdeavgiftsgrunnlag.skatteforholdsperioder.find(
+        const overlappingSkatteforhold = data.trygdeavgiftsgrunnlag.skatteforholdsperioder?.find(
           (s) => new Date(s.fomDato) <= new Date(period.tom) && new Date(s.tomDato) >= new Date(period.fom),
         );
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.test.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.test.ts
@@ -255,21 +255,22 @@ describe("utils", () => {
             kildetype: "",
             arbAvgBetales: "NEI",
             bruttoInntekt: undefined,
-            // erMaanedsbelop ikke satt - UI setter default
+            erMaanedsbelop: "JA",
           },
         ]);
       });
 
-      // MELOSYS-7639: Test for å bevise at erMaanedsbelop ikke skal være hardkodet
-      it("skal ikke sette hardkodet erMaanedsbelop når ingen inntektskilder finnes", () => {
+      // MELOSYS-7639: Test for forhåndsutfylt inntektskilde når backend ikke har data
+      it("skal sette default erMaanedsbelop når ingen inntektskilder finnes fra backend", () => {
         const membership = [createMockMedlemskapsperiode()];
         vi.mocked(Utils._isEmpty).mockReturnValue(false);
 
         const result = mapTilInntektskilderProps(undefined, membership);
 
-        // erMaanedsbelop skal IKKE være satt (undefined)
-        // UI-komponenten skal sette denne verdien når bruker klikker "Legg til inntekt"
-        expect(result[0].erMaanedsbelop).toBeUndefined();
+        // Forhåndsutfylt objekt MÅ ha erMaanedsbelop satt til default-verdi
+        // Dette sikrer at verdien ikke blir undefined ved beregning
+        // Default skal være "JA" (Md.) - konsistent med "Legg til inntekt"-knappen
+        expect(result[0].erMaanedsbelop).toBe("JA");
       });
 
       it("mapper erMaanedsbelop korrekt fra backend når inntektskilder finnes", () => {
@@ -289,6 +290,69 @@ describe("utils", () => {
 
         // Frontend skal få string "NEI"
         expect(result[0].erMaanedsbelop).toBe("NEI");
+      });
+
+      // MELOSYS-7639: Test for å verifisere at verdier holder seg sammen ved forskjellig rekkefølge
+      it("skal bevare korrekt mapping mellom datoer og periodetype selv om backend returnerer data i forskjellig rekkefølge", () => {
+        // Scenario: Backend returnerer tre inntektskilder med FORSKJELLIGE verdier i ALLE kolonner
+        // Dette gjør det lett å spotte om verdier "hopper" mellom rader
+        const inntektskilderFraBackend = [
+          {
+            fomDato: "2023-03-01", // Mars (siste periode)
+            tomDato: "2023-03-31",
+            type: "ARBEIDSINNTEKT",
+            arbeidsgiversavgiftBetales: true,
+            avgiftspliktigInntekt: 30000,
+            erMaanedsbelop: false, // Total
+          },
+          {
+            fomDato: "2023-01-01", // Januar (første periode)
+            tomDato: "2023-01-31",
+            type: "NÆRINGSINNTEKT",
+            arbeidsgiversavgiftBetales: false,
+            avgiftspliktigInntekt: 10000,
+            erMaanedsbelop: true, // Md.
+          },
+          {
+            fomDato: "2023-02-01", // Februar (midtre periode)
+            tomDato: "2023-02-28",
+            type: "PENSJON",
+            arbeidsgiversavgiftBetales: false,
+            avgiftspliktigInntekt: 20000,
+            erMaanedsbelop: true, // Md.
+          },
+        ];
+
+        vi.mocked(Utils._isEmpty).mockReturnValue(false);
+        // Mock datoformatering til å returnere input uendret for enklere assertions
+        vi.mocked(Utils.dato.formatterDatoTilNorsk).mockImplementation((dato) => dato);
+
+        const result = mapTilInntektskilderProps(inntektskilderFraBackend, []);
+
+        // UTEN sortering: Data kommer i samme rekkefølge som backend sendte (Mars, Januar, Februar)
+        // Index 0 = Mars (siste periode) med Total
+        expect(result[0].fomDato).toBe("2023-03-01");
+        expect(result[0].tomDato).toBe("2023-03-31");
+        expect(result[0].kildetype).toBe("ARBEIDSINNTEKT");
+        expect(result[0].bruttoInntekt).toBe(30000);
+        expect(result[0].erMaanedsbelop).toBe("NEI"); // Total skal følge Mars
+        expect(result[0].arbAvgBetales).toBe("JA");
+
+        // Index 1 = Januar (første periode) med Md.
+        expect(result[1].fomDato).toBe("2023-01-01");
+        expect(result[1].tomDato).toBe("2023-01-31");
+        expect(result[1].kildetype).toBe("NÆRINGSINNTEKT");
+        expect(result[1].bruttoInntekt).toBe(10000);
+        expect(result[1].erMaanedsbelop).toBe("JA"); // Md. skal følge Januar
+        expect(result[1].arbAvgBetales).toBe("NEI");
+
+        // Index 2 = Februar (midtre periode) med Md.
+        expect(result[2].fomDato).toBe("2023-02-01");
+        expect(result[2].tomDato).toBe("2023-02-28");
+        expect(result[2].kildetype).toBe("PENSJON");
+        expect(result[2].bruttoInntekt).toBe(20000);
+        expect(result[2].erMaanedsbelop).toBe("JA"); // Md. skal følge Februar
+        expect(result[2].arbAvgBetales).toBe("NEI");
       });
     });
   });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
@@ -112,9 +112,6 @@ export function beregnTrygdeavgiftsperioder(
 export const hentMedlemskapsFomTomDato = (medlemskapsperioder?: Medlemskapsperiode[]) => {
   if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
     const sorted = [...medlemskapsperioder].sort(Utils.dato.sorterEtterNorskFomDato);
-    /* eslint-disable-next-line no-console */
-    console.log("[hentMedlemskapsFomTomDato] sorted with Utils.dato.sorterEtterNorskFomDato", sorted);
-
     const fomISO = Utils.dato.formatterDatoTilISO(sorted[0].fomDato);
     const tomISO = Utils.dato.formatterDatoTilISO(sorted[sorted.length - 1].tomDato);
     return { fom: fomISO, tom: tomISO };
@@ -169,10 +166,11 @@ export const mapTilInntektskilderProps = (
         arbAvgBetales: Utils.streng.boolTilUppercaseStreng(false),
         bruttoInntekt: undefined,
         kildetype: "",
+        erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(true),
       },
     ];
   }
-  return [{}] as Inntektskilde[];
+  return [{ erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(true) }] as Inntektskilde[];
 };
 
 export const beregnSumTilFakturaEllerRefusjon = (

--- a/tests/e2e/pages/behandling/aarsavregning.page.ts
+++ b/tests/e2e/pages/behandling/aarsavregning.page.ts
@@ -271,7 +271,29 @@ export class AarsavregningPage extends BehandlingPage {
     await expect(select, `${saksnummer}: Kildetype-select for inntektsperiode ${index} skal være synlig`).toBeVisible({
       timeout: 10000,
     });
+
+    // Vent på at options er lastet inn i select-elementet
+    // Vi venter til select har minst 2 options (tom + minst én faktisk verdi)
+    await this.page.waitForFunction(
+      (selectName) => {
+        const selectEl = document.querySelector(`select[name="${selectName}"]`) as HTMLSelectElement;
+        return selectEl && selectEl.options.length >= 2;
+      },
+      `inntektskilder[${index}].kildetype`,
+      { timeout: 10000 },
+    );
+
     await select.selectOption({ label: type });
+  }
+
+  async assertValideringsfeilInneholder(tekst: string) {
+    const error = this.page.locator('[class*="error"], [class*="feil"]').filter({ hasText: new RegExp(tekst, "i") });
+    await expect(error).toBeVisible();
+  }
+
+  async assertIngenFeilmelding(tekst: string) {
+    const error = this.page.locator('[class*="error"], [class*="feil"]').filter({ hasText: new RegExp(tekst, "i") });
+    await expect(error).not.toBeVisible();
   }
 
   async fyllUtBruttoInntekt(index: number, belop: string) {
@@ -391,6 +413,90 @@ export class AarsavregningPage extends BehandlingPage {
     // Buttonene har format som "mandag 3", "tirsdag 4" osv., så vi må finne button som slutter med dagen
     const datoKnapp = dialog.getByRole("button", { name: new RegExp(`\\b${dag}$`) });
     await datoKnapp.click();
+  }
+
+  // Fyll ut og blur metoder for datovalidering
+  async fyllUtOgBlurMedlemskapsperiodeFomDato(index: number, verdi: string): Promise<string> {
+    const trygdedekningDropdown = this.page.getByRole("combobox", {
+      name: new RegExp(`Trygdedekning periode ${index + 1}`, "i"),
+    });
+    const saksnummer = getSaksnummerFraUrl(this.page);
+    await expect(
+      trygdedekningDropdown,
+      `${saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
+    ).toBeVisible({ timeout: 10000 });
+
+    const allInputs = await this.page
+      .locator('.perioder input[type="text"]:visible, .perioder input:not([type]):visible')
+      .all();
+    const inputIndex = index * 2;
+
+    expect(
+      inputIndex < allInputs.length,
+      `${saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
+    ).toBe(true);
+
+    const inputElement = allInputs[inputIndex];
+    await inputElement.fill(verdi);
+    await inputElement.blur();
+    // Vent litt for at blur-event skal behandles
+    await this.page.waitForTimeout(200);
+    return await inputElement.inputValue();
+  }
+
+  async fyllUtOgBlurMedlemskapsperiodeTomDato(index: number, verdi: string): Promise<string> {
+    const trygdedekningDropdown = this.page.getByRole("combobox", {
+      name: new RegExp(`Trygdedekning periode ${index + 1}`, "i"),
+    });
+    const saksnummer = getSaksnummerFraUrl(this.page);
+    await expect(
+      trygdedekningDropdown,
+      `${saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
+    ).toBeVisible({ timeout: 10000 });
+
+    const allInputs = await this.page
+      .locator('.perioder input[type="text"]:visible, .perioder input:not([type]):visible')
+      .all();
+    const inputIndex = index * 2 + 1;
+
+    expect(
+      inputIndex < allInputs.length,
+      `${saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
+    ).toBe(true);
+
+    const inputElement = allInputs[inputIndex];
+    await inputElement.fill(verdi);
+    await inputElement.blur();
+    // Vent litt for at blur-event skal behandles
+    await this.page.waitForTimeout(200);
+    return await inputElement.inputValue();
+  }
+
+  async fyllUtOgBlurSkatteforholdFomDato(index: number, verdi: string): Promise<string> {
+    const firstSkattLabel = this.page.locator('text="Skatteforhold"').first();
+    const saksnummer = getSaksnummerFraUrl(this.page);
+    await expect(firstSkattLabel, `${saksnummer}: Label 'Skatteforhold' skal være synlig`).toBeVisible({
+      timeout: 10000,
+    });
+
+    const skatteforholdContainer = this.page.locator(".perioder").filter({ has: firstSkattLabel });
+    const allInputs = await skatteforholdContainer
+      .locator('input[type="text"]:visible, input:not([type]):visible')
+      .all();
+
+    const inputIndex = index * 2;
+
+    expect(
+      inputIndex < allInputs.length,
+      `${saksnummer}: Kan ikke finne input ${inputIndex} for skatteforhold ${index}. Totalt ${allInputs.length} inputs funnet.`,
+    ).toBe(true);
+
+    const inputElement = allInputs[inputIndex];
+    await inputElement.fill(verdi);
+    await inputElement.blur();
+    // Vent litt for at blur-event skal behandles
+    await this.page.waitForTimeout(200);
+    return await inputElement.inputValue();
   }
 
   // Validering og feilmeldinger


### PR DESCRIPTION
Det sendes ikke lenger feil data til backend og periodetype bevares nå ved refresh

https://jira.adeo.no/browse/MELOSYS-7639

  Problem 1 - Periodetype endres:
  Ved årsavregning uten grunnlag ble periodetype (Md./Total) satt til undefined i React Hook Form state. Når verdien ble sendt til backend konverterte `undefined || false` til `false` (Total), noe som førte til at periodetype-verdier "hoppet" mellom rader ved refresh/beregning.

  Rotårsak:
  `mapTilInntektskilderProps` returnerte forhåndsutfylte objekter uten `erMaanedsbelop`-felt. React Hook Form registrerte ikke dropdown-verdien automatisk, og backend-payload fikk feil verdi.

  Løsning:
  La til `erMaanedsbelop: Utils.streng.boolTilUppercaseStreng(true)` i både forhåndsutfylt objekt (når medlemskapsperioder finnes) og tomt objekt (når ingen medlemskapsperioder). Dette sikrer at default-verdi "Md." blir registrert i React Hook Form state.

  Endringer:
  - utils.ts: Setter `erMaanedsbelop` i forhåndsutfylte objekter (linje 173 og 178)
  - utils.ts: Fjernet debug console.log fra `hentMedlemskapsFomTomDato`
  - rettet en feil e2e tester 
  - endret PW config til å alltid bruke ny port