### PR TITLE
7736 G4P La til 7 dagers dependency cooldown i Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       minor-and-patch:
         update-types:
@@ -14,4 +16,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
  - Lagt til cooldown.default-days: 7 for npm og github-actions
  - Endret github-actions fra daily til weekly schedule
  - Beskytter mot supply chain-angrep ved å vente på at nye versjoner "modnes" før de tilbys som oppdateringer