### PR TITLE
7138: Fikset feil som ble introdusert pga uklarhet i beskrivelse.

### DIFF
--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.test.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.test.tsx
@@ -179,8 +179,8 @@ describe("LinkGroupsFactory", () => {
     });
   });
 
-  describe("BESLUTNING_LOVVALG_NORGE uten Fra bruker-seksjon", () => {
-    it("skal IKKE inkludere Arbeidsgiver/virksomhet", () => {
+  describe("BESLUTNING_LOVVALG_NORGE ved vanlig søknadsbehandling", () => {
+    it("skal inkludere Arbeidsgiver/virksomhet", () => {
       const config = createConfig({
         behandlingstype: SØKNAD,
         behandlingstema: BESLUTNING_LOVVALG_NORGE,
@@ -189,10 +189,10 @@ describe("LinkGroupsFactory", () => {
       const linkGroups = LinkGroupsFactory.createLinkGroups(config);
       const allLabels = getAllLabels(linkGroups);
 
-      expect(allLabels).not.toContain("Arbeidsgiver/virksomhet");
+      expect(allLabels).toContain("Arbeidsgiver/virksomhet");
     });
 
-    it("skal IKKE inkludere Arbeidssted(er)", () => {
+    it("skal inkludere Arbeidssted(er)", () => {
       const config = createConfig({
         behandlingstype: SØKNAD,
         behandlingstema: BESLUTNING_LOVVALG_NORGE,
@@ -201,10 +201,10 @@ describe("LinkGroupsFactory", () => {
       const linkGroups = LinkGroupsFactory.createLinkGroups(config);
       const allLabels = getAllLabels(linkGroups);
 
-      expect(allLabels).not.toContain("Arbeidssted(er)");
+      expect(allLabels).toContain("Arbeidssted(er)");
     });
 
-    it("skal IKKE inkludere Fullmektig", () => {
+    it("skal inkludere Fullmektig", () => {
       const config = createConfig({
         behandlingstype: SØKNAD,
         behandlingstema: BESLUTNING_LOVVALG_NORGE,
@@ -213,7 +213,19 @@ describe("LinkGroupsFactory", () => {
       const linkGroups = LinkGroupsFactory.createLinkGroups(config);
       const allLabels = getAllLabels(linkGroups);
 
-      expect(allLabels).not.toContain("Fullmektig");
+      expect(allLabels).toContain("Fullmektig");
+    });
+
+    it("skal inkludere Periode og land", () => {
+      const config = createConfig({
+        behandlingstype: SØKNAD,
+        behandlingstema: BESLUTNING_LOVVALG_NORGE,
+      });
+
+      const linkGroups = LinkGroupsFactory.createLinkGroups(config);
+      const allLabels = getAllLabels(linkGroups);
+
+      expect(allLabels).toContain("Periode og land");
     });
   });
 });

--- a/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
+++ b/src/felleskomponenter/menypanel/linkgroups/linkgroupsFactory.tsx
@@ -162,6 +162,14 @@ class LinkGroupsFactory {
         return new LinkgroupsBuilder()
           .addFraRegisterOgBruker(new LinksBuilder(contentProps).addPerson().addFamilieForhold().build())
           .addFraRegister(new LinksBuilder(contentProps).addMedlemskap().addArbeidsforholdOgInntekt().build())
+          .addFraBruker(
+            new LinksBuilder(contentProps)
+              .addArbeidsgiverEllerVirksomhet()
+              .addFullmektig()
+              .addPeriode()
+              .addArbeidssteder()
+              .build(),
+          )
           .build();
       }
       case YRKESAKTIV: {


### PR DESCRIPTION
7138 Gjenopprettet "FRA BRUKER"-seksjon for BESLUTNING_LOVVALG_NORGE                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                        
  Forrige commit fjernet feilaktig hele "FRA BRUKER"-seksjonen for                                                                                                                                                                                                                                                        
  BESLUTNING_LOVVALG_NORGE. Dette behandlingstemaet har ikke                                                                                                                                                                                                                                                            
  årsavregning og skulle ikke vært endret i MELOSYS-7138.                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                        
  Endringer:                                                                                                                                                                                                                                                                                                            
  - Gjenopprettet original addFraBruker for BESLUTNING_LOVVALG_NORGE                                                                                                                                                                                                                                                    
    (Arbeidsgiver/virksomhet, Fullmektig, Periode og land, Arbeidssted(er))                                                                                                                                                                                                                                             
  - Rettet tester til å verifisere at alle menypunkter vises ved søknad                                                                                                                                                                                                                                                 
  - Årsavregning-logikk for UTSENDT_ARBEIDSTAKER og YRKESAKTIV er uendret 

JIRA: https://jira.adeo.no/browse/MELOSYS-7138