### PR TITLE
NOJIRA PW test forbedringer, en bug-fix

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -221,7 +221,9 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   );
   const forrigeÅrsavregningHarInnbetaltFraAvgiftssystem = Boolean(
     aarsavregningResponse?.tidligereTrygdeavgiftsGrunnlagsopplysninger?.tidligereTrygdeavgiftFraAvgiftssystemet !==
-      null,
+      null &&
+      aarsavregningResponse?.tidligereTrygdeavgiftsGrunnlagsopplysninger?.tidligereTrygdeavgiftFraAvgiftssystemet !==
+        undefined,
   );
 
   const sisteMuligeÅr = new Date().getFullYear() - 1;

--- a/tests/e2e/globalSetup.ts
+++ b/tests/e2e/globalSetup.ts
@@ -77,5 +77,3 @@ async function globalSetup() {
   }
   /* eslint-enable no-console */
 }
-
-export default globalSetup;

--- a/tests/e2e/globalSetup.ts
+++ b/tests/e2e/globalSetup.ts
@@ -47,7 +47,7 @@ async function clearOracleTestData(): Promise<void> {
   }
 }
 
-async function globalSetup() {
+export default async function globalSetup() {
   /* eslint-disable no-console */
   console.log("\n Global setup: Initializing test data...\n");
 

--- a/tests/e2e/pages/behandling/aarsavregning.page.ts
+++ b/tests/e2e/pages/behandling/aarsavregning.page.ts
@@ -1,11 +1,12 @@
 import { expect, Page } from "@playwright/test";
 import { BehandlingPage } from "./behandling.page";
+import { PrepopulertSaksnummer } from "../../utils/testdataUtils";
 
 /**
  * Page Object for Årsavregning-siden
  */
 export class AarsavregningPage extends BehandlingPage {
-  constructor(page: Page, saksnummer: string) {
+  constructor(page: Page, saksnummer: PrepopulertSaksnummer) {
     super(page, saksnummer);
   }
 
@@ -28,7 +29,7 @@ export class AarsavregningPage extends BehandlingPage {
   // År dropdown
   async velgÅr(år: string) {
     const årSelect = this.page.getByRole("combobox", { name: /år/i });
-    await expect(årSelect, `${this.saksnummer}: År-select skal være synlig`).toBeVisible({ timeout: 5000 });
+    await expect(årSelect, `${this.ctx}: År-select skal være synlig`).toBeVisible({ timeout: 5000 });
 
     // Sett opp lyttere for API-kall FØR vi velger år
     // Vi trenger å vente på ENTEN:
@@ -63,7 +64,7 @@ export class AarsavregningPage extends BehandlingPage {
     );
     await expect(
       trygdeavgiftSpørsmålTekst,
-      `${this.saksnummer}: Spørsmål om trygdeavgift fra avgiftssystemet skal være synlig etter årsskifte`,
+      `${this.ctx}: Spørsmål om trygdeavgift fra avgiftssystemet skal være synlig etter årsskifte`,
     ).toBeVisible({
       timeout: 5000,
     });
@@ -77,7 +78,7 @@ export class AarsavregningPage extends BehandlingPage {
   // Medlemskapsperiode operasjoner
   async leggTilMedlemskapsperiode() {
     const knapp = this.page.getByRole("button", { name: /legg til periode/i });
-    await expect(knapp, `${this.saksnummer}: Knapp 'Legg til periode' skal være synlig`).toBeVisible({ timeout: 5000 });
+    await expect(knapp, `${this.ctx}: Knapp 'Legg til periode' skal være synlig`).toBeVisible({ timeout: 5000 });
 
     // Tell antall perioder før klikk
     const perioder = this.page.locator(".medlemskapsperiode__rad");
@@ -86,7 +87,7 @@ export class AarsavregningPage extends BehandlingPage {
     await knapp.click();
 
     // Vent på at ny periode er lagt til
-    await expect(perioder, `${this.saksnummer}: Ny medlemskapsperiode skal være lagt til`).toHaveCount(antallFør + 1, {
+    await expect(perioder, `${this.ctx}: Ny medlemskapsperiode skal være lagt til`).toHaveCount(antallFør + 1, {
       timeout: 5000,
     });
   }
@@ -98,7 +99,7 @@ export class AarsavregningPage extends BehandlingPage {
     });
     await expect(
       trygdedekningDropdown,
-      `${this.saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
+      `${this.ctx}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
     ).toBeVisible({ timeout: 10000 });
 
     // Finn alle inputs på siden, og filtrér ved å telle medlemskapsperiode-inputs
@@ -113,7 +114,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.ctx}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
@@ -126,7 +127,7 @@ export class AarsavregningPage extends BehandlingPage {
     });
     await expect(
       trygdedekningDropdown,
-      `${this.saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
+      `${this.ctx}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
     ).toBeVisible({ timeout: 10000 });
 
     // Finn alle inputs på siden
@@ -139,7 +140,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.ctx}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
@@ -149,10 +150,7 @@ export class AarsavregningPage extends BehandlingPage {
     const select = this.page.getByRole("combobox", {
       name: new RegExp(`Trygdedekning periode ${index + 1}`, "i"),
     });
-    await expect(
-      select,
-      `${this.saksnummer}: Trygdedekning-select for periode ${index + 1} skal være synlig`,
-    ).toBeVisible({
+    await expect(select, `${this.ctx}: Trygdedekning-select for periode ${index + 1} skal være synlig`).toBeVisible({
       timeout: 10000,
     });
     await select.selectOption({ label: dekning });
@@ -172,7 +170,7 @@ export class AarsavregningPage extends BehandlingPage {
   async getAntallMedlemskapsperioder(): Promise<number> {
     // Vent på at minst ett trygdedekning-felt er synlig før telling
     const firstSelect = this.page.locator('select[name^="medlemskapsperioder["][name$="].trygdedekning"]').first();
-    await expect(firstSelect, `${this.saksnummer}: Første trygdedekning-select skal være synlig`).toBeVisible({
+    await expect(firstSelect, `${this.ctx}: Første trygdedekning-select skal være synlig`).toBeVisible({
       timeout: 10000,
     });
     return await this.page.locator('select[name^="medlemskapsperioder["][name$="].trygdedekning"]').count();
@@ -186,7 +184,7 @@ export class AarsavregningPage extends BehandlingPage {
   async fyllUtSkatteforholdFomDato(index: number, dato: string) {
     // Vent på at skatteforhold-seksjonen er synlig ved å sjekke for første textbox med label "Skatteforhold"
     const firstSkattLabel = this.page.locator('text="Skatteforhold"').first();
-    await expect(firstSkattLabel, `${this.saksnummer}: Label 'Skatteforhold' skal være synlig`).toBeVisible({
+    await expect(firstSkattLabel, `${this.ctx}: Label 'Skatteforhold' skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -202,7 +200,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for skatteforhold ${index}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.ctx}: Kan ikke finne input ${inputIndex} for skatteforhold ${index}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
@@ -210,7 +208,7 @@ export class AarsavregningPage extends BehandlingPage {
 
   async fyllUtSkatteforholdTomDato(index: number, dato: string) {
     const firstSkattLabel = this.page.locator('text="Skatteforhold"').first();
-    await expect(firstSkattLabel, `${this.saksnummer}: Label 'Skatteforhold' skal være synlig`).toBeVisible({
+    await expect(firstSkattLabel, `${this.ctx}: Label 'Skatteforhold' skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -224,7 +222,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for skatteforhold ${index}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.ctx}: Kan ikke finne input ${inputIndex} for skatteforhold ${index}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
@@ -238,10 +236,9 @@ export class AarsavregningPage extends BehandlingPage {
     // Finn radio-knappen ved å bruke group legend som anker
     const radioGroup = this.page.locator(`[name="skatteforholdsperioder[${index}].skatteplikttype"]`).locator("..");
     const radio = radioGroup.getByRole("radio", { name: new RegExp(radioValue, "i") });
-    await expect(
-      radio,
-      `${this.saksnummer}: Radio-button "${radioValue}" for skatteplikttype skal være synlig`,
-    ).toBeVisible({ timeout: 5000 });
+    await expect(radio, `${this.ctx}: Radio-button "${radioValue}" for skatteplikttype skal være synlig`).toBeVisible({
+      timeout: 5000,
+    });
     await radio.click({ force: true });
   }
 
@@ -253,7 +250,7 @@ export class AarsavregningPage extends BehandlingPage {
   async fyllUtInntektsperiodeFomDato(index: number, dato: string) {
     // Vent på at inntektsperiode-seksjonen er synlig
     const firstInntektLabel = this.page.locator('text="Inntektsperiode"').first();
-    await expect(firstInntektLabel, `${this.saksnummer}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
+    await expect(firstInntektLabel, `${this.ctx}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -268,7 +265,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.ctx}: Kan ikke finne input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
@@ -276,7 +273,7 @@ export class AarsavregningPage extends BehandlingPage {
 
   async fyllUtInntektsperiodeTomDato(index: number, dato: string) {
     const firstInntektLabel = this.page.locator('text="Inntektsperiode"').first();
-    await expect(firstInntektLabel, `${this.saksnummer}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
+    await expect(firstInntektLabel, `${this.ctx}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -287,7 +284,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.ctx}: Kan ikke finne input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
@@ -296,10 +293,7 @@ export class AarsavregningPage extends BehandlingPage {
   async velgKildetype(index: number, type: string) {
     // Bruk aria-label tilnærming for select, eller fall tilbake til name attribute hvis det fungerer
     const select = this.page.locator(`select[name="inntektskilder[${index}].kildetype"]`);
-    await expect(
-      select,
-      `${this.saksnummer}: Kildetype-select for inntektsperiode ${index} skal være synlig`,
-    ).toBeVisible({
+    await expect(select, `${this.ctx}: Kildetype-select for inntektsperiode ${index} skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -319,7 +313,7 @@ export class AarsavregningPage extends BehandlingPage {
 
   async fyllUtBruttoInntekt(index: number, belop: string) {
     const firstInntektLabel = this.page.locator('text="Inntektsperiode"').first();
-    await expect(firstInntektLabel, `${this.saksnummer}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
+    await expect(firstInntektLabel, `${this.ctx}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -331,7 +325,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${this.saksnummer}: Kan ikke finne bruttoInntekt input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.ctx}: Kan ikke finne bruttoInntekt input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(belop);
@@ -340,7 +334,7 @@ export class AarsavregningPage extends BehandlingPage {
   // Trygdeavgift fra Avgiftssystemet (delt grunnlag)
   async velgDeltGrunnlagJa() {
     const jaRadio = this.page.getByRole("radio", { name: /^ja$/i }).first();
-    await expect(jaRadio, `${this.saksnummer}: Radio-button 'Ja' skal være synlig`).toBeVisible({ timeout: 10000 });
+    await expect(jaRadio, `${this.ctx}: Radio-button 'Ja' skal være synlig`).toBeVisible({ timeout: 10000 });
 
     // Sjekk om radioknappen allerede er checked
     const isChecked = await jaRadio.isChecked();
@@ -363,7 +357,7 @@ export class AarsavregningPage extends BehandlingPage {
       } catch {
         // Radioknappen er sannsynligvis readonly - sjekk om dette er forventet
         throw new Error(
-          `${this.saksnummer}: Kunne ikke velge 'Ja' radioknapp. ` +
+          `${this.ctx}: Kunne ikke velge 'Ja' radioknapp. ` +
             `Feltet er sannsynligvis readonly (forrigeÅrsavregningHarInnbetaltFraAvgiftssystem=true). ` +
             `Denne testdataen støtter ikke delt grunnlag-test.`,
         );
@@ -378,7 +372,7 @@ export class AarsavregningPage extends BehandlingPage {
     const beregnEndeligRadio = this.page.getByRole("radio", { name: /beregn endelig trygdeavgift/i });
     await expect(
       beregnEndeligRadio,
-      `${this.saksnummer}: 'Beregn endelig trygdeavgift' radio skal være synlig etter Ja valgt`,
+      `${this.ctx}: 'Beregn endelig trygdeavgift' radio skal være synlig etter Ja valgt`,
     ).toBeVisible({ timeout: 15000 });
 
     // Sjekk om "Beregn endelig trygdeavgift" allerede er valgt
@@ -393,7 +387,7 @@ export class AarsavregningPage extends BehandlingPage {
     const medlemskapsperiodeFelt = this.page.getByRole("combobox", { name: /trygdedekning periode 1/i });
     await expect(
       medlemskapsperiodeFelt,
-      `${this.saksnummer}: Medlemskapsperiode-felt skal være synlig etter delt grunnlag valgt`,
+      `${this.ctx}: Medlemskapsperiode-felt skal være synlig etter delt grunnlag valgt`,
     ).toBeVisible({ timeout: 10000 });
   }
 
@@ -404,7 +398,7 @@ export class AarsavregningPage extends BehandlingPage {
     });
     await expect(
       trygdedekningDropdown,
-      `${this.saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
+      `${this.ctx}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
     ).toBeVisible({ timeout: 10000 });
 
     const allInputs = await this.page
@@ -414,7 +408,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.ctx}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     // Finn "Åpne datovelger" knappen som er søsken til input-feltet
@@ -426,13 +420,13 @@ export class AarsavregningPage extends BehandlingPage {
   async verifiserDatepickerErAktiv() {
     // NAV Design System bruker et dialog element for datepicker
     const datepicker = this.page.getByRole("dialog");
-    await expect(datepicker, `${this.saksnummer}: Datepicker-dialog skal være synlig`).toBeVisible({ timeout: 2000 });
+    await expect(datepicker, `${this.ctx}: Datepicker-dialog skal være synlig`).toBeVisible({ timeout: 2000 });
   }
 
   async verifiserDatepickerIkkeErAktiv() {
     // NAV Design System bruker et dialog element for datepicker
     const datepicker = this.page.getByRole("dialog");
-    await expect(datepicker, `${this.saksnummer}: Datepicker-dialog skal ikke være synlig`).not.toBeVisible();
+    await expect(datepicker, `${this.ctx}: Datepicker-dialog skal ikke være synlig`).not.toBeVisible();
   }
 
   async velgDatoIDatepicker(dato: Date) {
@@ -450,13 +444,13 @@ export class AarsavregningPage extends BehandlingPage {
 
   async verifiserIngenFeilmelding(tekst: string) {
     const error = this.page.locator('[class*="error"], [class*="feil"]').filter({ hasText: new RegExp(tekst, "i") });
-    await expect(error, `${this.saksnummer}: Feilmelding "${tekst}" skal ikke være synlig`).not.toBeVisible();
+    await expect(error, `${this.ctx}: Feilmelding "${tekst}" skal ikke være synlig`).not.toBeVisible();
   }
   // Verifiser at siden er lastet
   async verifiserAarsavregningside() {
     await expect(
       this.page.getByRole("heading", { name: /årsavregning/i }),
-      `${this.saksnummer}: Årsavregning-overskrift skal være synlig`,
+      `${this.ctx}: Årsavregning-overskrift skal være synlig`,
     ).toBeVisible();
   }
 }

--- a/tests/e2e/pages/behandling/aarsavregning.page.ts
+++ b/tests/e2e/pages/behandling/aarsavregning.page.ts
@@ -1,13 +1,12 @@
 import { expect, Page } from "@playwright/test";
-import { getSaksnummerFraUrl } from "../../utils/testUtils";
 import { BehandlingPage } from "./behandling.page";
 
 /**
  * Page Object for Årsavregning-siden
  */
 export class AarsavregningPage extends BehandlingPage {
-  constructor(page: Page) {
-    super(page);
+  constructor(page: Page, saksnummer: string) {
+    super(page, saksnummer);
   }
 
   // Hent første tilgjengelige år fra dropdown-en (ikke "Velg...")
@@ -28,9 +27,8 @@ export class AarsavregningPage extends BehandlingPage {
 
   // År dropdown
   async velgÅr(år: string) {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     const årSelect = this.page.getByRole("combobox", { name: /år/i });
-    await expect(årSelect, `${saksnummer}: År-select skal være synlig`).toBeVisible({ timeout: 5000 });
+    await expect(årSelect, `${this.saksnummer}: År-select skal være synlig`).toBeVisible({ timeout: 5000 });
 
     // Sett opp lyttere for API-kall FØR vi velger år
     // Vi trenger å vente på ENTEN:
@@ -65,7 +63,7 @@ export class AarsavregningPage extends BehandlingPage {
     );
     await expect(
       trygdeavgiftSpørsmålTekst,
-      `${saksnummer}: Spørsmål om trygdeavgift fra avgiftssystemet skal være synlig etter årsskifte`,
+      `${this.saksnummer}: Spørsmål om trygdeavgift fra avgiftssystemet skal være synlig etter årsskifte`,
     ).toBeVisible({
       timeout: 5000,
     });
@@ -78,9 +76,8 @@ export class AarsavregningPage extends BehandlingPage {
 
   // Medlemskapsperiode operasjoner
   async leggTilMedlemskapsperiode() {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     const knapp = this.page.getByRole("button", { name: /legg til periode/i });
-    await expect(knapp, `${saksnummer}: Knapp 'Legg til periode' skal være synlig`).toBeVisible({ timeout: 5000 });
+    await expect(knapp, `${this.saksnummer}: Knapp 'Legg til periode' skal være synlig`).toBeVisible({ timeout: 5000 });
 
     // Tell antall perioder før klikk
     const perioder = this.page.locator(".medlemskapsperiode__rad");
@@ -89,20 +86,19 @@ export class AarsavregningPage extends BehandlingPage {
     await knapp.click();
 
     // Vent på at ny periode er lagt til
-    await expect(perioder, `${saksnummer}: Ny medlemskapsperiode skal være lagt til`).toHaveCount(antallFør + 1, {
+    await expect(perioder, `${this.saksnummer}: Ny medlemskapsperiode skal være lagt til`).toHaveCount(antallFør + 1, {
       timeout: 5000,
     });
   }
 
   async fyllUtMedlemskapsperiodeFomDato(index: number, dato: string) {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     // Bruk trygdedekning combobox som anker - dette sikrer at perioden eksisterer
     const trygdedekningDropdown = this.page.getByRole("combobox", {
       name: new RegExp(`Trygdedekning periode ${index + 1}`, "i"),
     });
     await expect(
       trygdedekningDropdown,
-      `${saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
+      `${this.saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
     ).toBeVisible({ timeout: 10000 });
 
     // Finn alle inputs på siden, og filtrér ved å telle medlemskapsperiode-inputs
@@ -117,21 +113,20 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
   }
 
   async fyllUtMedlemskapsperiodeTomDato(index: number, dato: string) {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     // Bruk trygdedekning combobox som anker - dette sikrer at perioden eksisterer
     const trygdedekningDropdown = this.page.getByRole("combobox", {
       name: new RegExp(`Trygdedekning periode ${index + 1}`, "i"),
     });
     await expect(
       trygdedekningDropdown,
-      `${saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
+      `${this.saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
     ).toBeVisible({ timeout: 10000 });
 
     // Finn alle inputs på siden
@@ -144,18 +139,20 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
   }
 
   async velgTrygdedekning(index: number, dekning: string) {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     const select = this.page.getByRole("combobox", {
       name: new RegExp(`Trygdedekning periode ${index + 1}`, "i"),
     });
-    await expect(select, `${saksnummer}: Trygdedekning-select for periode ${index + 1} skal være synlig`).toBeVisible({
+    await expect(
+      select,
+      `${this.saksnummer}: Trygdedekning-select for periode ${index + 1} skal være synlig`,
+    ).toBeVisible({
       timeout: 10000,
     });
     await select.selectOption({ label: dekning });
@@ -173,10 +170,9 @@ export class AarsavregningPage extends BehandlingPage {
   }
 
   async getAntallMedlemskapsperioder(): Promise<number> {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     // Vent på at minst ett trygdedekning-felt er synlig før telling
     const firstSelect = this.page.locator('select[name^="medlemskapsperioder["][name$="].trygdedekning"]').first();
-    await expect(firstSelect, `${saksnummer}: Første trygdedekning-select skal være synlig`).toBeVisible({
+    await expect(firstSelect, `${this.saksnummer}: Første trygdedekning-select skal være synlig`).toBeVisible({
       timeout: 10000,
     });
     return await this.page.locator('select[name^="medlemskapsperioder["][name$="].trygdedekning"]').count();
@@ -190,8 +186,7 @@ export class AarsavregningPage extends BehandlingPage {
   async fyllUtSkatteforholdFomDato(index: number, dato: string) {
     // Vent på at skatteforhold-seksjonen er synlig ved å sjekke for første textbox med label "Skatteforhold"
     const firstSkattLabel = this.page.locator('text="Skatteforhold"').first();
-    const saksnummer = getSaksnummerFraUrl(this.page);
-    await expect(firstSkattLabel, `${saksnummer}: Label 'Skatteforhold' skal være synlig`).toBeVisible({
+    await expect(firstSkattLabel, `${this.saksnummer}: Label 'Skatteforhold' skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -207,7 +202,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${saksnummer}: Kan ikke finne input ${inputIndex} for skatteforhold ${index}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for skatteforhold ${index}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
@@ -215,8 +210,7 @@ export class AarsavregningPage extends BehandlingPage {
 
   async fyllUtSkatteforholdTomDato(index: number, dato: string) {
     const firstSkattLabel = this.page.locator('text="Skatteforhold"').first();
-    const saksnummer = getSaksnummerFraUrl(this.page);
-    await expect(firstSkattLabel, `${saksnummer}: Label 'Skatteforhold' skal være synlig`).toBeVisible({
+    await expect(firstSkattLabel, `${this.saksnummer}: Label 'Skatteforhold' skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -230,14 +224,13 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${saksnummer}: Kan ikke finne input ${inputIndex} for skatteforhold ${index}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for skatteforhold ${index}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
   }
 
   async velgSkatteplikttype(index: number, type: string) {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     // Skatteplikttype er en RadioGroup med "Ja"/"Nei", ikke en select
     // type parameter kan være "Ja" eller "Nei" (eller "Skattepliktig"/"Ikke skattepliktig")
     const radioValue = type.toLowerCase().includes("ja") || type.toLowerCase().includes("skattepliktig") ? "Ja" : "Nei";
@@ -245,9 +238,10 @@ export class AarsavregningPage extends BehandlingPage {
     // Finn radio-knappen ved å bruke group legend som anker
     const radioGroup = this.page.locator(`[name="skatteforholdsperioder[${index}].skatteplikttype"]`).locator("..");
     const radio = radioGroup.getByRole("radio", { name: new RegExp(radioValue, "i") });
-    await expect(radio, `${saksnummer}: Radio-button "${radioValue}" for skatteplikttype skal være synlig`).toBeVisible(
-      { timeout: 5000 },
-    );
+    await expect(
+      radio,
+      `${this.saksnummer}: Radio-button "${radioValue}" for skatteplikttype skal være synlig`,
+    ).toBeVisible({ timeout: 5000 });
     await radio.click({ force: true });
   }
 
@@ -259,8 +253,7 @@ export class AarsavregningPage extends BehandlingPage {
   async fyllUtInntektsperiodeFomDato(index: number, dato: string) {
     // Vent på at inntektsperiode-seksjonen er synlig
     const firstInntektLabel = this.page.locator('text="Inntektsperiode"').first();
-    const saksnummer = getSaksnummerFraUrl(this.page);
-    await expect(firstInntektLabel, `${saksnummer}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
+    await expect(firstInntektLabel, `${this.saksnummer}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -275,7 +268,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${saksnummer}: Kan ikke finne input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
@@ -283,8 +276,7 @@ export class AarsavregningPage extends BehandlingPage {
 
   async fyllUtInntektsperiodeTomDato(index: number, dato: string) {
     const firstInntektLabel = this.page.locator('text="Inntektsperiode"').first();
-    const saksnummer = getSaksnummerFraUrl(this.page);
-    await expect(firstInntektLabel, `${saksnummer}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
+    await expect(firstInntektLabel, `${this.saksnummer}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -295,17 +287,19 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${saksnummer}: Kan ikke finne input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(dato);
   }
 
   async velgKildetype(index: number, type: string) {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     // Bruk aria-label tilnærming for select, eller fall tilbake til name attribute hvis det fungerer
     const select = this.page.locator(`select[name="inntektskilder[${index}].kildetype"]`);
-    await expect(select, `${saksnummer}: Kildetype-select for inntektsperiode ${index} skal være synlig`).toBeVisible({
+    await expect(
+      select,
+      `${this.saksnummer}: Kildetype-select for inntektsperiode ${index} skal være synlig`,
+    ).toBeVisible({
       timeout: 10000,
     });
 
@@ -325,8 +319,7 @@ export class AarsavregningPage extends BehandlingPage {
 
   async fyllUtBruttoInntekt(index: number, belop: string) {
     const firstInntektLabel = this.page.locator('text="Inntektsperiode"').first();
-    const saksnummer = getSaksnummerFraUrl(this.page);
-    await expect(firstInntektLabel, `${saksnummer}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
+    await expect(firstInntektLabel, `${this.saksnummer}: Label 'Inntektsperiode' skal være synlig`).toBeVisible({
       timeout: 10000,
     });
 
@@ -338,7 +331,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${saksnummer}: Kan ikke finne bruttoInntekt input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.saksnummer}: Kan ikke finne bruttoInntekt input ${inputIndex} for inntektsperiode ${index}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     await allInputs[inputIndex].fill(belop);
@@ -346,9 +339,8 @@ export class AarsavregningPage extends BehandlingPage {
 
   // Trygdeavgift fra Avgiftssystemet (delt grunnlag)
   async velgDeltGrunnlagJa() {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     const jaRadio = this.page.getByRole("radio", { name: /^ja$/i }).first();
-    await expect(jaRadio, `${saksnummer}: Radio-button 'Ja' skal være synlig`).toBeVisible({ timeout: 10000 });
+    await expect(jaRadio, `${this.saksnummer}: Radio-button 'Ja' skal være synlig`).toBeVisible({ timeout: 10000 });
 
     // Sjekk om radioknappen allerede er checked
     const isChecked = await jaRadio.isChecked();
@@ -371,7 +363,7 @@ export class AarsavregningPage extends BehandlingPage {
       } catch {
         // Radioknappen er sannsynligvis readonly - sjekk om dette er forventet
         throw new Error(
-          `${saksnummer}: Kunne ikke velge 'Ja' radioknapp. ` +
+          `${this.saksnummer}: Kunne ikke velge 'Ja' radioknapp. ` +
             `Feltet er sannsynligvis readonly (forrigeÅrsavregningHarInnbetaltFraAvgiftssystem=true). ` +
             `Denne testdataen støtter ikke delt grunnlag-test.`,
         );
@@ -386,7 +378,7 @@ export class AarsavregningPage extends BehandlingPage {
     const beregnEndeligRadio = this.page.getByRole("radio", { name: /beregn endelig trygdeavgift/i });
     await expect(
       beregnEndeligRadio,
-      `${saksnummer}: 'Beregn endelig trygdeavgift' radio skal være synlig etter Ja valgt`,
+      `${this.saksnummer}: 'Beregn endelig trygdeavgift' radio skal være synlig etter Ja valgt`,
     ).toBeVisible({ timeout: 15000 });
 
     // Sjekk om "Beregn endelig trygdeavgift" allerede er valgt
@@ -401,7 +393,7 @@ export class AarsavregningPage extends BehandlingPage {
     const medlemskapsperiodeFelt = this.page.getByRole("combobox", { name: /trygdedekning periode 1/i });
     await expect(
       medlemskapsperiodeFelt,
-      `${saksnummer}: Medlemskapsperiode-felt skal være synlig etter delt grunnlag valgt`,
+      `${this.saksnummer}: Medlemskapsperiode-felt skal være synlig etter delt grunnlag valgt`,
     ).toBeVisible({ timeout: 10000 });
   }
 
@@ -410,10 +402,9 @@ export class AarsavregningPage extends BehandlingPage {
     const trygdedekningDropdown = this.page.getByRole("combobox", {
       name: new RegExp(`Trygdedekning periode ${index + 1}`, "i"),
     });
-    const saksnummer = getSaksnummerFraUrl(this.page);
     await expect(
       trygdedekningDropdown,
-      `${saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
+      `${this.saksnummer}: Trygdedekning-dropdown for periode ${index + 1} skal være synlig`,
     ).toBeVisible({ timeout: 10000 });
 
     const allInputs = await this.page
@@ -423,7 +414,7 @@ export class AarsavregningPage extends BehandlingPage {
 
     expect(
       inputIndex < allInputs.length,
-      `${saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
+      `${this.saksnummer}: Kan ikke finne input ${inputIndex} for periode ${index + 1}. Totalt ${allInputs.length} inputs funnet.`,
     ).toBe(true);
 
     // Finn "Åpne datovelger" knappen som er søsken til input-feltet
@@ -433,17 +424,15 @@ export class AarsavregningPage extends BehandlingPage {
   }
 
   async verifiserDatepickerErAktiv() {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     // NAV Design System bruker et dialog element for datepicker
     const datepicker = this.page.getByRole("dialog");
-    await expect(datepicker, `${saksnummer}: Datepicker-dialog skal være synlig`).toBeVisible({ timeout: 2000 });
+    await expect(datepicker, `${this.saksnummer}: Datepicker-dialog skal være synlig`).toBeVisible({ timeout: 2000 });
   }
 
   async verifiserDatepickerIkkeErAktiv() {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     // NAV Design System bruker et dialog element for datepicker
     const datepicker = this.page.getByRole("dialog");
-    await expect(datepicker, `${saksnummer}: Datepicker-dialog skal ikke være synlig`).not.toBeVisible();
+    await expect(datepicker, `${this.saksnummer}: Datepicker-dialog skal ikke være synlig`).not.toBeVisible();
   }
 
   async velgDatoIDatepicker(dato: Date) {
@@ -460,16 +449,14 @@ export class AarsavregningPage extends BehandlingPage {
   }
 
   async verifiserIngenFeilmelding(tekst: string) {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     const error = this.page.locator('[class*="error"], [class*="feil"]').filter({ hasText: new RegExp(tekst, "i") });
-    await expect(error, `${saksnummer}: Feilmelding "${tekst}" skal ikke være synlig`).not.toBeVisible();
+    await expect(error, `${this.saksnummer}: Feilmelding "${tekst}" skal ikke være synlig`).not.toBeVisible();
   }
   // Verifiser at siden er lastet
   async verifiserAarsavregningside() {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     await expect(
       this.page.getByRole("heading", { name: /årsavregning/i }),
-      `${saksnummer}: Årsavregning-overskrift skal være synlig`,
+      `${this.saksnummer}: Årsavregning-overskrift skal være synlig`,
     ).toBeVisible();
   }
 }

--- a/tests/e2e/pages/behandling/aarsavregning.page.ts
+++ b/tests/e2e/pages/behandling/aarsavregning.page.ts
@@ -10,15 +10,63 @@ export class AarsavregningPage extends BehandlingPage {
     super(page);
   }
 
+  // Hent første tilgjengelige år fra dropdown-en (ikke "Velg...")
+  async hentFørsteTilgjengeligeÅr(): Promise<string> {
+    const årSelect = this.page.getByRole("combobox", { name: /år/i });
+    await expect(årSelect, "År-select skal være synlig").toBeVisible({ timeout: 5000 });
+
+    // Hent alle options og finn første som ikke er disabled
+    const options = årSelect.locator("option:not([disabled])");
+    const førsteÅr = await options.first().textContent();
+
+    if (!førsteÅr) {
+      throw new Error("Kunne ikke finne tilgjengelige år i dropdown");
+    }
+
+    return førsteÅr.trim();
+  }
+
   // År dropdown
   async velgÅr(år: string) {
     const saksnummer = getSaksnummerFraUrl(this.page);
     const årSelect = this.page.getByRole("combobox", { name: /år/i });
     await expect(årSelect, `${saksnummer}: År-select skal være synlig`).toBeVisible({ timeout: 5000 });
+
+    // Sett opp lyttere for API-kall FØR vi velger år
+    // Vi trenger å vente på ENTEN:
+    // 1. POST til /aarsavregninger (oppretter ny årsavregning) - status 200
+    // 2. Feilmelding om aktiv årsavregning vises i UI (året har allerede en aktiv årsavregning)
+    const aarsavregningResponsePromise = this.page.waitForResponse(
+      (response) =>
+        response.url().includes("/aarsavregninger") &&
+        !response.url().includes("/grunnlagstype") &&
+        response.request().method() === "POST",
+      { timeout: 15000 },
+    );
+
     await årSelect.selectOption({ label: år });
-    // Vent på at data for året har lastet ved å sjekke at bestemmelse-dropdown er synlig
-    const bestemmelseSelect = this.page.getByRole("combobox", { name: /bestemmelse/i });
-    await expect(bestemmelseSelect, `${saksnummer}: Bestemmelse-select skal være synlig etter årsskifte`).toBeVisible({
+
+    // Vent på at API-kallet for å opprette årsavregning fullføres (uansett om det lykkes eller feiler)
+    // Dette sikrer at backend er ferdig før vi fortsetter
+    try {
+      const response = await aarsavregningResponsePromise;
+      if (!response.ok()) {
+        // Årsavregning-kallet feilet (f.eks. validering), men det er OK - vi venter på UI-oppdatering
+      }
+    } catch {
+      // Timeout - årsavregningen kan allerede eksistere, eller noe annet gikk galt
+      // Vi fortsetter likevel og lar neste sjekk fange eventuelle feil
+    }
+
+    // Vent på at data for året har lastet ved å sjekke at spørsmålet om trygdeavgift fra Avgiftssystemet vises
+    // Bestemmelse-dropdown vises ikke før etter at brukeren har svart på dette spørsmålet og valgt "endeligAvgiftValg"
+    const trygdeavgiftSpørsmålTekst = this.page.getByText(
+      /skal du legge til trygdeavgift fra avgiftssystemet til denne årsavregningen/i,
+    );
+    await expect(
+      trygdeavgiftSpørsmålTekst,
+      `${saksnummer}: Spørsmål om trygdeavgift fra avgiftssystemet skal være synlig etter årsskifte`,
+    ).toBeVisible({
       timeout: 5000,
     });
   }
@@ -299,20 +347,62 @@ export class AarsavregningPage extends BehandlingPage {
   // Trygdeavgift fra Avgiftssystemet (delt grunnlag)
   async velgDeltGrunnlagJa() {
     const saksnummer = getSaksnummerFraUrl(this.page);
-    const jaRadio = this.page.getByRole("radio", { name: /ja/i }).first();
+    const jaRadio = this.page.getByRole("radio", { name: /^ja$/i }).first();
     await expect(jaRadio, `${saksnummer}: Radio-button 'Ja' skal være synlig`).toBeVisible({ timeout: 10000 });
 
-    // Bruk click() i stedet for check() for å håndtere NAV Design System radio-knapper
-    // click() fungerer selv om knappen allerede er checked
-    await jaRadio.click({ force: true });
+    // Sjekk om radioknappen allerede er checked
+    const isChecked = await jaRadio.isChecked();
 
-    // Vent på at API-kallet for oppdaterHarTrygdeavgiftFraAvgiftssystemet fullføres
-    // og at skjemaet re-rendres med medlemskapsperiode-feltene
+    if (!isChecked) {
+      // Sett opp lytter for API-respons FØR vi klikker på radioknappen
+      // Dette sikrer at vi venter på at backend har oppdatert harTrygdeavgiftFraAvgiftssystemet
+      const grunnlagstypeResponsePromise = this.page.waitForResponse(
+        (response) =>
+          response.url().includes("/grunnlagstype") &&
+          response.request().method() === "POST" &&
+          response.status() === 200,
+        { timeout: 15000 },
+      );
+
+      // Prøv å velge radioknappen - hvis den er readonly vil dette feile
+      // men vi fanger feilen og gir en mer beskrivende feilmelding
+      try {
+        await jaRadio.check({ timeout: 5000 });
+      } catch {
+        // Radioknappen er sannsynligvis readonly - sjekk om dette er forventet
+        throw new Error(
+          `${saksnummer}: Kunne ikke velge 'Ja' radioknapp. ` +
+            `Feltet er sannsynligvis readonly (forrigeÅrsavregningHarInnbetaltFraAvgiftssystem=true). ` +
+            `Denne testdataen støtter ikke delt grunnlag-test.`,
+        );
+      }
+
+      // Vent på at API-kallet for oppdaterHarTrygdeavgiftFraAvgiftssystemet fullføres
+      await grunnlagstypeResponsePromise;
+    }
+
+    // Vent på at "Beregn endelig trygdeavgift" radioknappen vises
+    // Dette kan ta litt tid pga React re-rendering
+    const beregnEndeligRadio = this.page.getByRole("radio", { name: /beregn endelig trygdeavgift/i });
+    await expect(
+      beregnEndeligRadio,
+      `${saksnummer}: 'Beregn endelig trygdeavgift' radio skal være synlig etter Ja valgt`,
+    ).toBeVisible({ timeout: 15000 });
+
+    // Sjekk om "Beregn endelig trygdeavgift" allerede er valgt
+    const beregnIsChecked = await beregnEndeligRadio.isChecked();
+
+    if (!beregnIsChecked) {
+      // Velg "Beregn endelig trygdeavgift" for å vise medlemskapsperiode-skjemaet
+      await beregnEndeligRadio.check();
+    }
+
+    // Vent på at skjemaet re-rendres med medlemskapsperiode-feltene
     const medlemskapsperiodeFelt = this.page.getByRole("combobox", { name: /trygdedekning periode 1/i });
     await expect(
       medlemskapsperiodeFelt,
       `${saksnummer}: Medlemskapsperiode-felt skal være synlig etter delt grunnlag valgt`,
-    ).toBeVisible({ timeout: 5000 });
+    ).toBeVisible({ timeout: 10000 });
   }
 
   // Datepicker-spesifikke metoder for å teste datovelger

--- a/tests/e2e/pages/behandling/behandling.page.ts
+++ b/tests/e2e/pages/behandling/behandling.page.ts
@@ -1,5 +1,4 @@
 import { expect, Locator, Page } from "@playwright/test";
-import { getSaksnummerFraUrl } from "../../utils/testUtils";
 
 /**
  * Page Object Model for visning og håndtering av behandlinger
@@ -7,9 +6,15 @@ import { getSaksnummerFraUrl } from "../../utils/testUtils";
  */
 export class BehandlingPage {
   readonly page: Page;
+  readonly saksnummer: string;
 
-  constructor(page: Page) {
+  /**
+   * @param page - Playwright Page
+   * @param saksnummer - Saksnummer (f.eks. "MEL-1001")
+   */
+  constructor(page: Page, saksnummer: string) {
     this.page = page;
+    this.saksnummer = saksnummer;
   }
 
   /**
@@ -42,19 +47,17 @@ export class BehandlingPage {
     // Vent på at siden lastes med behandlingsinnhold
     await this.page.waitForLoadState("domcontentloaded");
 
-    const saksnummer = getSaksnummerFraUrl(this.page);
-
     // Vent på informasjonslinjen (finnes alltid på behandlingssider, inneholder personnavn og fnr)
     await expect(
       this.page.locator(".informasjonlinje"),
-      `${saksnummer}: Informasjonslinjen skal være synlig`,
+      `${this.saksnummer}: Informasjonslinjen skal være synlig`,
     ).toBeVisible({ timeout: 10000 });
 
     // Hvis forventet tittel er oppgitt, verifiser at den finnes
     if (forventetTittel) {
       await expect(
         this.page.locator("h1.stegvelgertittel"),
-        `${saksnummer}: Tittelen "${forventetTittel}" skal være synlig`,
+        `${this.saksnummer}: Tittelen "${forventetTittel}" skal være synlig`,
       ).toHaveText(forventetTittel, { timeout: 10000 });
     }
   }
@@ -68,9 +71,8 @@ export class BehandlingPage {
 
     if (!menyErSynlig) {
       const hamburgerMeny = this.page.locator(".behandlingsmeny__knapp");
-      const saksnummer = getSaksnummerFraUrl(this.page);
 
-      await expect(hamburgerMeny, `${saksnummer}: Hamburger-meny skal være synlig`).toBeVisible({ timeout: 5000 });
+      await expect(hamburgerMeny, `${this.saksnummer}: Hamburger-meny skal være synlig`).toBeVisible({ timeout: 5000 });
       await hamburgerMeny.click();
     }
 
@@ -78,9 +80,11 @@ export class BehandlingPage {
     const accordionHeader = this.page.locator(
       '.behandlingsmeny__meny .navds-accordion__header:has(.navds-accordion__header-content:has-text("Avslutt behandling"))',
     );
-    const saksnummer = getSaksnummerFraUrl(this.page);
 
-    await expect(accordionHeader, `${saksnummer}: Accordion-header "Avslutt behandling" skal være synlig`).toBeVisible({
+    await expect(
+      accordionHeader,
+      `${this.saksnummer}: Accordion-header "Avslutt behandling" skal være synlig`,
+    ).toBeVisible({
       timeout: 2000,
     });
     await accordionHeader.click();
@@ -91,7 +95,7 @@ export class BehandlingPage {
     );
     await expect(
       accordionContent,
-      `${saksnummer}: Accordion-innhold "Avslutt behandling" skal være synlig`,
+      `${this.saksnummer}: Accordion-innhold "Avslutt behandling" skal være synlig`,
     ).toBeVisible({ timeout: 3000 });
   }
 
@@ -209,7 +213,6 @@ export class BehandlingPage {
    * @param selectText - Valgfri spesifikk tekst på bekreft-knappen (hvis den avviker fra menyteksten)
    */
   async bekreftAvslutning(buttonText: string, selectText?: string): Promise<void> {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     const modalSelectors = [".navds-modal[open]", ".modal[open]", '[role="dialog"]', ".dialog", ".confirmation-modal"];
 
     let modal = null;
@@ -221,7 +224,7 @@ export class BehandlingPage {
       }
     }
 
-    expect(modal, `${saksnummer}: Fant ingen åpen modal for bekreftelse`).not.toBeNull();
+    expect(modal, `${this.saksnummer}: Fant ingen åpen modal for bekreftelse`).not.toBeNull();
     if (!modal) return; // Type guard for TypeScript
 
     // Sjekk om det er en "Henlegg saken" modal som krever begrunnelse
@@ -244,7 +247,7 @@ export class BehandlingPage {
     // Finn "Bekreft" knappen inne i modalen
     const bekreftKnapp = modal.locator(`button:has-text("${buttonText}")`);
 
-    await expect(bekreftKnapp, `${saksnummer}: Bekreft-knapp skal være synlig`).toBeVisible({ timeout: 2000 });
+    await expect(bekreftKnapp, `${this.saksnummer}: Bekreft-knapp skal være synlig`).toBeVisible({ timeout: 2000 });
 
     const erEnabled = await bekreftKnapp.isEnabled();
 

--- a/tests/e2e/pages/behandling/behandling.page.ts
+++ b/tests/e2e/pages/behandling/behandling.page.ts
@@ -1,4 +1,5 @@
 import { expect, Locator, Page } from "@playwright/test";
+import { hentSakMetadata, PrepopulertSaksnummer } from "../../utils/testdataUtils";
 
 /**
  * Page Object Model for visning og håndtering av behandlinger
@@ -6,15 +7,32 @@ import { expect, Locator, Page } from "@playwright/test";
  */
 export class BehandlingPage {
   readonly page: Page;
-  readonly saksnummer: string;
+  readonly saksnummer: PrepopulertSaksnummer;
 
   /**
    * @param page - Playwright Page
    * @param saksnummer - Saksnummer (f.eks. "MEL-1001")
    */
-  constructor(page: Page, saksnummer: string) {
+  constructor(page: Page, saksnummer: PrepopulertSaksnummer) {
     this.page = page;
     this.saksnummer = saksnummer;
+  }
+
+  /**
+   * Formatert kontekst for feilmeldinger (saksnummer + metadata)
+   */
+  get ctx(): string {
+    const meta = hentSakMetadata(this.saksnummer);
+    if (!meta) {
+      return `[${this.saksnummer}]`;
+    }
+    return `[${this.saksnummer}]
+  behandlingID: ${meta.behandlingID}
+  sakstype: ${meta.sakstype}
+  sakstema: ${meta.sakstema}
+  behandlingstema: ${meta.behandlingstema}
+  behandlingstype: ${meta.behandlingstype}
+  behandlingsstatus: ${meta.behandlingsstatus}`;
   }
 
   /**
@@ -50,14 +68,14 @@ export class BehandlingPage {
     // Vent på informasjonslinjen (finnes alltid på behandlingssider, inneholder personnavn og fnr)
     await expect(
       this.page.locator(".informasjonlinje"),
-      `${this.saksnummer}: Informasjonslinjen skal være synlig`,
+      `${this.ctx}: Fant ikke behandlingssiden (informasjonslinje mangler)`,
     ).toBeVisible({ timeout: 10000 });
 
     // Hvis forventet tittel er oppgitt, verifiser at den finnes
     if (forventetTittel) {
       await expect(
         this.page.locator("h1.stegvelgertittel"),
-        `${this.saksnummer}: Tittelen "${forventetTittel}" skal være synlig`,
+        `${this.ctx}: Fant ikke tittelen "${forventetTittel}"`,
       ).toHaveText(forventetTittel, { timeout: 10000 });
     }
   }
@@ -72,7 +90,7 @@ export class BehandlingPage {
     if (!menyErSynlig) {
       const hamburgerMeny = this.page.locator(".behandlingsmeny__knapp");
 
-      await expect(hamburgerMeny, `${this.saksnummer}: Hamburger-meny skal være synlig`).toBeVisible({ timeout: 5000 });
+      await expect(hamburgerMeny, `${this.ctx}: Fant ikke menyknappen`).toBeVisible({ timeout: 5000 });
       await hamburgerMeny.click();
     }
 
@@ -81,10 +99,7 @@ export class BehandlingPage {
       '.behandlingsmeny__meny .navds-accordion__header:has(.navds-accordion__header-content:has-text("Avslutt behandling"))',
     );
 
-    await expect(
-      accordionHeader,
-      `${this.saksnummer}: Accordion-header "Avslutt behandling" skal være synlig`,
-    ).toBeVisible({
+    await expect(accordionHeader, `${this.ctx}: Fant ikke "Avslutt behandling" i menyen`).toBeVisible({
       timeout: 2000,
     });
     await accordionHeader.click();
@@ -93,34 +108,29 @@ export class BehandlingPage {
     const accordionContent = this.page.locator(
       '.behandlingsmeny__meny .navds-accordion__item:has(.navds-accordion__header:has(.navds-accordion__header-content:has-text("Avslutt behandling"))) .navds-accordion__content',
     );
-    await expect(
-      accordionContent,
-      `${this.saksnummer}: Accordion-innhold "Avslutt behandling" skal være synlig`,
-    ).toBeVisible({ timeout: 3000 });
+    await expect(accordionContent, `${this.ctx}: Menyen "Avslutt behandling" åpnet ikke`).toBeVisible({
+      timeout: 3000,
+    });
   }
 
   /**
    * Velg "Søknaden er innvilget" som avslutningsgrunn
-   * @param saksnummer - Valgfritt saksnummer for bedre feilmeldinger
    */
-  async velgSoknadenErInnvilget(saksnummer: string): Promise<void> {
+  async velgSoknadenErInnvilget(): Promise<void> {
     // Først, sjekk at accordion-innholdet fortsatt er synlig
     const accordionContent = this.page.locator(
       '.behandlingsmeny__meny .navds-accordion__item:has(.navds-accordion__header:has(.navds-accordion__header-content:has-text("Avslutt behandling"))) .navds-accordion__content',
     );
 
-    await expect(
-      accordionContent,
-      `${saksnummer}: Accordion content for "Avslutt behandling" skal være synlig`,
-    ).toBeVisible({ timeout: 2000 });
+    await expect(accordionContent, `${this.ctx}: Menyen "Avslutt behandling" er ikke åpen`).toBeVisible({
+      timeout: 2000,
+    });
 
     // List alle tilgjengelige alternativer innen accordion content
     const alleHandlinger = accordionContent.locator(".behandlingsmeny__handling");
     const antallHandlinger = await alleHandlinger.count();
 
-    expect(antallHandlinger > 0, `Ingen behandlingshandlinger funnet i accordion content på sak ${saksnummer}`).toBe(
-      true,
-    );
+    expect(antallHandlinger > 0, `${this.ctx}: Fant ingen avslutningsalternativer i menyen`).toBe(true);
 
     const tilgjengeligeAlternativer: Array<{ element: Locator; tekst: string }> = [];
     for (let i = 0; i < antallHandlinger; i++) {
@@ -136,10 +146,7 @@ export class BehandlingPage {
       }
     }
 
-    expect(
-      tilgjengeligeAlternativer.length > 0,
-      `Ingen lesbare behandlingshandlinger funnet på sak ${saksnummer}`,
-    ).toBe(true);
+    expect(tilgjengeligeAlternativer.length > 0, `${this.ctx}: Fant ingen lesbare alternativer i menyen`).toBe(true);
 
     // Finn ekte avslutningsalternativer (ikke oppgavelisteflytting)
     const avslutningsalternativer = tilgjengeligeAlternativer.filter(
@@ -156,24 +163,23 @@ export class BehandlingPage {
     const tilgjengeligeTekster = tilgjengeligeAlternativer.map((alt) => `"${alt.tekst}"`).join(", ");
     expect(
       avslutningsalternativer.length > 0,
-      `Ingen ekte avslutningsalternativer funnet på sak ${saksnummer}. Tilgjengelige: ${tilgjengeligeTekster}`,
+      `${this.ctx}: Ingen ekte avslutningsalternativer funnet. Tilgjengelige: ${tilgjengeligeTekster}`,
     ).toBe(true);
 
     // Bruk første ekte avslutningsalternativ
     const valgtAlternativ = avslutningsalternativer[0];
 
     // Vent på at elementet blir synlig og klikk
-    await expect(
-      valgtAlternativ.element,
-      `${saksnummer}: Avslutningsalternativ "${valgtAlternativ.tekst}" skal være synlig`,
-    ).toBeVisible({ timeout: 3000 });
+    await expect(valgtAlternativ.element, `${this.ctx}: Fant ikke alternativet "${valgtAlternativ.tekst}"`).toBeVisible(
+      { timeout: 3000 },
+    );
     await valgtAlternativ.element.click();
   }
 
   /**
    * Velg en generisk avslutningstype basert på tekst
    */
-  async velgAvslutningstype(tekst: string, saksnummer: string): Promise<void> {
+  async velgAvslutningstype(tekst: string): Promise<void> {
     // Første prioritet: Søk etter behandlingsmeny__handling elementer
     const behandlingsHandling = this.page.locator(
       `.behandlingsmeny__handling:has(.behandlingsmeny__handling__tekst:has-text("${tekst}"))`,
@@ -204,7 +210,7 @@ export class BehandlingPage {
       }
     }
 
-    expect(alternativFunnet, `Avslutningsalternativ "${tekst}" ikke funnet på sak ${saksnummer}`).toBe(true);
+    expect(alternativFunnet, `${this.ctx}: Fant ikke alternativet "${tekst}"`).toBe(true);
   }
 
   /**
@@ -247,7 +253,7 @@ export class BehandlingPage {
     // Finn "Bekreft" knappen inne i modalen
     const bekreftKnapp = modal.locator(`button:has-text("${buttonText}")`);
 
-    await expect(bekreftKnapp, `${this.saksnummer}: Bekreft-knapp skal være synlig`).toBeVisible({ timeout: 2000 });
+    await expect(bekreftKnapp, `${this.ctx}: Fant ikke bekreft-knappen`).toBeVisible({ timeout: 2000 });
 
     const erEnabled = await bekreftKnapp.isEnabled();
 
@@ -261,12 +267,10 @@ export class BehandlingPage {
   /**
    * Fullfør hele prosessen med å avslutte en behandling med spesifisert type
    * @param vedtaksType - type avslutning
-   * @param saksnummer - saksnummer for feilmeldinger
-   * @param bekreftKnappTekst - valgfri spesifikk tekst på bekreft-knappen hvis den avviker fra vedtaksType
-   * @param selectText
+   * @param bekreftKnappTekst - tekst på bekreft-knappen
+   * @param selectText - valgfri tekst for dropdown i modal
    */
   async avsluttBehandling(
-    saksnummer: string,
     vedtaksType:
       | "Søknaden er innvilget"
       | "Søknaden er avslått"
@@ -280,19 +284,19 @@ export class BehandlingPage {
     await this.klikkAvsluttBehandling();
 
     if (vedtaksType === "Søknaden er innvilget") {
-      await this.velgSoknadenErInnvilget(saksnummer);
+      await this.velgSoknadenErInnvilget();
     } else {
-      await this.velgAvslutningstype(vedtaksType, saksnummer);
+      await this.velgAvslutningstype(vedtaksType);
     }
 
     await this.bekreftAvslutning(bekreftKnappTekst, selectText);
-    await this.verifiserVellykketAvslutning(saksnummer);
+    await this.verifiserVellykketAvslutning();
   }
 
   /**
    * Verifiser at vi blir redirectet til hovedsiden uten feilmeldinger
    */
-  async verifiserVellykketAvslutning(saksnummer: string): Promise<void> {
+  async verifiserVellykketAvslutning(): Promise<void> {
     await this.page.waitForURL(/\/melosys\/$/);
 
     // Sjekk at det ikke er noen feilmeldinger
@@ -300,7 +304,7 @@ export class BehandlingPage {
 
     for (const selector of feilmeldinger) {
       const feilmelding = this.page.locator(selector);
-      await expect(feilmelding, `${saksnummer}: Ingen feilmeldinger skal vises etter avslutning`).not.toBeVisible();
+      await expect(feilmelding, `${this.ctx}: Feilmelding vises etter avslutning`).not.toBeVisible();
     }
   }
 }

--- a/tests/e2e/pages/behandling/inngang.page.ts
+++ b/tests/e2e/pages/behandling/inngang.page.ts
@@ -6,8 +6,8 @@ import { BehandlingPage } from "./behandling.page";
  * Page Object Model for Inngang-steget
  */
 export class InngangPage extends BehandlingPage {
-  constructor(page: Page) {
-    super(page);
+  constructor(page: Page, saksnummer: string) {
+    super(page, saksnummer);
   }
 
   /**

--- a/tests/e2e/pages/behandling/inngang.page.ts
+++ b/tests/e2e/pages/behandling/inngang.page.ts
@@ -1,12 +1,13 @@
 import { Page } from "@playwright/test";
 import { setDatoFelt } from "../../utils/testUtils";
 import { BehandlingPage } from "./behandling.page";
+import { PrepopulertSaksnummer } from "../../utils/testdataUtils";
 
 /**
  * Page Object Model for Inngang-steget
  */
 export class InngangPage extends BehandlingPage {
-  constructor(page: Page, saksnummer: string) {
+  constructor(page: Page, saksnummer: PrepopulertSaksnummer) {
     super(page, saksnummer);
   }
 

--- a/tests/e2e/pages/behandling/send-brev.page.ts
+++ b/tests/e2e/pages/behandling/send-brev.page.ts
@@ -1,8 +1,9 @@
 import { Page, Locator, expect } from "@playwright/test";
 import { BehandlingPage } from "./behandling.page";
+import { PrepopulertSaksnummer } from "../../utils/testdataUtils";
 
 export class SendBrevPage extends BehandlingPage {
-  constructor(page: Page, saksnummer: string) {
+  constructor(page: Page, saksnummer: PrepopulertSaksnummer) {
     super(page, saksnummer);
   }
 
@@ -46,7 +47,7 @@ export class SendBrevPage extends BehandlingPage {
   async clickSendBrevTab(): Promise<void> {
     const tab = this.sendBrevTab;
 
-    await expect(tab, `${this.saksnummer}: Fant ikke "Send brev"-fanen`).toBeVisible();
+    await expect(tab, `${this.ctx}: Fant ikke "Send brev"-fanen`).toBeVisible();
 
     const panelId = await tab.getAttribute("aria-controls");
     await tab.click();
@@ -84,7 +85,7 @@ export class SendBrevPage extends BehandlingPage {
   async selectFirstMottaker() {
     // Bruk native select[name="mottaker"] direkte
     const sel = this.mottakerNativeSelect;
-    await expect(sel, this.sakId + ': Fant ikke native select for "Mottaker" sak ').toBeVisible();
+    await expect(sel, `${this.ctx}: Fant ikke mottaker-feltet`).toBeVisible();
 
     // Velg første reelle alternativ (index 1, siden index 0 er "Velg...")
     await sel.selectOption({ index: 1 });
@@ -120,7 +121,7 @@ export class SendBrevPage extends BehandlingPage {
         },
         label as string | RegExp,
       );
-      expect(value, `${this.sakId}: Fant ikke brevmal med gitt label "${label}" for sak`).toBeTruthy();
+      expect(value, `${this.ctx}: Fant ikke brevmalen "${label}"`).toBeTruthy();
       await ctl.selectOption(value);
     } else {
       await ctl.click({ force: true });
@@ -130,16 +131,16 @@ export class SendBrevPage extends BehandlingPage {
   }
 
   async verifiserSendKnappDeaktivert() {
-    await expect(this.sendButton, `${this.sakId}: Send-knapp skal være deaktivert`).toBeDisabled();
+    await expect(this.sendButton, `${this.ctx}: Send-knappen er uventet aktiv`).toBeDisabled();
   }
 
   async verifiserSendKnappAktivert() {
-    await expect(this.sendButton, `${this.sakId}: Send-knapp skal være aktivert`).toBeEnabled();
+    await expect(this.sendButton, `${this.ctx}: Send-knappen er uventet deaktivert`).toBeEnabled();
   }
 
   async selectMottakerByLabel(label: string | RegExp) {
     const sel = this.mottakerNativeSelect;
-    await expect(sel, `${this.sakId}: Fant ikke native select for "Mottaker"`).toBeVisible();
+    await expect(sel, `${this.ctx}: Fant ikke mottaker-feltet`).toBeVisible();
 
     const value = await sel.evaluate(
       (el, l) => {
@@ -151,7 +152,7 @@ export class SendBrevPage extends BehandlingPage {
       label as string | RegExp,
     );
 
-    expect(value, `${this.sakId}: Fant ikke mottaker med label: ${label}`).toBeTruthy();
+    expect(value, `${this.ctx}: Fant ikke mottakeren "${label}"`).toBeTruthy();
     await sel.selectOption(value);
 
     await this.waitForBrevmalSelect();

--- a/tests/e2e/pages/behandling/send-brev.page.ts
+++ b/tests/e2e/pages/behandling/send-brev.page.ts
@@ -1,10 +1,9 @@
 import { Page, Locator, expect } from "@playwright/test";
-import { getSaksnummerFraUrl } from "../../utils/testUtils";
 import { BehandlingPage } from "./behandling.page";
 
 export class SendBrevPage extends BehandlingPage {
-  constructor(page: Page) {
-    super(page);
+  constructor(page: Page, saksnummer: string) {
+    super(page, saksnummer);
   }
 
   // Dersom SendBrev ligger på en dedikert sti etter at man er inne i en sak, sett path her.
@@ -18,7 +17,6 @@ export class SendBrevPage extends BehandlingPage {
   };
 
   private sendBrevPanel?: Locator;
-  private sakId?: string;
 
   get sendButton(): Locator {
     return this.page.getByRole("button", { name: this.labels.sendBrev });
@@ -47,9 +45,8 @@ export class SendBrevPage extends BehandlingPage {
 
   async clickSendBrevTab(): Promise<void> {
     const tab = this.sendBrevTab;
-    this.sakId = getSaksnummerFraUrl(this.page);
 
-    await expect(tab, this.sakId + ': Fant ikke "Send brev"-fanen for sak ').toBeVisible();
+    await expect(tab, `${this.saksnummer}: Fant ikke "Send brev"-fanen`).toBeVisible();
 
     const panelId = await tab.getAttribute("aria-controls");
     await tab.click();

--- a/tests/e2e/pages/behandling/stegvelger.page.ts
+++ b/tests/e2e/pages/behandling/stegvelger.page.ts
@@ -125,43 +125,44 @@ export class StegvelgerPage extends BehandlingPage {
    * - Trygdedekning (Select)
    */
   async fyllUtInngangMinimum(fomDato: string, arbeidsland: string = "Sverige"): Promise<void> {
-    // Fyll ut fra og med dato (NAV DatePicker er readonly, må bruke pressSequentially)
+    // Fyll ut fra og med dato
     const fomInput = this.page.getByLabel(/fra og med/i);
+    await expect(fomInput, `${this.ctx}: Fant ikke "Fra og med"-felt`).toBeVisible({ timeout: 5000 });
     await fomInput.click();
     await fomInput.pressSequentially(fomDato, { delay: 50 });
     await this.page.keyboard.press("Tab"); // Lukk evt. datepicker
 
-    // Velg "Velg land fra liste" radio (hvis ikke allerede valgt)
+    // Velg "Velg land fra liste" radio
     const velgLandRadio = this.page.getByRole("radio", { name: /velg land fra liste/i });
-    if (await velgLandRadio.isVisible({ timeout: 2000 }).catch(() => false)) {
-      const isChecked = await velgLandRadio.isChecked();
-      if (!isChecked) {
-        await velgLandRadio.click({ force: true });
-      }
-      await this.page.waitForTimeout(300);
+    await expect(velgLandRadio, `${this.ctx}: Fant ikke "Velg land fra liste"-radioknapp`).toBeVisible({
+      timeout: 5000,
+    });
 
-      // Velg land fra MultiSelect - klikk for å åpne og velg fra dropdown
-      const landMultiSelect = this.page.locator(".land_multiselect");
-      if (await landMultiSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
-        // Klikk på input for å åpne dropdown
-        const landInput = landMultiSelect.locator("input");
-        await landInput.click();
-        await this.page.waitForTimeout(200);
-
-        // Velg land fra dropdown-listen
-        const landOption = this.page.getByRole("option", { name: new RegExp(arbeidsland, "i") });
-        if (await landOption.isVisible({ timeout: 2000 }).catch(() => false)) {
-          await landOption.click();
-        }
-      }
+    const isChecked = await velgLandRadio.isChecked();
+    if (!isChecked) {
+      await velgLandRadio.click({ force: true });
     }
+
+    // Vent på at MultiSelect-komponenten vises etter radioknapp-klikk
+    const landMultiSelect = this.page.locator(".land_multiselect");
+    await expect(landMultiSelect, `${this.ctx}: Land MultiSelect dukket ikke opp etter radioknapp-klikk`).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Åpne dropdown og velg land
+    const landInput = landMultiSelect.locator("input");
+    await landInput.click();
+
+    const landOption = this.page.getByRole("option", { name: new RegExp(arbeidsland, "i") });
+    await expect(landOption, `${this.ctx}: Land-option "${arbeidsland}" ikke funnet i dropdown`).toBeVisible({
+      timeout: 5000,
+    });
+    await landOption.click();
 
     // Velg trygdedekning fra dropdown
     const trygdedekningSelect = this.page.getByRole("combobox", { name: /trygdedekning/i });
-    if (await trygdedekningSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
-      // Velg første ikke-tomme alternativ
-      await trygdedekningSelect.selectOption({ index: 1 });
-    }
+    await expect(trygdedekningSelect, `${this.ctx}: Fant ikke trygdedekning-dropdown`).toBeVisible({ timeout: 5000 });
+    await trygdedekningSelect.selectOption({ index: 1 });
 
     // Vent på at validering kjører
     await this.page.waitForTimeout(500);

--- a/tests/e2e/pages/behandling/stegvelger.page.ts
+++ b/tests/e2e/pages/behandling/stegvelger.page.ts
@@ -125,14 +125,19 @@ export class StegvelgerPage extends BehandlingPage {
    * - Trygdedekning (Select)
    */
   async fyllUtInngangMinimum(fomDato: string, arbeidsland: string = "Sverige"): Promise<void> {
-    // Fyll ut fra og med dato
+    // Fyll ut fra og med dato (NAV DatePicker er readonly, må bruke pressSequentially)
     const fomInput = this.page.getByLabel(/fra og med/i);
-    await fomInput.fill(fomDato);
+    await fomInput.click();
+    await fomInput.pressSequentially(fomDato, { delay: 50 });
+    await this.page.keyboard.press("Tab"); // Lukk evt. datepicker
 
-    // Velg "Velg land fra liste" radio
+    // Velg "Velg land fra liste" radio (hvis ikke allerede valgt)
     const velgLandRadio = this.page.getByRole("radio", { name: /velg land fra liste/i });
     if (await velgLandRadio.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await velgLandRadio.check();
+      const isChecked = await velgLandRadio.isChecked();
+      if (!isChecked) {
+        await velgLandRadio.click({ force: true });
+      }
       await this.page.waitForTimeout(300);
 
       // Velg land fra MultiSelect - klikk for å åpne og velg fra dropdown

--- a/tests/e2e/pages/behandling/stegvelger.page.ts
+++ b/tests/e2e/pages/behandling/stegvelger.page.ts
@@ -1,0 +1,312 @@
+import { expect, Locator, Page } from "@playwright/test";
+import { BehandlingPage } from "./behandling.page";
+import { PrepopulertSaksnummer } from "../../utils/testdataUtils";
+
+/**
+ * Page Object for stegvelger-navigasjon
+ * Håndterer navigasjon mellom steg og verifisering av steg-status
+ */
+export class StegvelgerPage extends BehandlingPage {
+  constructor(page: Page, saksnummer: PrepopulertSaksnummer) {
+    super(page, saksnummer);
+  }
+
+  /**
+   * Hent "Bekreft og fortsett"-knappen i aktivt steg
+   */
+  private get bekreftKnapp(): Locator {
+    return this.page.locator(".stegFane--aktiv button.stegKnapper__bekreft");
+  }
+
+  /**
+   * Hent "Tilbake"-knappen i aktivt steg
+   */
+  private get tilbakeKnapp(): Locator {
+    return this.page.locator(".stegFane--aktiv button.stegKnapper__tilbake");
+  }
+
+  /**
+   * Hent steg-tittel (h1) i aktivt steg
+   */
+  private get stegTittel(): Locator {
+    return this.page.locator("h1.stegvelgertittel");
+  }
+
+  /**
+   * Hent progressbar-elementene
+   * Støtter både hovedstegvelger (.stegvelger__steg) og enkelStegvelger (.stegIkon)
+   */
+  private get progressbarSteg(): Locator {
+    return this.page.locator(".stegvelger__steg, .stegIkon");
+  }
+
+  /**
+   * Verifiser at "Bekreft og fortsett"-knappen er deaktivert
+   */
+  async verifiserBekreftKnappDeaktivert(): Promise<void> {
+    await expect(this.bekreftKnapp, `${this.ctx}: "Bekreft og fortsett" er uventet aktivert`).toBeDisabled();
+  }
+
+  /**
+   * Verifiser at "Bekreft og fortsett"-knappen er aktivert
+   */
+  async verifiserBekreftKnappAktivert(): Promise<void> {
+    await expect(this.bekreftKnapp, `${this.ctx}: "Bekreft og fortsett" er uventet deaktivert`).toBeEnabled();
+  }
+
+  /**
+   * Klikk "Bekreft og fortsett" og vent på neste steg
+   */
+  async bekreftOgFortsett(): Promise<void> {
+    await this.verifiserBekreftKnappAktivert();
+    const nåværendeTittel = await this.stegTittel.textContent();
+    await this.bekreftKnapp.click();
+
+    // Vent på at tittelen endres (vi er på nytt steg)
+    await expect(this.stegTittel, `${this.ctx}: Steget endret seg ikke etter klikk`).not.toHaveText(nåværendeTittel!, {
+      timeout: 10000,
+    });
+  }
+
+  /**
+   * Klikk "Tilbake" og vent på forrige steg
+   */
+  async gåTilbake(): Promise<void> {
+    const nåværendeTittel = await this.stegTittel.textContent();
+    await this.tilbakeKnapp.click();
+
+    // Vent på at tittelen endres
+    await expect(this.stegTittel, `${this.ctx}: Steget endret seg ikke etter tilbake`).not.toHaveText(
+      nåværendeTittel!,
+      {
+        timeout: 10000,
+      },
+    );
+  }
+
+  /**
+   * Hent nåværende steg-tittel
+   */
+  async hentStegTittel(): Promise<string> {
+    return (await this.stegTittel.textContent()) || "";
+  }
+
+  /**
+   * Verifiser at vi er på forventet steg
+   */
+  async verifiserSteg(forventetTittel: string | RegExp): Promise<void> {
+    await expect(this.stegTittel, `${this.ctx}: Feil steg-tittel`).toHaveText(forventetTittel, { timeout: 10000 });
+  }
+
+  /**
+   * Verifiser at progressbar viser forventet antall steg
+   */
+  async verifiserAntallSteg(forventetAntall: number): Promise<void> {
+    await expect(this.progressbarSteg, `${this.ctx}: Feil antall steg i progressbar`).toHaveCount(forventetAntall);
+  }
+
+  /**
+   * Klikk på et spesifikt steg i progressbar
+   */
+  async klikkPåSteg(stegNummer: number): Promise<void> {
+    const steg = this.progressbarSteg.nth(stegNummer - 1);
+    await expect(steg, `${this.ctx}: Fant ikke steg ${stegNummer} i progressbar`).toBeVisible();
+    await steg.click();
+  }
+
+  // === FTRL-spesifikke hjelpemetoder ===
+
+  /**
+   * Fyll ut minimum for Inngang-steget (FTRL YRKESAKTIV)
+   *
+   * FTRL Inngang krever:
+   * - Fra og med dato
+   * - Arbeidsland (RadioGroup: "Velg land fra liste" + MultiSelect)
+   * - Trygdedekning (Select)
+   */
+  async fyllUtInngangMinimum(fomDato: string, arbeidsland: string = "Sverige"): Promise<void> {
+    // Fyll ut fra og med dato
+    const fomInput = this.page.getByLabel(/fra og med/i);
+    await fomInput.fill(fomDato);
+
+    // Velg "Velg land fra liste" radio
+    const velgLandRadio = this.page.getByRole("radio", { name: /velg land fra liste/i });
+    if (await velgLandRadio.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await velgLandRadio.check();
+      await this.page.waitForTimeout(300);
+
+      // Velg land fra MultiSelect - klikk for å åpne og velg fra dropdown
+      const landMultiSelect = this.page.locator(".land_multiselect");
+      if (await landMultiSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
+        // Klikk på input for å åpne dropdown
+        const landInput = landMultiSelect.locator("input");
+        await landInput.click();
+        await this.page.waitForTimeout(200);
+
+        // Velg land fra dropdown-listen
+        const landOption = this.page.getByRole("option", { name: new RegExp(arbeidsland, "i") });
+        if (await landOption.isVisible({ timeout: 2000 }).catch(() => false)) {
+          await landOption.click();
+        }
+      }
+    }
+
+    // Velg trygdedekning fra dropdown
+    const trygdedekningSelect = this.page.getByRole("combobox", { name: /trygdedekning/i });
+    if (await trygdedekningSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
+      // Velg første ikke-tomme alternativ
+      await trygdedekningSelect.selectOption({ index: 1 });
+    }
+
+    // Vent på at validering kjører
+    await this.page.waitForTimeout(500);
+  }
+
+  /**
+   * Velg første virksomhet i Virksomhet-steget (FTRL)
+   */
+  async velgFørsteVirksomhet(): Promise<void> {
+    const virksomhetCheckbox = this.page.locator('input[type="checkbox"]').first();
+    await expect(virksomhetCheckbox, `${this.ctx}: Fant ingen virksomhet-checkbox`).toBeVisible({ timeout: 5000 });
+    await virksomhetCheckbox.check();
+  }
+
+  /**
+   * Velg bestemmelse i Bestemmelse-steget (FTRL)
+   * @param bestemmelse Søkestreng for bestemmelse (kan være delvis match, f.eks. "§ 2-5")
+   */
+  async velgBestemmelse(bestemmelse: string): Promise<void> {
+    const bestemmelseSelect = this.page.getByRole("combobox", { name: /bestemmelse/i });
+    await expect(bestemmelseSelect, `${this.ctx}: Fant ikke bestemmelse-dropdown`).toBeVisible({ timeout: 5000 });
+
+    // Hent alle options og finn første som inneholder søkestrengen
+    const options = bestemmelseSelect.locator("option");
+    const count = await options.count();
+
+    for (let i = 0; i < count; i++) {
+      const optionText = await options.nth(i).textContent();
+      if (optionText && optionText.includes(bestemmelse)) {
+        await bestemmelseSelect.selectOption({ index: i });
+        break;
+      }
+    }
+
+    // Vent litt for at evt. tilleggsfelter skal vises
+    await this.page.waitForTimeout(300);
+
+    // Noen bestemmelser viser tilleggsspørsmål som må besvares.
+    // Svarer "Ja" på alle radiogrupper som dukker opp (dynamisk)
+    // Maks 3 iterasjoner for å håndtere dynamisk visning
+    for (let i = 0; i < 3; i++) {
+      // Finn alle synlige radiogrupper
+      const radioGroups = this.page.locator("fieldset, [role='group']").filter({
+        has: this.page.getByRole("radio"),
+      });
+
+      const groupCount = await radioGroups.count();
+      let foundUnchecked = false;
+
+      for (let g = 0; g < groupCount; g++) {
+        const group = radioGroups.nth(g);
+        const jaRadio = group.getByRole("radio", { name: /^ja$/i });
+
+        if (await jaRadio.isVisible({ timeout: 500 }).catch(() => false)) {
+          const isChecked = await jaRadio.isChecked();
+          if (!isChecked) {
+            await jaRadio.check();
+            foundUnchecked = true;
+            await this.page.waitForTimeout(300);
+            break; // Ny radiogruppe kan ha blitt vist, start på nytt
+          }
+        }
+      }
+
+      if (!foundUnchecked) break;
+    }
+
+    await this.page.waitForTimeout(300);
+  }
+
+  /**
+   * Fyll ut minimum for Perioder-steget (FTRL)
+   * Fyller ut "Til og med" dato, trygdedekning og resultat for første periode
+   */
+  async fyllUtPerioderMinimum(): Promise<void> {
+    // Fyll ut "Til og med" dato hvis tom (påkrevd felt)
+    const tomInput = this.page.getByRole("textbox", { name: /til og med/i }).first();
+    if (await tomInput.isVisible({ timeout: 2000 }).catch(() => false)) {
+      const currentValue = await tomInput.inputValue();
+      if (!currentValue) {
+        // Sett til 31.12.2024 som standard sluttdato
+        await tomInput.fill("31.12.2024");
+        await this.page.waitForTimeout(300);
+      }
+    }
+
+    // Velg trygdedekning for første periode
+    const trygdedekningSelect = this.page.getByRole("combobox", { name: /trygdedekning/i }).first();
+    if (await trygdedekningSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
+      const selectedIndex = await trygdedekningSelect.evaluate((el: HTMLSelectElement) => el.selectedIndex);
+      if (selectedIndex <= 0) {
+        await trygdedekningSelect.selectOption({ index: 1 });
+      }
+    }
+
+    // Velg resultat for første periode
+    const resultatSelect = this.page.getByRole("combobox", { name: /resultat/i }).first();
+    if (await resultatSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
+      const selectedIndex = await resultatSelect.evaluate((el: HTMLSelectElement) => el.selectedIndex);
+      if (selectedIndex <= 0) {
+        await resultatSelect.selectOption({ index: 1 });
+      }
+    }
+
+    await this.page.waitForTimeout(500);
+  }
+
+  // === EU/EØS IKKE_YRKESAKTIV-spesifikke hjelpemetoder ===
+
+  /**
+   * Fyll ut minimum for EU/EØS IKKE_YRKESAKTIV Inngang-steget.
+   *
+   * For IKKE_YRKESAKTIV vises et skjema med:
+   * - Fra og med (fom) - påkrevd
+   * - Til og med (tom) - valgfri
+   * - Land - påkrevd
+   *
+   * @param fomDato Fra og med dato (norsk format: DD.MM.YYYY)
+   * @param land Landkode eller landnavn å velge
+   */
+  async fyllUtEosIkkeYrkesaktivInngang(fomDato: string = "01.01.2024", land: string = "Sverige"): Promise<void> {
+    // Sjekk om knappen allerede er aktiv (data forhåndsutfylt)
+    const erAktiv = await this.bekreftKnapp.isEnabled().catch(() => false);
+    if (erAktiv) return;
+
+    // Fyll ut "Fra og med" dato
+    const fomInput = this.page.getByLabel(/fra og med/i);
+    if (await fomInput.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await fomInput.fill(fomDato);
+    }
+
+    // Velg land fra dropdown
+    const landSelect = this.page.getByRole("combobox", { name: /^land$/i });
+    if (await landSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
+      // Prøv å velge basert på landnavn (label)
+      try {
+        await landSelect.selectOption({ label: land });
+      } catch {
+        // Fallback: velg første ikke-tomme alternativ
+        await landSelect.selectOption({ index: 1 });
+      }
+    }
+
+    await this.page.waitForTimeout(500);
+  }
+
+  /**
+   * @deprecated Bruk fyllUtEosIkkeYrkesaktivInngang() i stedet
+   */
+  async fyllUtEosInngangMinimum(): Promise<void> {
+    await this.fyllUtEosIkkeYrkesaktivInngang();
+  }
+}

--- a/tests/e2e/pages/behandling/trygdeavgift.page.ts
+++ b/tests/e2e/pages/behandling/trygdeavgift.page.ts
@@ -1,5 +1,4 @@
 import { expect, Page } from "@playwright/test";
-import { getSaksnummerFraUrl } from "../../utils/testUtils";
 import { BehandlingPage } from "./behandling.page";
 
 /**
@@ -7,18 +6,17 @@ import { BehandlingPage } from "./behandling.page";
  * Håndterer interaksjon med skatteforholdsperioder og inntektskilder
  */
 export class TrygdeavgiftPage extends BehandlingPage {
-  constructor(page: Page) {
-    super(page);
+  constructor(page: Page, saksnummer: string) {
+    super(page, saksnummer);
   }
 
   /**
    * Vent på at et spesifikt steg i trygdeavgift-komponenten er synlig
    */
   async verifiserSteg(stegnavn: string, timeout = 10000): Promise<void> {
-    const saksnummer = getSaksnummerFraUrl(this.page);
     await expect(
       this.page.locator(`text=${stegnavn}`).first(),
-      `${saksnummer}: Steg "${stegnavn}" skal være synlig`,
+      `${this.saksnummer}: Steg "${stegnavn}" skal være synlig`,
     ).toBeVisible({ timeout });
   }
 
@@ -33,18 +31,28 @@ export class TrygdeavgiftPage extends BehandlingPage {
     // Radio-knappene har verdier "SKATTEPLIKTIG" (Ja) og "IKKE_SKATTEPLIKTIG" (Nei)
     const name = `skatteforholdsperioder[${indeks}].skatteplikttype`;
     const value = erSkattepliktig ? "SKATTEPLIKTIG" : "IKKE_SKATTEPLIKTIG";
+    const valgtekst = erSkattepliktig ? "Ja" : "Nei";
 
     // Vent på at skatteforholdsperioder-delen er synlig før vi prøver å klikke
     const skatteforholdsHeading = this.page.locator("text=Oppgi informasjon om brukers skatteforhold");
-    await skatteforholdsHeading.waitFor({ state: "visible", timeout: 10000 });
+    await expect(
+      skatteforholdsHeading,
+      `${this.saksnummer}: Overskrift 'Oppgi informasjon om brukers skatteforhold' skal være synlig`,
+    ).toBeVisible({ timeout: 10000 });
 
     // Finn fieldset-et for denne skatteforholdsperioden
     const fieldset = this.page.locator("fieldset.skatteforholdsperioder-radio-group").nth(indeks);
-    await fieldset.waitFor({ state: "visible", timeout: 10000 });
+    await expect(
+      fieldset,
+      `${this.saksnummer}: Fieldset for skatteforholdsperiode ${indeks} skal være synlig`,
+    ).toBeVisible({ timeout: 10000 });
 
     // Finn radio-input med riktig name og value
     const radioInput = fieldset.locator(`input[name="${name}"][type="radio"][value="${value}"]`);
-    await radioInput.waitFor({ state: "visible", timeout: 10000 });
+    await expect(
+      radioInput,
+      `${this.saksnummer}: Radio-knapp '${valgtekst}' for skatteforholdsperiode ${indeks} skal være synlig`,
+    ).toBeVisible({ timeout: 10000 });
 
     // Bruk check() for å velge radio-knappen (Playwright sin anbefalte metode)
     await radioInput.check({ force: true });
@@ -57,8 +65,7 @@ export class TrygdeavgiftPage extends BehandlingPage {
     const name = `skatteforholdsperioder[0].skatteplikttype`;
     const radioInput = this.page.locator(`input[name="${name}"][type="radio"][value="SKATTEPLIKTIG"]`);
     const isit = await radioInput.isChecked().catch(() => false);
-    const saksnummer = getSaksnummerFraUrl(this.page);
-    expect(isit, `[${saksnummer}] Skattepliktig skal IKKE være valgt`).toBe(false);
+    expect(isit, `${this.saksnummer}: Skattepliktig skal IKKE være valgt`).toBe(false);
   }
 
   /**
@@ -67,7 +74,7 @@ export class TrygdeavgiftPage extends BehandlingPage {
   async verifiserInntektskilderSynlige(synlig: boolean): Promise<void> {
     const heading = this.page.locator("h1.undertittel:has-text('Oppgi informasjon om brukers inntekt')");
     const val = await heading.isVisible({ timeout: 5000 }).catch(() => false);
-    const saksnummer = getSaksnummerFraUrl(this.page);
-    expect(val, `[${saksnummer}] Inntektskilder skal IKKE være synlig`).toBe(synlig);
+    const forventetTekst = synlig ? "skal være synlig" : "skal IKKE være synlig";
+    expect(val, `${this.saksnummer}: Inntektskilder ${forventetTekst}`).toBe(synlig);
   }
 }

--- a/tests/e2e/pages/behandling/trygdeavgift.page.ts
+++ b/tests/e2e/pages/behandling/trygdeavgift.page.ts
@@ -1,12 +1,13 @@
 import { expect, Page } from "@playwright/test";
 import { BehandlingPage } from "./behandling.page";
+import { PrepopulertSaksnummer } from "../../utils/testdataUtils";
 
 /**
  * Page Object Model for trygdeavgift-komponenten
  * Håndterer interaksjon med skatteforholdsperioder og inntektskilder
  */
 export class TrygdeavgiftPage extends BehandlingPage {
-  constructor(page: Page, saksnummer: string) {
+  constructor(page: Page, saksnummer: PrepopulertSaksnummer) {
     super(page, saksnummer);
   }
 
@@ -16,7 +17,7 @@ export class TrygdeavgiftPage extends BehandlingPage {
   async verifiserSteg(stegnavn: string, timeout = 10000): Promise<void> {
     await expect(
       this.page.locator(`text=${stegnavn}`).first(),
-      `${this.saksnummer}: Steg "${stegnavn}" skal være synlig`,
+      `${this.ctx}: Fant ikke steget "${stegnavn}"`,
     ).toBeVisible({ timeout });
   }
 
@@ -35,24 +36,24 @@ export class TrygdeavgiftPage extends BehandlingPage {
 
     // Vent på at skatteforholdsperioder-delen er synlig før vi prøver å klikke
     const skatteforholdsHeading = this.page.locator("text=Oppgi informasjon om brukers skatteforhold");
-    await expect(
-      skatteforholdsHeading,
-      `${this.saksnummer}: Overskrift 'Oppgi informasjon om brukers skatteforhold' skal være synlig`,
-    ).toBeVisible({ timeout: 10000 });
+    await expect(skatteforholdsHeading, `${this.ctx}: Fant ikke skatteforhold-seksjonen`).toBeVisible({
+      timeout: 10000,
+    });
 
     // Finn fieldset-et for denne skatteforholdsperioden
     const fieldset = this.page.locator("fieldset.skatteforholdsperioder-radio-group").nth(indeks);
-    await expect(
-      fieldset,
-      `${this.saksnummer}: Fieldset for skatteforholdsperiode ${indeks} skal være synlig`,
-    ).toBeVisible({ timeout: 10000 });
+    await expect(fieldset, `${this.ctx}: Fant ikke skatteforholdsperiode ${indeks}`).toBeVisible({
+      timeout: 10000,
+    });
 
     // Finn radio-input med riktig name og value
     const radioInput = fieldset.locator(`input[name="${name}"][type="radio"][value="${value}"]`);
     await expect(
       radioInput,
-      `${this.saksnummer}: Radio-knapp '${valgtekst}' for skatteforholdsperiode ${indeks} skal være synlig`,
-    ).toBeVisible({ timeout: 10000 });
+      `${this.ctx}: Fant ikke valget "${valgtekst}" for skatteforholdsperiode ${indeks}`,
+    ).toBeVisible({
+      timeout: 10000,
+    });
 
     // Bruk check() for å velge radio-knappen (Playwright sin anbefalte metode)
     await radioInput.check({ force: true });
@@ -65,7 +66,7 @@ export class TrygdeavgiftPage extends BehandlingPage {
     const name = `skatteforholdsperioder[0].skatteplikttype`;
     const radioInput = this.page.locator(`input[name="${name}"][type="radio"][value="SKATTEPLIKTIG"]`);
     const isit = await radioInput.isChecked().catch(() => false);
-    expect(isit, `${this.saksnummer}: Skattepliktig skal IKKE være valgt`).toBe(false);
+    expect(isit, `${this.ctx}: "Skattepliktig" er uventet valgt`).toBe(false);
   }
 
   /**
@@ -74,7 +75,7 @@ export class TrygdeavgiftPage extends BehandlingPage {
   async verifiserInntektskilderSynlige(synlig: boolean): Promise<void> {
     const heading = this.page.locator("h1.undertittel:has-text('Oppgi informasjon om brukers inntekt')");
     const val = await heading.isVisible({ timeout: 5000 }).catch(() => false);
-    const forventetTekst = synlig ? "skal være synlig" : "skal IKKE være synlig";
-    expect(val, `${this.saksnummer}: Inntektskilder ${forventetTekst}`).toBe(synlig);
+    const feilmelding = synlig ? "Inntektskilder vises ikke" : "Inntektskilder vises uventet";
+    expect(val, `${this.ctx}: ${feilmelding}`).toBe(synlig);
   }
 }

--- a/tests/e2e/specs/avslutt-behandling/avslutt-avtaleland-behandling.spec.ts
+++ b/tests/e2e/specs/avslutt-behandling/avslutt-avtaleland-behandling.spec.ts
@@ -14,7 +14,7 @@ test.describe("Avslutt Avtaleland-behandling for testdata", () => {
     const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
-    await behandlingPage.avsluttBehandling(saksnummer, "Søknaden er innvilget", "Bekreft");
+    await behandlingPage.avsluttBehandling("Søknaden er innvilget", "Bekreft");
 
     await runAxeAnalyze(page, testInfo.title);
   });

--- a/tests/e2e/specs/avslutt-behandling/avslutt-avtaleland-behandling.spec.ts
+++ b/tests/e2e/specs/avslutt-behandling/avslutt-avtaleland-behandling.spec.ts
@@ -1,5 +1,5 @@
 import { test } from "@playwright/test";
-import { getSaksnummerFraUrl, TIMEOUT_FOR_COMPLEX_TESTS } from "../../utils/testUtils";
+import { TIMEOUT_FOR_COMPLEX_TESTS } from "../../utils/testUtils";
 import { BehandlingPage } from "../../pages/behandling/behandling.page";
 import { runAxeAnalyze } from "../../utils/axeUtils";
 import { hentPrepopulertSakUrl } from "../../utils/testdataUtils";
@@ -7,14 +7,14 @@ import { hentPrepopulertSakUrl } from "../../utils/testdataUtils";
 test.describe("Avslutt Avtaleland-behandling for testdata", () => {
   test("Opprett og avslutt Avtaleland-sak, verifiser redirect til hovedside", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Økt timeout siden vi oppretter og avslutter sak
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1001";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert Avtaleland-sak og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1001");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
-    const sakId = getSaksnummerFraUrl(page);
-    await behandlingPage.avsluttBehandling(sakId, "Søknaden er innvilget", "Bekreft");
+    await behandlingPage.avsluttBehandling(saksnummer, "Søknaden er innvilget", "Bekreft");
 
     await runAxeAnalyze(page, testInfo.title);
   });

--- a/tests/e2e/specs/avslutt-behandling/avslutt-ftrl-behandling.spec.ts
+++ b/tests/e2e/specs/avslutt-behandling/avslutt-ftrl-behandling.spec.ts
@@ -1,5 +1,5 @@
 import { test } from "@playwright/test";
-import { TIMEOUT_FOR_COMPLEX_TESTS, getSaksnummerFraUrl } from "../../utils/testUtils";
+import { TIMEOUT_FOR_COMPLEX_TESTS } from "../../utils/testUtils";
 import { BehandlingPage } from "../../pages/behandling/behandling.page";
 import { runAxeAnalyze } from "../../utils/axeUtils";
 import { hentPrepopulertSakUrl } from "../../utils/testdataUtils";
@@ -7,28 +7,28 @@ import { hentPrepopulertSakUrl } from "../../utils/testdataUtils";
 test.describe("Avslutt 'Utenfor avtaleland'-behandling for testdata", () => {
   test("Opprett og avslutt 'Utenfor avtaleland'-sak, verifiser redirect til hovedside", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Økt timeout siden vi oppretter og avslutter sak
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1015";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert FTRL-sak og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1015");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
-    const sakId = getSaksnummerFraUrl(page);
-    await behandlingPage.avsluttBehandling(sakId, "Søknaden er innvilget", "Bekreft");
+    await behandlingPage.avsluttBehandling(saksnummer, "Søknaden er innvilget", "Bekreft");
 
     await runAxeAnalyze(page, testInfo.title);
   });
 
   test("Opprett og avslutt 'Utenfor avtaleland'-sak for å sikre full avslutning", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Økt timeout siden vi oppretter og avslutter sak
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1016";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert FTRL-sak og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1016");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
-    const sakId = getSaksnummerFraUrl(page);
-    await behandlingPage.avsluttBehandling(sakId, "Søknaden er innvilget", "Bekreft");
+    await behandlingPage.avsluttBehandling(saksnummer, "Søknaden er innvilget", "Bekreft");
 
     await runAxeAnalyze(page, testInfo.title);
   });

--- a/tests/e2e/specs/avslutt-behandling/avslutt-ftrl-behandling.spec.ts
+++ b/tests/e2e/specs/avslutt-behandling/avslutt-ftrl-behandling.spec.ts
@@ -14,7 +14,7 @@ test.describe("Avslutt 'Utenfor avtaleland'-behandling for testdata", () => {
     const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
-    await behandlingPage.avsluttBehandling(saksnummer, "Søknaden er innvilget", "Bekreft");
+    await behandlingPage.avsluttBehandling("Søknaden er innvilget", "Bekreft");
 
     await runAxeAnalyze(page, testInfo.title);
   });
@@ -28,7 +28,7 @@ test.describe("Avslutt 'Utenfor avtaleland'-behandling for testdata", () => {
     const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
-    await behandlingPage.avsluttBehandling(saksnummer, "Søknaden er innvilget", "Bekreft");
+    await behandlingPage.avsluttBehandling("Søknaden er innvilget", "Bekreft");
 
     await runAxeAnalyze(page, testInfo.title);
   });

--- a/tests/e2e/specs/behandle-sak/aarsavregning-delt-grunnlag.spec.ts
+++ b/tests/e2e/specs/behandle-sak/aarsavregning-delt-grunnlag.spec.ts
@@ -18,7 +18,7 @@ import { runAxeAnalyze } from "../../utils/axeUtils";
  */
 
 let aarsavregningPage: AarsavregningPage;
-let valgtTestÅr: string = "2020"; // Default år som sannsynligvis er ledig
+let valgtTestÅr: string;
 
 /**
  * Hjelpefunksjon for å lage dato med riktig år
@@ -48,27 +48,9 @@ async function setupAarsavregningTest(page: Page, saksnummer: PrepopulertSaksnum
 
   await aarsavregningPage.verifiserAarsavregningside();
 
-  // Prøv år 2022, 2021, 2020 inntil vi finner ett uten aktiv årsavregning
-  const muligeÅr = ["2022", "2021", "2020"];
-  let årValgt = false;
-
-  for (const år of muligeÅr) {
-    await aarsavregningPage.velgÅr(år);
-
-    // Sjekk om det er feilmelding om aktiv årsavregning
-    const aktivFeilmelding = page.locator('[class*="error"], [class*="feil"]').filter({
-      hasText: /har allerede en aktiv årsavregning/i,
-    });
-
-    if (!(await aktivFeilmelding.isVisible().catch(() => false))) {
-      // Ingen feilmelding - dette året er tilgjengelig
-      valgtTestÅr = år; // Lagre det valgte året for bruk i testene
-      årValgt = true;
-      break;
-    }
-  }
-
-  expect(årValgt, "Kunne ikke finne et tilgjengelig år for årsavregning").toBe(true);
+  // Hent første tilgjengelige år fra dropdown-en og velg det
+  valgtTestÅr = await aarsavregningPage.hentFørsteTilgjengeligeÅr();
+  await aarsavregningPage.velgÅr(valgtTestÅr);
 }
 
 // Hver test oppretter sine egne testdata via setupAarsavregningTest

--- a/tests/e2e/specs/behandle-sak/aarsavregning-delt-grunnlag.spec.ts
+++ b/tests/e2e/specs/behandle-sak/aarsavregning-delt-grunnlag.spec.ts
@@ -6,15 +6,15 @@ import { hentPrepopulertSakUrl, PrepopulertSaksnummer } from "../../utils/testda
 import { runAxeAnalyze } from "../../utils/axeUtils";
 
 /**
- * MELOSYS-7612: Valideringsfeil ved delt grunnlag i årsavregning
+ * Valideringsfeil ved delt grunnlag i årsavregning
  *
  * Bug i validering og datovelger for medlemskapsperioder, skatteforholdsperioder
  * og inntektsperioder når man legger til trygdeavgift fra Avgiftssystemet (delt grunnlag).
  *
  * Testene verifiserer at:
- * - AC1: Medlemskapsperioder kan legges til uten valideringsfeil
- * - AC2: Skatteforholdsperioder kan legges til/utvides uten valideringsfeil
- * - AC3: Inntektsperioder kan legges til/utvides uten valideringsfeil
+ * - Medlemskapsperioder kan legges til uten valideringsfeil
+ * - Skatteforholdsperioder kan legges til/utvides uten valideringsfeil
+ * - Inntektsperioder kan legges til/utvides uten valideringsfeil
  */
 
 let aarsavregningPage: AarsavregningPage;
@@ -55,7 +55,7 @@ async function setupAarsavregningTest(page: Page, saksnummer: PrepopulertSaksnum
 
 // Hver test oppretter sine egne testdata via setupAarsavregningTest
 test.describe("Årsavregning delt grunnlag - Alle tester", () => {
-  test.describe("AC1 - Medlemskapsperiode validering", () => {
+  test.describe("Medlemskapsperiode validering", () => {
     test("Kan legge til ny medlemskapsperiode etter å ha valgt delt grunnlag", async ({ page }, testInfo) => {
       test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Sett timeout til 30 sekunder for setup
       await setupAarsavregningTest(page, "MEL-1026");
@@ -155,7 +155,7 @@ test.describe("Årsavregning delt grunnlag - Alle tester", () => {
     });
   });
 
-  test.describe("AC2 - Skatteforholdsperiode validering", () => {
+  test.describe("Skatteforholdsperiode validering", () => {
     test("Kan legge til ny skatteforholdsperiode etter å ha valgt delt grunnlag", async ({ page }, testInfo) => {
       test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
       await setupAarsavregningTest(page, "MEL-1041");
@@ -222,7 +222,7 @@ test.describe("Årsavregning delt grunnlag - Alle tester", () => {
     });
   });
 
-  test.describe("AC2.5 - Legg til periode med pliktig bestemmelse (bugfix)", () => {
+  test.describe("Legg til periode med pliktig bestemmelse (bugfix)", () => {
     test("skal vise 'Legg til periode'-knappen for delt grunnlag selv med pliktig bestemmelse", async ({
       page,
     }, testInfo) => {
@@ -283,7 +283,7 @@ test.describe("Årsavregning delt grunnlag - Alle tester", () => {
     });
   });
 
-  test.describe("AC3 - Inntektsperiode validering", () => {
+  test.describe("Inntektsperiode validering", () => {
     test("Kan legge til ny inntektsperiode etter å ha valgt delt grunnlag", async ({ page }, testInfo) => {
       test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
       await setupAarsavregningTest(page, "MEL-1045");

--- a/tests/e2e/specs/behandle-sak/aarsavregning-delt-grunnlag.spec.ts
+++ b/tests/e2e/specs/behandle-sak/aarsavregning-delt-grunnlag.spec.ts
@@ -31,8 +31,8 @@ function lagDato(dagMåned: string): string {
  * Gjenbrukbar setup-funksjon som oppretter testdata og navigerer til en årsavregning-behandling
  */
 async function setupAarsavregningTest(page: Page, saksnummer: PrepopulertSaksnummer) {
-  const behandlingPage = new BehandlingPage(page);
-  aarsavregningPage = new AarsavregningPage(page);
+  const behandlingPage = new BehandlingPage(page, saksnummer);
+  aarsavregningPage = new AarsavregningPage(page, saksnummer);
 
   // Hent URL til prepopulert FTRL-sak med årsavregning og naviger direkte dit
   const url = hentPrepopulertSakUrl(saksnummer);

--- a/tests/e2e/specs/behandle-sak/eu-eøs/eu-eos-trygdeavgift.spec.ts
+++ b/tests/e2e/specs/behandle-sak/eu-eøs/eu-eos-trygdeavgift.spec.ts
@@ -20,24 +20,25 @@ import { runAxeAnalyze } from "../../../utils/axeUtils";
 
 test.describe("EU/EØS Trygdeavgift", () => {
   test("skal vise inntektskilder når bruker ikke er skattepliktig", async ({ page }, testInfo) => {
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1054";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert EØS pensjonist-sak med trygdeavgift og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1054");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url, "Oppgi opplysninger fra attest / S1");
 
     // Bruk inneværende år for å unngå at skatteforhold skjules pga "tidligere år"-logikk
     const inneværendeÅr = new Date().getFullYear();
 
     // Steg 1: Inngang (Oppgi opplysninger fra attest / S1)
-    const inngangPage = new InngangPage(page);
+    const inngangPage = new InngangPage(page, saksnummer);
     await inngangPage.setFraOgMedDato(`01.01.${inneværendeÅr}`);
     await inngangPage.setTilOgMedDato(`31.12.${inneværendeÅr}`);
     await inngangPage.velgLand("SE");
 
     // Steg 2: Gå til Trygdeavgift og verifiser intiell tilstand
     await inngangPage.klikkBekreftOgFortsett();
-    const trygdeavgiftPage = new TrygdeavgiftPage(page);
+    const trygdeavgiftPage = new TrygdeavgiftPage(page, saksnummer);
     await trygdeavgiftPage.verifiserSteg("Trygdeavgift");
     await trygdeavgiftPage.verifiserSkattepliktigErIkkeValgt();
     await trygdeavgiftPage.verifiserInntektskilderSynlige(false);

--- a/tests/e2e/specs/behandle-sak/eu-eøs/eu-eos-trygdeavgift.spec.ts
+++ b/tests/e2e/specs/behandle-sak/eu-eøs/eu-eos-trygdeavgift.spec.ts
@@ -26,10 +26,13 @@ test.describe("EU/EØS Trygdeavgift", () => {
     const url = hentPrepopulertSakUrl("MEL-1054");
     await behandlingPage.goto(url, "Oppgi opplysninger fra attest / S1");
 
+    // Bruk inneværende år for å unngå at skatteforhold skjules pga "tidligere år"-logikk
+    const inneværendeÅr = new Date().getFullYear();
+
     // Steg 1: Inngang (Oppgi opplysninger fra attest / S1)
     const inngangPage = new InngangPage(page);
-    await inngangPage.setFraOgMedDato("01.01.2024");
-    await inngangPage.setTilOgMedDato("31.12.2024");
+    await inngangPage.setFraOgMedDato(`01.01.${inneværendeÅr}`);
+    await inngangPage.setTilOgMedDato(`31.12.${inneværendeÅr}`);
     await inngangPage.velgLand("SE");
 
     // Steg 2: Gå til Trygdeavgift og verifiser intiell tilstand

--- a/tests/e2e/specs/behandle-sak/eu-eøs/eu-eos-trygdeavgift.spec.ts
+++ b/tests/e2e/specs/behandle-sak/eu-eøs/eu-eos-trygdeavgift.spec.ts
@@ -8,7 +8,7 @@ import { runAxeAnalyze } from "../../../utils/axeUtils";
 /**
  * E2E-tester for Trygdeavgift-steget i EU/EØS saksbehandling
  *
- * MELOSYS-7661: Legge til steget "trygdeavgift"
+ * Legge til steget "trygdeavgift"
  *
  * Disse testene verifiserer:
  * - Trygdeavgift-steget vises i stegflyten

--- a/tests/e2e/specs/behandle-sak/eu-eøs/navigasjon.spec.ts
+++ b/tests/e2e/specs/behandle-sak/eu-eøs/navigasjon.spec.ts
@@ -1,52 +1,118 @@
 import { test } from "@playwright/test";
 import { TIMEOUT_FOR_COMPLEX_TESTS } from "../../../utils/testUtils";
-import { BehandlingPage } from "../../../pages/behandling/behandling.page";
 import { hentPrepopulertSakUrl } from "../../../utils/testdataUtils";
 import { runAxeAnalyze } from "../../../utils/axeUtils";
+import { StegvelgerPage } from "../../../pages/behandling/stegvelger.page";
 
 /**
- * E2E-tester for Stegvelger (Hovedstegvelger) i EU/EØS saksbehandling
+ * E2E-tester for Stegvelger i EU/EØS IKKE_YRKESAKTIV saksbehandling
  *
- * Disse testene verifiserer stegnavigasjon for EU/EØS-saker som bruker
- * hovedstegvelgeren (src/felleskomponenter/ftrl/Stegvelger.jsx).
+ * For IKKE_YRKESAKTIV vises et skjema i Inngang-steget med:
+ * - Fra og med (fom) - påkrevd
+ * - Til og med (tom) - valgfri
+ * - Land - påkrevd
  *
- * Stegvelgeren brukes kun i:
- * - EU/EØS saksbehandling (saksopplysninger.jsx)
- * - EU/EØS vurder utpeking (vurderutpeking.jsx)
+ * "Bekreft og fortsett" er deaktivert inntil skjemaet er gyldig utfylt.
  */
 test.describe("EU/EØS Stegvelger - Navigasjon", () => {
-  test("EU/EØS-behandling åpnes - viser stegvelger", async ({ page }, testInfo) => {
+  test("EU/EØS Ikke yrkesaktiv - Navigasjon gjennom steg med minimum input", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
     const saksnummer = "MEL-1051";
-    const behandlingPage = new BehandlingPage(page, saksnummer);
+    const stegvelgerPage = new StegvelgerPage(page, saksnummer);
 
-    // Hent URL til prepopulert EU/EØS-sak (Ikke yrkesaktiv) og naviger direkte dit
     const url = hentPrepopulertSakUrl(saksnummer);
-    await behandlingPage.goto(url);
+    await stegvelgerPage.goto(url);
+
+    // === STEG 1: Inngang ===
+    await stegvelgerPage.verifiserSteg(/inngang|opplysninger/i);
+
+    // Knapp skal være deaktivert uten input
+    await stegvelgerPage.verifiserBekreftKnappDeaktivert();
+
+    // Fyll ut minimum: fom-dato og land
+    await stegvelgerPage.fyllUtEosIkkeYrkesaktivInngang("01.01.2024", "Sverige");
+
+    // Nå skal knappen være aktivert
+    await stegvelgerPage.verifiserBekreftKnappAktivert();
+    await stegvelgerPage.bekreftOgFortsett();
+
+    // === STEG 2: Neste steg (avhengig av flyt) ===
+    // Verifiser at vi har navigert videre
+    const nyttStegTittel = await stegvelgerPage.hentStegTittel();
+    // Inngang-steget skal ikke lenger være aktivt
+    await stegvelgerPage.verifiserSteg(new RegExp(`^(?!.*inngang).*$`, "i"));
 
     await runAxeAnalyze(page, testInfo.title);
   });
 
-  test("Navigasjon mellom steg - frem og tilbake fungerer", async ({ page }, testInfo) => {
+  test("EU/EØS Ikke yrkesaktiv - Navigasjon frem og tilbake", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
     const saksnummer = "MEL-1052";
-    const behandlingPage = new BehandlingPage(page, saksnummer);
+    const stegvelgerPage = new StegvelgerPage(page, saksnummer);
 
-    // Hent URL til prepopulert EU/EØS-sak (Ikke yrkesaktiv) og naviger direkte dit
     const url = hentPrepopulertSakUrl(saksnummer);
-    await behandlingPage.goto(url);
+    await stegvelgerPage.goto(url);
+
+    // Start på Inngang
+    await stegvelgerPage.verifiserSteg(/inngang|opplysninger/i);
+
+    // Fyll ut og gå videre
+    await stegvelgerPage.fyllUtEosIkkeYrkesaktivInngang("01.01.2024", "Sverige");
+    await stegvelgerPage.bekreftOgFortsett();
+
+    // Hent tittel på neste steg
+    const andreStegTittel = await stegvelgerPage.hentStegTittel();
+
+    // Gå tilbake til Inngang
+    await stegvelgerPage.gåTilbake();
+    await stegvelgerPage.verifiserSteg(/inngang|opplysninger/i);
+
+    // Gå frem igjen
+    await stegvelgerPage.bekreftOgFortsett();
+    await stegvelgerPage.verifiserSteg(new RegExp(andreStegTittel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
 
     await runAxeAnalyze(page, testInfo.title);
   });
 
-  test("Progressbar - viser alle steg", async ({ page }, testInfo) => {
+  test("EU/EØS Ikke yrkesaktiv - Progressbar viser steg og navigasjon via klikk", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
     const saksnummer = "MEL-1053";
-    const behandlingPage = new BehandlingPage(page, saksnummer);
+    const stegvelgerPage = new StegvelgerPage(page, saksnummer);
 
-    // Hent URL til prepopulert EU/EØS-sak (Ikke yrkesaktiv) og naviger direkte dit
     const url = hentPrepopulertSakUrl(saksnummer);
-    await behandlingPage.goto(url);
+    await stegvelgerPage.goto(url);
+
+    // Fyll ut Inngang og gå til neste steg
+    await stegvelgerPage.fyllUtEosIkkeYrkesaktivInngang("01.01.2024", "Sverige");
+    await stegvelgerPage.bekreftOgFortsett();
+
+    // Klikk på steg 1 i progressbar for å gå tilbake
+    await stegvelgerPage.klikkPåSteg(1);
+    await stegvelgerPage.verifiserSteg(/inngang|opplysninger/i);
+
+    await runAxeAnalyze(page, testInfo.title);
+  });
+
+  test("EU/EØS Ikke yrkesaktiv - Bekreft-knapp forblir deaktivert ved ugyldig input", async ({ page }, testInfo) => {
+    test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
+    const saksnummer = "MEL-1071"; // Dedikert sak for denne testen
+    const stegvelgerPage = new StegvelgerPage(page, saksnummer);
+
+    const url = hentPrepopulertSakUrl(saksnummer);
+    await stegvelgerPage.goto(url);
+
+    await stegvelgerPage.verifiserSteg(/inngang|opplysninger/i);
+
+    // Knappen skal være deaktivert ved start
+    await stegvelgerPage.verifiserBekreftKnappDeaktivert();
+
+    // Fyll ut kun dato (uten land) - knappen bør fortsatt være deaktivert
+    const fomInput = page.getByLabel(/fra og med/i);
+    await fomInput.fill("01.01.2024");
+    await page.waitForTimeout(500);
+
+    // Knappen skal fortsatt være deaktivert siden land mangler
+    await stegvelgerPage.verifiserBekreftKnappDeaktivert();
 
     await runAxeAnalyze(page, testInfo.title);
   });

--- a/tests/e2e/specs/behandle-sak/eu-eøs/navigasjon.spec.ts
+++ b/tests/e2e/specs/behandle-sak/eu-eøs/navigasjon.spec.ts
@@ -25,21 +25,17 @@ test.describe("EU/EØS Stegvelger - Navigasjon", () => {
 
     // === STEG 1: Inngang ===
     await stegvelgerPage.verifiserSteg(/inngang|opplysninger/i);
-
-    // Knapp skal være deaktivert uten input
+    await stegvelgerPage.verifiserAntallSteg(1);
     await stegvelgerPage.verifiserBekreftKnappDeaktivert();
 
     // Fyll ut minimum: fom-dato og land
     await stegvelgerPage.fyllUtEosIkkeYrkesaktivInngang("01.01.2024", "Sverige");
-
-    // Nå skal knappen være aktivert
     await stegvelgerPage.verifiserBekreftKnappAktivert();
     await stegvelgerPage.bekreftOgFortsett();
 
-    // === STEG 2: Neste steg (avhengig av flyt) ===
-    // Verifiser at vi har navigert videre
-    const nyttStegTittel = await stegvelgerPage.hentStegTittel();
-    // Inngang-steget skal ikke lenger være aktivt
+    // === STEG 2: Neste steg ===
+    await stegvelgerPage.verifiserAntallSteg(2);
+    // Verifiser at vi har navigert videre (ikke lenger på Inngang)
     await stegvelgerPage.verifiserSteg(new RegExp(`^(?!.*inngang).*$`, "i"));
 
     await runAxeAnalyze(page, testInfo.title);
@@ -55,6 +51,7 @@ test.describe("EU/EØS Stegvelger - Navigasjon", () => {
 
     // Start på Inngang
     await stegvelgerPage.verifiserSteg(/inngang|opplysninger/i);
+    await stegvelgerPage.verifiserAntallSteg(1);
 
     // Fyll ut og gå videre
     await stegvelgerPage.fyllUtEosIkkeYrkesaktivInngang("01.01.2024", "Sverige");
@@ -62,31 +59,19 @@ test.describe("EU/EØS Stegvelger - Navigasjon", () => {
 
     // Hent tittel på neste steg
     const andreStegTittel = await stegvelgerPage.hentStegTittel();
+    await stegvelgerPage.verifiserAntallSteg(2);
 
-    // Gå tilbake til Inngang
+    // Gå tilbake til Inngang via Tilbake-knapp
     await stegvelgerPage.gåTilbake();
     await stegvelgerPage.verifiserSteg(/inngang|opplysninger/i);
+    await stegvelgerPage.verifiserAntallSteg(2); // Progressbar beholder 2 steg
 
-    // Gå frem igjen
+    // Gå frem igjen via Bekreft-knapp
     await stegvelgerPage.bekreftOgFortsett();
     await stegvelgerPage.verifiserSteg(new RegExp(andreStegTittel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
+    await stegvelgerPage.verifiserAntallSteg(2);
 
-    await runAxeAnalyze(page, testInfo.title);
-  });
-
-  test("EU/EØS Ikke yrkesaktiv - Progressbar viser steg og navigasjon via klikk", async ({ page }, testInfo) => {
-    test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-    const saksnummer = "MEL-1053";
-    const stegvelgerPage = new StegvelgerPage(page, saksnummer);
-
-    const url = hentPrepopulertSakUrl(saksnummer);
-    await stegvelgerPage.goto(url);
-
-    // Fyll ut Inngang og gå til neste steg
-    await stegvelgerPage.fyllUtEosIkkeYrkesaktivInngang("01.01.2024", "Sverige");
-    await stegvelgerPage.bekreftOgFortsett();
-
-    // Klikk på steg 1 i progressbar for å gå tilbake
+    // Gå tilbake via klikk på steg 1 i progressbar
     await stegvelgerPage.klikkPåSteg(1);
     await stegvelgerPage.verifiserSteg(/inngang|opplysninger/i);
 

--- a/tests/e2e/specs/behandle-sak/eu-eøs/navigasjon.spec.ts
+++ b/tests/e2e/specs/behandle-sak/eu-eøs/navigasjon.spec.ts
@@ -17,11 +17,11 @@ import { runAxeAnalyze } from "../../../utils/axeUtils";
 test.describe("EU/EØS Stegvelger - Navigasjon", () => {
   test("EU/EØS-behandling åpnes - viser stegvelger", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1051";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert EU/EØS-sak (Ikke yrkesaktiv) og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1051");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
     await runAxeAnalyze(page, testInfo.title);
@@ -29,11 +29,11 @@ test.describe("EU/EØS Stegvelger - Navigasjon", () => {
 
   test("Navigasjon mellom steg - frem og tilbake fungerer", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1052";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert EU/EØS-sak (Ikke yrkesaktiv) og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1052");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
     await runAxeAnalyze(page, testInfo.title);
@@ -41,11 +41,11 @@ test.describe("EU/EØS Stegvelger - Navigasjon", () => {
 
   test("Progressbar - viser alle steg", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1053";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert EU/EØS-sak (Ikke yrkesaktiv) og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1053");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
     await runAxeAnalyze(page, testInfo.title);

--- a/tests/e2e/specs/behandle-sak/eu-eøs/navigasjon.spec.ts
+++ b/tests/e2e/specs/behandle-sak/eu-eøs/navigasjon.spec.ts
@@ -17,7 +17,7 @@ import { StegvelgerPage } from "../../../pages/behandling/stegvelger.page";
 test.describe("EU/EØS Stegvelger - Navigasjon", () => {
   test("EU/EØS Ikke yrkesaktiv - Navigasjon gjennom steg med minimum input", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-    const saksnummer = "MEL-1051";
+    const saksnummer = "MEL-1052";
     const stegvelgerPage = new StegvelgerPage(page, saksnummer);
 
     const url = hentPrepopulertSakUrl(saksnummer);
@@ -80,7 +80,7 @@ test.describe("EU/EØS Stegvelger - Navigasjon", () => {
 
   test("EU/EØS Ikke yrkesaktiv - Bekreft-knapp forblir deaktivert ved ugyldig input", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-    const saksnummer = "MEL-1071"; // Dedikert sak for denne testen
+    const saksnummer = "MEL-1053";
     const stegvelgerPage = new StegvelgerPage(page, saksnummer);
 
     const url = hentPrepopulertSakUrl(saksnummer);

--- a/tests/e2e/specs/behandle-sak/ftrl/navigasjon.spec.ts
+++ b/tests/e2e/specs/behandle-sak/ftrl/navigasjon.spec.ts
@@ -1,8 +1,8 @@
 import { test } from "@playwright/test";
 import { TIMEOUT_FOR_COMPLEX_TESTS } from "../../../utils/testUtils";
-import { BehandlingPage } from "../../../pages/behandling/behandling.page";
 import { hentPrepopulertSakUrl } from "../../../utils/testdataUtils";
 import { runAxeAnalyze } from "../../../utils/axeUtils";
+import { StegvelgerPage } from "../../../pages/behandling/stegvelger.page";
 
 /**
  * E2E-tester for EnkelStegvelger i FTRL (Utenfor avtaleland) saksbehandling
@@ -10,58 +10,153 @@ import { runAxeAnalyze } from "../../../utils/axeUtils";
  * Disse testene verifiserer stegnavigasjon for FTRL-saker som bruker
  * enkelStegvelgeren (src/felleskomponenter/enkelStegvelger/enkelStegvelger.tsx).
  *
- * EnkelStegvelger brukes i:
- * - FTRL/Utenfor avtaleland saksbehandling
- * - Ikke yrkesaktiv
- * - EU/EØS pensjonist
- * - Årsavregning
- * - Unntaksregistrering
+ * FTRL-steg (rekkefølge):
+ * 1. Inngang - Fra og med dato, arbeidsland
+ * 2. Virksomhet - Velg virksomhet
+ * 3. Bestemmelse - Velg lovvalgsbestemmelse
+ * 4. Perioder - Trygdedekning og innvilgelsesresultat
+ * 5. Trygdeavgift - Avgiftsberegning
+ * 6. Vedtak - Avslutt behandling
  */
 test.describe("FTRL Stegvelger - Navigasjon", () => {
-  test("FTRL-behandling åpnes - viser stegvelger", async ({ page }, testInfo) => {
+  test("Navigasjon gjennom alle steg med minimum input", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
     const saksnummer = "MEL-1016";
-    const behandlingPage = new BehandlingPage(page, saksnummer);
+    const stegvelgerPage = new StegvelgerPage(page, saksnummer);
 
     // Hent URL til prepopulert FTRL-sak og naviger direkte dit
     const url = hentPrepopulertSakUrl(saksnummer);
-    await behandlingPage.goto(url);
+    await stegvelgerPage.goto(url);
+
+    // === STEG 1: Inngang ("Oppgi opplysninger fra søknaden") ===
+    await stegvelgerPage.verifiserSteg(/oppgi opplysninger|søknaden/i);
+    // Knapp skal være deaktivert uten input
+    await stegvelgerPage.verifiserBekreftKnappDeaktivert();
+    // Fyll ut minimum for å aktivere knappen
+    await stegvelgerPage.fyllUtInngangMinimum("01.01.2024", "Sverige");
+    await stegvelgerPage.verifiserBekreftKnappAktivert();
+    await stegvelgerPage.bekreftOgFortsett();
+
+    // === STEG 2: Virksomhet ===
+    await stegvelgerPage.verifiserSteg(/virksomhet/i);
+    await stegvelgerPage.verifiserBekreftKnappDeaktivert();
+    await stegvelgerPage.velgFørsteVirksomhet();
+    await stegvelgerPage.verifiserBekreftKnappAktivert();
+    await stegvelgerPage.bekreftOgFortsett();
+
+    // === STEG 3: Bestemmelse ===
+    await stegvelgerPage.verifiserSteg(/bestemmelse/i);
+    // Bestemmelse kan være forhåndsutfylt, sjekk om knapp allerede er aktivert
+    const bestemmelseAktiv = await page
+      .locator(".stegFane--aktiv button.stegKnapper__bekreft")
+      .isEnabled()
+      .catch(() => false);
+    if (!bestemmelseAktiv) {
+      await stegvelgerPage.velgBestemmelse("§ 2-5");
+    }
+    await stegvelgerPage.verifiserBekreftKnappAktivert();
+    await stegvelgerPage.bekreftOgFortsett();
+
+    // === STEG 4: Perioder ===
+    await stegvelgerPage.verifiserSteg(/periode/i);
+    // Perioder kan være forhåndsutfylt
+    const perioderAktiv = await page
+      .locator(".stegFane--aktiv button.stegKnapper__bekreft")
+      .isEnabled()
+      .catch(() => false);
+    if (!perioderAktiv) {
+      await stegvelgerPage.fyllUtPerioderMinimum();
+    }
+    await stegvelgerPage.verifiserBekreftKnappAktivert();
+    await stegvelgerPage.bekreftOgFortsett();
+
+    // === STEG 5: Trygdeavgift ===
+    await stegvelgerPage.verifiserSteg(/trygdeavgift/i);
+    // Trygdeavgift har som regel forhåndsutfylte data
+    await stegvelgerPage.verifiserBekreftKnappAktivert();
+    await stegvelgerPage.bekreftOgFortsett();
+
+    // === STEG 6: Vedtak ("Pliktig medlemskap etter folketrygdloven") ===
+    await stegvelgerPage.verifiserSteg(/pliktig medlemskap|vedtak/i);
+    // Vi stopper her - vedtak avsluttes ikke i denne testen
 
     await runAxeAnalyze(page, testInfo.title);
   });
 
-  test("Navigasjon mellom steg - frem og tilbake fungerer", async ({ page }, testInfo) => {
+  test("Navigasjon frem og tilbake mellom steg", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
     const saksnummer = "MEL-1017";
-    const behandlingPage = new BehandlingPage(page, saksnummer);
+    const stegvelgerPage = new StegvelgerPage(page, saksnummer);
 
-    // Hent URL til prepopulert FTRL-sak og naviger direkte dit
     const url = hentPrepopulertSakUrl(saksnummer);
-    await behandlingPage.goto(url);
+    await stegvelgerPage.goto(url);
+
+    // Start på Inngang ("Oppgi opplysninger fra søknaden")
+    await stegvelgerPage.verifiserSteg(/oppgi opplysninger|søknaden/i);
+
+    // Fyll ut og gå til Virksomhet
+    await stegvelgerPage.fyllUtInngangMinimum("01.01.2024", "Sverige");
+    await stegvelgerPage.bekreftOgFortsett();
+    await stegvelgerPage.verifiserSteg(/virksomhet/i);
+
+    // Gå tilbake til Inngang
+    await stegvelgerPage.gåTilbake();
+    await stegvelgerPage.verifiserSteg(/oppgi opplysninger|søknaden/i);
+
+    // Gå frem igjen
+    await stegvelgerPage.bekreftOgFortsett();
+    await stegvelgerPage.verifiserSteg(/virksomhet/i);
 
     await runAxeAnalyze(page, testInfo.title);
   });
 
-  test("Progressbar - viser alle steg", async ({ page }, testInfo) => {
+  test("Progressbar - navigasjon via klikk på steg", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
     const saksnummer = "MEL-1018";
-    const behandlingPage = new BehandlingPage(page, saksnummer);
+    const stegvelgerPage = new StegvelgerPage(page, saksnummer);
 
-    // Hent URL til prepopulert FTRL-sak og naviger direkte dit
     const url = hentPrepopulertSakUrl(saksnummer);
-    await behandlingPage.goto(url);
+    await stegvelgerPage.goto(url);
+
+    // EnkelStegvelger viser kun steg som er "låst opp"
+    // Ved start vises kun første steg (Inngang)
+    await stegvelgerPage.verifiserAntallSteg(1);
+
+    // Fyll ut Inngang og gå til Virksomhet
+    await stegvelgerPage.fyllUtInngangMinimum("01.01.2024", "Sverige");
+    await stegvelgerPage.bekreftOgFortsett();
+    await stegvelgerPage.verifiserSteg(/virksomhet/i);
+
+    // Nå skal det være 2 steg i progressbar
+    await stegvelgerPage.verifiserAntallSteg(2);
+
+    // Klikk på steg 1 i progressbar for å gå tilbake
+    await stegvelgerPage.klikkPåSteg(1);
+    await stegvelgerPage.verifiserSteg(/oppgi opplysninger|søknaden/i);
 
     await runAxeAnalyze(page, testInfo.title);
   });
 
-  test("Progressbar - klikk på steg navigerer til steget", async ({ page }, testInfo) => {
+  test("Bekreft-knapp forblir deaktivert ved ugyldig input", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
     const saksnummer = "MEL-1019";
-    const behandlingPage = new BehandlingPage(page, saksnummer);
+    const stegvelgerPage = new StegvelgerPage(page, saksnummer);
 
-    // Hent URL til prepopulert FTRL-sak og naviger direkte dit
     const url = hentPrepopulertSakUrl(saksnummer);
-    await behandlingPage.goto(url);
+    await stegvelgerPage.goto(url);
+
+    await stegvelgerPage.verifiserSteg(/oppgi opplysninger|søknaden/i);
+
+    // Knappen skal være deaktivert ved start
+    await stegvelgerPage.verifiserBekreftKnappDeaktivert();
+
+    // Fyll ut kun dato (uten arbeidsland) - knappen bør fortsatt være deaktivert
+    const fomInput = page.getByLabel(/fra og med/i);
+    await fomInput.fill("01.01.2024");
+    await page.waitForTimeout(500);
+
+    // Knappen skal fortsatt være deaktivert siden arbeidsland mangler
+    await stegvelgerPage.verifiserBekreftKnappDeaktivert();
 
     await runAxeAnalyze(page, testInfo.title);
   });

--- a/tests/e2e/specs/behandle-sak/ftrl/navigasjon.spec.ts
+++ b/tests/e2e/specs/behandle-sak/ftrl/navigasjon.spec.ts
@@ -30,15 +30,15 @@ test.describe("FTRL Stegvelger - Navigasjon", () => {
 
     // === STEG 1: Inngang ("Oppgi opplysninger fra søknaden") ===
     await stegvelgerPage.verifiserSteg(/oppgi opplysninger|søknaden/i);
-    // Knapp skal være deaktivert uten input
+    await stegvelgerPage.verifiserAntallSteg(1);
     await stegvelgerPage.verifiserBekreftKnappDeaktivert();
-    // Fyll ut minimum for å aktivere knappen
     await stegvelgerPage.fyllUtInngangMinimum("01.01.2024", "Sverige");
     await stegvelgerPage.verifiserBekreftKnappAktivert();
     await stegvelgerPage.bekreftOgFortsett();
 
     // === STEG 2: Virksomhet ===
     await stegvelgerPage.verifiserSteg(/virksomhet/i);
+    await stegvelgerPage.verifiserAntallSteg(2);
     await stegvelgerPage.verifiserBekreftKnappDeaktivert();
     await stegvelgerPage.velgFørsteVirksomhet();
     await stegvelgerPage.verifiserBekreftKnappAktivert();
@@ -46,6 +46,7 @@ test.describe("FTRL Stegvelger - Navigasjon", () => {
 
     // === STEG 3: Bestemmelse ===
     await stegvelgerPage.verifiserSteg(/bestemmelse/i);
+    await stegvelgerPage.verifiserAntallSteg(3);
     // Bestemmelse kan være forhåndsutfylt, sjekk om knapp allerede er aktivert
     const bestemmelseAktiv = await page
       .locator(".stegFane--aktiv button.stegKnapper__bekreft")
@@ -59,6 +60,7 @@ test.describe("FTRL Stegvelger - Navigasjon", () => {
 
     // === STEG 4: Perioder ===
     await stegvelgerPage.verifiserSteg(/periode/i);
+    await stegvelgerPage.verifiserAntallSteg(4);
     // Perioder kan være forhåndsutfylt
     const perioderAktiv = await page
       .locator(".stegFane--aktiv button.stegKnapper__bekreft")
@@ -72,13 +74,13 @@ test.describe("FTRL Stegvelger - Navigasjon", () => {
 
     // === STEG 5: Trygdeavgift ===
     await stegvelgerPage.verifiserSteg(/trygdeavgift/i);
-    // Trygdeavgift har som regel forhåndsutfylte data
+    await stegvelgerPage.verifiserAntallSteg(6); // Alle 6 steg vises fra Trygdeavgift
     await stegvelgerPage.verifiserBekreftKnappAktivert();
     await stegvelgerPage.bekreftOgFortsett();
 
     // === STEG 6: Vedtak ("Pliktig medlemskap etter folketrygdloven") ===
     await stegvelgerPage.verifiserSteg(/pliktig medlemskap|vedtak/i);
-    // Vi stopper her - vedtak avsluttes ikke i denne testen
+    await stegvelgerPage.verifiserAntallSteg(6);
 
     await runAxeAnalyze(page, testInfo.title);
   });
@@ -91,46 +93,27 @@ test.describe("FTRL Stegvelger - Navigasjon", () => {
     const url = hentPrepopulertSakUrl(saksnummer);
     await stegvelgerPage.goto(url);
 
-    // Start på Inngang ("Oppgi opplysninger fra søknaden")
+    // Start på Inngang
     await stegvelgerPage.verifiserSteg(/oppgi opplysninger|søknaden/i);
+    await stegvelgerPage.verifiserAntallSteg(1);
 
     // Fyll ut og gå til Virksomhet
     await stegvelgerPage.fyllUtInngangMinimum("01.01.2024", "Sverige");
     await stegvelgerPage.bekreftOgFortsett();
     await stegvelgerPage.verifiserSteg(/virksomhet/i);
-
-    // Gå tilbake til Inngang
-    await stegvelgerPage.gåTilbake();
-    await stegvelgerPage.verifiserSteg(/oppgi opplysninger|søknaden/i);
-
-    // Gå frem igjen
-    await stegvelgerPage.bekreftOgFortsett();
-    await stegvelgerPage.verifiserSteg(/virksomhet/i);
-
-    await runAxeAnalyze(page, testInfo.title);
-  });
-
-  test("Progressbar - navigasjon via klikk på steg", async ({ page }, testInfo) => {
-    test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-    const saksnummer = "MEL-1018";
-    const stegvelgerPage = new StegvelgerPage(page, saksnummer);
-
-    const url = hentPrepopulertSakUrl(saksnummer);
-    await stegvelgerPage.goto(url);
-
-    // EnkelStegvelger viser kun steg som er "låst opp"
-    // Ved start vises kun første steg (Inngang)
-    await stegvelgerPage.verifiserAntallSteg(1);
-
-    // Fyll ut Inngang og gå til Virksomhet
-    await stegvelgerPage.fyllUtInngangMinimum("01.01.2024", "Sverige");
-    await stegvelgerPage.bekreftOgFortsett();
-    await stegvelgerPage.verifiserSteg(/virksomhet/i);
-
-    // Nå skal det være 2 steg i progressbar
     await stegvelgerPage.verifiserAntallSteg(2);
 
-    // Klikk på steg 1 i progressbar for å gå tilbake
+    // Gå tilbake til Inngang via Tilbake-knapp
+    await stegvelgerPage.gåTilbake();
+    await stegvelgerPage.verifiserSteg(/oppgi opplysninger|søknaden/i);
+    await stegvelgerPage.verifiserAntallSteg(2); // Progressbar beholder 2 steg
+
+    // Gå frem igjen via Bekreft-knapp
+    await stegvelgerPage.bekreftOgFortsett();
+    await stegvelgerPage.verifiserSteg(/virksomhet/i);
+    await stegvelgerPage.verifiserAntallSteg(2);
+
+    // Gå tilbake via klikk på steg 1 i progressbar
     await stegvelgerPage.klikkPåSteg(1);
     await stegvelgerPage.verifiserSteg(/oppgi opplysninger|søknaden/i);
 

--- a/tests/e2e/specs/behandle-sak/ftrl/navigasjon.spec.ts
+++ b/tests/e2e/specs/behandle-sak/ftrl/navigasjon.spec.ts
@@ -21,7 +21,8 @@ import { StegvelgerPage } from "../../../pages/behandling/stegvelger.page";
 test.describe("FTRL Stegvelger - Navigasjon", () => {
   test("Navigasjon gjennom alle steg med minimum input", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-    const saksnummer = "MEL-1016";
+    // Bruker MEL-1021 for å unngå konflikt med avslutt-ftrl-behandling.spec.ts som bruker MEL-1016
+    const saksnummer = "MEL-1021";
     const stegvelgerPage = new StegvelgerPage(page, saksnummer);
 
     // Hent URL til prepopulert FTRL-sak og naviger direkte dit

--- a/tests/e2e/specs/behandle-sak/ftrl/navigasjon.spec.ts
+++ b/tests/e2e/specs/behandle-sak/ftrl/navigasjon.spec.ts
@@ -20,11 +20,11 @@ import { runAxeAnalyze } from "../../../utils/axeUtils";
 test.describe("FTRL Stegvelger - Navigasjon", () => {
   test("FTRL-behandling åpnes - viser stegvelger", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1016";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert FTRL-sak og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1016");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
     await runAxeAnalyze(page, testInfo.title);
@@ -32,11 +32,11 @@ test.describe("FTRL Stegvelger - Navigasjon", () => {
 
   test("Navigasjon mellom steg - frem og tilbake fungerer", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1017";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert FTRL-sak og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1017");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
     await runAxeAnalyze(page, testInfo.title);
@@ -44,11 +44,11 @@ test.describe("FTRL Stegvelger - Navigasjon", () => {
 
   test("Progressbar - viser alle steg", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1018";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert FTRL-sak og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1018");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
     await runAxeAnalyze(page, testInfo.title);
@@ -56,11 +56,11 @@ test.describe("FTRL Stegvelger - Navigasjon", () => {
 
   test("Progressbar - klikk på steg navigerer til steget", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
-
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1019";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert FTRL-sak og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1019");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
     await runAxeAnalyze(page, testInfo.title);

--- a/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts
+++ b/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts
@@ -7,8 +7,8 @@ import { hentPrepopulertSakUrl } from "../../utils/testdataUtils";
 let sendBrevPage: SendBrevPage;
 
 // Gjenbrukbar setup-funksjon som oppretter egen testdata
-async function setupSendBrevTest(page: Page, saksnummer: string = "MEL-1003") {
-  sendBrevPage = new SendBrevPage(page);
+async function setupSendBrevTest(page: Page, saksnummer: string) {
+  sendBrevPage = new SendBrevPage(page, saksnummer);
 
   // Hent URL til prepopulert Avtaleland-sak og naviger direkte dit
   const url = hentPrepopulertSakUrl(saksnummer);
@@ -77,10 +77,11 @@ test.describe("Validering av årsavregning brevmaler", () => {
     page,
   }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Økt timeout siden vi oppretter sak med årsavregning
-    sendBrevPage = new SendBrevPage(page);
+    const saksnummer = "MEL-1023";
+    sendBrevPage = new SendBrevPage(page, saksnummer);
 
     // Hent URL til prepopulert FTRL-sak med årsavregning og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1023");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await sendBrevPage.goto(url);
 
     await page.waitForLoadState("domcontentloaded");

--- a/tests/e2e/specs/behandle-sak/setup-henlegg-avtaleland.spec.ts
+++ b/tests/e2e/specs/behandle-sak/setup-henlegg-avtaleland.spec.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 import { BehandlingPage } from "../../pages/behandling/behandling.page";
-import { getSaksnummerFraUrl, TIMEOUT_FOR_COMPLEX_TESTS } from "../../utils/testUtils";
+import { TIMEOUT_FOR_COMPLEX_TESTS } from "../../utils/testUtils";
 import { hentPrepopulertSakUrl } from "../../utils/testdataUtils";
 import { runAxeAnalyze } from "../../utils/axeUtils";
 
@@ -16,14 +16,19 @@ import { runAxeAnalyze } from "../../utils/axeUtils";
 test.describe("Setup: Avtaleland-sak med henlagt behandling", () => {
   test("Opprett Avtaleland-sak og henlegg behandlingen", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Økt timeout siden vi oppretter og henlegger sak
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1009";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert Avtaleland-sak og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1009");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
-    const sakId = getSaksnummerFraUrl(page);
-    await behandlingPage.avsluttBehandling(sakId, "Søknaden/klagen er trukket", "Henlegg saken", "Søknaden er trukket");
+    await behandlingPage.avsluttBehandling(
+      saksnummer,
+      "Søknaden/klagen er trukket",
+      "Henlegg saken",
+      "Søknaden er trukket",
+    );
 
     await runAxeAnalyze(page, testInfo.title);
   });

--- a/tests/e2e/specs/behandle-sak/setup-henlegg-avtaleland.spec.ts
+++ b/tests/e2e/specs/behandle-sak/setup-henlegg-avtaleland.spec.ts
@@ -23,12 +23,7 @@ test.describe("Setup: Avtaleland-sak med henlagt behandling", () => {
     const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
-    await behandlingPage.avsluttBehandling(
-      saksnummer,
-      "Søknaden/klagen er trukket",
-      "Henlegg saken",
-      "Søknaden er trukket",
-    );
+    await behandlingPage.avsluttBehandling("Søknaden/klagen er trukket", "Henlegg saken", "Søknaden er trukket");
 
     await runAxeAnalyze(page, testInfo.title);
   });

--- a/tests/e2e/specs/behandle-sak/setup-henlegg-avtaleland.spec.ts
+++ b/tests/e2e/specs/behandle-sak/setup-henlegg-avtaleland.spec.ts
@@ -5,7 +5,7 @@ import { hentPrepopulertSakUrl } from "../../utils/testdataUtils";
 import { runAxeAnalyze } from "../../utils/axeUtils";
 
 /**
- * MELOSYS-7385: Setup testdata - Avtaleland-sak med HENLAGT behandling
+ * Setup testdata - Avtaleland-sak med HENLAGT behandling
  *
  * Akseptansekriterium som testes:
  * "Dersom behandlingen ble avsluttet som HENLAGT skal man fortsatt få gul varselmelding om det."

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk.spec.ts
@@ -105,8 +105,8 @@ test.describe("Avtaleland behandlingslogikk (regresjon)", () => {
   }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
 
-    // Bruk prepopulert AVSLUTTET Avtaleland-sak (MEL-1064)
-    const sakId = "MEL-1064";
+    // Bruk prepopulert AVSLUTTET Avtaleland-sak (MEL-1067)
+    const sakId = "MEL-1067";
 
     const hovedsidePage = new HovedsidePage(page);
     await hovedsidePage.goto();

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk.spec.ts
@@ -5,7 +5,7 @@ import { OpprettNySakPage } from "../../../pages/opprett-ny-sak/opprett-ny-sak.p
 import { TIMEOUT_FOR_COMPLEX_TESTS } from "../../../utils/testUtils";
 
 /**
- * MELOSYS-7385: Test regresjonstest for Avtaleland-saker
+ * Test regresjonstest for Avtaleland-saker
  *
  * Regresjonstest akseptansekriterium:
  * "Gitt at jeg skal opprette en behandling på en eksistrende sakstype EØS/AVTALELAND

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet.spec.ts
@@ -50,7 +50,7 @@ test.describe("'Opprett ny sak for bruker - knytt til eksisterende sak", () => {
 
   test("EØS pensjonist med trygdeavgift - årsavregning tilgjengelig", async ({ page }, testInfo) => {
     // Test unntaket for EØS pensjonister med trygdeavgift som skal kunne opprette årsavregning
-    // selv om de har aktive behandlinger (MELOSYS-7603)
+    // selv om de har aktive behandlinger
     await opprettNySakPage.fyllInnBrukerId(USER_ID_VALID);
     await opprettNySakPage.velgKnyttTilEksisterendeSak();
 

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/eos-pensjonist-aarsavregning.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/eos-pensjonist-aarsavregning.spec.ts
@@ -15,7 +15,7 @@ test.describe("EØS pensjonist med trygdeavgift - årsavregning", () => {
 
   test("Opprett EØS pensjonist-sak med trygdeavgift for testdata", async ({ page }, testInfo) => {
     // Denne testen oppretter testdata som brukes av de andre testene
-    const url = hentPrepopulertSakUrl("MEL-1055");
+    const url = hentPrepopulertSakUrl("MEL-1056");
 
     expect(url, "URL skal være opprettet").toBeTruthy();
     expect(url).toContain("/melosys/EU_EOS/");

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/eos-pensjonist-aarsavregning.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/eos-pensjonist-aarsavregning.spec.ts
@@ -7,7 +7,6 @@ import { hentPrepopulertSakUrl } from "../../../utils/testdataUtils";
 let opprettNySakPage: OpprettNySakPage;
 let hovedsidePage: HovedsidePage;
 
-// MELOSYS-7603
 test.describe("EØS pensjonist med trygdeavgift - årsavregning", () => {
   test.beforeEach(async ({ page }) => {
     hovedsidePage = new HovedsidePage(page);
@@ -40,7 +39,6 @@ test.describe("EØS pensjonist med trygdeavgift - årsavregning", () => {
     await valgtSak.click();
 
     // Verifiser at årsavregning er tilgjengelig (unntak fra vanlig EØS-regel)
-    // Dette er hovedpoenget med MELOSYS-7603
     await opprettNySakPage.verifiserTilgjengeligeBehandlingstyper(valgtSak, ["Årsavregning"]);
 
     // Verifiser at ingen feilmelding vises

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/regresjon-state-ved-saksbytting.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/regresjon-state-ved-saksbytting.spec.ts
@@ -54,8 +54,8 @@ test.describe("State-håndtering ved saksbytting", () => {
   });
 
   test("Utenfor avtaleland med aktiv behandling - årsavregning tilgjengelig", async ({ page }, testInfo) => {
-    // Bruk prepopulert OPPRETTET sak MEL-1059 (FTRL)
-    const sakId = "MEL-1059";
+    // Bruk prepopulert UNDER_BEHANDLING sak MEL-1018 (FTRL - Utenfor avtaleland)
+    const sakId = "MEL-1018";
     const valgtSak = opprettNySakPage.finnSakBySaksnummer(sakId);
 
     await valgtSak.click();

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/regresjon-state-ved-saksbytting.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/regresjon-state-ved-saksbytting.spec.ts
@@ -5,7 +5,7 @@ import { OpprettNySakPage } from "../../../pages/opprett-ny-sak/opprett-ny-sak.p
 import { TIMEOUT_FOR_COMPLEX_TESTS } from "../../../utils/testUtils";
 
 /**
- * MELOSYS-7624: Test state-håndtering ved saksbytting
+ * Test state-håndtering ved saksbytting
  *
  * Disse testene verifiserer at refaktoreringen fra 8 useEffects til Redux action creator
  * fungerer korrekt, spesielt ved rask saksbytting og komplekse states.

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk.spec.ts
@@ -103,7 +103,7 @@ test.describe("'Utenfor avtaleland' behandlingslogikk", () => {
     const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
-    await behandlingPage.avsluttBehandling(saksnummer, "Søknaden er innvilget", "Bekreft");
+    await behandlingPage.avsluttBehandling("Søknaden er innvilget", "Bekreft");
 
     const hovedsidePage = new HovedsidePage(page);
 

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk.spec.ts
@@ -7,7 +7,7 @@ import { hentPrepopulertSakUrl } from "../../../utils/testdataUtils";
 import { BehandlingPage } from "../../../pages/behandling/behandling.page";
 
 /**
- * MELOSYS-7385: Test akseptansekriterier for 'Utenfor avtaleland'-saker
+ * Test akseptansekriterier for 'Utenfor avtaleland'-saker
  *
  * Disse testene verifiserer de spesifikke akseptansekriteriene:
  * 1. Sak med åpen ikke-årsavregning → kun Årsavregning tilgjengelig
@@ -26,7 +26,7 @@ test.describe("'Utenfor avtaleland' behandlingslogikk", () => {
     await mainPage.klikkOpprettNySakKnapp();
   });
 
-  test("AC1: Utenfor avtaleland med åpen behandling - kun årsavregning tilgjengelig", async ({ page }, testInfo) => {
+  test("Utenfor avtaleland med åpen behandling - kun årsavregning tilgjengelig", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Økt timeout siden vi oppretter sak
 
     // Bruk prepopulert FTRL-sak med UNDER_BEHANDLING status
@@ -51,7 +51,7 @@ test.describe("'Utenfor avtaleland' behandlingslogikk", () => {
     await runAxeAnalyze(page, testInfo.title);
   });
 
-  test("AC2: Utenfor avtaleland med åpen årsavregning - finner sak", async ({ page }, testInfo) => {
+  test("Utenfor avtaleland med åpen årsavregning - finner sak", async ({ page }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Økt timeout siden vi oppretter sak + årsavregning
 
     // Bruk prepopulert FTRL-sak med UNDER_BEHANDLING status
@@ -91,7 +91,7 @@ test.describe("'Utenfor avtaleland' behandlingslogikk", () => {
     await runAxeAnalyze(page, testInfo.title);
   });
 
-  test("AC3: Utenfor avtaleland med avsluttet behandling - alle behandlingstyper tilgjengelige", async ({
+  test("Utenfor avtaleland med avsluttet behandling - alle behandlingstyper tilgjengelige", async ({
     page,
   }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Økt timeout siden vi oppretter og avslutter sak

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { runAxeAnalyze } from "../../../utils/axeUtils";
 import { HovedsidePage, USER_ID_VALID } from "../../../pages/hovedside.page";
 import { OpprettNySakPage } from "../../../pages/opprett-ny-sak/opprett-ny-sak.page";
-import { TIMEOUT_FOR_COMPLEX_TESTS, getSaksnummerFraUrl } from "../../../utils/testUtils";
+import { TIMEOUT_FOR_COMPLEX_TESTS } from "../../../utils/testUtils";
 import { hentPrepopulertSakUrl } from "../../../utils/testdataUtils";
 import { BehandlingPage } from "../../../pages/behandling/behandling.page";
 
@@ -96,14 +96,14 @@ test.describe("'Utenfor avtaleland' behandlingslogikk", () => {
   }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Økt timeout siden vi oppretter og avslutter sak
 
-    const behandlingPage = new BehandlingPage(page);
+    const saksnummer = "MEL-1020";
+    const behandlingPage = new BehandlingPage(page, saksnummer);
 
     // Hent URL til prepopulert FTRL-sak og naviger direkte dit
-    const url = hentPrepopulertSakUrl("MEL-1020");
+    const url = hentPrepopulertSakUrl(saksnummer);
     await behandlingPage.goto(url);
 
-    const sakId = getSaksnummerFraUrl(page);
-    await behandlingPage.avsluttBehandling(sakId, "Søknaden er innvilget", "Bekreft");
+    await behandlingPage.avsluttBehandling(saksnummer, "Søknaden er innvilget", "Bekreft");
 
     const hovedsidePage = new HovedsidePage(page);
 
@@ -113,7 +113,7 @@ test.describe("'Utenfor avtaleland' behandlingslogikk", () => {
     await opprettNySakPage.fyllInnBrukerId(USER_ID_VALID);
     await opprettNySakPage.velgKnyttTilEksisterendeSak();
 
-    const valgtSak = opprettNySakPage.finnSakBySaksnummer(sakId);
+    const valgtSak = opprettNySakPage.finnSakBySaksnummer(saksnummer);
     await valgtSak.click();
 
     // === AKSEPTANSEKRITERIUM 3 ===

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk.spec.ts
@@ -30,7 +30,7 @@ test.describe("'Utenfor avtaleland' behandlingslogikk", () => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS); // Økt timeout siden vi oppretter sak
 
     // Bruk prepopulert FTRL-sak med UNDER_BEHANDLING status
-    const sakId = "MEL-1013";
+    const sakId = "MEL-1014";
 
     const hovedsidePage = new HovedsidePage(page);
     await hovedsidePage.goto();

--- a/tests/e2e/utils/databaseHelper.ts
+++ b/tests/e2e/utils/databaseHelper.ts
@@ -46,6 +46,8 @@ export class DatabaseHelper {
 
   /**
    * Execute a query
+   * @param sql
+   * @param binds
    * @param suppressErrors - If true, don't log errors to console
    */
   async query<T = Record<string, unknown>>(

--- a/tests/e2e/utils/testUtils.ts
+++ b/tests/e2e/utils/testUtils.ts
@@ -34,15 +34,6 @@ export function getSaksnummerFraLocator(sak: Locator): string {
 }
 
 /**
- * Hent saksnummer fra URL
- * @returns Saksnummer (f.eks. "MEL-123") eller "ukjent"
- */
-export function getSaksnummerFraUrl(page: Page): string {
-  const match = page.url().match(/MEL-\d+/);
-  return match ? match[0] : "ukjent";
-}
-
-/**
  * Sanitizes a filename by replacing characters that are invalid in file paths
  * with safe alternatives.
  *

--- a/tests/e2e/utils/testdataUtils.ts
+++ b/tests/e2e/utils/testdataUtils.ts
@@ -72,9 +72,9 @@ function loadMetadataFromFile(): Record<string, SakMetadata> | null {
 }
 
 /**
- * Alle gyldige saksnummer
+ * Alle gyldige saksnummer for prepopulerte test-saker.
+ * Brukes for å utlede typen PrepopulertSaksnummer.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Used only for type inference
 const ALL_SAKSNUMMER = [
   // MEL-1001 til MEL-1011: Avtaleland UNDER_BEHANDLING
   "MEL-1001",
@@ -219,13 +219,6 @@ export function hentSakMetadata(saksnummer: PrepopulertSaksnummer): SakMetadata 
 }
 
 /**
- * Henter behandlings-ID for en sak
- */
-export function hentBehandlingID(saksnummer: PrepopulertSaksnummer): number {
-  return hentSakMetadata(saksnummer).behandlingID;
-}
-
-/**
  * Hjelpefunksjon for å få URL til en test-sak
  * @param saksnummer - Saksnummer (f.eks. "MEL-1001")
  * @returns URL til behandlingssiden for saken
@@ -254,8 +247,3 @@ export function hentPrepopulertSakUrl(saksnummer: PrepopulertSaksnummer): string
 
   return `${url}?behandlingID=${behandlingID}`;
 }
-
-/**
- * Test-FNR som brukes for alle test-saker
- */
-export const TEST_FNR = "30056928150";


### PR DESCRIPTION
Fikset delte saksnummer mellom E2E-tester
Fikset flaky FTRL navigasjonstest
Refaktorerte navigasjonstester og fjernet separate progressbar-tester

Bugfix i frontend:
  - forrigeÅrsavregningHarInnbetaltFraAvgiftssystem sjekket bare !== null,
    men undefined !== null er true, så radioknappen ble feilaktig readonly

