### PR TITLE
Fjern automatisk deploy til q1 ved merge til master

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -83,14 +83,6 @@ jobs:
           IMAGE: ${{ needs.build.outputs.image }}
           VARS: nais/vars-q2.json
           TELEMETRY: ${{ needs.build.outputs.telemetry }}
-      - name: Deploy q1
-        uses: nais/deploy/actions/deploy@v2
-        env:
-          CLUSTER: dev-fss
-          RESOURCE: nais/nais.yaml
-          IMAGE: ${{ needs.build.outputs.image }}
-          VARS: nais/vars-q1.json
-          TELEMETRY: ${{ needs.build.outputs.telemetry }}
       - name: Get commit message
         run: echo "COMMIT_MSG=$(git log --format=%s -n 1)" >> $GITHUB_ENV
       - name: Slack Notification
@@ -99,7 +91,7 @@ jobs:
           SLACK_COLOR: "${{ job.status == 'success' && 'good' || 'danger' }}"
           SLACK_USERNAME: Github Actions
           SLACK_ICON: https://github.com/github.png?size=48
-          SLACK_TITLE: "melosys-web ${{ job.status == 'success' && 'ble deployet' || 'kunne ikke deployes' }} til q1 og q2"
+          SLACK_TITLE: "melosys-web ${{ job.status == 'success' && 'ble deployet' || 'kunne ikke deployes' }} til q2"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: ${{ env.COMMIT_MSG }}
       - name: post-deploy


### PR DESCRIPTION
## Summary
- Fjerner automatisk deploy til q1 fra deploy-dev workflow
- Oppdaterer Slack-notifikasjonen til å bare nevne q2
- Q1 må nå deployes manuelt via deploy-manuelt.yml

## Test plan
- [ ] Verifiser at merge til master kun deployer til q2
- [ ] Verifiser at manuell deploy til q1 fortsatt fungerer