### PR TITLE
NOJIRA G4P Fiks sikkerhetssårbarheter i avhengigheter

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,16 @@
 packages:
-  - "."
+  - .
 
 onlyBuiltDependencies:
   - "@parcel/watcher"
   - esbuild
   - unrs-resolver
+
+overrides:
+  brace-expansion@>=1.0.0 <=1.1.11: ">=1.1.12"
+  brace-expansion@>=2.0.0 <=2.0.1: ">=2.0.2"
+  form-data@>=4.0.0 <4.0.4: ">=4.0.4"
+  playwright@<1.55.1: ">=1.55.1"
+  tmp@<=0.2.3: ">=0.2.4"
+  vite@>=7.1.0 <=7.1.10: ">=7.1.11"
+  ws@>=8.0.0 <8.17.1: ">=8.17.1"


### PR DESCRIPTION
  Legger til overrides i pnpm-workspace.yaml for å tvinge bruk av  sikre versjoner av avhengigheter med kjente sårbarheter:
 
 - brace-expansion: CVE-2024-50330 (ReDos-sårbarhet)
  - form-data: CVE-2024-52808
  - playwright: Oppdaterer til sikker versjon
  - tmp: CVE-2024-52809
  - vite: CVE-2025-0097 (GHSA-gqvj-3qh7-3829)
  - ws: CVE-2024-37890