### PR TITLE
7659 periode steg bug fixes

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
@@ -161,7 +161,6 @@ export function VurderingPeriode({
         );
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formValues.forkortLovvalgsperiode, formValues.fomDato, formValues.tomDato, redigerbart]);
 
   const onCheckboxClick = (checked: boolean) => {
@@ -174,12 +173,8 @@ export function VurderingPeriode({
     bekreftOgFortsett();
   };
 
-  const fom = Utils.dato.formatterDatoTilNorsk(
-    (formValues.forkortLovvalgsperiode && formValues.fomDato) || soknadsperiode.fom,
-  );
-  const tom = Utils.dato.formatterDatoTilNorsk(
-    (formValues.forkortLovvalgsperiode && formValues.tomDato) || soknadsperiode.tom,
-  );
+  const fom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.fom);
+  const tom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.tom);
 
   const stegErGyldig = redigerbart && formState.isValid && !!formValues.lovvalgsbestemmelse;
 

--- a/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
@@ -149,6 +149,31 @@ export function VurderingPeriode({
     }
   }, [formValues.lovvalgsbestemmelse]);
 
+  // Oppdater lovvalgsperioden når brukeren endrer datoer eller checkbox
+  useEffect(() => {
+    if (redigerbart) {
+      const fomDato =
+        formValues.forkortLovvalgsperiode && formValues.fomDato
+          ? Utils.dato.formatterDatoTilISO(formValues.fomDato)
+          : mottatteOpplysningerFom;
+      const tomDato =
+        formValues.forkortLovvalgsperiode && formValues.tomDato
+          ? Utils.dato.formatterDatoTilISO(formValues.tomDato)
+          : mottatteOpplysningerTom;
+
+      // Bare oppdater hvis vi har gyldige datoer
+      if (fomDato && tomDato) {
+        oppdaterData(
+          lagLovvalgsperiode({
+            fomDato,
+            tomDato,
+          }),
+        );
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formValues.forkortLovvalgsperiode, formValues.fomDato, formValues.tomDato, redigerbart]);
+
   const onCheckboxClick = (checked: boolean) => {
     if (!checked && gjenopprettOpprinneligLovvalgsperiode) {
       gjenopprettOpprinneligLovvalgsperiode();

--- a/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
@@ -161,6 +161,7 @@ export function VurderingPeriode({
         );
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formValues.forkortLovvalgsperiode, formValues.fomDato, formValues.tomDato, redigerbart]);
 
   const onCheckboxClick = (checked: boolean) => {
@@ -173,8 +174,12 @@ export function VurderingPeriode({
     bekreftOgFortsett();
   };
 
-  const fom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.fom);
-  const tom = Utils.dato.formatterDatoTilNorsk(soknadsperiode.tom);
+  const fom = Utils.dato.formatterDatoTilNorsk(
+    (formValues.forkortLovvalgsperiode && formValues.fomDato) || soknadsperiode.fom,
+  );
+  const tom = Utils.dato.formatterDatoTilNorsk(
+    (formValues.forkortLovvalgsperiode && formValues.tomDato) || soknadsperiode.tom,
+  );
 
   const stegErGyldig = redigerbart && formState.isValid && !!formValues.lovvalgsbestemmelse;
 

--- a/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
@@ -89,16 +89,6 @@ export function VurderingPeriode({
     if (lovvalgsbestemmelseSomSkalLagres) {
       oppdaterData(konverterLovvalgsbestemmelseTilStegData(lovvalgsbestemmelseSomSkalLagres));
     }
-
-    if (redigerbart) {
-      oppdaterData(
-        lagLovvalgsperiode({
-          fomDato: mottatteOpplysningerFom,
-          tomDato: mottatteOpplysningerTom,
-        }),
-      );
-    }
-
     return () => {
       slettData();
     };

--- a/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
@@ -75,7 +75,7 @@ export function VurderingPeriode({
       forkortLovvalgsperiode,
       tomDato: Utils.dato.formatterDatoTilNorsk(lovvalgsTomDato),
       fomDato: Utils.dato.formatterDatoTilNorsk(lovvalgsFomDato),
-      lovvalgsbestemmelse: lovvalgsbestemmelseSomSkalVises,
+      lovvalgsbestemmelse: lovvalgsbestemmelseSomSkalVises || undefined,
     },
   });
 
@@ -156,18 +156,18 @@ export function VurderingPeriode({
       </Nav.Heading>
       <Nav.Row className="velgLovvalgsbestemmelse">
         <Nav.Column xs="7">
-          <Forms.Select
-            label="Velg en lovvalgsbestemmelse"
+          <Forms.RadioGroup
+            legend="Velg en lovvalgsbestemmelse"
             name="lovvalgsbestemmelse"
             control={control}
             readOnly={!redigerbart}
           >
             {valgbareLovvalgsbestemmelser.map((bestemmelse) => (
-              <option key={bestemmelse.kode} value={bestemmelse.kode}>
+              <Nav.Radio key={bestemmelse.kode} value={bestemmelse.kode}>
                 {bestemmelse.term}
-              </option>
+              </Nav.Radio>
             ))}
-          </Forms.Select>
+          </Forms.RadioGroup>
         </Nav.Column>
       </Nav.Row>
       {redigerbart && (

--- a/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
@@ -62,9 +62,6 @@ export function VurderingPeriode({
   const forkortLovvalgsperiode =
     !redigerbart && Utils.dato.datoDiffPure(mottatteOpplysningerTom, lovvalgsTomDato, "days") !== 0;
 
-  // Note: yupResolver type doesn't match React Hook Form's Resolver<FormValues> type perfectly,
-  // so we use 'as any' here. This is a known limitation with @hookform/resolvers v3.x.
-  // The runtime validation still works correctly.
   // Utled checkbox-state: hvis lovvalgsperioden er ulik søknadsperioden, er den forkortet
   const harForkortetPeriode =
     lovvalgsFomDato &&
@@ -72,7 +69,8 @@ export function VurderingPeriode({
     (lovvalgsFomDato !== mottatteOpplysningerFom || lovvalgsTomDato !== mottatteOpplysningerTom);
 
   const { control, watch, formState, handleSubmit, reset } = useForm<FormValues>({
-    resolver: yupResolver(VurderingPeriodeSchema) as any,
+    // @ts-expect-error - yup schema nullable() matcher ikke FormValues optional field perfekt
+    resolver: yupResolver(VurderingPeriodeSchema),
     mode: "onChange",
     context: {
       soknadsperiode,
@@ -121,7 +119,6 @@ export function VurderingPeriode({
         lovvalgsbestemmelse: lovvalgsbestemmelseSomSkalVises || undefined,
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lovvalgsFomDato, lovvalgsTomDato]);
 
   const valgbareLovvalgsbestemmelser = [

--- a/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriode.tsx
@@ -65,16 +65,22 @@ export function VurderingPeriode({
   // Note: yupResolver type doesn't match React Hook Form's Resolver<FormValues> type perfectly,
   // so we use 'as any' here. This is a known limitation with @hookform/resolvers v3.x.
   // The runtime validation still works correctly.
-  const { control, watch, formState, handleSubmit } = useForm<FormValues>({
+  // Utled checkbox-state: hvis lovvalgsperioden er ulik søknadsperioden, er den forkortet
+  const harForkortetPeriode =
+    lovvalgsFomDato &&
+    lovvalgsTomDato &&
+    (lovvalgsFomDato !== mottatteOpplysningerFom || lovvalgsTomDato !== mottatteOpplysningerTom);
+
+  const { control, watch, formState, handleSubmit, reset } = useForm<FormValues>({
     resolver: yupResolver(VurderingPeriodeSchema) as any,
     mode: "onChange",
     context: {
       soknadsperiode,
     },
     defaultValues: {
-      forkortLovvalgsperiode,
-      tomDato: Utils.dato.formatterDatoTilNorsk(lovvalgsTomDato),
-      fomDato: Utils.dato.formatterDatoTilNorsk(lovvalgsFomDato),
+      forkortLovvalgsperiode: harForkortetPeriode || forkortLovvalgsperiode,
+      tomDato: Utils.dato.formatterDatoTilNorsk(mottatteOpplysningerTom),
+      fomDato: Utils.dato.formatterDatoTilNorsk(mottatteOpplysningerFom),
       lovvalgsbestemmelse: lovvalgsbestemmelseSomSkalVises || undefined,
     },
   });
@@ -99,6 +105,24 @@ export function VurderingPeriode({
       slettData();
     };
   }, []);
+
+  // Oppdater form-verdiene hvis det finnes en eksisterende forkortet lovvalgsperiode
+  useEffect(() => {
+    if (
+      lovvalgsFomDato &&
+      lovvalgsTomDato &&
+      (lovvalgsFomDato !== mottatteOpplysningerFom || lovvalgsTomDato !== mottatteOpplysningerTom)
+    ) {
+      // Det finnes en eksisterende forkortet periode - oppdater form
+      reset({
+        forkortLovvalgsperiode: true,
+        fomDato: Utils.dato.formatterDatoTilNorsk(lovvalgsFomDato),
+        tomDato: Utils.dato.formatterDatoTilNorsk(lovvalgsTomDato),
+        lovvalgsbestemmelse: lovvalgsbestemmelseSomSkalVises || undefined,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lovvalgsFomDato, lovvalgsTomDato]);
 
   const valgbareLovvalgsbestemmelser = [
     ...MKV.KTObjects.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.filter(

--- a/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriodeSchema.ts
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingPeriode/vurderingPeriodeSchema.ts
@@ -10,11 +10,13 @@ const vurderingPeriodeSchema = object().shape({
   forkortLovvalgsperiode: bool().required(),
   fomDato: string().when("forkortLovvalgsperiode", {
     is: true,
+    // Custom yup-utvidelser (erInnenforSoknadsperioden, erGyldigDato) finnes ikke i StringSchema-typen
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     then: (schema: any) => schema.erInnenforSoknadsperioden().erGyldigDato().required(MAA_FYLLES_UT),
   }),
   tomDato: string().when("forkortLovvalgsperiode", {
     is: true,
+    // Custom yup-utvidelser (erInnenforSoknadsperioden, erEtterDatofelt, erGyldigDato) finnes ikke i StringSchema-typen
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     then: (schema: any) =>
       schema.erInnenforSoknadsperioden().erEtterDatofelt("fomDato").erGyldigDato().required(MAA_FYLLES_UT),


### PR DESCRIPTION
# MELOSYS 7659: Forbedringer og bugfikser for periode-steget i EØS-flyt

  ## Sammendrag

  Tre forbedringer til periode-steget for offentlig ansatt i EØS-flyt:
  1. UI-forbedring: Radio-buttons i stedet for nedtrekksmeny
  2. Bugfiks: Datofelt-initialisering og checkbox-state
  3. Opprydding: useEffect-optimalisering og type-sikkerhet

  ## Problem

  ### Radio-buttons
  Nedtrekksmeny var unødvendig når det kun er to valgmuligheter (art.11(3)(b) og art.11(5)).

  ### Datofelt-initialisering
  - Datofeltene var tomme når checkbox ble huket av (krevde refresh)
  - Checkbox-state ble ikke persistert ved gjenåpning av sak
  - Endrede datoer ble ikke sendt til backend ved "Bekreft og fortsett"

  **Root cause:**
  - defaultValues brukte `lovvalgsFomDato/tomDato` som kunne være undefined ved mount
  - Backend har ikke felt for checkbox-state - må utledes fra periodedata
  - Manglet useEffect for å oppdatere Redux state ved datoendringer

  ### useEffect-duplikat
  Mount useEffect og periode-oppdatering useEffect gjorde overlappende jobb, noe som kunne skape race conditions.

  ## Løsning

  ### Radio-buttons
  Byttet `Forms.Select` til `Forms.RadioGroup`. Ingen default-valg ved oppstart.

  ### Datofelt-initialisering
  - Bruk søknadsperioden som defaultValues for datoer
  - Utled checkbox-state fra om perioden er forkortet
  - useEffect oppdaterer form ved eksisterende forkortet periode
  - useEffect oppdaterer Redux state når bruker endrer datoer/checkbox

  ### useEffect-optimalisering
  Fjernet duplikat periode-initialisering fra mount useEffect. Periode-oppdatering useEffect håndterer nå både initial state og endringer.

  ### Type-sikkerhet
  Byttet `as any` til `@ts-expect-error` med presise forklaringer på norsk.

  ## Resultat

  - ✅ Bedre UX med radio-buttons
  - ✅ Datofelt fylles automatisk med søknadsperioden
  - ✅ Checkbox vises korrekt ved gjenåpning
  - ✅ Endrede datoer sendes til backend
  - ✅ Ingen infinite loops eller race conditions
  - ✅ Forbedret type-sikkerhet

  ## Testing

  Manuell testing utført:
  - [x] Radio-buttons uten default-valg
  - [x] Huker av checkbox → datoer fylles automatisk
  - [x] Endrer datoer → sendes til backend
  - [x] Forkortet periode vises korrekt ved gjenåpning
  - [x] Ingen app-heng eller infinite loops

  ## Relatert

  - JIRA: [MELOSYS-7659](https://jira.adeo.no/browse/MELOSYS-7659)
  - Epos: [MELOSYS-7656](https://jira.adeo.no/browse/MELOSYS-7656)
