### PR TITLE
7677 TOGGLE: Vis skatteforhold og inntektsperioder hvis trygdeavgifts…

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -124,11 +124,20 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     medlemskapsperioder,
     innvilgetMedlemskapsperiode,
   );
+
+  const trygdeavgiftErIkkeTom = !Utils._isEmpty(lagretTrygdeavgift?.trygdeavgiftsperioder);
+
   const skalIkkeBeregneForelopigTrygdeavgift =
     skalIkkeViseTidligerePerioderToggle &&
     medlemskapsperioder.length > 0 &&
     medlemskapsperioder.every((periode) => new Date(periode.tomDato).getFullYear() < new Date().getFullYear()) &&
     behandlingstype === NY_VURDERING;
+
+  const skalViseSkatteforholdOgInntektsperioder =
+    !skalIkkeViseTidligerePerioderToggle ||
+    (trygdeavgiftErIkkeTom && !redigerbart) ||
+    !skalIkkeBeregneForelopigTrygdeavgift;
+
   const stegErGyldig =
     (formIsValid || skalIkkeBeregneForelopigTrygdeavgift) && !feilMeldingBlokkerer(aktivFeilmeldingType) && !feil;
   const skalBeregneForelopigTrygdeavgift =
@@ -137,8 +146,6 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     formValues?.inntektskilder.some(
       (inntektskilde: Inntektskilde) => inntektskilde.bruttoInntekt && inntektskilde.bruttoInntekt !== 0,
     );
-
-  const trygdeavgiftErIkkeTom = !Utils._isEmpty(lagretTrygdeavgift?.trygdeavgiftsperioder);
 
   const harBeregnetForeløpigTrygdeavgift =
     !skalBeregneForelopigTrygdeavgift || trygdeavgiftErIkkeTom || skalIkkeBeregneForelopigTrygdeavgift;
@@ -330,7 +337,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
           </Alert>
         )}
 
-      {!erÅpenSluttDato && !skalIkkeBeregneForelopigTrygdeavgift && (
+      {!erÅpenSluttDato && skalViseSkatteforholdOgInntektsperioder && (
         <>
           <Nav.Heading size="xsmall">Oppgi informasjon om brukers skatteforhold</Nav.Heading>
           <Skatteforholdsperioder
@@ -345,7 +352,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
         </>
       )}
 
-      {skalViseInntektskilder && (
+      {skalViseInntektskilder && skalViseSkatteforholdOgInntektsperioder && (
         <>
           <LabelMedHjelpetekst
             label="Oppgi informasjon om brukers inntekt"


### PR DESCRIPTION
…perioder

Hvis alle perioder er tilbake i tid, så skal ikke skatteforhold og inntektsperioder vises, men det er gitt at behandlingen ikke er avsluttet, eller har trygdeavgiftsperioder. Hvis det er trygdeavgiftsperioder i behandlingen allerede og behandlingen er avsluttet, må de vises.