### PR TITLE
7739 Dobbeltregistrering av helseperiode

### DIFF
--- a/src/ducks/helseutgiftdekkesperiode/reducers.ts
+++ b/src/ducks/helseutgiftdekkesperiode/reducers.ts
@@ -4,7 +4,7 @@
  * Dette er Redux-reducere som håndterer state-manipulasjon direkte, basert på
  * action types som sendes inn sammen med dataene.
  */
-import { STATUS } from "../../services/utils";
+import { STATUS } from "../../services";
 import * as Types from "./types";
 
 const initialState = {
@@ -14,6 +14,8 @@ const initialState = {
 
 export default function reducer(state = initialState, action: Types.Action) {
   switch (action.type) {
+    case Types.PENDING:
+      return { ...state, status: STATUS.PENDING };
     case Types.OK:
       return { ...state, status: STATUS.OK, data: action.data };
     case Types.FEILET:

--- a/src/ducks/helseutgiftdekkesperiode/selectors.ts
+++ b/src/ducks/helseutgiftdekkesperiode/selectors.ts
@@ -8,6 +8,7 @@
 import { createSelector, Selector } from "reselect";
 import { RootState, StateSection } from "AppTypes";
 import { HelseutgiftDekkesPeriodeDto } from "../../services/modules/helseutgiftDekkesPeriode/helseutgiftDekkesPeriode";
+import { STATUS } from "../../services";
 
 export const HelseutgiftDekkesPeriodeSelector: Selector<
   RootState,
@@ -15,7 +16,7 @@ export const HelseutgiftDekkesPeriodeSelector: Selector<
 > = createSelector(
   (state: RootState) => state.helseutgiftdekkesperiode,
   (helseutgiftdekkesperiode) => {
-    if (helseutgiftdekkesperiode?.status === "ERROR") {
+    if (helseutgiftdekkesperiode?.status === STATUS.ERROR) {
       return {
         ...helseutgiftdekkesperiode,
         data: {} as HelseutgiftDekkesPeriodeDto,
@@ -27,5 +28,5 @@ export const HelseutgiftDekkesPeriodeSelector: Selector<
 
 export const HelseutgiftDekkesPeriodeErPendingSelector: Selector<RootState, boolean> = createSelector(
   (state: RootState) => state.helseutgiftdekkesperiode,
-  (helseutgiftdekkesperiode) => helseutgiftdekkesperiode?.status === "PENDING",
+  (helseutgiftdekkesperiode) => helseutgiftdekkesperiode?.status === STATUS.PENDING,
 );

--- a/src/ducks/helseutgiftdekkesperiode/selectors.ts
+++ b/src/ducks/helseutgiftdekkesperiode/selectors.ts
@@ -24,3 +24,8 @@ export const HelseutgiftDekkesPeriodeSelector: Selector<
     return helseutgiftdekkesperiode;
   },
 );
+
+export const HelseutgiftDekkesPeriodeErPendingSelector: Selector<RootState, boolean> = createSelector(
+  (state: RootState) => state.helseutgiftdekkesperiode,
+  (helseutgiftdekkesperiode) => helseutgiftdekkesperiode?.status === "PENDING",
+);

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.test.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.test.tsx
@@ -7,7 +7,7 @@ import VurderingOpplysninger from "./vurderingOpplysninger";
 import { FellesHandlersContext } from "../../../../../contexts";
 
 /**
- * UNIT TESTER FOR VURDERINGOPPLYSNINGER - MELOSYS-7642
+ * UNIT TESTER FOR VURDERINGOPPLYSNINGER
  *
  * Disse testene verifiserer kritisk forretningslogikk for oppfriskning av registeropplysninger:
  * - Når skal oppfrisk-dialog vises vs direkte navigasjon
@@ -27,6 +27,7 @@ vi.mock("../../../../../ducks/helseutgiftdekkesperiode", () => ({
   },
   helseutgiftDekkesPeriodeSelector: {
     HelseutgiftDekkesPeriodeSelector: (state: any) => state.helseutgiftdekkesperiode,
+    HelseutgiftDekkesPeriodeErPendingSelector: (state: any) => state.helseutgiftdekkesperiode?.status === "PENDING",
   },
 }));
 
@@ -140,7 +141,7 @@ const mockDispatch = vi.fn((action: any) => {
   return Promise.resolve(action);
 });
 
-describe("VurderingOpplysninger - MELOSYS-7642", () => {
+describe("VurderingOpplysninger", () => {
   const mockBekreft = vi.fn();
   const mockTilbake = vi.fn();
   const mockOppdaterStatus = vi.fn();
@@ -507,21 +508,17 @@ describe("VurderingOpplysninger - MELOSYS-7642", () => {
     });
   });
 
-  describe("MELOSYS-7739: Dobbeltklikk-beskyttelse", () => {
-    it("skal ikke kalle dispatch flere ganger ved dobbeltklikk", async () => {
-      const user = userEvent.setup();
-
-      // Mock en forsinket dispatch
-      let resolveDispatch: () => void;
-      const delayedDispatch = vi.fn(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveDispatch = resolve;
-          }),
-      );
-      vi.mocked(mockDispatch).mockImplementation(delayedDispatch);
-
-      const mockStore = createMockStore(defaultState);
+  describe("Dobbeltklikk-beskyttelse", () => {
+    it("skal disable knappen når status er PENDING", async () => {
+      // Opprett store med PENDING status
+      const pendingState = {
+        ...defaultState,
+        helseutgiftdekkesperiode: {
+          ...defaultState.helseutgiftdekkesperiode,
+          status: "PENDING",
+        },
+      };
+      const mockStore = createMockStore(pendingState);
 
       render(
         <Provider store={mockStore}>
@@ -533,15 +530,38 @@ describe("VurderingOpplysninger - MELOSYS-7642", () => {
 
       const nesteBtn = screen.getByTestId("neste-btn");
 
-      // Dobbeltklikk raskt
-      await user.click(nesteBtn);
+      // Knappen skal være disabled når isPending er true
+      expect(nesteBtn).toBeDisabled();
+    });
+
+    it("skal ikke kalle dispatch når isPending er true", async () => {
+      const user = userEvent.setup();
+
+      // Opprett store med PENDING status
+      const pendingState = {
+        ...defaultState,
+        helseutgiftdekkesperiode: {
+          ...defaultState.helseutgiftdekkesperiode,
+          status: "PENDING",
+        },
+      };
+      const mockStore = createMockStore(pendingState);
+
+      render(
+        <Provider store={mockStore}>
+          <FellesHandlersContext.Provider value={contextValue}>
+            <VurderingOpplysninger {...defaultProps} />
+          </FellesHandlersContext.Provider>
+        </Provider>,
+      );
+
+      const nesteBtn = screen.getByTestId("neste-btn");
+
+      // Forsøk å klikke på disabled knapp (ingenting skal skje)
       await user.click(nesteBtn);
 
-      // dispatch skal kun kalles én gang (første klikk)
-      expect(delayedDispatch).toHaveBeenCalledTimes(1);
-
-      // Cleanup
-      resolveDispatch!();
+      // dispatch skal ikke kalles siden knappen er disabled
+      expect(mockDispatch).not.toHaveBeenCalled();
     });
   });
 

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.test.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.test.tsx
@@ -534,7 +534,7 @@ describe("VurderingOpplysninger", () => {
       expect(nesteBtn).toBeDisabled();
     });
 
-    it("skal ikke kalle dispatch når isPending er true", async () => {
+    it("skal ikke kalle dispatch når knappen er disabled pga PENDING status", async () => {
       const user = userEvent.setup();
 
       // Opprett store med PENDING status

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.test.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.test.tsx
@@ -507,6 +507,44 @@ describe("VurderingOpplysninger - MELOSYS-7642", () => {
     });
   });
 
+  describe("MELOSYS-7739: Dobbeltklikk-beskyttelse", () => {
+    it("skal ikke kalle dispatch flere ganger ved dobbeltklikk", async () => {
+      const user = userEvent.setup();
+
+      // Mock en forsinket dispatch
+      let resolveDispatch: () => void;
+      const delayedDispatch = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveDispatch = resolve;
+          }),
+      );
+      vi.mocked(mockDispatch).mockImplementation(delayedDispatch);
+
+      const mockStore = createMockStore(defaultState);
+
+      render(
+        <Provider store={mockStore}>
+          <FellesHandlersContext.Provider value={contextValue}>
+            <VurderingOpplysninger {...defaultProps} />
+          </FellesHandlersContext.Provider>
+        </Provider>,
+      );
+
+      const nesteBtn = screen.getByTestId("neste-btn");
+
+      // Dobbeltklikk raskt
+      await user.click(nesteBtn);
+      await user.click(nesteBtn);
+
+      // dispatch skal kun kalles én gang (første klikk)
+      expect(delayedDispatch).toHaveBeenCalledTimes(1);
+
+      // Cleanup
+      resolveDispatch!();
+    });
+  });
+
   describe("Regression tests - Forbedringer fra code review", () => {
     it("skal kun ha én useEffect for oppdaterStatus (ikke duplikat)", () => {
       // Dette er et regression test for at vi fjernet duplikat useEffect

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.test.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.test.tsx
@@ -530,7 +530,7 @@ describe("VurderingOpplysninger", () => {
 
       const nesteBtn = screen.getByTestId("neste-btn");
 
-      // Knappen skal være disabled når isPending er true
+      // Knappen skal være disabled når helseutgiftDekkesPeriodeErPending er true
       expect(nesteBtn).toBeDisabled();
     });
 

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -41,7 +41,9 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
   const [visOppfrisk, setVisOppfrisk] = useState(false);
 
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
-  const erPending = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeErPendingSelector);
+  const helseutgiftDekkesPeriodeErPending = useSelector(
+    helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeErPendingSelector,
+  );
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
   const helseutgiftDekkesPeriode = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeSelector).data;
   const { fomDato, tomDato, bostedLandkode } = helseutgiftDekkesPeriode;
@@ -185,7 +187,7 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
 
       <Mui.StegKnapper
         bekreftKnappProps={{
-          disabled: !redigerbart || !formIsValid || erPending,
+          disabled: !redigerbart || !formIsValid || helseutgiftDekkesPeriodeErPending,
           onClick: bekreftOgFortsett,
         }}
       />

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -41,7 +41,7 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
   const [visOppfrisk, setVisOppfrisk] = useState(false);
 
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
-  const isPending = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeErPendingSelector);
+  const erPending = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeErPendingSelector);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
   const helseutgiftDekkesPeriode = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeSelector).data;
   const { fomDato, tomDato, bostedLandkode } = helseutgiftDekkesPeriode;
@@ -185,7 +185,7 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
 
       <Mui.StegKnapper
         bekreftKnappProps={{
-          disabled: !redigerbart || !formIsValid || isPending,
+          disabled: !redigerbart || !formIsValid || erPending,
           onClick: bekreftOgFortsett,
         }}
       />

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -16,7 +16,7 @@ import {
   helseutgiftDekkesPeriodeSelector,
 } from "../../../../../ducks/helseutgiftdekkesperiode";
 import { HelseutgiftDekkesPeriodeDto } from "../../../../../services/modules/helseutgiftDekkesPeriode/helseutgiftDekkesPeriode";
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { UkjentSluttdatoMedlemskapsperiode } from "../../../../ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/ukjentSluttdatoMedlemskapsperiode";
 import { oppsummertfaktaOperations, oppsummertfaktaSelectors } from "../../../../../ducks/oppsummertfakta";
 import { FellesHandlersContext } from "../../../../../contexts";
@@ -39,6 +39,7 @@ interface FellesHandlers {
 export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: Props) {
   const dispatch = useDispatch();
   const [visOppfrisk, setVisOppfrisk] = useState(false);
+  const isSubmittingRef = useRef(false);
 
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
@@ -124,7 +125,10 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
   };
 
   const bekreftOgFortsett = async () => {
+    if (isSubmittingRef.current) return;
+    isSubmittingRef.current = true;
     await dispatch(helseutgiftDekkesPeriodeOperations.hentHelseutgiftDekkesPeriode(behandlingID));
+    isSubmittingRef.current = false;
     if (skalHenteRegisteropplysninger) {
       setVisOppfrisk(true);
     } else {

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -125,7 +125,6 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
   };
 
   const bekreftOgFortsett = async () => {
-    if (isPending) return;
     await dispatch(helseutgiftDekkesPeriodeOperations.hentHelseutgiftDekkesPeriode(behandlingID));
     if (skalHenteRegisteropplysninger) {
       setVisOppfrisk(true);

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -16,7 +16,7 @@ import {
   helseutgiftDekkesPeriodeSelector,
 } from "../../../../../ducks/helseutgiftdekkesperiode";
 import { HelseutgiftDekkesPeriodeDto } from "../../../../../services/modules/helseutgiftDekkesPeriode/helseutgiftDekkesPeriode";
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { UkjentSluttdatoMedlemskapsperiode } from "../../../../ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/ukjentSluttdatoMedlemskapsperiode";
 import { oppsummertfaktaOperations, oppsummertfaktaSelectors } from "../../../../../ducks/oppsummertfakta";
 import { FellesHandlersContext } from "../../../../../contexts";
@@ -39,9 +39,9 @@ interface FellesHandlers {
 export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: Props) {
   const dispatch = useDispatch();
   const [visOppfrisk, setVisOppfrisk] = useState(false);
-  const isSubmittingRef = useRef(false);
 
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);
+  const isPending = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeErPendingSelector);
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
   const helseutgiftDekkesPeriode = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeSelector).data;
   const { fomDato, tomDato, bostedLandkode } = helseutgiftDekkesPeriode;
@@ -125,10 +125,8 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
   };
 
   const bekreftOgFortsett = async () => {
-    if (isSubmittingRef.current) return;
-    isSubmittingRef.current = true;
+    if (isPending) return;
     await dispatch(helseutgiftDekkesPeriodeOperations.hentHelseutgiftDekkesPeriode(behandlingID));
-    isSubmittingRef.current = false;
     if (skalHenteRegisteropplysninger) {
       setVisOppfrisk(true);
     } else {
@@ -188,7 +186,7 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
 
       <Mui.StegKnapper
         bekreftKnappProps={{
-          disabled: !redigerbart || !formIsValid,
+          disabled: !redigerbart || !formIsValid || isPending,
           onClick: bekreftOgFortsett,
         }}
       />


### PR DESCRIPTION
Fixen hindrer dobbeltregistrering av helsedekningperiode ved dobbeltklikk på "Bekreft og fortsett" i "Inngang" steget.

https://jira.adeo.no/browse/MELOSYS-7739

Bruker redux PENDING-status:

  1. reducers.ts - La til PENDING-håndtering
  2. selectors.ts - La til erPending selector

La til test for å verifiserer at ved dobbeltklikk kalles dispatch kun én gang (ikke to).