### PR TITLE
7856 TOGGLE Visning feil i Periode og Trygdeavgift steg 11.3.b

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 
 # misc
 .claude
+.opencode
 .idea
 !.idea/runConfigurations/
 .vscode

--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -488,6 +488,7 @@ class Stegvelger extends Component {
       art11_4_1eller13_4_1: props.art11_4_1eller13_4_1,
       art11_4_2eller13_4_2: props.art11_4_2eller13_4_2,
       eøsFaktureringAvTrygdeavgiftToggleEnabled: props.eøsFaktureringAvTrygdeavgiftToggleEnabled,
+      oppsummering: props.oppsummering,
       harTrygdeavgiftperiode,
     };
 

--- a/src/sider/eu_eøs/saksbehandling/stegMap/arbeid_tjenesteperson_eller_fly_vedtak.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/arbeid_tjenesteperson_eller_fly_vedtak.js
@@ -55,15 +55,17 @@ class ArbeidTjenestepersonEllerFlyVedtak extends Steg {
   }
 
   skalBrukeLegacyKomponent = (propsLight) => {
+    const oppsummering = propsLight.oppsummering;
+    const flytProduksjonDato = new Date("2025-11-15T00:00:00Z");
+
+    const behandlingAvsluttetFørNyEndringEØS_11_3_b =
+      oppsummering.behandlingsstatus.kode === "AVSLUTTET" && new Date(oppsummering.endretDato) < flytProduksjonDato;
+
     const innsynsmodusSkalIkkeViseEndringerFraFaktureringAvTrygdeavgift =
-      !propsLight.generiskStegRedigerbart && !propsLight.harTrygdeavgiftperiode;
+      !propsLight.generiskStegRedigerbart && behandlingAvsluttetFørNyEndringEØS_11_3_b;
 
     if (propsLight.eøsFaktureringAvTrygdeavgiftToggleEnabled) {
-      if (innsynsmodusSkalIkkeViseEndringerFraFaktureringAvTrygdeavgift) {
-        return true;
-      }
-
-      return false;
+      return !!innsynsmodusSkalIkkeViseEndringerFraFaktureringAvTrygdeavgift;
     }
 
     return true;

--- a/src/sider/eu_eøs/saksbehandling/stegMap/arbeid_tjenesteperson_eller_fly_vedtak.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/arbeid_tjenesteperson_eller_fly_vedtak.js
@@ -1,9 +1,12 @@
+import moment from "moment";
+
 import Steg from "../../../../felleskomponenter/stegvelger/stegMotor/steg";
 import { FANE_STATUS, STEG } from "../../../../felleskomponenter/stegvelger";
 import VurderingArbeidTjenestepersonEllerFlyVedtak from "../../stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak";
 import VurderingArbeidTjenestepersonEllerFlyVedtakLegacy from "../../stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak_Legacy/vurderingArbeidTjenestepersonEllerFlyVedtak";
 
 import { hentFakta } from "../../../../domeneUtils";
+import { FLYT_PRODUKSJON_DATO_EØS_11_3_B } from "../../../../utils/dato";
 
 import MKV from "../../../../melosyskodeverk";
 
@@ -56,10 +59,10 @@ class ArbeidTjenestepersonEllerFlyVedtak extends Steg {
 
   skalBrukeLegacyKomponent = (propsLight) => {
     const oppsummering = propsLight.oppsummering;
-    const flytProduksjonDato = new Date("2025-11-15T00:00:00Z");
 
     const behandlingAvsluttetFørNyEndringEØS_11_3_b =
-      oppsummering.behandlingsstatus.kode === "AVSLUTTET" && new Date(oppsummering.endretDato) < flytProduksjonDato;
+      oppsummering.behandlingsstatus.kode === "AVSLUTTET" &&
+      moment(oppsummering.endretDato).isBefore(FLYT_PRODUKSJON_DATO_EØS_11_3_B);
 
     const innsynsmodusSkalIkkeViseEndringerFraFaktureringAvTrygdeavgift =
       !propsLight.generiskStegRedigerbart && behandlingAvsluttetFørNyEndringEØS_11_3_b;

--- a/src/sider/eu_eøs/saksbehandling/stegMap/medfolgende_barn.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/medfolgende_barn.js
@@ -5,6 +5,8 @@ import Steg from "../../../../felleskomponenter/stegvelger/stegMotor/stegLegacy"
 import { FANE_STATUS, STEG } from "../../../../felleskomponenter/stegvelger";
 import VurderingMedfolgendeBarn from "../../stegKomponenter/vurderingMedfolgendeBarn";
 import { hentFaktaListe } from "../../../../domeneUtils";
+import { FLYT_PRODUKSJON_DATO_EØS_11_3_B } from "../../../../utils/dato";
+import moment from "moment";
 
 class VesentligVirksomhet extends Steg {
   constructor(propsLight, stegPosisjon) {
@@ -66,10 +68,10 @@ class VesentligVirksomhet extends Steg {
 
   beregnNesteStegForFlyt11_3_b = (propsLight) => {
     const oppsummering = propsLight.oppsummering;
-    const flytProduksjonDato = new Date("2025-11-15T00:00:00Z");
 
     const behandlingAvsluttetFørNyEndringEØS_11_3_b =
-      oppsummering.behandlingsstatus.kode === "AVSLUTTET" && new Date(oppsummering.endretDato) < flytProduksjonDato;
+      oppsummering.behandlingsstatus.kode === "AVSLUTTET" &&
+      moment(oppsummering.endretDato).isBefore(FLYT_PRODUKSJON_DATO_EØS_11_3_B);
 
     const innsynsmodusSkalIkkeViseEndringerFraFaktureringAvTrygdeavgift =
       !propsLight.generiskStegRedigerbart && behandlingAvsluttetFørNyEndringEØS_11_3_b;

--- a/src/sider/eu_eøs/saksbehandling/stegMap/medfolgende_barn.js
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/medfolgende_barn.js
@@ -65,8 +65,14 @@ class VesentligVirksomhet extends Steg {
     );
 
   beregnNesteStegForFlyt11_3_b = (propsLight) => {
+    const oppsummering = propsLight.oppsummering;
+    const flytProduksjonDato = new Date("2025-11-15T00:00:00Z");
+
+    const behandlingAvsluttetFørNyEndringEØS_11_3_b =
+      oppsummering.behandlingsstatus.kode === "AVSLUTTET" && new Date(oppsummering.endretDato) < flytProduksjonDato;
+
     const innsynsmodusSkalIkkeViseEndringerFraFaktureringAvTrygdeavgift =
-      !propsLight.generiskStegRedigerbart && !propsLight.harTrygdeavgiftperiode;
+      !propsLight.generiskStegRedigerbart && behandlingAvsluttetFørNyEndringEØS_11_3_b;
 
     if (propsLight.eøsFaktureringAvTrygdeavgiftToggleEnabled) {
       if (innsynsmodusSkalIkkeViseEndringerFraFaktureringAvTrygdeavgift) {

--- a/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.jsx
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.jsx
@@ -7,6 +7,8 @@ import SokkelSkip from "./sokkel_skip";
 import Yrkesgruppe from "./yrkesgruppe";
 import { hentFaktaListe } from "../../../../domeneUtils";
 import { BOOLSK_STRING } from "../../../../constants";
+import { FLYT_PRODUKSJON_DATO_EØS_11_3_B } from "../../../../utils/dato";
+import moment from "moment";
 
 class SaksbehandlingVirksomheter extends Virksomheter {
   constructor(propsLight, stegPosisjon) {
@@ -53,15 +55,16 @@ class SaksbehandlingVirksomheter extends Virksomheter {
 
       const harAvklaringBarn = harAvklaring(vurderingLovvalgBarnFakta, propsLight.medfolgendeBarn);
       const erInnsynsmodus = !propsLight.generiskStegRedigerbart;
+
       if (harAvklaringBarn && erInnsynsmodus) {
         return STEG.MEDFOLGENDE_BARN;
       }
 
       const oppsummering = propsLight.oppsummering;
-      const flytProduksjonDato = new Date("2025-11-15T00:00:00Z");
 
       const behandlingAvsluttetFørNyEndringEØS_11_3_b =
-        oppsummering.behandlingsstatus.kode === "AVSLUTTET" && new Date(oppsummering.endretDato) < flytProduksjonDato;
+        oppsummering.behandlingsstatus.kode === "AVSLUTTET" &&
+        moment(oppsummering.endretDato).isBefore(FLYT_PRODUKSJON_DATO_EØS_11_3_B);
 
       const innsynsmodusSkalIkkeViseEndringerFraFaktureringAvTrygdeavgift =
         !propsLight.generiskStegRedigerbart && behandlingAvsluttetFørNyEndringEØS_11_3_b;

--- a/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.jsx
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.jsx
@@ -35,13 +35,13 @@ class SaksbehandlingVirksomheter extends Virksomheter {
 
     const harAvklaring = (vurderingLovvalgBarnFakta, mottatteOpplysningerMedfolgendeBarn) => {
       return (
-        !(vurderingLovvalgBarnFakta.length === 0 && mottatteOpplysningerMedfolgendeBarn.length === 0) &&
-        vurderingLovvalgBarnFakta.length === mottatteOpplysningerMedfolgendeBarn.length &&
-        vurderingLovvalgBarnFakta.every(
-          (enkeltFakta) =>
-            enkeltFakta.fakta.includes(BOOLSK_STRING.SANN) ||
-            (enkeltFakta.fakta.includes(BOOLSK_STRING.USANN) && enkeltFakta.begrunnelseKoder.length > 0),
-        )
+        !(vurderingLovvalgBarnFakta.length === 0 && mottatteOpplysningerMedfolgendeBarn.length === 0) ||
+        (vurderingLovvalgBarnFakta.length === mottatteOpplysningerMedfolgendeBarn.length &&
+          vurderingLovvalgBarnFakta.every(
+            (enkeltFakta) =>
+              enkeltFakta.fakta.includes(BOOLSK_STRING.SANN) ||
+              (enkeltFakta.fakta.includes(BOOLSK_STRING.USANN) && enkeltFakta.begrunnelseKoder.length > 0),
+          ))
       );
     };
 

--- a/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.jsx
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.jsx
@@ -35,13 +35,13 @@ class SaksbehandlingVirksomheter extends Virksomheter {
 
     const harAvklaring = (vurderingLovvalgBarnFakta, mottatteOpplysningerMedfolgendeBarn) => {
       return (
-        !(vurderingLovvalgBarnFakta.length === 0 && mottatteOpplysningerMedfolgendeBarn.length === 0) ||
-        (vurderingLovvalgBarnFakta.length === mottatteOpplysningerMedfolgendeBarn.length &&
-          vurderingLovvalgBarnFakta.every(
-            (enkeltFakta) =>
-              enkeltFakta.fakta.includes(BOOLSK_STRING.SANN) ||
-              (enkeltFakta.fakta.includes(BOOLSK_STRING.USANN) && enkeltFakta.begrunnelseKoder.length > 0),
-          ))
+        !(vurderingLovvalgBarnFakta.length === 0 && mottatteOpplysningerMedfolgendeBarn.length === 0) &&
+        vurderingLovvalgBarnFakta.length === mottatteOpplysningerMedfolgendeBarn.length &&
+        vurderingLovvalgBarnFakta.every(
+          (enkeltFakta) =>
+            enkeltFakta.fakta.includes(BOOLSK_STRING.SANN) ||
+            (enkeltFakta.fakta.includes(BOOLSK_STRING.USANN) && enkeltFakta.begrunnelseKoder.length > 0),
+        )
       );
     };
 

--- a/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.jsx
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.jsx
@@ -35,6 +35,7 @@ class SaksbehandlingVirksomheter extends Virksomheter {
 
     const harAvklaring = (vurderingLovvalgBarnFakta, mottatteOpplysningerMedfolgendeBarn) => {
       return (
+        !(vurderingLovvalgBarnFakta.length === 0 && mottatteOpplysningerMedfolgendeBarn.length === 0) &&
         vurderingLovvalgBarnFakta.length === mottatteOpplysningerMedfolgendeBarn.length &&
         vurderingLovvalgBarnFakta.every(
           (enkeltFakta) =>
@@ -51,14 +52,19 @@ class SaksbehandlingVirksomheter extends Virksomheter {
       );
 
       const harAvklaringBarn = harAvklaring(vurderingLovvalgBarnFakta, propsLight.medfolgendeBarn);
-
       const erInnsynsmodus = !propsLight.generiskStegRedigerbart;
       if (harAvklaringBarn && erInnsynsmodus) {
         return STEG.MEDFOLGENDE_BARN;
       }
 
+      const oppsummering = propsLight.oppsummering;
+      const flytProduksjonDato = new Date("2025-11-15T00:00:00Z");
+
+      const behandlingAvsluttetFørNyEndringEØS_11_3_b =
+        oppsummering.behandlingsstatus.kode === "AVSLUTTET" && new Date(oppsummering.endretDato) < flytProduksjonDato;
+
       const innsynsmodusSkalIkkeViseEndringerFraFaktureringAvTrygdeavgift =
-        !propsLight.generiskStegRedigerbart && !propsLight.harTrygdeavgiftperiode;
+        !propsLight.generiskStegRedigerbart && behandlingAvsluttetFørNyEndringEØS_11_3_b;
 
       if (propsLight.eøsFaktureringAvTrygdeavgiftToggleEnabled) {
         if (innsynsmodusSkalIkkeViseEndringerFraFaktureringAvTrygdeavgift) {

--- a/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.test.ts
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.test.ts
@@ -4,12 +4,17 @@ import { STEG } from "../../../../felleskomponenter/stegvelger";
 import * as KV from "../../../../kodeverk";
 import MKV from "../../../../melosyskodeverk";
 import { BOOLSK_STRING } from "../../../../constants";
+import { FLYT_PRODUKSJON_DATO_EØS_11_3_B } from "../../../../utils/dato";
+
+// Datoer avledet fra produksjonsdatoen for å sikre konsistens
+const DATO_FØR_PRODUKSJON = FLYT_PRODUKSJON_DATO_EØS_11_3_B.clone().subtract(14, "days").toISOString();
+const DATO_ETTER_PRODUKSJON = FLYT_PRODUKSJON_DATO_EØS_11_3_B.clone().add(1, "days").toISOString();
 
 describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende personell flyt", () => {
   // Helper for å lage oppsummering med behandlingsstatus og endretDato
   const createOppsummering = (
     behandlingsstatusKode: string = "UNDER_BEHANDLING",
-    endretDato: string = "2026-02-01", // Default: etter flytProduksjonDato
+    endretDato: string = DATO_ETTER_PRODUKSJON, // Default: etter flytProduksjonDato
   ) => ({
     behandlingsstatus: { kode: behandlingsstatusKode },
     endretDato,
@@ -123,7 +128,7 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
         erArbeidTjenestepersonEllerFly: true,
         medfolgendeBarn: createMedfolgendeBarn(1),
         eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
-        oppsummering: createOppsummering("AVSLUTTET", "2025-11-01"),
+        oppsummering: createOppsummering("AVSLUTTET", DATO_FØR_PRODUKSJON),
       });
 
       const virksomheter = new SaksbehandlingVirksomheter(propsLight, 3);
@@ -193,7 +198,7 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
         erArbeidTjenestepersonEllerFly: true,
         medfolgendeBarn: createMedfolgendeBarn(2),
         eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
-        oppsummering: createOppsummering("AVSLUTTET", "2025-11-01"),
+        oppsummering: createOppsummering("AVSLUTTET", DATO_FØR_PRODUKSJON),
         avklartefakta: [
           {
             referanse: KV.Koder.avklartefaktaKoder.VIRKSOMHET,
@@ -216,7 +221,7 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
         erArbeidTjenestepersonEllerFly: true,
         medfolgendeBarn: createMedfolgendeBarn(1),
         eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
-        oppsummering: createOppsummering("AVSLUTTET", "2025-11-16"),
+        oppsummering: createOppsummering("AVSLUTTET", DATO_ETTER_PRODUKSJON),
         avklartefakta: [
           {
             referanse: KV.Koder.avklartefaktaKoder.VIRKSOMHET,
@@ -264,9 +269,6 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
   });
 
   describe("Innsyn: Dato-basert logikk for visning av legacy komponent", () => {
-    const DATO_FØR_PRODUKSJON = "2025-11-01T00:00:00Z";
-    const DATO_ETTER_PRODUKSJON = "2025-11-16T00:00:00Z"; // Etter 2025-11-15
-
     it("Avsluttet behandling FØR flytProduksjonDato skal bruke legacy komponent (gå til ARBEID_TJENESTEPERSON_ELLER_FLY_VEDTAK)", () => {
       const propsLight = createMockPropsLight({
         generiskStegRedigerbart: false,

--- a/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.test.ts
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.test.ts
@@ -123,6 +123,7 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
         erArbeidTjenestepersonEllerFly: true,
         medfolgendeBarn: createMedfolgendeBarn(1),
         eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
+        oppsummering: createOppsummering("AVSLUTTET", "2025-11-01"),
       });
 
       const virksomheter = new SaksbehandlingVirksomheter(propsLight, 3);
@@ -192,6 +193,7 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
         erArbeidTjenestepersonEllerFly: true,
         medfolgendeBarn: createMedfolgendeBarn(2),
         eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
+        oppsummering: createOppsummering("AVSLUTTET", "2025-11-01"),
         avklartefakta: [
           {
             referanse: KV.Koder.avklartefaktaKoder.VIRKSOMHET,
@@ -214,6 +216,7 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
         erArbeidTjenestepersonEllerFly: true,
         medfolgendeBarn: createMedfolgendeBarn(1),
         eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
+        oppsummering: createOppsummering("AVSLUTTET", "2025-11-16"),
         avklartefakta: [
           {
             referanse: KV.Koder.avklartefaktaKoder.VIRKSOMHET,
@@ -231,7 +234,7 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
       const nesteSteg = virksomheter.nesteSteg();
 
       expect(nesteSteg).not.toBe(STEG.MEDFOLGENDE_BARN);
-      expect(nesteSteg).toBe(STEG.ARBEID_TJENESTEPERSON_ELLER_FLY_VEDTAK);
+      expect(nesteSteg).toBe(STEG.VURDERING_PERIODE);
     });
 
     it("Når VURDERING_LOVVALG_BARN har USANN med begrunnelseKoder, skal harAvklaring være true", () => {

--- a/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.test.ts
+++ b/src/sider/eu_eøs/saksbehandling/stegMap/virksomheter.test.ts
@@ -6,6 +6,15 @@ import MKV from "../../../../melosyskodeverk";
 import { BOOLSK_STRING } from "../../../../constants";
 
 describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende personell flyt", () => {
+  // Helper for å lage oppsummering med behandlingsstatus og endretDato
+  const createOppsummering = (
+    behandlingsstatusKode: string = "UNDER_BEHANDLING",
+    endretDato: string = "2026-02-01", // Default: etter flytProduksjonDato
+  ) => ({
+    behandlingsstatus: { kode: behandlingsstatusKode },
+    endretDato,
+  });
+
   const createMockPropsLight = (overrides = {}) => ({
     avklartefakta: [
       {
@@ -21,6 +30,7 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
     erArbeidTjenestepersonEllerFly: false,
     eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
     harTrygdeavgiftperiode: false,
+    oppsummering: createOppsummering(),
     tilgjengeligeHandlers: {
       bekreftOgFortsett: vi.fn(),
       tilbake: vi.fn(),
@@ -122,9 +132,9 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
       expect(nesteSteg).toBe(STEG.ARBEID_TJENESTEPERSON_ELLER_FLY_VEDTAK);
     });
 
-    it("Gitt at jeg er i innsyn med offentlig tjenesteperson/fly uten barn-data og toggle av, skal gå til barn-steget (harAvklaring = true for tom liste)", () => {
+    it("Gitt at jeg er i innsyn med offentlig tjenesteperson/fly uten barn-data og toggle av, skal IKKE gå til barn-steget (harAvklaring = false for tomme lister)", () => {
       // Merk: Når medfolgendeBarn er tom og det ikke finnes VURDERING_LOVVALG_BARN,
-      // er harAvklaring = true fordi begge lengder er 0 og every() på tom array returnerer true
+      // er harAvklaring = false fordi begge lengder er 0 (ny logikk ekskluderer tomme lister)
       const propsLight = createMockPropsLight({
         generiskStegRedigerbart: false,
         erArbeidTjenestepersonEllerFly: true,
@@ -135,8 +145,9 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
       const virksomheter = new SaksbehandlingVirksomheter(propsLight, 3);
       const nesteSteg = virksomheter.nesteSteg();
 
-      // harAvklaring er true, så går til MEDFOLGENDE_BARN
-      expect(nesteSteg).toBe(STEG.MEDFOLGENDE_BARN);
+      // harAvklaring er false for tomme lister, så går til ARBEID_TJENESTEPERSON_ELLER_FLY_VEDTAK
+      expect(nesteSteg).toBe(STEG.ARBEID_TJENESTEPERSON_ELLER_FLY_VEDTAK);
+      expect(nesteSteg).not.toBe(STEG.MEDFOLGENDE_BARN);
     });
   });
 
@@ -246,6 +257,67 @@ describe("SaksbehandlingVirksomheter - Offentlig tjenesteperson/flyvende persone
       const nesteSteg = virksomheter.nesteSteg();
 
       expect(nesteSteg).toBe(STEG.MEDFOLGENDE_BARN);
+    });
+  });
+
+  describe("Innsyn: Dato-basert logikk for visning av legacy komponent", () => {
+    const DATO_FØR_PRODUKSJON = "2025-11-01T00:00:00Z";
+    const DATO_ETTER_PRODUKSJON = "2025-11-16T00:00:00Z"; // Etter 2025-11-15
+
+    it("Avsluttet behandling FØR flytProduksjonDato skal bruke legacy komponent (gå til ARBEID_TJENESTEPERSON_ELLER_FLY_VEDTAK)", () => {
+      const propsLight = createMockPropsLight({
+        generiskStegRedigerbart: false,
+        erArbeidTjenestepersonEllerFly: true,
+        eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
+        oppsummering: createOppsummering("AVSLUTTET", DATO_FØR_PRODUKSJON),
+      });
+
+      const virksomheter = new SaksbehandlingVirksomheter(propsLight, 3);
+      const nesteSteg = virksomheter.nesteSteg();
+
+      expect(nesteSteg).toBe(STEG.ARBEID_TJENESTEPERSON_ELLER_FLY_VEDTAK);
+    });
+
+    it("Avsluttet behandling ETTER flytProduksjonDato skal bruke ny komponent (gå til VURDERING_PERIODE)", () => {
+      const propsLight = createMockPropsLight({
+        generiskStegRedigerbart: false,
+        erArbeidTjenestepersonEllerFly: true,
+        eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
+        oppsummering: createOppsummering("AVSLUTTET", DATO_ETTER_PRODUKSJON),
+      });
+
+      const virksomheter = new SaksbehandlingVirksomheter(propsLight, 3);
+      const nesteSteg = virksomheter.nesteSteg();
+
+      expect(nesteSteg).toBe(STEG.VURDERING_PERIODE);
+    });
+
+    it("Behandling som IKKE er avsluttet skal bruke ny komponent uavhengig av dato", () => {
+      const propsLight = createMockPropsLight({
+        generiskStegRedigerbart: false,
+        erArbeidTjenestepersonEllerFly: true,
+        eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
+        oppsummering: createOppsummering("UNDER_BEHANDLING", DATO_FØR_PRODUKSJON),
+      });
+
+      const virksomheter = new SaksbehandlingVirksomheter(propsLight, 3);
+      const nesteSteg = virksomheter.nesteSteg();
+
+      expect(nesteSteg).toBe(STEG.VURDERING_PERIODE);
+    });
+
+    it("I saksbehandlingsmodus (redigerbar) skal alltid bruke ny komponent", () => {
+      const propsLight = createMockPropsLight({
+        generiskStegRedigerbart: true,
+        erArbeidTjenestepersonEllerFly: true,
+        eøsFaktureringAvTrygdeavgiftToggleEnabled: true,
+        oppsummering: createOppsummering("AVSLUTTET", DATO_FØR_PRODUKSJON),
+      });
+
+      const virksomheter = new SaksbehandlingVirksomheter(propsLight, 3);
+      const nesteSteg = virksomheter.nesteSteg();
+
+      expect(nesteSteg).toBe(STEG.VURDERING_PERIODE);
     });
   });
 });

--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -12,6 +12,8 @@ import momentTZ from "moment-timezone";
  */
 const MAX_AR_FREM_I_TID = 10;
 
+const FLYT_PRODUKSJON_DATO_EØS_11_3_B = moment("2025-11-15T00:00:00Z");
+
 /** Gjør et beste forsøk på å vaske inputdato. Dersom vask ikke er mulig (feks ved helt feil datoformat eller
  * ugyldig dato, returner false.
  * @param dato
@@ -308,6 +310,7 @@ export {
   formatterKortDatoTilNorsk,
   isoStringTilDate,
   MAX_AR_FREM_I_TID,
+  FLYT_PRODUKSJON_DATO_EØS_11_3_B,
   normaliserInputDato,
   norskStringTilDate,
   perioderOverlapper,


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7856

Nå værende visnings logikk for periode og trygdeavgift har vist seg å ikke være tilstrekkelig ettersom vi har behandlinger med periode der hele perioden er i tidligere år. I slike tilfeller vil det ikke lagres noe trygdeavgiftsperioder i databasen og logikken i dag er avhengig av det. Innfører derfor `flytProduksjonDato` der i tillegg til trygdeavgifstperioder sjekker vi også når behandlingen ble ferdigbehandlet. Ble den ferdigbehandlet før produksjonsdato skal den ikke ha nye endringene, og det motsatte.
