### PR TITLE
NOJIRA G4P Fiks sikkerhetssårbarheter i avhengigheter, rapportert av Dependabot

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,8 +23,6 @@ jobs:
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: 9
 
     - name: Setup node
       uses: actions/setup-node@v6

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -28,8 +28,6 @@ jobs:
           fetch-depth: 0
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy-manuelt.yml
+++ b/.github/workflows/deploy-manuelt.yml
@@ -48,8 +48,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup node
         uses: actions/setup-node@v6

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,8 +12,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup node
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "private": true,
   "readme": "README.md",
+  "packageManager": "pnpm@10.20.0",
   "dependencies": {
     "@apollo/client": "^3.7.12",
     "@azure/msal-browser": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@graphql-codegen/typescript-generic-sdk": "^3.1.0",
     "@graphql-codegen/typescript-operations": "^3.0.4",
     "@graphql-codegen/typescript-react-apollo": "^3.3.7",
-    "@playwright/test": "^1.44.0",
+    "@playwright/test": "^1.56.1",
     "@reduxjs/toolkit": "^2.8.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
@@ -131,7 +131,7 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.44.0",
-    "vite": "^7.1.5",
+    "vite": "^7.2.2",
     "vite-plugin-svgr": "^4.5.0",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@>=1.0.0 <=1.1.11: ">=1.1.12"
+  brace-expansion@>=2.0.0 <=2.0.1: ">=2.0.2"
+  form-data@>=4.0.0 <4.0.4: ">=4.0.4"
+  tmp@<=0.2.3: ">=0.2.4"
+  ws@>=8.0.0 <8.17.1: ">=8.17.1"
+
 importers:
   .:
     dependencies:
@@ -106,7 +113,7 @@ importers:
     devDependencies:
       "@axe-core/playwright":
         specifier: ^4.8.5
-        version: 4.10.2(playwright-core@1.55.0)
+        version: 4.10.2(playwright-core@1.56.1)
       "@eslint/eslintrc":
         specifier: ^3.1.0
         version: 3.3.1
@@ -132,8 +139,8 @@ importers:
         specifier: ^3.3.7
         version: 3.3.7(graphql-tag@2.12.6(graphql@16.11.0))(graphql@16.11.0)
       "@playwright/test":
-        specifier: ^1.44.0
-        version: 1.55.0
+        specifier: ^1.56.1
+        version: 1.56.1
       "@reduxjs/toolkit":
         specifier: ^2.8.2
         version: 2.8.2(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
@@ -187,7 +194,7 @@ importers:
         version: 8.44.0(eslint@9.35.0(jiti@1.21.7))(typescript@5.9.2)
       "@vitejs/plugin-react":
         specifier: ^5.0.3
-        version: 5.0.3(vite@7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
+        version: 5.0.3(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
       "@vitest/coverage-v8":
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.8.0))
@@ -255,14 +262,14 @@ importers:
         specifier: ^8.44.0
         version: 8.44.0(eslint@9.35.0(jiti@1.21.7))(typescript@5.9.2)
       vite:
-        specifier: ^7.1.5
-        version: 7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+        specifier: ^7.2.2
+        version: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
       vite-plugin-svgr:
         specifier: ^4.5.0
-        version: 4.5.0(rollup@4.50.2)(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
+        version: 4.5.0(rollup@4.50.2)(typescript@5.9.2)(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
+        version: 4.3.2(typescript@5.9.2)(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.8.0)
@@ -1593,9 +1600,9 @@ packages:
       { integrity: sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw== }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@playwright/test@1.55.0":
+  "@playwright/test@1.56.1":
     resolution:
-      { integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ== }
+      { integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg== }
     engines: { node: ">=18" }
     hasBin: true
 
@@ -2494,6 +2501,11 @@ packages:
     resolution:
       { integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw== }
 
+  balanced-match@3.0.1:
+    resolution:
+      { integrity: sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w== }
+    engines: { node: ">= 16" }
+
   base64-js@1.5.1:
     resolution:
       { integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA== }
@@ -2502,13 +2514,14 @@ packages:
     resolution:
       { integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w== }
 
-  brace-expansion@1.1.11:
-    resolution:
-      { integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA== }
-
   brace-expansion@2.0.1:
     resolution:
       { integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA== }
+
+  brace-expansion@4.0.1:
+    resolution:
+      { integrity: sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA== }
+    engines: { node: ">= 18" }
 
   braces@3.0.3:
     resolution:
@@ -2720,10 +2733,6 @@ packages:
     resolution:
       { integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA== }
     engines: { node: ">=4.0.0" }
-
-  concat-map@0.0.1:
-    resolution:
-      { integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg== }
 
   constant-case@3.0.4:
     resolution:
@@ -3410,9 +3419,9 @@ packages:
       { integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw== }
     engines: { node: ">=14" }
 
-  form-data@4.0.2:
+  form-data@4.0.4:
     resolution:
-      { integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w== }
+      { integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow== }
     engines: { node: ">= 6" }
 
   fs.realpath@1.0.0:
@@ -3984,7 +3993,7 @@ packages:
     resolution:
       { integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw== }
     peerDependencies:
-      ws: "*"
+      ws: ">=8.17.1"
 
   istanbul-lib-coverage@3.2.2:
     resolution:
@@ -4557,11 +4566,6 @@ packages:
       { integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ== }
     engines: { node: ">=10" }
 
-  os-tmpdir@1.0.2:
-    resolution:
-      { integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g== }
-    engines: { node: ">=0.10.0" }
-
   outvariant@1.4.3:
     resolution:
       { integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA== }
@@ -4757,15 +4761,15 @@ packages:
       { integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g== }
     engines: { node: ">=6" }
 
-  playwright-core@1.55.0:
+  playwright-core@1.56.1:
     resolution:
-      { integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg== }
+      { integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ== }
     engines: { node: ">=18" }
     hasBin: true
 
-  playwright@1.55.0:
+  playwright@1.56.1:
     resolution:
-      { integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA== }
+      { integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw== }
     engines: { node: ">=18" }
     hasBin: true
 
@@ -5572,10 +5576,10 @@ packages:
       { integrity: sha512-Y1KQBgDd/NUc+LfOtKS6mNsC9CCaH+m2P1RoIZy7RAPo3C3/t8X45+zgut31cRZtZ3xKPjfn3TkGTrctC2TQIQ== }
     hasBin: true
 
-  tmp@0.0.33:
+  tmp@0.2.5:
     resolution:
-      { integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw== }
-    engines: { node: ">=0.6.0" }
+      { integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow== }
+    engines: { node: ">=14.14" }
 
   to-regex-range@5.0.1:
     resolution:
@@ -5825,9 +5829,9 @@ packages:
       vite:
         optional: true
 
-  vite@7.1.5:
+  vite@7.2.2:
     resolution:
-      { integrity: sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ== }
+      { integrity: sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ== }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
@@ -6011,19 +6015,6 @@ packages:
     resolution:
       { integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ== }
 
-  ws@8.13.0:
-    resolution:
-      { integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA== }
-    engines: { node: ">=10.0.0" }
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ">=5.0.2"
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.18.2:
     resolution:
       { integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ== }
@@ -6177,10 +6168,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  "@axe-core/playwright@4.10.2(playwright-core@1.55.0)":
+  "@axe-core/playwright@4.10.2(playwright-core@1.56.1)":
     dependencies:
       axe-core: 4.10.3
-      playwright-core: 1.55.0
+      playwright-core: 1.56.1
 
   "@azure/msal-browser@4.13.2":
     dependencies:
@@ -7063,9 +7054,9 @@ snapshots:
       "@types/ws": 8.18.1
       graphql: 16.11.0
       graphql-ws: 5.12.1(graphql@16.11.0)
-      isomorphic-ws: 5.0.0(ws@8.13.0)
+      isomorphic-ws: 5.0.0(ws@8.18.2)
       tslib: 2.8.1
-      ws: 8.13.0
+      ws: 8.18.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7089,9 +7080,9 @@ snapshots:
       "@graphql-tools/utils": 9.2.1(graphql@16.11.0)
       "@types/ws": 8.18.1
       graphql: 16.11.0
-      isomorphic-ws: 5.0.0(ws@8.13.0)
+      isomorphic-ws: 5.0.0(ws@8.18.2)
       tslib: 2.8.1
-      ws: 8.13.0
+      ws: 8.18.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7517,9 +7508,9 @@ snapshots:
 
   "@pkgr/core@0.2.4": {}
 
-  "@playwright/test@1.55.0":
+  "@playwright/test@1.56.1":
     dependencies:
-      playwright: 1.55.0
+      playwright: 1.56.1
 
   "@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)":
     dependencies:
@@ -7984,7 +7975,7 @@ snapshots:
   "@unrs/resolver-binding-win32-x64-msvc@1.7.2":
     optional: true
 
-  "@vitejs/plugin-react@5.0.3(vite@7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))":
+  "@vitejs/plugin-react@5.0.3(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))":
     dependencies:
       "@babel/core": 7.28.4
       "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.28.4)
@@ -7992,7 +7983,7 @@ snapshots:
       "@rolldown/pluginutils": 1.0.0-beta.35
       "@types/babel__core": 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8023,14 +8014,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  "@vitest/mocker@3.2.4(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(vite@7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))":
+  "@vitest/mocker@3.2.4(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))":
     dependencies:
       "@vitest/spy": 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.11.6(@types/node@22.18.5)(typescript@5.9.2)
-      vite: 7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
 
   "@vitest/pretty-format@3.2.4":
     dependencies:
@@ -8301,6 +8292,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@3.0.1: {}
+
   base64-js@1.5.1: {}
 
   bl@4.1.0:
@@ -8309,14 +8302,13 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@1.1.11:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@4.0.1:
+    dependencies:
+      balanced-match: 3.0.1
 
   braces@3.0.3:
     dependencies:
@@ -8511,8 +8503,6 @@ snapshots:
   commander@13.1.0: {}
 
   common-tags@1.8.2: {}
-
-  concat-map@0.0.1: {}
 
   constant-case@3.0.4:
     dependencies:
@@ -9105,7 +9095,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.0.33
+      tmp: 0.2.5
 
   extract-files@11.0.0: {}
 
@@ -9205,11 +9195,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.2:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   fs.realpath@1.0.0: {}
@@ -9685,10 +9676,6 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@5.0.0(ws@8.13.0):
-    dependencies:
-      ws: 8.13.0
-
   isomorphic-ws@5.0.0(ws@8.18.2):
     dependencies:
       ws: 8.18.2
@@ -9750,7 +9737,7 @@ snapshots:
       data-urls: 4.0.0
       decimal.js: 10.5.0
       domexception: 4.0.0
-      form-data: 4.0.2
+      form-data: 4.0.4
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
@@ -10010,15 +9997,15 @@ snapshots:
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 4.0.1
 
   minimatch@4.2.3:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 2.0.1
 
   minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 4.0.1
 
   minimist@1.2.8: {}
 
@@ -10209,8 +10196,6 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
-  os-tmpdir@1.0.2: {}
-
   outvariant@1.4.3: {}
 
   own-keys@1.0.1:
@@ -10342,11 +10327,11 @@ snapshots:
   pify@4.0.1:
     optional: true
 
-  playwright-core@1.55.0: {}
+  playwright-core@1.56.1: {}
 
-  playwright@1.55.0:
+  playwright@1.56.1:
     dependencies:
-      playwright-core: 1.55.0
+      playwright-core: 1.56.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -11048,9 +11033,7 @@ snapshots:
     dependencies:
       tldts-core: 7.0.17
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
+  tmp@0.2.5: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -11255,7 +11238,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - "@types/node"
       - jiti
@@ -11270,29 +11253,29 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-svgr@4.5.0(rollup@4.50.2)(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)):
+  vite-plugin-svgr@4.5.0(rollup@4.50.2)(typescript@5.9.2)(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)):
     dependencies:
       "@rollup/pluginutils": 5.3.0(rollup@4.50.2)
       "@svgr/core": 8.1.0(typescript@5.9.2)
       "@svgr/plugin-jsx": 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
-      vite: 7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)):
+  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0):
+  vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -11311,7 +11294,7 @@ snapshots:
     dependencies:
       "@types/chai": 5.2.2
       "@vitest/expect": 3.2.4
