### PR TITLE
NOJIRA G4P Oppdatering avhengighet ihht dependabot warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.43",
     "prop-types": "^15.8.1",
-    "qs": "^6.10.3",
+    "qs": "^6.14.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.43.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         specifier: ^15.8.1
         version: 15.8.1
       qs:
-        specifier: ^6.10.3
-        version: 6.14.0
+        specifier: 6.14.1
+        version: 6.14.1
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -4854,9 +4854,9 @@ packages:
       { integrity: sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ== }
     engines: { node: ">=6.0.0" }
 
-  qs@6.14.0:
+  qs@6.14.1:
     resolution:
-      { integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w== }
+      { integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ== }
     engines: { node: ">=0.6" }
 
   querystringify@2.2.0:
@@ -10405,7 +10405,7 @@ snapshots:
 
   pvutils@1.1.3: {}
 
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         specifier: ^15.8.1
         version: 15.8.1
       qs:
-        specifier: 6.14.1
+        specifier: ^6.14.1
         version: 6.14.1
       react:
         specifier: ^19.0.0


### PR DESCRIPTION
Vulnerability found in dependency:

https://www.mend.io/vulnerability-database/CVE-2025-15284

Oppdaterte qs-pakken til versjon 6.14.1
Oppdatert pnpm-lock.yaml
