### PR TITLE
7878 Fiks race condition i årsavregning differansevisning

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -383,6 +383,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
         !feilmelding &&
         !arrayValideringsfeil &&
         aarsavregningResponse?.avregning &&
+        aarsavregningResponse?.nyttTrygdeavgiftsGrunnlag &&
         endeligAvgiftValg === OPPLYSNINGER_ENDRET && (
           <SumArsavregningTabell
             nyTrygdeavgift={aarsavregningResponse.avregning.beregnetAvgiftBelop}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -874,7 +874,8 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         !debouncedBeregningPagaar &&
         !arrayValideringsfeil &&
         !feilmelding &&
-        endeligAvgiftValg === OPPLYSNINGER_ENDRET && (
+        endeligAvgiftValg === OPPLYSNINGER_ENDRET &&
+        aarsavregningResponse?.nyttTrygdeavgiftsGrunnlag && (
           <SumArsavregningTabell
             harGrunnlagIMelosys={harTidligereTrygdeavgiftsgrunnlag}
             nyTrygdeavgift={aarsavregningResponse?.avregning?.beregnetAvgiftBelop}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
@@ -97,10 +97,10 @@ export function beregnTrygdeavgiftsperioder(
       : [],
   })
     .then(() => {
-      Api.Aarsavregning.hentAarsavregning(behandlingID).then((response: AarsavregningResponse) => {
+      setFeilmelding(undefined);
+      return Api.Aarsavregning.hentAarsavregning(behandlingID).then((response: AarsavregningResponse) => {
         setAarsavregningResponse(response);
       });
-      setFeilmelding(undefined);
     })
     .catch((error) => setFeilmelding(mapFeilmelding(error)));
 }


### PR DESCRIPTION
Fikser at SumArsavregningTabell viste feil differanse ved årsavregning på årsavregning.

Backend-fiksen (#3004) sørget for at beregnetAvgiftBelop settes i samme transaksjon
som beregningen, men frontend hadde to problemer som fortsatt ga feil visning:
promise-kjeden i beregnTrygdeavgiftsperioder ventet ikke på hentAarsavregning,
og tabellen ble vist før beregning var utført.
[MELOSYS-7878](https://jira.adeo.no/browse/MELOSYS-7878)

- Returnerer hentAarsavregning-promise slik at beregningPaagar venter på oppdatert data
- Krever nyttTrygdeavgiftsGrunnlag for å vise SumArsavregningTabell i begge form-varianter

### Testing
- [x] Enhetstester (3162 tester, 0 failures)
- [x] TypeScript-sjekk
- [x] Manuell testing lokalt (reprodusert på master, verifisert fiks på branch)