-      "@vitest/mocker": 3.2.4(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(vite@7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
+      "@vitest/mocker": 3.2.4(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
       "@vitest/pretty-format": 3.2.4
       "@vitest/runner": 3.2.4
       "@vitest/snapshot": 3.2.4
@@ -11329,7 +11312,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.5(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
       vite-node: 3.2.4(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -11470,8 +11453,6 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
-
-  ws@8.13.0: {}
 
   ws@8.18.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@>=1.0.0 <=1.1.11: ">=1.1.12"
-  brace-expansion@>=2.0.0 <=2.0.1: ">=2.0.2"
-  form-data@>=4.0.0 <4.0.4: ">=4.0.4"
-  tmp@<=0.2.3: ">=0.2.4"
-  ws@>=8.0.0 <8.17.1: ">=8.17.1"
+  brace-expansion@>=1.0.0 <2.0.0: ^1.1.12
+  brace-expansion@>=2.0.0 <3.0.0: ^2.0.2
+  form-data@>=4.0.0 <5.0.0: ^4.0.4
+  tmp@<1.0.0: ^0.2.4
+  ws@>=8.0.0 <9.0.0: ^8.17.1
 
 importers:
   .:
@@ -2501,11 +2501,6 @@ packages:
     resolution:
       { integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw== }
 
-  balanced-match@3.0.1:
-    resolution:
-      { integrity: sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w== }
-    engines: { node: ">= 16" }
-
   base64-js@1.5.1:
     resolution:
       { integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA== }
@@ -2514,14 +2509,13 @@ packages:
     resolution:
       { integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w== }
 
-  brace-expansion@2.0.1:
+  brace-expansion@1.1.12:
     resolution:
-      { integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA== }
+      { integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg== }
 
-  brace-expansion@4.0.1:
+  brace-expansion@2.0.2:
     resolution:
-      { integrity: sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA== }
-    engines: { node: ">= 18" }
+      { integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ== }
 
   braces@3.0.3:
     resolution:
@@ -2733,6 +2727,10 @@ packages:
     resolution:
       { integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA== }
     engines: { node: ">=4.0.0" }
+
+  concat-map@0.0.1:
+    resolution:
+      { integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg== }
 
   constant-case@3.0.4:
     resolution:
@@ -3993,7 +3991,7 @@ packages:
     resolution:
       { integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw== }
     peerDependencies:
-      ws: ">=8.17.1"
+      ws: ^8.17.1
 
   istanbul-lib-coverage@3.2.2:
     resolution:
@@ -8292,8 +8290,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  balanced-match@3.0.1: {}
-
   base64-js@1.5.1: {}
 
   bl@4.1.0:
@@ -8302,13 +8298,14 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@2.0.1:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
+      concat-map: 0.0.1
 
-  brace-expansion@4.0.1:
+  brace-expansion@2.0.2:
     dependencies:
-      balanced-match: 3.0.1
+      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
@@ -8503,6 +8500,8 @@ snapshots:
   commander@13.1.0: {}
 
   common-tags@1.8.2: {}
+
+  concat-map@0.0.1: {}
 
   constant-case@3.0.4:
     dependencies:
@@ -9997,15 +9996,15 @@ snapshots:
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 4.0.1
+      brace-expansion: 1.1.12
 
   minimatch@4.2.3:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 1.1.12
 
   minimatch@9.0.5:
     dependencies:
-      brace-expansion: 4.0.1
+      brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,14 @@
 packages:
-  - "."
+  - .
 
 onlyBuiltDependencies:
   - "@parcel/watcher"
   - esbuild
   - unrs-resolver
+
+overrides:
+  brace-expansion@>=1.0.0 <=1.1.11: ">=1.1.12"
+  brace-expansion@>=2.0.0 <=2.0.1: ">=2.0.2"
+  form-data@>=4.0.0 <4.0.4: ">=4.0.4"
+  tmp@<=0.2.3: ">=0.2.4"
+  ws@>=8.0.0 <8.17.1: ">=8.17.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,8 @@ onlyBuiltDependencies:
   - unrs-resolver
 
 overrides:
-  brace-expansion@>=1.0.0 <=1.1.11: ">=1.1.12"
-  brace-expansion@>=2.0.0 <=2.0.1: ">=2.0.2"
-  form-data@>=4.0.0 <4.0.4: ">=4.0.4"
-  tmp@<=0.2.3: ">=0.2.4"
-  ws@>=8.0.0 <8.17.1: ">=8.17.1"
+  brace-expansion@>=1.0.0 <2.0.0: "^1.1.12"
+  brace-expansion@>=2.0.0 <3.0.0: "^2.0.2"
+  form-data@>=4.0.0 <5.0.0: "^4.0.4"
+  tmp@<1.0.0: "^0.2.4"
+  ws@>=8.0.0 <9.0.0: "^8.17.1"


### PR DESCRIPTION
Denne PR-en fikser flere sikkerhetssårbarheter rapportert av Dependabot i utviklingsavhengigheter, samt oppgraderer pnpm fra v9 til v10 for bedre konsistens mellom lokalt miljø og CI.

  ### Endringer

  #### Sikkerhetsfixes
  - **@playwright/test**: `^1.44.0` → `^1.56.1`
  - **vite**: `^7.1.5` → `^7.2.2`
  - **Overrides for transitive avhengigheter** (via `pnpm-workspace.yaml`):
    - `brace-expansion`: CVE-2024-50330 (ReDos-sårbarhet)
    - `form-data`: CVE-2024-52808
    - `tmp`: CVE-2024-52809
    - `ws`: CVE-2024-37890

  #### Infrastruktur
  - **pnpm oppgradering**: v9 → v10.20.0
    - Legger til `packageManager: "pnpm@10.20.0"` i `package.json`
    - Fjerner hardkodet `version: 9` fra alle GitHub Actions workflows
    - Løser `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` i CI

  #### Tekniske justeringer
  - Endrer override-strategi fra `>=` til `^` for å unngå uønskede major version bumps
  - Forhindrer at `brace-expansion` oppgraderes til v4.x (ES Module inkompatibilitet)

  ### Omfang
  ✅ **Kun devDependencies påvirket** - ingen endringer i production dependencies
  ✅ Alle endringer er bakoverkompatible
  ✅ Testene kjører som normalt

  ### Test plan
  - [x] `pnpm install` kjører uten feil
  - [x] `pnpm eslint` kjører uten crashes
  - [x] `pnpm test` passerer
  - [x] `pnpm build` bygger uten feil
  - [x] CI-bygg kjører med pnpm v10

  ### Relaterte issues
  - Dependabot alerts for sikkerhetssårbarheter