### PR TITLE
NOJIRA G4P Opprydding av test-warnings og debug-logging

### DIFF
--- a/src/ducks/anmodningsperioder/operations.test.ts
+++ b/src/ducks/anmodningsperioder/operations.test.ts
@@ -62,7 +62,7 @@ describe("Anmodningsperioder operations", () => {
 
       mswServer.use(
         http.post("/api/anmodningsperioder/4", () => {
-          return new HttpResponse(null, { status: 500 });
+          return HttpResponse.json({ message: "Internal Server Error" }, { status: 500 });
         }),
       );
 

--- a/src/ducks/journalforing/operations.test.ts
+++ b/src/ducks/journalforing/operations.test.ts
@@ -42,7 +42,11 @@ describe("journalforing operations", () => {
 
       const journalpostID = "12345";
 
-      mswServer.use(http.get(`/api/journalforing/${journalpostID}`, () => new HttpResponse(null, { status: 500 })));
+      mswServer.use(
+        http.get(`/api/journalforing/${journalpostID}`, () =>
+          HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
+        ),
+      );
 
       const store = createTestStore(initialState);
 
@@ -480,15 +484,17 @@ describe("journalforing operations", () => {
 
     it("håndterer API-feil gracefully med .catch() fallbacks", async () => {
       mswServer.use(
-        http.get("/api/anmodningsperioder/:behandlingId", () => new HttpResponse(null, { status: 500 })),
-        http.get("/api/fagsaker/:saksnummer/trygdeavgift/oppsummering", () => new HttpResponse(null, { status: 500 })),
-        http.get(
-          "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
-          () => new HttpResponse(null, { status: 500 }),
+        http.get("/api/anmodningsperioder/:behandlingId", () =>
+          HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
         ),
-        http.get(
-          "/api/saksbehandling/:saksnummer/behandlingstyper/kombinasjoner-for-knytt-sak/",
-          () => new HttpResponse(null, { status: 500 }),
+        http.get("/api/fagsaker/:saksnummer/trygdeavgift/oppsummering", () =>
+          HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
+        ),
+        http.get("/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/", () =>
+          HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
+        ),
+        http.get("/api/saksbehandling/:saksnummer/behandlingstyper/kombinasjoner-for-knytt-sak/", () =>
+          HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
         ),
       );
 

--- a/src/ducks/journalforing/operations.test.ts
+++ b/src/ducks/journalforing/operations.test.ts
@@ -484,38 +484,43 @@ describe("journalforing operations", () => {
 
     it("håndterer API-feil gracefully med .catch() fallbacks", async () => {
       const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      mswServer.use(
-        http.get("/api/anmodningsperioder/:behandlingId", () =>
-          HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
-        ),
-        http.get("/api/fagsaker/:saksnummer/trygdeavgift/oppsummering", () =>
-          HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
-        ),
-        http.get("/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/", () =>
-          HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
-        ),
-        http.get("/api/saksbehandling/:saksnummer/behandlingstyper/kombinasjoner-for-knytt-sak/", () =>
-          HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
-        ),
-      );
+      try {
+        mswServer.use(
+          http.get("/api/anmodningsperioder/:behandlingId", () =>
+            HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
+          ),
+          http.get("/api/fagsaker/:saksnummer/trygdeavgift/oppsummering", () =>
+            HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
+          ),
+          http.get("/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/", () =>
+            HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
+          ),
+          http.get("/api/saksbehandling/:saksnummer/behandlingstyper/kombinasjoner-for-knytt-sak/", () =>
+            HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
+          ),
+        );
 
-      const initialState: Partial<RootState> = {
-        form: {
-          testForm: {
-            values: {},
+        const initialState: Partial<RootState> = {
+          form: {
+            testForm: {
+              values: {},
+            },
           },
-        },
-      };
+        };
 
-      const store = createTestStore(initialState);
+        const store = createTestStore(initialState);
 
-      // Skal ikke kaste feil, men returnere fallback-verdier
-      const result = await store.dispatch(operations.prepareKnyttTilSakForm(baseSak, false, "BRUKER", feltNavn) as any);
+        // Skal ikke kaste feil, men returnere fallback-verdier
+        const result = await store.dispatch(
+          operations.prepareKnyttTilSakForm(baseSak, false, "BRUKER", feltNavn) as any,
+        );
 
-      expect(result.muligeBehandlingstemaer).toEqual([]);
-      expect(result.muligeBehandlingstyper).toEqual([]);
-      expect(result.harBehandlingMedTrygdeavgift).toBe(false);
-      consoleErrorSpy.mockRestore();
+        expect(result.muligeBehandlingstemaer).toEqual([]);
+        expect(result.muligeBehandlingstyper).toEqual([]);
+        expect(result.harBehandlingMedTrygdeavgift).toBe(false);
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
     });
 
     it("returnerer harBehandlingMedTrygdeavgift=true når sak har trygdeavgift", async () => {

--- a/src/ducks/journalforing/operations.test.ts
+++ b/src/ducks/journalforing/operations.test.ts
@@ -483,6 +483,7 @@ describe("journalforing operations", () => {
     });
 
     it("håndterer API-feil gracefully med .catch() fallbacks", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       mswServer.use(
         http.get("/api/anmodningsperioder/:behandlingId", () =>
           HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
@@ -514,6 +515,7 @@ describe("journalforing operations", () => {
       expect(result.muligeBehandlingstemaer).toEqual([]);
       expect(result.muligeBehandlingstyper).toEqual([]);
       expect(result.harBehandlingMedTrygdeavgift).toBe(false);
+      consoleErrorSpy.mockRestore();
     });
 
     it("returnerer harBehandlingMedTrygdeavgift=true når sak har trygdeavgift", async () => {

--- a/src/ducks/lovvalgsperioder/operations.test.ts
+++ b/src/ducks/lovvalgsperioder/operations.test.ts
@@ -129,7 +129,7 @@ describe("Lovvalgsperioder operations", () => {
 
       mswServer.use(
         http.post("/api/lovvalgsperioder/4", () => {
-          return new HttpResponse(null, { status: 500 });
+          return HttpResponse.json({ message: "Internal Server Error" }, { status: 500 });
         }),
       );
 

--- a/src/ducks/mottatteOpplysninger/operations.test.ts
+++ b/src/ducks/mottatteOpplysninger/operations.test.ts
@@ -71,20 +71,6 @@ interface TestState {
 describe("MottatteOpplysninger operations", () => {
   let initialState: TestState;
 
-  const fellesFelt = {
-    juridiskArbeidsgiverNorge: {},
-    personOpplysninger: {},
-    foretakUtland: {},
-    oppholdUtland: {},
-    bosted: {},
-    selvstendigArbeid: {},
-    soeknadsland: {},
-    periode: {},
-    arbeidPaaLand: {},
-    maritimtArbeid: [],
-    luftfartBaser: [],
-  };
-
   beforeEach(() => {
     initialState = {
       form: {
@@ -151,9 +137,7 @@ describe("MottatteOpplysninger operations", () => {
         MKV.Koder.mottatteopplysningertyper.SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS;
 
       mswServer.use(
-        http.post("/api/mottatteopplysninger/:behandlingId", async ({ request, params }) => {
-          const body = await request.json();
-          // Kan verifisere request body her hvis nødvendig
+        http.post("/api/mottatteopplysninger/:behandlingId", () => {
           return HttpResponse.json({});
         }),
       );
@@ -221,7 +205,9 @@ describe("MottatteOpplysninger operations", () => {
 
     it("lager FEILET ved feil i api-kall", async () => {
       mswServer.use(
-        http.post("/api/mottatteopplysninger/:behandlingId", () => new HttpResponse(null, { status: 500 })),
+        http.post("/api/mottatteopplysninger/:behandlingId", () =>
+          HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
+        ),
       );
 
       const store = createTestStore(initialState);

--- a/src/ducks/utpekingsperioder/operations.test.ts
+++ b/src/ducks/utpekingsperioder/operations.test.ts
@@ -83,7 +83,7 @@ describe("utpekingsperioder operations", () => {
 
       mswServer.use(
         http.post("/api/utpekingsperioder/4", () => {
-          return new HttpResponse(null, { status: 500 });
+          return HttpResponse.json({ message: "Internal Server Error" }, { status: 500 });
         }),
       );
 

--- a/src/ducks/vilkar/operations.test.ts
+++ b/src/ducks/vilkar/operations.test.ts
@@ -61,7 +61,7 @@ describe("vilkar operations", () => {
 
       mswServer.use(
         http.get(`/api/vilkaar/${behandlingID}`, () => {
-          return new HttpResponse(null, { status: 500 });
+          return HttpResponse.json({ message: "Internal Server Error" }, { status: 500 });
         }),
       );
 
@@ -103,7 +103,7 @@ describe("vilkar operations", () => {
 
       mswServer.use(
         http.post("/api/vilkaar/4", () => {
-          return new HttpResponse(null, { status: 500 });
+          return HttpResponse.json({ message: "Internal Server Error" }, { status: 500 });
         }),
       );
 

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/representantIUtlandet/redigeringUtfort.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/representantIUtlandet/redigeringUtfort.test.tsx
@@ -15,8 +15,9 @@ vi.mock("../../../../../melosyskodeverk", () => ({
   default: { KTObjects: { land_iso2: [] } },
 }));
 
+let uuidCounter = 0;
 vi.mock("../../../../../utils", () => ({
-  _uuid: () => "mock-uuid",
+  _uuid: () => `mock-uuid-${++uuidCounter}`,
 }));
 
 import RedigeringUtfort from "./redigeringUtfort";

--- a/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmer/tables/barnTable.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmer/tables/barnTable.test.tsx
@@ -11,8 +11,9 @@ vi.mock("../../../../../../navFrontend", () => ({
   }),
 }));
 
+let uuidCounter = 0;
 vi.mock("../../../../../../utils", () => ({
-  _uuid: () => "mock-uuid",
+  _uuid: () => `mock-uuid-${++uuidCounter}`,
 }));
 
 vi.mock("../../../../../../utils/streng", () => ({

--- a/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmer/tables/ektefelleTable.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/familieforhold/familiemedlemmer/tables/ektefelleTable.test.tsx
@@ -11,8 +11,9 @@ vi.mock("../../../../../../navFrontend", () => ({
   }),
 }));
 
+let uuidCounter = 0;
 vi.mock("../../../../../../utils", () => ({
-  _uuid: () => "mock-uuid",
+  _uuid: () => `mock-uuid-${++uuidCounter}`,
   dato: { formatterDatoTilNorsk: (d: string) => d ?? "" },
 }));
 

--- a/src/felleskomponenter/menypanel/menypunkter/familieforhold/medfolgendeFamilie/redigeringUtfort.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/familieforhold/medfolgendeFamilie/redigeringUtfort.test.tsx
@@ -19,7 +19,8 @@ vi.mock("../../../../../navFrontend", () => ({
 }));
 
 vi.mock("../../../../../kodeverk", () => ({ Form: {} }));
-vi.mock("../../../../../utils", () => ({ _uuid: () => "mock-uuid" }));
+let uuidCounter = 0;
+vi.mock("../../../../../utils", () => ({ _uuid: () => `mock-uuid-${++uuidCounter}` }));
 
 import RedigeringUtfort from "./redigeringUtfort";
 

--- a/src/felleskomponenter/menypanel/menypunkter/fullmektig/fullmektigHistorikk.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/fullmektig/fullmektigHistorikk.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import MKV from "../../../../melosyskodeverk";
 
 vi.mock("react-redux", () => ({
@@ -9,6 +9,8 @@ vi.mock("react-redux", () => ({
 vi.mock("../../../../ducks/fagsaker", () => ({
   fagsakSelectors: { SaksnummerSelector: () => "SAK123" },
 }));
+
+import { hentFullmektigHistorikk } from "../../../../services/modules/fagsaker/fagsak";
 
 vi.mock("../../../../services/modules/fagsaker/fagsak", () => ({
   hentFullmektigHistorikk: vi.fn(() => Promise.resolve([])),
@@ -43,16 +45,22 @@ describe("FullmektigHistorikk", () => {
     finnPersonAdresse: vi.fn(),
   };
 
-  it("rendrer tabellheader med kolonner", () => {
+  it("rendrer tabellheader med kolonner", async () => {
     render(<FullmektigHistorikk {...defaultProps} />);
     expect(screen.getByText("Registrert fra")).toBeDefined();
     expect(screen.getByText("Registrert til")).toBeDefined();
     expect(screen.getByText("Fullmakt")).toBeDefined();
     expect(screen.getByText("Fullmektig Org.nr./F.nr.")).toBeDefined();
+    await waitFor(() => {
+      expect(hentFullmektigHistorikk).toHaveBeenCalled();
+    });
   });
 
-  it("rendrer tom tabell når ingen historikk", () => {
+  it("rendrer tom tabell når ingen historikk", async () => {
     const { container } = render(<FullmektigHistorikk {...defaultProps} />);
+    await waitFor(() => {
+      expect(hentFullmektigHistorikk).toHaveBeenCalled();
+    });
     const rows = container.querySelectorAll("tbody tr");
     expect(rows).toHaveLength(0);
   });

--- a/src/felleskomponenter/menypanel/menypunkter/fullmektig/fullmektigHistorikk.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/fullmektig/fullmektigHistorikk.test.tsx
@@ -45,6 +45,10 @@ describe("FullmektigHistorikk", () => {
     finnPersonAdresse: vi.fn(),
   };
 
+  beforeEach(() => {
+    vi.mocked(hentFullmektigHistorikk).mockClear();
+  });
+
   it("rendrer tabellheader med kolonner", async () => {
     render(<FullmektigHistorikk {...defaultProps} />);
     expect(screen.getByText("Registrert fra")).toBeDefined();

--- a/src/felleskomponenter/menypanel/menypunkter/medlemskap/medlemskapTable.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/medlemskap/medlemskapTable.test.tsx
@@ -11,8 +11,9 @@ vi.mock("../../../../navFrontend", () => ({
   }),
 }));
 
+let uuidCounter = 0;
 vi.mock("../../../../utils", () => ({
-  _uuid: () => "mock-uuid",
+  _uuid: () => `mock-uuid-${++uuidCounter}`,
   dato: { formatterDatoTilNorsk: (d: string) => d ?? "" },
 }));
 

--- a/src/felleskomponenter/sokkelskipliste/arbeidslandRadioButtons.test.tsx
+++ b/src/felleskomponenter/sokkelskipliste/arbeidslandRadioButtons.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
+let uuidCounter = 0;
 vi.mock("../../utils", () => ({
   _isEmpty: (val: any) => !val || val.length === 0,
-  _uuid: () => "mock-uuid",
+  _uuid: () => `mock-uuid-${++uuidCounter}`,
 }));
 
 vi.mock("../../navFrontend", () => ({

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -148,8 +148,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
   );
 
   const debouncedBeregning = useCallback(() => {
-    /* eslint-disable-next-line no-console */
-    console.log("[debouncedBeregning] debouncedBeregningPagaar set false", debouncedBeregningPagaar);
     setDebouncedBeregningPagaar(false);
     if (
       !redigerbart ||
@@ -224,10 +222,6 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         const currentFormState = mapFormState(getValues("skatteforholdsperioder"), getValues("inntektskilder"));
 
         if (!Utils._isEqual(currentFormState, previousFormValues)) {
-          /* eslint-disable-next-line no-console */
-          // console.log("[useEffect] currentFormState", currentFormState);
-          /* eslint-disable-next-line no-console */
-          // console.log("[useEffect] previousFormValues", previousFormValues);
           setDebouncedBeregningPagaar(true);
           debouncedBeregningRef.current();
         } else {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
@@ -31,14 +31,6 @@ const dekkerHeleMedlemskapsperiode = (perioder: any[], medlemskapsperiode: any):
     })
     .reduce((max, current) => Math.max(max, current), -Infinity);
 
-  /* eslint-disable-next-line no-console */
-  console.log("[dekkerHeleMedlemskapsperiode] min max", {
-    minFomDato,
-    maxTomDato,
-    medlemskapsperiodeFom,
-    medlemskapsperiodeTom,
-  });
-
   // Dekning
   const medlemskapsperiodeFomDate = Utils.dato.isoStringTilDate(medlemskapsperiodeFom);
   if (!medlemskapsperiodeFomDate || minFomDato === Infinity || minFomDato !== medlemskapsperiodeFomDate.getTime()) {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -45,28 +45,12 @@ import { Feilmelding, finnAktivFeilmelding, finnAktivFeilmeldingForMedlemskapspe
 
 const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
-const LOGS_ENABLED = false; // Sett til true hvis du ønsker logging på useEffects etc.
-
-const consoleLog = (message: string, ...args: unknown[]) => {
-  if (!LOGS_ENABLED) return;
-  if (args.length === 0) {
-    // eslint-disable-next-line no-console
-    console.log(`[AarsavregningUtenEllerDeltGrunnlagForm] ${message}`);
-  } else {
-    // eslint-disable-next-line no-console
-    console.log(`[AarsavregningUtenEllerDeltGrunnlagForm] ${message}`, ...args);
-  }
-};
-
-// Hjelpefunksjon for å logge og returnere endrede avhengigheter
 const getChangedDependencies = (
   currentDeps: Record<string, unknown>,
   previousDepsRef: React.MutableRefObject<Record<string, unknown> | null>,
-  consoleLogCallback: (message: string, ...args: unknown[]) => void,
 ) => {
   const changedDeps: Record<string, { prev: unknown; curr: unknown }> = {};
   if (previousDepsRef.current) {
-    // Sammenlign nåværende avhengigheter med tidligere
     Object.keys(currentDeps).forEach((key) => {
       if (
         previousDepsRef.current &&
@@ -78,20 +62,10 @@ const getChangedDependencies = (
         };
       }
     });
-    // Logg kun hvis det er endrede avhengigheter
-    if (Object.keys(changedDeps).length > 0) {
-      consoleLogCallback("[getChangedDependencies] Endrede avhengigheter", changedDeps);
-    } else {
-      consoleLogCallback("[getChangedDependencies] Ingen endrede avhengigheter?!");
-    }
-  } else {
-    // Logg alle avhengigheter ved første kjøring
-    consoleLogCallback("[getChangedDependencies] Første kjøring avhengigheter", currentDeps);
   }
 
-  // Oppdater forrige avhengigheter ref
   previousDepsRef.current = currentDeps;
-  return changedDeps; // Returner de endrede avhengighetene
+  return changedDeps;
 };
 
 export function AarsavregningUtenEllerDeltGrunnlagForm({
@@ -204,10 +178,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       .filter((periode: Avgiftspliktigperiode) => periode.fomDato && periode.tomDato)
       .sort(Utils.dato.sorterEtterNorskFomDato);
     const medlemskapsperiodeFomTom = hentMedlemskapsFomTomDato(sorterteGyldigePerioder);
-
-    consoleLog("[finnMedlemskapsperiode] medlemskapsperiodeFomTom", medlemskapsperiodeFomTom);
-    consoleLog("[finnMedlemskapsperiode] sorterteGyldigePerioder", sorterteGyldigePerioder);
-    consoleLog("[finnMedlemskapsperiode] perioder", perioder);
 
     return {
       fomDato: Utils.dato.vaskOgFormatterDatoTilNorsk(medlemskapsperiodeFomTom?.fom),
@@ -324,7 +294,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   );
 
   const debouncedBeregning = useCallback(() => {
-    consoleLog("[debouncedBeregning] setter debouncedBeregningPagaar til false");
     setDebouncedBeregningPagaar(false);
     if (
       !redigerbart ||
@@ -334,7 +303,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       lagreMedlemskapsperioderPaagar ||
       endeligAvgiftValg !== OPPLYSNINGER_ENDRET
     ) {
-      consoleLog("[debouncedBeregning] return tidlig i debouncedBeregning");
       return;
     }
 
@@ -349,8 +317,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     );
     const medlemskapsperiodeFomTom = finnMedlemskapsperiode(medlemskapsperioderFormState);
 
-    consoleLog("[debouncedBeregning] medlemskapsperiodeFomTom", medlemskapsperiodeFomTom);
-
     if (!Utils._isEqual(formState, previousFormState)) {
       const aktivFeilmelding = finnAktivFeilmelding({
         skatteforholdsperioder: formState.skatteforholdsperioder,
@@ -360,13 +326,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         medlemskapstypeErPliktig,
       });
 
-      consoleLog("[debouncedBeregning] Aktive feilmeldinger", aktivFeilmelding, {
-        skatteforholdsperioder: formState.skatteforholdsperioder,
-        inntektskilder: formState.inntektskilder,
-        medlemskapsperiodeFomTom,
-        medlemskapsperioder: medlemskapsperioderFormState as Avgiftspliktigperiode[],
-        medlemskapstypeErPliktig,
-      });
       if (!aktivFeilmelding) {
         setArrayValideringsfeil(undefined);
         setBeregningPaagar(true);
@@ -381,8 +340,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         setArrayValideringsfeil(aktivFeilmelding);
       }
     }
-
-    consoleLog("[debouncedBeregning] ferdig");
   }, [
     aarsavregningID,
     beregningPaagar,
@@ -429,8 +386,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
           }
           return periode;
         });
-
-        consoleLog("[lagreMedlemskapsperioder] oppdaterteMedlemskapsperioder", oppdaterteMedlemskapsperioder);
 
         setLagredeMedlemskapsperioder(oppdaterteMedlemskapsperioder);
         setValue("medlemskapsperioder", oppdaterteMedlemskapsperioder);
@@ -510,12 +465,9 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
           return;
         }
 
-        consoleLog("[lagreMedlemskapsperioderEffect] setter lagrerMedlemskapsperioder til true");
         setLagreMedlemskapsperioderPaagar(true);
         const medlemskapsperioderTilLagring = [...medlemskapsperioder];
-        consoleLog("[lagreMedlemskapsperioderEffect] medlemskapsperioderTilLagring", medlemskapsperioderTilLagring);
         debouncedLagreMedlemskapsperioder(medlemskapsperioderTilLagring, () => {
-          consoleLog("[lagreMedlemskapsperioderEffect] Setter lagrerMedlemskapsperioder til false");
           setLagreMedlemskapsperioderPaagar(false);
         });
       }
@@ -615,16 +567,10 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     setDebouncedBeregningPagaar(false);
     debouncedBeregningRef.current = Utils._debounce(debouncedBeregning, 600);
 
-    consoleLog("[useEffect debouncedBeregning] Lager en ny debounce funksjon når beregning callback endres");
-
     // Cancel på unmount
     return () => {
       if (debouncedBeregningRef.current?.cancel) {
         setDebouncedBeregningPagaar(false);
-
-        consoleLog(
-          "[useEffect debouncedBeregning] Avbryter eventuelt eksisterende beregning for å sette opp ny debounce funksjon.",
-        );
         debouncedBeregningRef.current.cancel();
       }
     };
@@ -657,28 +603,15 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       errors,
     };
 
-    // Get the changed dependencies
-    const changedDependencies = getChangedDependencies(currentDeps, previousDepsRef, consoleLog);
+    const changedDependencies = getChangedDependencies(currentDeps, previousDepsRef);
     const medlemskapsperiodeEndret = Object.keys(changedDependencies).includes("medlemskapsperiode");
 
-    // Avbryter hvis vi allerede har en beregning som venter
     if (debouncedBeregningRef.current?.cancel && Object.keys(changedDependencies).length > 0) {
       setDebouncedBeregningPagaar(false);
-
-      consoleLog("[useEffect hovedberegning] Avbryter eventuelt eksisterende beregning.", {
-        beregningPaagar,
-        lagreMedlemskapsperioderPaagar,
-        debouncedBeregningPagaar,
-      });
       debouncedBeregningRef.current.cancel();
     }
 
     if (medlemskapsperiodeEndret || Object.keys(changedDependencies).length === 0 || lagreMedlemskapsperioderPaagar) {
-      consoleLog("[useEffect hovedberegning] Avbryter useEffect uten å gjøre noe.", {
-        medlemskapsperiodeEndret,
-        changedDependencies,
-        lagreMedlemskapsperioderPaagar,
-      });
       return;
     }
 
@@ -693,17 +626,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       );
 
       if (!redigerbart || !aarsavregningID || endrerBestemmelse || beregningPaagar || lagreMedlemskapsperioderPaagar) {
-        consoleLog(
-          "[useEffect hovedberegning] return tidlig i fordi redigerbart, aarsavregningID, endrerBestemmelse, lagreMedlemskapsperioderPaagar",
-          {
-            redigerbart,
-            aarsavregningID,
-            endrerBestemmelse,
-            lagreMedlemskapsperioderPaagar,
-            beregningPaagar,
-            debouncedBeregningPagaar,
-          },
-        );
         return;
       }
 
@@ -718,21 +640,13 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
             return;
           }
           setDebouncedBeregningPagaar(true);
-          consoleLog("[useEffect hovedberegning] sette debouncedBeregningPaagar true");
           if (debouncedBeregningRef.current) {
             debouncedBeregningRef.current();
           }
         });
       } else {
         setArrayValideringsfeil(undefined);
-
-        consoleLog("[useEffect hovedberegning] Clear arrayValideringsfeil", {
-          currentFormState,
-          previousFormState,
-        });
       }
-    } else {
-      consoleLog("[useEffect hovedberegning] debouncedBeregningRef.current er undefined");
     }
   }, [
     skatteforholdsperioder,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
@@ -19,8 +19,6 @@ const harOppholdsperioder = (perioder: any[]) => {
   }
 
   const sortedPerioder = perioder.sort(Utils.dato.sorterEtterISOFomDato);
-  /* eslint-disable-next-line no-console */
-  console.log("[harOppholdsperioder] sortedPerioder", sortedPerioder);
 
   for (let i = 0; i < sortedPerioder.length - 1; i++) {
     const currentTom = sortedPerioder[i].tomDato;
@@ -95,8 +93,6 @@ const ingenOverlappendePerioder = (perioder: any[]): boolean => {
 
   try {
     const sortedPerioder = perioder.sort(Utils.dato.sorterEtterISOFomDato);
-    /* eslint-disable-next-line no-console */
-    console.log("[ingenOverlappendePerioder] sortedPerioder", sortedPerioder);
 
     // Check for overlapping periods
     for (let i = 0; i < sortedPerioder.length - 1; i++) {
@@ -181,24 +177,14 @@ export function finnAktivFeilmelding({
   if (
     !dekkerHeleMedlemskapsperiode(vaskedeSkatteforholdsperioder, medlemskapsperiodeFomTomIsoFormat, "skatteforhold")
   ) {
-    /* eslint-disable-next-line no-console */
-    console.log(
-      "[finnAktivFeilmelding] dekkerHeleMedlemskapsperiode",
-      vaskedeSkatteforholdsperioder,
-      vaskedeMedlemskapsperioder,
-    );
     return TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN;
   }
 
   if (!ingenOverlappendePerioder(vaskedeSkatteforholdsperioder)) {
-    /* eslint-disable-next-line no-console */
-    console.log("[finnAktivFeilmelding] ingenOverlappendePerioder", vaskedeSkatteforholdsperioder);
     return TypeFeilmelding.OVERLAPPENDE_SKATTEFORHOLDSPERIODER;
   }
 
   if (!ikkeAlleSammeSkatteforholdstyper(vaskedeSkatteforholdsperioder)) {
-    /* eslint-disable-next-line no-console */
-    console.log("[finnAktivFeilmelding] ikkeAlleSammeSkatteforholdstyper", vaskedeSkatteforholdsperioder);
     return TypeFeilmelding.LIKE_SKATTEPLIKTTYPER;
   }
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
@@ -75,10 +75,6 @@ const dekkerHeleMedlemskapsperiode = (
     );
 
     if (!minFomDato || minFomDato !== medlemskapsperiodeFom || !maxTomDato || maxTomDato !== medlemskapsperiodeTom) {
-      /* eslint-disable-next-line no-console */
-      console.log(
-        `[dekkerHeleMedlemskapsperiode, ${type}] Datoer dekker ikke. MinFom: ${minFomDato} (Skal være: ${medlemskapsperiodeFom}), MaxTom: ${maxTomDato} (Skal være: ${medlemskapsperiodeTom})`,
-      );
       return false;
     }
 

--- a/src/sider/vurderingTrygdeavgift/vurderingTrygdeavgift.test.tsx
+++ b/src/sider/vurderingTrygdeavgift/vurderingTrygdeavgift.test.tsx
@@ -131,19 +131,25 @@ describe("VurderingTrygdeavgift", () => {
   });
 
   describe("rendering", () => {
-    it("rendrer ingenting når steget ikke er aktivt", () => {
+    it("rendrer ingenting når steget ikke er aktivt", async () => {
       const { container } = renderComponent({}, { aktivtSteg: false });
 
       expect(container.firstChild).toBeNull();
+      await waitFor(() => {
+        expect(Api.Trygdeavgift.hentBeregnetTrygdeavgift).toHaveBeenCalled();
+      });
     });
 
-    it("viser heading når steget er aktivt", () => {
+    it("viser heading når steget er aktivt", async () => {
       renderComponent();
 
       expect(screen.getByRole("heading", { name: "Trygdeavgift" })).toBeInTheDocument();
+      await waitFor(() => {
+        expect(Api.Trygdeavgift.hentBeregnetTrygdeavgift).toHaveBeenCalled();
+      });
     });
 
-    it("viser info når medlemskapsperioden mangler sluttdato", () => {
+    it("viser info når medlemskapsperioden mangler sluttdato", async () => {
       renderComponent({
         medlemskapsperioder: [createMockMedlemskapsperiode({ tomDato: undefined })],
         redigerbart: false,
@@ -152,11 +158,14 @@ describe("VurderingTrygdeavgift", () => {
       expect(
         screen.getByText(/Trygdeavgift kan ikke beregnes for medlemskapsperiode uten sluttdato/),
       ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(Api.Trygdeavgift.hentBeregnetTrygdeavgift).toHaveBeenCalled();
+      });
     });
   });
 
   describe("feature toggles", () => {
-    it("viser advarsel når tidligere år skal skjules", () => {
+    it("viser advarsel når tidligere år skal skjules", async () => {
       vi.mocked(useFeatureToggle).mockImplementation(
         (toggle) => toggle === MELOSYS_FAKTURERINGSKOMPONENTEN_IKKE_TIDLIGERE_PERIODER,
       );
@@ -166,6 +175,9 @@ describe("VurderingTrygdeavgift", () => {
       });
 
       expect(screen.getByText(/Trygdeavgift for tidligere år skal fastsettes på årsavregning/)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(Api.Trygdeavgift.hentBeregnetTrygdeavgift).toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -35,7 +35,7 @@ export const handlers = [
   http.get("/api/behandlinger/:id", ({ params }) => {
     const { id } = params;
     if (id === "undefined") {
-      return new HttpResponse(null, { status: 404 });
+      return HttpResponse.json({ message: "Not Found" }, { status: 404 });
     }
     return HttpResponse.json({
       behandlingID: id,
@@ -48,7 +48,7 @@ export const handlers = [
   http.get("/api/behandlinger/:id/resultat", ({ params }) => {
     const { id } = params;
     if (id === "undefined") {
-      return new HttpResponse(null, { status: 404 });
+      return HttpResponse.json({ message: "Not Found" }, { status: 404 });
     }
     return HttpResponse.json({
       behandlingsresultatType: "",
@@ -64,7 +64,7 @@ export const handlers = [
   http.get("/api/lovvalgsperioder/:id", ({ params }) => {
     const { id } = params;
     if (id === "undefined" || id === "-1") {
-      return new HttpResponse(null, { status: 404 });
+      return HttpResponse.json({ message: "Not Found" }, { status: 404 });
     }
     return HttpResponse.json({
       id,
@@ -78,7 +78,7 @@ export const handlers = [
   http.get("/api/mottatteopplysninger/:id", ({ params }) => {
     const { id } = params;
     if (id === "undefined") {
-      return new HttpResponse(null, { status: 404 });
+      return HttpResponse.json({ message: "Not Found" }, { status: 404 });
     }
     return HttpResponse.json({
       brukerID: "12345678901",

--- a/src/yup/lagYupToReduxformErrorMapper.test.ts
+++ b/src/yup/lagYupToReduxformErrorMapper.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { mixed, object, string } from "yup";
 
 import { lagYupToReduxformErrorMapper } from "./lagYupToReduxformErrorMapper";
@@ -44,6 +44,7 @@ describe("lagYupToReduxformErrorMapper", () => {
     });
 
     it("obfuskerer ikke errors som ikke er valideringsfeil(error.inner er undefined)", () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const schema = mixed();
       schema.validateSync = () => {
         throw new Error("Feil");
@@ -53,6 +54,7 @@ describe("lagYupToReduxformErrorMapper", () => {
       expect(() => {
         mapYupToReduxformError({});
       }).toThrowError(new Error("Feil"));
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/src/yup/lagYupToReduxformErrorMapper.test.ts
+++ b/src/yup/lagYupToReduxformErrorMapper.test.ts
@@ -45,16 +45,19 @@ describe("lagYupToReduxformErrorMapper", () => {
 
     it("obfuskerer ikke errors som ikke er valideringsfeil(error.inner er undefined)", () => {
       const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const schema = mixed();
-      schema.validateSync = () => {
-        throw new Error("Feil");
-      };
-      const mapYupToReduxformError = lagYupToReduxformErrorMapper(schema);
+      try {
+        const schema = mixed();
+        schema.validateSync = () => {
+          throw new Error("Feil");
+        };
+        const mapYupToReduxformError = lagYupToReduxformErrorMapper(schema);
 
-      expect(() => {
-        mapYupToReduxformError({});
-      }).toThrowError(new Error("Feil"));
-      consoleErrorSpy.mockRestore();
+        expect(() => {
+          mapYupToReduxformError({});
+        }).toThrowError(new Error("Feil"));
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
  ## Sammendrag                                                                                                                                                                                                                                                                                                           
  Fjernet støy fra testkjøring: SyntaxError, act()-warnings, duplicate key-warnings,
  uønsket console-output og ~120 linjer debug-logging fra produksjonskode.
  Ingen funksjonell endring.           
                                                                                                                                                                                                                                                                                                                          
  ## Endringer                         
                                                                                                                                                                                                                                                                                                                          
  ### Test/mock-fiks (13 filer)                         
  - Erstattet `HttpResponse(null)` med `HttpResponse.json()` i 10 MSW-mocker
    for å unngå SyntaxError ved JSON-parsing av tom body
  - Lagt til `waitFor` i VurderingTrygdeavgift (4) og FullmektigHistorikk (2)                                                                                                                                                                                                                                             
    tester for å fjerne act()-warnings
  - UUID-mock returnerer nå unike verdier for å unngå React duplicate key-warnings (6 filer)                                                                                                                                                                                                                              
  - Suppressed forventet console.error i journalforing- og Yup-tester
  - Fjernet ubrukte variabler i mottatteOpplysninger/operations.test.ts

  ### Debug-logging fjernet (4 filer)
  - Fjernet `LOGS_ENABLED`, `consoleLog()` wrapper og ~25 kall i
    aarsavregningUtenEllerDeltGrunnlagForm.tsx (-86 linjer)
  - Forenklet `getChangedDependencies()` (beholdt sammenligningslogikk,
    fjernet logging-parameter)
  - Fjernet console.log fra aarsavregningMedGrunnlagForm.tsx og
    begge valideringsfeil.tsx