### PR TITLE
7553 Fiks for tidlig valideringsfeil på videresend søknad-steget

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/arbeidsforholdNorgeListe/__snapshots__/arbeidsforholdNorgeListe.test.tsx.snap
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/arbeidsforholdNorgeListe/__snapshots__/arbeidsforholdNorgeListe.test.tsx.snap
@@ -83,7 +83,10 @@ exports[`ArbeidsforholdNorgeListe > snapshot test 1`] = `
       </div>
     </div>
     <div class="leggTilKnapp">
-      <button class="navds-button navds-button--tertiary navds-button--small">
+      <button
+        type="button"
+        class="navds-button navds-button--tertiary navds-button--small"
+      >
         <span class="navds-button__icon">
           <svg
             width="20"

--- a/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/__snapshots__/editerbartElementListe.test.tsx.snap
+++ b/src/felleskomponenter/menypanel/menypunkter/editerbartElementListe/__snapshots__/editerbartElementListe.test.tsx.snap
@@ -158,7 +158,10 @@ exports[`EditerbartElementListe > snapshot test 1`] = `
         </div>
       </div>
       <div class="legg__til__knapp">
-        <button class="navds-button navds-button--tertiary navds-button--small">
+        <button
+          type="button"
+          class="navds-button navds-button--tertiary navds-button--small"
+        >
           <span class="navds-button__icon">
             <svg
               width="20"

