### PR TITLE
7683: Fiks bug relatert til avgift fra avgiftssystemet

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -304,6 +304,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
             <Nav.Row>
               <Nav.Column xs="12">
                 <Nav.RadioGroup
+                  key={`trygdeavgiftFraAvgiftssystemetRadioGroup ${valgtÅr || initieltÅr || ""}`}
                   onChange={håndterHarTrygdeavgiftFraAvgiftssystemet}
                   legend={
                     <LabelMedHjelpetekst
@@ -330,7 +331,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
             )}
           {!harTrygdeavgiftFraAvgiftssystemetIsPending &&
             (harGrunnlag === false || harTrygdeavgiftFraAvgiftssystemet) &&
-            harTrygdeavgiftFraAvgiftssystemet !== null && (
+            harTrygdeavgiftFraAvgiftssystemet === true && (
               <AarsavregningUtenEllerDeltGrunnlag
                 bekreft={bekreft}
                 aktivtSteg={aktivtSteg}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -331,7 +331,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
             )}
           {!harTrygdeavgiftFraAvgiftssystemetIsPending &&
             (harGrunnlag === false || harTrygdeavgiftFraAvgiftssystemet) &&
-            harTrygdeavgiftFraAvgiftssystemet === true && (
+            (harTrygdeavgiftFraAvgiftssystemet === true || harTrygdeavgiftFraAvgiftssystemet === false) && (
               <AarsavregningUtenEllerDeltGrunnlag
                 bekreft={bekreft}
                 aktivtSteg={aktivtSteg}


### PR DESCRIPTION
Vi har tidligere fikset en bug relatert til avgift fra avgiftssystemet når det gjelder divese behandlinger som mangler data om spørsmålet. Vi vet derfor at harTrygdeavgiftFraAvgiftssystemet alltid skal være true, false eller undefined. Undefined betyr ikke "NEI". true = ja, false = nei, undefined = ikke valgt noe.

Fikser også en annen bug der når vi endret på år, så ble ikke radioknappen clearet. Dette er fikset ved å sette en key for å rendre komponenten på nytt basert på valg av år.
