### PR TITLE
7878 DAPI feil i utregning av beregnet trygdeavgift

### DIFF
--- a/src/services/modules/aarsavregning/aarsavregning.test.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.test.ts
@@ -6,7 +6,6 @@ import {
   oppdaterHarSkjoennsfastsattInntekt,
   oppdaterEndeligAvgiftValg,
   hentFiltrertAarsavregningList,
-  oppdaterBeregnetAvgiftBeloep,
   oppdaterManueltAvgiftBeloep,
   oppdaterAarsavregning,
 } from "./aarsavregning";
@@ -46,10 +45,6 @@ describe("aarsavregning", () => {
 
   it("hentFiltrertAarsavregningList med filtre returnerer promise", () => {
     expect(hentFiltrertAarsavregningList("123", "INNVILGET", 2024)).toBeInstanceOf(Promise);
-  });
-
-  it("oppdaterBeregnetAvgiftBeloep returnerer promise", () => {
-    expect(oppdaterBeregnetAvgiftBeloep(1, 2, 1000)).toBeInstanceOf(Promise);
   });
 
   it("oppdaterManueltAvgiftBeloep returnerer promise", () => {

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -127,21 +127,7 @@ export const hentFiltrertAarsavregningList = (
   }
   return getAsJson(url);
 };
-export const oppdaterBeregnetAvgiftBeloep = async (
-  behandlingID: number,
-  aarsavregningID: number,
-  beregnetAvgiftBelop?: number,
-) => {
-  return oppdaterAarsavregning(
-    behandlingID,
-    {
-      avregning: {
-        beregnetAvgiftBelop,
-      },
-    },
-    aarsavregningID,
-  );
-};
+
 export const oppdaterManueltAvgiftBeloep = async (
   behandlingID: number,
   aarsavregningID: number,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -261,27 +261,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     oppdaterStatus(stegErGyldig);
   }, [stegErGyldig]);
 
-  useEffect(() => {
-    if (redigerbart && aarsavregningResponse?.nyttTrygdeavgiftsGrunnlag && aarsavregningID) {
-      const { totalAvgift } = aarsavregningResponse.nyttTrygdeavgiftsGrunnlag.avgift;
-      const beregnetAvgiftBelop = aarsavregningResponse.avregning?.beregnetAvgiftBelop;
-
-      if (totalAvgift !== beregnetAvgiftBelop) {
-        Api.Aarsavregning.oppdaterBeregnetAvgiftBeloep(behandlingID, aarsavregningID, totalAvgift).then(
-          (res: AarsavregningResponse) => {
-            setAarsavregningResponse(res);
-          },
-        );
-      }
-    }
-  }, [
-    redigerbart,
-    behandlingID,
-    aarsavregningID,
-    aarsavregningResponse?.nyttTrygdeavgiftsGrunnlag?.avgift.totalAvgift,
-    aarsavregningResponse?.avregning?.beregnetAvgiftBelop,
-  ]);
-
   const handleEndeligAvgiftValgChange = useCallback(
     (value: string) => {
       setEndrerEndeligAvgiftValg(true);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -224,10 +224,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         const currentFormState = mapFormState(getValues("skatteforholdsperioder"), getValues("inntektskilder"));
 
         if (!Utils._isEqual(currentFormState, previousFormValues)) {
-          /* eslint-disable-next-line no-console */
-          // console.log("[useEffect] currentFormState", currentFormState);
-          /* eslint-disable-next-line no-console */
-          // console.log("[useEffect] previousFormValues", previousFormValues);
           setDebouncedBeregningPagaar(true);
           debouncedBeregningRef.current();
         } else {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -251,23 +251,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     bestemmelse: bestemmelseFormState,
   });
 
-  useEffect(() => {
-    if (redigerbart && aarsavregningResponse?.nyttTrygdeavgiftsGrunnlag) {
-      if (
-        aarsavregningResponse.nyttTrygdeavgiftsGrunnlag?.avgift.totalAvgift !==
-        aarsavregningResponse.avregning?.beregnetAvgiftBelop
-      ) {
-        Api.Aarsavregning.oppdaterBeregnetAvgiftBeloep(
-          behandlingID,
-          aarsavregningID,
-          aarsavregningResponse?.nyttTrygdeavgiftsGrunnlag?.avgift.totalAvgift,
-        ).then((response: AarsavregningResponse) => {
-          setAarsavregningResponse(response);
-        });
-      }
-    }
-  }, [aarsavregningResponse?.nyttTrygdeavgiftsGrunnlag?.avgift.totalAvgift]);
-
   const lagreMedlemskapsperiodeHvisEndret = async (
     periode: Avgiftspliktigperiode,
     lagredePerioder: Avgiftspliktigperiode[],


### PR DESCRIPTION
Fjernet frontend-ansvar for oppdatering av beregnetAvgiftBelop

  ### Bakgrunn
  Backend setter nå `beregnetAvgiftBelop` automatisk ved trygdeavgiftsberegning (se backend-PR).
  Frontend trenger derfor ikke lenger sende et separat PUT-kall for å oppdatere denne verdien.

  ### Endringer
  - Fjernet useEffect-blokk i `aarsavregningMedGrunnlagForm.tsx` som kalte
    `Api.Aarsavregning.oppdaterBeregnetAvgiftBeloep` etter beregning
  - Fjernet tilsvarende useEffect-blokk i `aarsavregningUtenEllerDeltGrunnlagForm.tsx`
  - Fjernet utkommenterte console.log-statements

JIRA: https://jira.adeo.no/browse/MELOSYS-7878