### PR TITLE
7840 Valideringer på trygdeavgiftsteget

### DIFF
--- a/src/sider/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
+++ b/src/sider/vurderingTrygdeavgift/vurderingTrygdeavgift.tsx
@@ -329,19 +329,17 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
 
   useEffect(() => {
     if (redigerbart && aktivtSteg) {
-      if (!formIsValid) {
-        formValues?.skatteforholdsperioder?.forEach((_periode: any, index: number) => {
-          trigger(`skatteforholdsperioder[${index}].fomDato`);
-          trigger(`skatteforholdsperioder[${index}].tomDato`);
-        });
-        formValues?.inntektskilder?.forEach((_periode: any, index: number) => {
-          trigger(`inntektskilder[${index}].fomDato`);
-          trigger(`inntektskilder[${index}].tomDato`);
-        });
-        if (!erÅpenSluttDato && (feil || harEndretInnvilgetMedlemskapsperiode)) {
-          debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
-          setHarEndretInnvilgetMedlemskapsperiode(false);
-        }
+      formValues?.skatteforholdsperioder?.forEach((_periode: any, index: number) => {
+        trigger(`skatteforholdsperioder[${index}].fomDato`);
+        trigger(`skatteforholdsperioder[${index}].tomDato`);
+      });
+      formValues?.inntektskilder?.forEach((_periode: any, index: number) => {
+        trigger(`inntektskilder[${index}].fomDato`);
+        trigger(`inntektskilder[${index}].tomDato`);
+      });
+      if (!erÅpenSluttDato && (feil || harEndretInnvilgetMedlemskapsperiode)) {
+        debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
+        setHarEndretInnvilgetMedlemskapsperiode(false);
       }
     }
   }, [aktivtSteg, harEndretInnvilgetMedlemskapsperiode]);


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7840

Ting blir ikke validert i den useeffecten her når man går frem og tilbake, fordi verdien formIsValid er alltid true, men lite vits å starte med true.. bare fjerner denne og lar den validere så kan formIsValid også bli false