### PR TITLE
NOJIRA G4P Dependabot fixes - revert

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
  Byttet fra "pnpm" til "npm" - Dependabot støtter ikke "pnpm" som
  ecosystem-verdi. Den bruker "npm" for alle JavaScript package managers
  og detekterer automatisk pnpm fra pnpm-lock.yaml.