### PR TITLE
NOJIRA G4P Legg til automatisk triggering av E2E-tester ved deploy

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -118,3 +118,28 @@ jobs:
           body: ${{ env.CHANGE_LOG }}
           draft: true
           prerelease: false
+
+  trigger-e2e-tests:
+    name: Trigger E2E tests
+    runs-on: ubuntu-latest
+    needs: [ build, deploy ]
+    if: always() && (needs.deploy.result == 'success' || needs.deploy.result == 'skipped')
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v5
+      - name: Get commit message
+        run: echo "COMMIT_MSG=$(git log --format=%s -n 1)" >> $GITHUB_ENV
+      - name: Trigger E2E tests in melosys-e2e-tests
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.E2E_TRIGGER_PAT }}
+          repository: navikt/melosys-e2e-tests
+          event-type: melosys-web-published
+          client-payload: |
+            {
+              "repository": "melosys-web",
+              "image_tag": "${{ github.sha }}",
+              "commit_sha": "${{ github.sha }}",
+              "commit_message": "${{ env.COMMIT_MSG }}",
+              "actor": "${{ github.actor }}"
+            }


### PR DESCRIPTION
 ## Summary

  Legger til automatisk triggering av E2E-tester når melosys-web deployes til Q1/Q2.

  ## Endringer

  - ✅ Ny job `trigger-e2e-tests` som kjører etter vellykket deploy
  - ✅ Sender repository dispatch event til `melosys-e2e-tests`
  - ✅ Inkluderer commit SHA, commit message og actor i payload