--- a/src/felleskomponenter/ui/lenkeknapp/lenkeknapp.tsx
+++ b/src/felleskomponenter/ui/lenkeknapp/lenkeknapp.tsx
@@ -17,6 +17,7 @@ interface LenkeknappProps {
 function Lenkeknapp({ onClick, children, className, ikon: Ikon, value, disabled }: LenkeknappProps) {
   return (
     <Nav.Button
+      type="button"
       icon={Ikon && <Ikon className="ikon" />}
       onClick={onClick}
       className={className}

--- a/src/felleskomponenter/vedleggvelger/vedleggVelger.test.tsx
+++ b/src/felleskomponenter/vedleggvelger/vedleggVelger.test.tsx
@@ -1,4 +1,5 @@
 import { ComponentProps } from "react";
+import userEvent from "@testing-library/user-event";
 
 import VedleggVelger from "./vedleggVelger";
 import VedleggVelgerModal from "./vedleggVelgerModal";
@@ -23,6 +24,46 @@ describe("VedleggVelger", () => {
     };
     render(<VedleggVelger {...props} />);
     expect(screen.getByRole("button", { name: /legg til vedlegg/i })).toBeInTheDocument();
+  });
+
+  it("kaller onOpen når 'Legg til vedlegg' klikkes", async () => {
+    const onOpen = vi.fn();
+    props.valgteVedlegg = {
+      saksvedlegg: [],
+      standardvedlegg: null,
+    };
+    props.redigerbart = true;
+    props.onOpen = onOpen;
+
+    render(<VedleggVelger {...props} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /legg til vedlegg/i }));
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("kaller ikke onOpen når modalen lukkes", async () => {
+    const onOpen = vi.fn();
+    props.valgteVedlegg = {
+      saksvedlegg: [],
+      standardvedlegg: null,
+    };
+    props.redigerbart = true;
+    props.onOpen = onOpen;
+    props.dokumenter = [];
+    props.standardvedlegg = [];
+
+    render(<VedleggVelger {...props} />);
+
+    // Åpne modalen
+    await userEvent.click(screen.getByRole("button", { name: /legg til vedlegg/i }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    // Lukk modalen via Lukk-knappen
+    onOpen.mockClear();
+    await userEvent.click(screen.getByRole("button", { name: /lukk/i }));
+
+    expect(onOpen).not.toHaveBeenCalled();
   });
 });
 

--- a/src/felleskomponenter/vedleggvelger/vedleggVelger.tsx
+++ b/src/felleskomponenter/vedleggvelger/vedleggVelger.tsx
@@ -14,12 +14,25 @@ interface VedleggVelgerProps {
   onChange: (valgteVedlegg: DokumenterV2.BrevVedleggVisningstabellInterface) => void;
   redigerbart: boolean;
   standardvedlegg: DokumenterV2.TilgjengeligStandardvedlegg[];
+  onOpen?: () => void;
 }
 
-function VedleggVelger({ dokumenter, valgteVedlegg, onChange, redigerbart, standardvedlegg }: VedleggVelgerProps) {
+function VedleggVelger({
+  dokumenter,
+  valgteVedlegg,
+  onChange,
+  redigerbart,
+  standardvedlegg,
+  onOpen,
+}: VedleggVelgerProps) {
   const [redigerer, setRedigerer] = useState<boolean>(false);
 
-  const toggleRedigerer = () => setRedigerer(!redigerer);
+  const toggleRedigerer = () => {
+    if (!redigerer && onOpen) {
+      onOpen();
+    }
+    setRedigerer(!redigerer);
+  };
 
   const velgStandardvedlegg = (vedlegg: TilgjengeligStandardvedlegg) => {
     onChange({

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { getFormValues, reduxForm } from "redux-form";
 import { connect } from "react-redux";
 import PT from "prop-types";
@@ -60,8 +60,12 @@ export function VurderingVideresend({
 
   const isMounted = Hooks.useIsMounted();
 
-  // Clear error message when vedlegg changes, so the validation error
-  // only appears after attempting to submit without vedlegg
+  // Nullstill eventuelle feilmeldinger når steget vises
+  useEffect(() => {
+    resetFeiletRespons();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleVedleggChange = (newVedlegg) => {
     resetFeiletRespons();
     setValgteVedlegg(newVedlegg);
@@ -122,6 +126,7 @@ export function VurderingVideresend({
               <VedleggVelger
                 valgteVedlegg={valgteVedlegg}
                 onChange={handleVedleggChange}
+                onOpen={resetFeiletRespons}
                 dokumenter={fysiskeDokument}
                 redigerbart={redigerbart}
                 standardvedlegg={tilgjengeligeStandardvedlegg}

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
@@ -20,6 +20,7 @@ import VedleggTable from "../../../../felleskomponenter/vedleggTable";
 import { behandlingerSelectors } from "../../../../ducks/behandlinger";
 import { avklartefaktaSelectors } from "../../../../ducks/avklartefakta";
 import { dokumenterSelectors } from "../../../../ducks/dokumenter";
+import { feiletResponsOperations } from "../../../../ducks/feiletRespons";
 
 import { lagYupToReduxformErrorMapper } from "../../../../yup";
 import vurderingVideresendSchema from "../vurderingVideresendSchema";
@@ -34,6 +35,7 @@ export function VurderingVideresend({
   form,
   formValues = {},
   tilbake,
+  resetFeiletRespons,
 }) {
   const pdfDokumenter = [
     {
@@ -57,6 +59,13 @@ export function VurderingVideresend({
   const tilgjengeligeStandardvedlegg = []; // TODO: Skal implementeres i MELOSYS-7071
 
   const isMounted = Hooks.useIsMounted();
+
+  // Clear error message when vedlegg changes, so the validation error
+  // only appears after attempting to submit without vedlegg
+  const handleVedleggChange = (newVedlegg) => {
+    resetFeiletRespons();
+    setValgteVedlegg(newVedlegg);
+  };
 
   const videresendSoknad = async (values, dispatch, props) => {
     setVideresendPending(true);
@@ -107,12 +116,12 @@ export function VurderingVideresend({
               <VedleggTable
                 valgteVedlegg={valgteVedlegg}
                 label="Vedlegg til SED"
-                setValgteVedlegg={setValgteVedlegg}
+                setValgteVedlegg={handleVedleggChange}
                 redigerbart={redigerbart}
               />
               <VedleggVelger
                 valgteVedlegg={valgteVedlegg}
-                onChange={setValgteVedlegg}
+                onChange={handleVedleggChange}
                 dokumenter={fysiskeDokument}
                 redigerbart={redigerbart}
                 standardvedlegg={tilgjengeligeStandardvedlegg}
@@ -153,6 +162,7 @@ VurderingVideresend.propTypes = {
   form: PT.string.isRequired,
   formValues: PT.object,
   fysiskeDokument: PT.arrayOf(PT.object).isRequired,
+  resetFeiletRespons: PT.func.isRequired,
 };
 
 const VurderingVideresendForm = reduxForm({
@@ -175,4 +185,8 @@ const mapStateToProps = (state) => ({
   },
 });
 
-export default connect(mapStateToProps)(VurderingVideresendForm);
+const mapDispatchToProps = (dispatch) => ({
+  resetFeiletRespons: () => dispatch(feiletResponsOperations.resetFeiletRespons()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(VurderingVideresendForm);

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.test.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import userEvent from "@testing-library/user-event";
 
 import { reduxForm } from "redux-form";
 import * as KV from "../../../../kodeverk";
-import VurderingVideresend from "./vurderingVideresend";
+import { VurderingVideresend } from "./vurderingVideresend";
 import { renderWithProviders } from "../../../../ducks/test-utils/renderWithProviders";
 
 const initialReduxState = {
@@ -44,6 +45,7 @@ describe("Vurderingvideresend", () => {
       videresendSoknad: vi.fn(),
       tilbake: vi.fn(),
       handleSubmit: vi.fn(),
+      resetFeiletRespons: vi.fn(),
     };
   });
 
@@ -67,5 +69,33 @@ describe("Vurderingvideresend", () => {
       preloadedState: initialReduxState,
     });
     expect(queryByText("SED A008")).not.toBeInTheDocument();
+  });
+
+  it("kaller resetFeiletRespons ved mount", () => {
+    const resetFeiletRespons = vi.fn();
+    props.resetFeiletRespons = resetFeiletRespons;
+
+    renderWithProviders(<WrappedVurderingVideresend {...props} />, {
+      preloadedState: initialReduxState,
+    });
+
+    expect(resetFeiletRespons).toHaveBeenCalledTimes(1);
+  });
+
+  it("kaller resetFeiletRespons når vedleggvelger åpnes", async () => {
+    const resetFeiletRespons = vi.fn();
+    props.resetFeiletRespons = resetFeiletRespons;
+
+    renderWithProviders(<WrappedVurderingVideresend {...props} />, {
+      preloadedState: initialReduxState,
+    });
+
+    // Nullstill mock etter mount-kallet
+    resetFeiletRespons.mockClear();
+
+    // Klikk på "Legg til vedlegg" for å åpne vedleggvelgeren
+    await userEvent.click(document.querySelector(".vedleggvelger") as HTMLElement);
+
+    expect(resetFeiletRespons).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Nullstill feiletRespons-feiltilstanden når vedleggsvalg endres, slik at feilen «Kan ikke videresende søknad uten vedlegg» bare vises etter at man faktisk forsøker å sende inn uten vedlegg, ikke når man går inn på steget eller klikker «Legg til vedlegg».

Fikse før vi forseetter på https://jira.adeo.no/browse/MELOSYS-7553 