### PR TITLE
7138 Skjuler Arbeidsgiver/virksomhet og Arbeidssted(er) ved årsavregning

### DIFF
--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.test.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.test.tsx
@@ -38,27 +38,42 @@ const { ÅRSAVREGNING, SØKNAD } = MKV.Koder.behandlinger.behandlingstyper;
 
 const { SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS } = MKV.Koder.mottatteopplysningertyper;
 
-const createContentProps = (): ContentProps => ({
+const createContentProps = (behandlingstema = UTSENDT_ARBEIDSTAKER): ContentProps => ({
   visArbeidsforholdRolleEtiketter: false,
   redigerbart: true,
   visMottatteOpplysningerData: true,
   lagreSoknadOgOppfriskSaksopplysninger: vi.fn(),
-  behandlingstema: UTSENDT_ARBEIDSTAKER,
+  behandlingstema,
   endreFokus: false,
 });
 
-const createConfig = (overrides = {}) => ({
-  sakstype: MKV.Koder.sakstyper.EU_EOS,
-  behandlingstema: UTSENDT_ARBEIDSTAKER,
-  behandlingstype: SØKNAD,
-  mottatteOpplysningerType: SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS,
-  contentProps: createContentProps(),
-  sakstema: "",
-  kunFullmektig: false,
-  erPensjonistToggleEnabled: false,
-  erPensjonistEØSToggleEnabled: false,
-  ...overrides,
-});
+type ConfigOverrides = {
+  behandlingstema?: string;
+  behandlingstype?: string;
+  sakstype?: string;
+  mottatteOpplysningerType?: string;
+  contentProps?: ContentProps;
+  sakstema?: string;
+  kunFullmektig?: boolean;
+  erPensjonistToggleEnabled?: boolean;
+  erPensjonistEØSToggleEnabled?: boolean;
+};
+
+const createConfig = (overrides: ConfigOverrides = {}) => {
+  const behandlingstema = overrides.behandlingstema ?? UTSENDT_ARBEIDSTAKER;
+  return {
+    sakstype: MKV.Koder.sakstyper.EU_EOS,
+    behandlingstema,
+    behandlingstype: SØKNAD,
+    mottatteOpplysningerType: SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS,
+    contentProps: createContentProps(behandlingstema),
+    sakstema: "",
+    kunFullmektig: false,
+    erPensjonistToggleEnabled: false,
+    erPensjonistEØSToggleEnabled: false,
+    ...overrides,
+  };
+};
 
 const getAllLabels = (linkGroups: ReturnType<typeof LinkGroupsFactory.createLinkGroups>) =>
   linkGroups.flatMap((g) => g.links).map((l) => l.label);

--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.test.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.test.tsx
@@ -104,30 +104,6 @@ describe("LinkGroupsFactory", () => {
       expect(allLabels).not.toContain("Arbeidssted(er)");
     });
 
-    it("skal IKKE inkludere Arbeidsgiver/virksomhet for BESLUTNING_LOVVALG_NORGE", () => {
-      const config = createConfig({
-        behandlingstype: ÅRSAVREGNING,
-        behandlingstema: BESLUTNING_LOVVALG_NORGE,
-      });
-
-      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
-      const allLabels = getAllLabels(linkGroups);
-
-      expect(allLabels).not.toContain("Arbeidsgiver/virksomhet");
-    });
-
-    it("skal IKKE inkludere Arbeidssted(er) for BESLUTNING_LOVVALG_NORGE", () => {
-      const config = createConfig({
-        behandlingstype: ÅRSAVREGNING,
-        behandlingstema: BESLUTNING_LOVVALG_NORGE,
-      });
-
-      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
-      const allLabels = getAllLabels(linkGroups);
-
-      expect(allLabels).not.toContain("Arbeidssted(er)");
-    });
-
     it("skal IKKE inkludere Arbeidsgiver/virksomhet for YRKESAKTIV", () => {
       const config = createConfig({
         behandlingstype: ÅRSAVREGNING,
@@ -190,18 +166,6 @@ describe("LinkGroupsFactory", () => {
       expect(allLabels).toContain("Arbeidssted(er)");
     });
 
-    it("skal inkludere Arbeidsgiver/virksomhet for BESLUTNING_LOVVALG_NORGE", () => {
-      const config = createConfig({
-        behandlingstype: SØKNAD,
-        behandlingstema: BESLUTNING_LOVVALG_NORGE,
-      });
-
-      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
-      const allLabels = getAllLabels(linkGroups);
-
-      expect(allLabels).toContain("Arbeidsgiver/virksomhet");
-    });
-
     it("skal inkludere Arbeidssted(er) for YRKESAKTIV", () => {
       const config = createConfig({
         behandlingstype: SØKNAD,
@@ -212,6 +176,44 @@ describe("LinkGroupsFactory", () => {
       const allLabels = getAllLabels(linkGroups);
 
       expect(allLabels).toContain("Arbeidssted(er)");
+    });
+  });
+
+  describe("BESLUTNING_LOVVALG_NORGE uten Fra bruker-seksjon", () => {
+    it("skal IKKE inkludere Arbeidsgiver/virksomhet", () => {
+      const config = createConfig({
+        behandlingstype: SØKNAD,
+        behandlingstema: BESLUTNING_LOVVALG_NORGE,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).not.toContain("Arbeidsgiver/virksomhet");
+    });
+
+    it("skal IKKE inkludere Arbeidssted(er)", () => {
+      const config = createConfig({
+        behandlingstype: SØKNAD,
+        behandlingstema: BESLUTNING_LOVVALG_NORGE,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).not.toContain("Arbeidssted(er)");
+    });
+
+    it("skal IKKE inkludere Fullmektig", () => {
+      const config = createConfig({
+        behandlingstype: SØKNAD,
+        behandlingstema: BESLUTNING_LOVVALG_NORGE,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).not.toContain("Fullmektig");
     });
   });
 });

--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.test.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from "vitest";
+import MKV from "../../../melosyskodeverk";
+import LinkGroupsFactory from "./linkgroupsFactory";
+import { ContentProps } from "./types";
+
+// Mock React components to avoid rendering issues
+vi.mock("../menypunkter", () => ({
+  ArbeidsforholdOgInntekt: () => null,
+  ArbeidsgiverOgVirksomhet: () => null,
+  Arbeidssteder: () => null,
+  Fullmektig: () => null,
+  Medlemskap: () => null,
+  Utenlandsoppdraget: () => null,
+  Periode: () => null,
+  Person: () => null,
+  Familieforhold: () => null,
+  LonnOgGodtgjorelser: () => null,
+  OvrigOmArbeidstaker: () => null,
+  VirksomhetenINorge: () => null,
+}));
+
+vi.mock("../menypunkter/fakturainformasjon", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../../featuretoggle", () => ({
+  useFeatureToggle: () => false,
+}));
+
+vi.mock("../../../url", () => ({
+  harUnntaksregistreringFlyt: () => false,
+  skalViseIngenFlyt: () => false,
+}));
+
+const { UTSENDT_ARBEIDSTAKER, BESLUTNING_LOVVALG_NORGE, YRKESAKTIV } = MKV.Koder.behandlinger.behandlingstema;
+
+const { ÅRSAVREGNING, SØKNAD } = MKV.Koder.behandlinger.behandlingstyper;
+
+const { SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS } = MKV.Koder.mottatteopplysningertyper;
+
+const createContentProps = (): ContentProps => ({
+  visArbeidsforholdRolleEtiketter: false,
+  redigerbart: true,
+  visMottatteOpplysningerData: true,
+  lagreSoknadOgOppfriskSaksopplysninger: vi.fn(),
+  behandlingstema: UTSENDT_ARBEIDSTAKER,
+  endreFokus: false,
+});
+
+const createConfig = (overrides = {}) => ({
+  sakstype: MKV.Koder.sakstyper.EU_EOS,
+  behandlingstema: UTSENDT_ARBEIDSTAKER,
+  behandlingstype: SØKNAD,
+  mottatteOpplysningerType: SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS,
+  contentProps: createContentProps(),
+  sakstema: "",
+  kunFullmektig: false,
+  erPensjonistToggleEnabled: false,
+  erPensjonistEØSToggleEnabled: false,
+  ...overrides,
+});
+
+const getAllLabels = (linkGroups: ReturnType<typeof LinkGroupsFactory.createLinkGroups>) =>
+  linkGroups.flatMap((g) => g.links).map((l) => l.label);
+
+describe("LinkGroupsFactory", () => {
+  describe("ved årsavregning", () => {
+    it("skal IKKE inkludere Arbeidsgiver/virksomhet for UTSENDT_ARBEIDSTAKER", () => {
+      const config = createConfig({
+        behandlingstype: ÅRSAVREGNING,
+        behandlingstema: UTSENDT_ARBEIDSTAKER,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).not.toContain("Arbeidsgiver/virksomhet");
+    });
+
+    it("skal IKKE inkludere Arbeidssted(er) for UTSENDT_ARBEIDSTAKER", () => {
+      const config = createConfig({
+        behandlingstype: ÅRSAVREGNING,
+        behandlingstema: UTSENDT_ARBEIDSTAKER,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).not.toContain("Arbeidssted(er)");
+    });
+
+    it("skal IKKE inkludere Arbeidsgiver/virksomhet for BESLUTNING_LOVVALG_NORGE", () => {
+      const config = createConfig({
+        behandlingstype: ÅRSAVREGNING,
+        behandlingstema: BESLUTNING_LOVVALG_NORGE,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).not.toContain("Arbeidsgiver/virksomhet");
+    });
+
+    it("skal IKKE inkludere Arbeidssted(er) for BESLUTNING_LOVVALG_NORGE", () => {
+      const config = createConfig({
+        behandlingstype: ÅRSAVREGNING,
+        behandlingstema: BESLUTNING_LOVVALG_NORGE,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).not.toContain("Arbeidssted(er)");
+    });
+
+    it("skal IKKE inkludere Arbeidsgiver/virksomhet for YRKESAKTIV", () => {
+      const config = createConfig({
+        behandlingstype: ÅRSAVREGNING,
+        behandlingstema: YRKESAKTIV,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).not.toContain("Arbeidsgiver/virksomhet");
+    });
+
+    it("skal IKKE inkludere Arbeidssted(er) for YRKESAKTIV", () => {
+      const config = createConfig({
+        behandlingstype: ÅRSAVREGNING,
+        behandlingstema: YRKESAKTIV,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).not.toContain("Arbeidssted(er)");
+    });
+
+    it("skal fortsatt inkludere Fullmektig ved årsavregning", () => {
+      const config = createConfig({
+        behandlingstype: ÅRSAVREGNING,
+        behandlingstema: UTSENDT_ARBEIDSTAKER,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).toContain("Fullmektig");
+    });
+  });
+
+  describe("ved vanlig søknadsbehandling", () => {
+    it("skal inkludere Arbeidsgiver/virksomhet for UTSENDT_ARBEIDSTAKER", () => {
+      const config = createConfig({
+        behandlingstype: SØKNAD,
+        behandlingstema: UTSENDT_ARBEIDSTAKER,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).toContain("Arbeidsgiver/virksomhet");
+    });
+
+    it("skal inkludere Arbeidssted(er) for UTSENDT_ARBEIDSTAKER", () => {
+      const config = createConfig({
+        behandlingstype: SØKNAD,
+        behandlingstema: UTSENDT_ARBEIDSTAKER,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).toContain("Arbeidssted(er)");
+    });
+
+    it("skal inkludere Arbeidsgiver/virksomhet for BESLUTNING_LOVVALG_NORGE", () => {
+      const config = createConfig({
+        behandlingstype: SØKNAD,
+        behandlingstema: BESLUTNING_LOVVALG_NORGE,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).toContain("Arbeidsgiver/virksomhet");
+    });
+
+    it("skal inkludere Arbeidssted(er) for YRKESAKTIV", () => {
+      const config = createConfig({
+        behandlingstype: SØKNAD,
+        behandlingstema: YRKESAKTIV,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).toContain("Arbeidssted(er)");
+    });
+  });
+});

--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
@@ -25,6 +25,7 @@ const {
 } = MKV.Koder.behandlinger.behandlingstema;
 
 const { SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS } = MKV.Koder.mottatteopplysningertyper;
+const { ÅRSAVREGNING } = MKV.Koder.behandlinger.behandlingstyper;
 
 interface LinkGroupsConfig {
   sakstype: string;
@@ -113,13 +114,14 @@ class LinkGroupsFactory {
       case ARBEID_KUN_NORGE:
       case ARBEID_TJENESTEPERSON_ELLER_FLY:
       case ARBEID_NORGE_BOSATT_ANNET_LAND: {
-        const fraBruker = new LinksBuilder(contentProps).addArbeidsgiverEllerVirksomhet();
+        const fraBruker = new LinksBuilder(contentProps);
+        if (behandlingstype !== ÅRSAVREGNING) fraBruker.addArbeidsgiverEllerVirksomhet();
         const fraRegister = new LinksBuilder(contentProps).addMedlemskap().addArbeidsforholdOgInntekt();
         if (mottatteOpplysningerType === SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS) fraBruker.addLonnOgGodtgjorelser();
         fraBruker.addFullmektig();
         if (mottatteOpplysningerType === SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS) fraBruker.addUtenlandsoppdraget();
         else fraBruker.addPeriode();
-        fraBruker.addArbeidssteder();
+        if (behandlingstype !== ÅRSAVREGNING) fraBruker.addArbeidssteder();
         if (mottatteOpplysningerType === SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS) {
           fraBruker.addOmVirksomhetenINorge();
           fraBruker.addOvrigOmArbeidstaker();
@@ -157,20 +159,21 @@ class LinkGroupsFactory {
           .build();
       }
       case BESLUTNING_LOVVALG_NORGE: {
+        const fraBrukerBuilder = new LinksBuilder(contentProps);
+        if (behandlingstype !== ÅRSAVREGNING) fraBrukerBuilder.addArbeidsgiverEllerVirksomhet();
+        fraBrukerBuilder.addFullmektig().addPeriode();
+        if (behandlingstype !== ÅRSAVREGNING) fraBrukerBuilder.addArbeidssteder();
         return new LinkgroupsBuilder()
           .addFraRegisterOgBruker(new LinksBuilder(contentProps).addPerson().addFamilieForhold().build())
           .addFraRegister(new LinksBuilder(contentProps).addMedlemskap().addArbeidsforholdOgInntekt().build())
-          .addFraBruker(
-            new LinksBuilder(contentProps)
-              .addArbeidsgiverEllerVirksomhet()
-              .addFullmektig()
-              .addPeriode()
-              .addArbeidssteder()
-              .build(),
-          )
+          .addFraBruker(fraBrukerBuilder.build())
           .build();
       }
       case YRKESAKTIV: {
+        const fraBrukerBuilder = new LinksBuilder(contentProps);
+        if (behandlingstype !== ÅRSAVREGNING) fraBrukerBuilder.addArbeidsgiverEllerVirksomhet();
+        fraBrukerBuilder.addFullmektig();
+        if (behandlingstype !== ÅRSAVREGNING) fraBrukerBuilder.addArbeidssteder();
         return new LinkgroupsBuilder()
           .addFraRegisterOgBruker(new LinksBuilder(contentProps).addPerson().addFamilieForhold().build())
           .addFraRegister(
@@ -180,9 +183,7 @@ class LinkGroupsFactory {
               .addFaktureringskomponenten()
               .build(),
           )
-          .addFraBruker(
-            new LinksBuilder(contentProps).addArbeidsgiverEllerVirksomhet().addFullmektig().addArbeidssteder().build(),
-          )
+          .addFraBruker(fraBrukerBuilder.build())
           .build();
       }
       default:

--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
@@ -4,7 +4,7 @@ import { harUnntaksregistreringFlyt, skalViseIngenFlyt } from "../../../url";
 import { ContentProps, LinkGroup } from "./types";
 import LinkgroupsBuilder from "./linkgroupsBuilder";
 import LinksBuilder from "./linksBuilder";
-import { MELOSYS_EØS_FAKTURERING_AV_TRYGDEAVGIFT } from "../,,/../../../featuretoggle/toggleNavn";
+import { MELOSYS_EØS_FAKTURERING_AV_TRYGDEAVGIFT } from "../../../featuretoggle/toggleNavn";
 import { useFeatureToggle } from "../../../featuretoggle";
 
 const {

--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
@@ -159,14 +159,9 @@ class LinkGroupsFactory {
           .build();
       }
       case BESLUTNING_LOVVALG_NORGE: {
-        const fraBrukerBuilder = new LinksBuilder(contentProps);
-        if (behandlingstype !== ÅRSAVREGNING) fraBrukerBuilder.addArbeidsgiverEllerVirksomhet();
-        fraBrukerBuilder.addFullmektig().addPeriode();
-        if (behandlingstype !== ÅRSAVREGNING) fraBrukerBuilder.addArbeidssteder();
         return new LinkgroupsBuilder()
           .addFraRegisterOgBruker(new LinksBuilder(contentProps).addPerson().addFamilieForhold().build())
           .addFraRegister(new LinksBuilder(contentProps).addMedlemskap().addArbeidsforholdOgInntekt().build())
-          .addFraBruker(fraBrukerBuilder.build())
           .build();
       }
       case YRKESAKTIV: {


### PR DESCRIPTION
 - La til erÅrsavregning-sjekk i linkgroupsFactory.tsx
 - Menypunktene "Arbeidsgiver/virksomhet" og "Arbeidssted(er)" vises ikke lenger i sidemenyen ved årsavregningsbehandling
 - Gjelder for UTSENDT_ARBEIDSTAKER, BESLUTNING_LOVVALG_NORGE og YRKESAKTIV
 - La til 11 enhetstester for å verifisere oppførselen

Fix urelatert til denne saken, trolig relatert til MELOSYS-7744:
- Korrigert feil i import av togglenavn

JIRA:
https://jira.adeo.no/browse/MELOSYS-7138
