### PR TITLE
NOJIRA-G4P-fix-for-pw-tester

### DIFF
--- a/src/sider/aarsavregning/saksbehandling.tsx
+++ b/src/sider/aarsavregning/saksbehandling.tsx
@@ -72,7 +72,7 @@ function Saksbehandling({ match, location }: Props) {
     try {
       const behandlingId = Utils._toInteger(behandlingIDFraParam);
       setBehandlingID(behandlingId);
-      dispatch(fagsakOperations.hent(saksnr));
+      await dispatch(fagsakOperations.hent(saksnr));
       const response = await dispatch(behandlingerOperations.hentBehandling(behandlingId));
       const behandling = response.data;
       if (!behandling) return false;

--- a/tests/e2e/recordings/specs/avslutt-behandling/avslutt-avtaleland-behandling/opprett-og-avslutt-avtaleland-sak-verifiser-redirect-til-hovedside.json
+++ b/tests/e2e/recordings/specs/avslutt-behandling/avslutt-avtaleland-behandling/opprett-og-avslutt-avtaleland-sak-verifiser-redirect-til-hovedside.json
@@ -294,11 +294,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -322,7 +322,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/avslutt-behandling/avslutt-ftrl-behandling/opprett-og-avslutt-utenfor-avtaleland-sak-for-a-sikre-full-avslutning.json
+++ b/tests/e2e/recordings/specs/avslutt-behandling/avslutt-ftrl-behandling/opprett-og-avslutt-utenfor-avtaleland-sak-for-a-sikre-full-avslutning.json
@@ -350,11 +350,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -378,7 +378,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/avslutt-behandling/avslutt-ftrl-behandling/opprett-og-avslutt-utenfor-avtaleland-sak-verifiser-redirect-til-hovedside.json
+++ b/tests/e2e/recordings/specs/avslutt-behandling/avslutt-ftrl-behandling/opprett-og-avslutt-utenfor-avtaleland-sak-verifiser-redirect-til-hovedside.json
@@ -350,11 +350,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -378,7 +378,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/basic/hovedside-søk/sok-etter-gyldig-id-og-verifiser-resultater.json
+++ b/tests/e2e/recordings/specs/basic/hovedside-søk/sok-etter-gyldig-id-og-verifiser-resultater.json
@@ -7,11 +7,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "2",
               "prioritet": "NORM",
@@ -1128,13 +1129,19 @@
                 "kode": "MEDLEMSKAP_LOVVALG",
                 "term": "Medlemskap og lovvalg"
               },
-              "land": null,
-              "periode": null,
+              "land": {
+                "landkoder": [],
+                "flereLandUkjentHvilke": false
+              },
+              "periode": {
+                "fom": null,
+                "tom": null
+              },
               "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-1001\n",
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1175,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1216,7 +1223,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1257,7 +1264,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1298,7 +1305,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1339,7 +1346,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1380,7 +1387,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1421,7 +1428,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1462,7 +1469,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1503,7 +1510,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1544,7 +1551,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1585,7 +1592,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1626,7 +1633,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1667,7 +1674,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "16",
               "prioritet": "NORM",
@@ -1708,7 +1715,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "17",
               "prioritet": "NORM",
@@ -1749,7 +1756,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1790,7 +1797,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1831,7 +1838,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1872,7 +1879,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1913,7 +1920,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1954,7 +1961,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1995,7 +2002,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2036,7 +2043,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2077,7 +2084,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2118,7 +2125,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2159,7 +2166,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2200,7 +2207,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2241,7 +2248,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2282,7 +2289,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2323,7 +2330,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2364,7 +2371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2405,7 +2412,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2446,7 +2453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2487,7 +2494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2528,7 +2535,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2569,7 +2576,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2610,7 +2617,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2651,7 +2658,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2692,7 +2699,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2733,7 +2740,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2774,7 +2781,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2815,7 +2822,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2856,7 +2863,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2897,7 +2904,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2938,7 +2945,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -2979,7 +2986,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3020,7 +3027,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3061,7 +3068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3102,7 +3109,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3143,7 +3150,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3184,7 +3191,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3225,7 +3232,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3266,7 +3273,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3307,7 +3314,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3348,7 +3355,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3389,7 +3396,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3430,7 +3437,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3471,7 +3478,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3512,7 +3519,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3553,7 +3560,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3594,7 +3601,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3635,7 +3642,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3676,7 +3683,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/basic/hovedside-søk/sok-etter-ugyldig-id-og-verifiser-feilmelding.json
+++ b/tests/e2e/recordings/specs/basic/hovedside-søk/sok-etter-ugyldig-id-og-verifiser-feilmelding.json
@@ -7,11 +7,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/basic/hovedside/hovedsiden-lastes-korrekt-og-viser-forventede-seksjoner.json
+++ b/tests/e2e/recordings/specs/basic/hovedside/hovedsiden-lastes-korrekt-og-viser-forventede-seksjoner.json
@@ -1,17 +1,17 @@
 {
   "version": "1.0",
   "recordedAt": "2025-01-01T00:00:00.000Z",
-  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web/tests/e2e/specs/basic/hovedside.spec.ts",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web-2/tests/e2e/specs/basic/hovedside.spec.ts",
   "testName": "Hovedsiden lastes korrekt og viser forventede seksjoner",
   "exchanges": [
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/datepicker-skal-fungere-for-fra-dato-pa-ny-medlemskapsperiode.json
+++ b/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/datepicker-skal-fungere-for-fra-dato-pa-ny-medlemskapsperiode.json
@@ -316,7 +316,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -332,13 +332,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -434,7 +434,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -463,7 +463,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -492,7 +492,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -521,7 +521,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -550,7 +550,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -579,7 +579,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -608,7 +608,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -637,7 +637,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -666,7 +666,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -695,7 +695,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -724,7 +724,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -753,7 +753,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -782,7 +782,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -811,7 +811,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -840,7 +840,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -869,7 +869,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -898,7 +898,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -927,7 +927,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1148,11 +1148,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1176,7 +1176,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1865,7 +1866,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1888,7 +1889,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2010,7 +2011,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -2033,7 +2034,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2198,122 +2199,6 @@
           "authorization": "[REDACTED]"
         },
         "body": {
-          "operationName": "hentPersoninfo",
-          "variables": {
-            "behandlingID": 24
-          },
-          "query": "query hentPersoninfo($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      folkeregisterpersonstatuser {\n        kode\n        tekst\n        master\n        kilde\n        fregGyldighetstidspunkt\n        erHistorisk\n        __typename\n      }\n      foedsel {\n        foedeland\n        foedested\n        foedselsaar\n        foedselsdato\n        __typename\n      }\n      sivilstand {\n        type\n        relatertVedSivilstand\n        gyldigFraOgMed\n        bekreftelsesdato\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "folkeregisterpersonstatuser": [
-                  {
-                    "kode": "BOSATT",
-                    "tekst": "Bosatt etter folkeregisterloven",
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "1990-01-01",
-                    "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "MIDLERTIDIG",
-                    "tekst": "Midlertidig (D-nummer)",
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "2020-10-22",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "tekst": "Utflyttet",
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "2012-03-15",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  }
-                ],
-                "foedsel": {
-                  "foedeland": "NO",
-                  "foedested": "OSLO",
-                  "foedselsaar": 1969,
-                  "foedselsdato": "1969-05-30",
-                  "__typename": "Foedsel"
-                },
-                "sivilstand": [
-                  {
-                    "type": "Gift",
-                    "relatertVedSivilstand": "12028536819",
-                    "gyldigFraOgMed": "2011-02-02",
-                    "bekreftelsesdato": null,
-                    "master": "Freg",
-                    "kilde": "KILDE_DSF",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Gift",
-                    "relatertVedSivilstand": "21075114491",
-                    "gyldigFraOgMed": "2019-08-03",
-                    "bekreftelsesdato": null,
-                    "master": "Freg",
-                    "kilde": "FREG",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Separert",
-                    "relatertVedSivilstand": "12028536819",
-                    "gyldigFraOgMed": "2013-01-03",
-                    "bekreftelsesdato": null,
-                    "master": "NAV (PDL)",
-                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "relatertVedSivilstand": null,
-                    "gyldigFraOgMed": "2014-04-09",
-                    "bekreftelsesdato": null,
-                    "master": "NAV (PDL)",
-                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
           "operationName": "hentPersonopplysninger",
           "variables": {
             "behandlingID": 24
@@ -2475,6 +2360,56 @@
                     "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentStatsborgerskap",
+          "variables": {
+            "behandlingID": 24
+          },
+          "query": "query hentStatsborgerskap($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      statsborgerskap {\n        land\n        bekreftelsesdato\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "bekreftelsesdato": null,
+                    "gyldigFraOgMed": "1990-01-01",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
                   }
                 ],
                 "__typename": "Personopplysninger"

--- a/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-flere-inntektsperioder-innenfor-samme-ar.json
+++ b/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-flere-inntektsperioder-innenfor-samme-ar.json
@@ -316,7 +316,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -332,13 +332,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -434,7 +434,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -463,7 +463,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -492,7 +492,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -521,7 +521,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -550,7 +550,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -579,7 +579,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -608,7 +608,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -637,7 +637,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -666,7 +666,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -695,7 +695,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -724,7 +724,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -753,7 +753,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -782,7 +782,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -811,7 +811,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -840,7 +840,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -869,7 +869,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -898,7 +898,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -927,7 +927,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1148,11 +1148,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1176,7 +1176,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1865,7 +1866,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1888,7 +1889,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2010,7 +2011,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -2033,7 +2034,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2314,11 +2315,11 @@
           "authorization": "[REDACTED]"
         },
         "body": {
-          "operationName": "hentPersonopplysninger",
+          "operationName": "hentPersoninfo",
           "variables": {
             "behandlingID": 47
           },
-          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+          "query": "query hentPersoninfo($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      folkeregisterpersonstatuser {\n        kode\n        tekst\n        master\n        kilde\n        fregGyldighetstidspunkt\n        erHistorisk\n        __typename\n      }\n      foedsel {\n        foedeland\n        foedested\n        foedselsaar\n        foedselsdato\n        __typename\n      }\n      sivilstand {\n        type\n        relatertVedSivilstand\n        gyldigFraOgMed\n        bekreftelsesdato\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
         }
       },
       "response": {
@@ -2331,56 +2332,80 @@
           "data": {
             "hentSaksopplysninger": {
               "persondata": {
-                "navn": {
-                  "fornavn": "KARAFFEL",
-                  "mellomnavn": null,
-                  "etternavn": "TRIVIELL",
-                  "__typename": "Navn"
-                },
-                "kjoenn": "MANN",
                 "folkeregisterpersonstatuser": [
                   {
                     "kode": "BOSATT",
+                    "tekst": "Bosatt etter folkeregisterloven",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "1990-01-01",
                     "erHistorisk": false,
                     "__typename": "Folkeregisterpersonstatus"
                   },
                   {
                     "kode": "MIDLERTIDIG",
+                    "tekst": "Midlertidig (D-nummer)",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "2020-10-22",
                     "erHistorisk": true,
                     "__typename": "Folkeregisterpersonstatus"
                   },
                   {
                     "kode": "UTFLYTTET",
+                    "tekst": "Utflyttet",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "2012-03-15",
                     "erHistorisk": true,
                     "__typename": "Folkeregisterpersonstatus"
                   }
                 ],
-                "folkeregisteridentifikator": "30056928150",
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
-                    "erHistorisk": false,
-                    "__typename": "Statsborgerskap"
-                  }
-                ],
+                "foedsel": {
+                  "foedeland": "NO",
+                  "foedested": "OSLO",
+                  "foedselsaar": 1969,
+                  "foedselsdato": "1969-05-30",
+                  "__typename": "Foedsel"
+                },
                 "sivilstand": [
                   {
                     "type": "Gift",
+                    "relatertVedSivilstand": "12028536819",
+                    "gyldigFraOgMed": "2011-02-02",
+                    "bekreftelsesdato": null,
+                    "master": "Freg",
+                    "kilde": "KILDE_DSF",
                     "erHistorisk": false,
                     "__typename": "Sivilstand"
                   },
                   {
                     "type": "Gift",
+                    "relatertVedSivilstand": "21075114491",
+                    "gyldigFraOgMed": "2019-08-03",
+                    "bekreftelsesdato": null,
+                    "master": "Freg",
+                    "kilde": "FREG",
                     "erHistorisk": false,
                     "__typename": "Sivilstand"
                   },
                   {
                     "type": "Separert",
+                    "relatertVedSivilstand": "12028536819",
+                    "gyldigFraOgMed": "2013-01-03",
+                    "bekreftelsesdato": null,
+                    "master": "NAV (PDL)",
+                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
                   },
                   {
                     "type": "Skilt",
+                    "relatertVedSivilstand": null,
+                    "gyldigFraOgMed": "2014-04-09",
+                    "bekreftelsesdato": null,
+                    "master": "NAV (PDL)",
+                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
                   }
@@ -2567,6 +2592,56 @@
                     "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentStatsborgerskap",
+          "variables": {
+            "behandlingID": 47
+          },
+          "query": "query hentStatsborgerskap($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      statsborgerskap {\n        land\n        bekreftelsesdato\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "bekreftelsesdato": null,
+                    "gyldigFraOgMed": "1990-01-01",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
                   }
                 ],
                 "__typename": "Personopplysninger"

--- a/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-ny-inntektsperiode-etter-a-ha-valgt-delt-grunnlag.json
+++ b/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-ny-inntektsperiode-etter-a-ha-valgt-delt-grunnlag.json
@@ -316,7 +316,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -332,13 +332,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -434,7 +434,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -463,7 +463,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -492,7 +492,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -521,7 +521,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -550,7 +550,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -579,7 +579,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -608,7 +608,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -637,7 +637,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -666,7 +666,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -695,7 +695,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -724,7 +724,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -753,7 +753,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -782,7 +782,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -811,7 +811,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -840,7 +840,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -869,7 +869,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -898,7 +898,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -927,7 +927,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1148,11 +1148,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1176,7 +1176,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1865,7 +1866,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1888,7 +1889,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -1937,11 +1938,11 @@
           "authorization": "[REDACTED]"
         },
         "body": {
-          "operationName": "hentPersoninfo",
+          "operationName": "hentAdresser",
           "variables": {
             "behandlingID": 45
           },
-          "query": "query hentPersoninfo($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      folkeregisterpersonstatuser {\n        kode\n        tekst\n        master\n        kilde\n        fregGyldighetstidspunkt\n        erHistorisk\n        __typename\n      }\n      foedsel {\n        foedeland\n        foedested\n        foedselsaar\n        foedselsdato\n        __typename\n      }\n      sivilstand {\n        type\n        relatertVedSivilstand\n        gyldigFraOgMed\n        bekreftelsesdato\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+          "query": "query hentAdresser($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      bostedsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      oppholdsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      kontaktadresser {\n        coAdressenavn\n        semistrukturertAdresse {\n          adresselinje1\n          adresselinje2\n          adresselinje3\n          adresselinje4\n          postnummer\n          poststed\n          land\n          __typename\n        }\n        strukturertAdresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
         }
       },
       "response": {
@@ -1954,82 +1955,111 @@
           "data": {
             "hentSaksopplysninger": {
               "persondata": {
-                "folkeregisterpersonstatuser": [
+                "bostedsadresser": [
                   {
-                    "kode": "BOSATT",
-                    "tekst": "Bosatt etter folkeregisterloven",
-                    "master": "FREG",
+                    "coAdressenavn": "Co Yo 1",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "bosted gata 3",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "STORBRITANNIA",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1995-06-16",
+                    "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "1990-01-01",
+                    "master": "FREG",
                     "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
+                    "__typename": "Bostedsadresse"
                   },
                   {
-                    "kode": "MIDLERTIDIG",
-                    "tekst": "Midlertidig (D-nummer)",
-                    "master": "FREG",
+                    "coAdressenavn": null,
+                    "adresse": {
+                      "tilleggsnavn": "tilleggg navn",
+                      "gatenavn": null,
+                      "husnummerEtasjeLeilighet": null,
+                      "postboks": null,
+                      "postnummer": "2414",
+                      "poststed": "ELVERUM",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1957-09-12",
+                    "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "2020-10-22",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "tekst": "Utflyttet",
                     "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "2012-03-15",
                     "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
+                    "__typename": "Bostedsadresse"
                   }
                 ],
-                "foedsel": {
-                  "foedeland": "NO",
-                  "foedested": "OSLO",
-                  "foedselsaar": 1969,
-                  "foedselsdato": "1969-05-30",
-                  "__typename": "Foedsel"
-                },
-                "sivilstand": [
+                "oppholdsadresser": [
                   {
-                    "type": "Gift",
-                    "relatertVedSivilstand": "12028536819",
-                    "gyldigFraOgMed": "2011-02-02",
-                    "bekreftelsesdato": null,
-                    "master": "Freg",
-                    "kilde": "KILDE_DSF",
+                    "coAdressenavn": "CO 3",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "opphold gata 1",
+                      "husnummerEtasjeLeilighet": "42 B",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": "OSLO",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
                     "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
+                    "__typename": "Oppholdsadresse"
+                  }
+                ],
+                "kontaktadresser": [
                   {
-                    "type": "Gift",
-                    "relatertVedSivilstand": "21075114491",
-                    "gyldigFraOgMed": "2019-08-03",
-                    "bekreftelsesdato": null,
-                    "master": "Freg",
-                    "kilde": "FREG",
+                    "coAdressenavn": "CO 2",
+                    "semistrukturertAdresse": null,
+                    "strukturertAdresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "kontakt gata 1",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "SVERIGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
                     "erHistorisk": false,
-                    "__typename": "Sivilstand"
+                    "__typename": "Kontaktadresse"
                   },
                   {
-                    "type": "Separert",
-                    "relatertVedSivilstand": "12028536819",
-                    "gyldigFraOgMed": "2013-01-03",
-                    "bekreftelsesdato": null,
-                    "master": "NAV (PDL)",
-                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "coAdressenavn": null,
+                    "semistrukturertAdresse": {
+                      "adresselinje1": null,
+                      "adresselinje2": null,
+                      "adresselinje3": null,
+                      "adresselinje4": null,
+                      "postnummer": "3011",
+                      "poststed": "DRAMMEN",
+                      "land": "NORGE",
+                      "__typename": "SemistrukturertAdresseformat"
+                    },
+                    "strukturertAdresse": null,
+                    "gyldigFraOgMed": null,
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
                     "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "relatertVedSivilstand": null,
-                    "gyldigFraOgMed": "2014-04-09",
-                    "bekreftelsesdato": null,
-                    "master": "NAV (PDL)",
-                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
+                    "__typename": "Kontaktadresse"
                   }
                 ],
                 "__typename": "Personopplysninger"

--- a/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-ny-medlemskapsperiode-etter-a-ha-valgt-delt-grunnlag.json
+++ b/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-ny-medlemskapsperiode-etter-a-ha-valgt-delt-grunnlag.json
@@ -316,7 +316,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -332,13 +332,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -434,7 +434,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -463,7 +463,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -492,7 +492,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -521,7 +521,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -550,7 +550,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -579,7 +579,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -608,7 +608,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -637,7 +637,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -666,7 +666,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -695,7 +695,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -724,7 +724,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -753,7 +753,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -782,7 +782,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -811,7 +811,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -840,7 +840,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -869,7 +869,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -898,7 +898,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -927,7 +927,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1148,11 +1148,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1176,7 +1176,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1865,7 +1866,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1888,7 +1889,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -1937,11 +1938,11 @@
           "authorization": "[REDACTED]"
         },
         "body": {
-          "operationName": "hentPersoninfo",
+          "operationName": "hentAdresser",
           "variables": {
             "behandlingID": 26
           },
-          "query": "query hentPersoninfo($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      folkeregisterpersonstatuser {\n        kode\n        tekst\n        master\n        kilde\n        fregGyldighetstidspunkt\n        erHistorisk\n        __typename\n      }\n      foedsel {\n        foedeland\n        foedested\n        foedselsaar\n        foedselsdato\n        __typename\n      }\n      sivilstand {\n        type\n        relatertVedSivilstand\n        gyldigFraOgMed\n        bekreftelsesdato\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+          "query": "query hentAdresser($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      bostedsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      oppholdsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      kontaktadresser {\n        coAdressenavn\n        semistrukturertAdresse {\n          adresselinje1\n          adresselinje2\n          adresselinje3\n          adresselinje4\n          postnummer\n          poststed\n          land\n          __typename\n        }\n        strukturertAdresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
         }
       },
       "response": {
@@ -1954,82 +1955,111 @@
           "data": {
             "hentSaksopplysninger": {
               "persondata": {
-                "folkeregisterpersonstatuser": [
+                "bostedsadresser": [
                   {
-                    "kode": "BOSATT",
-                    "tekst": "Bosatt etter folkeregisterloven",
-                    "master": "FREG",
+                    "coAdressenavn": "Co Yo 1",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "bosted gata 3",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "STORBRITANNIA",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1995-06-16",
+                    "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "1990-01-01",
+                    "master": "FREG",
                     "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
+                    "__typename": "Bostedsadresse"
                   },
                   {
-                    "kode": "MIDLERTIDIG",
-                    "tekst": "Midlertidig (D-nummer)",
-                    "master": "FREG",
+                    "coAdressenavn": null,
+                    "adresse": {
+                      "tilleggsnavn": "tilleggg navn",
+                      "gatenavn": null,
+                      "husnummerEtasjeLeilighet": null,
+                      "postboks": null,
+                      "postnummer": "2414",
+                      "poststed": "ELVERUM",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1957-09-12",
+                    "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "2020-10-22",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "tekst": "Utflyttet",
                     "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "2012-03-15",
                     "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
+                    "__typename": "Bostedsadresse"
                   }
                 ],
-                "foedsel": {
-                  "foedeland": "NO",
-                  "foedested": "OSLO",
-                  "foedselsaar": 1969,
-                  "foedselsdato": "1969-05-30",
-                  "__typename": "Foedsel"
-                },
-                "sivilstand": [
+                "oppholdsadresser": [
                   {
-                    "type": "Gift",
-                    "relatertVedSivilstand": "12028536819",
-                    "gyldigFraOgMed": "2011-02-02",
-                    "bekreftelsesdato": null,
-                    "master": "Freg",
-                    "kilde": "KILDE_DSF",
+                    "coAdressenavn": "CO 3",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "opphold gata 1",
+                      "husnummerEtasjeLeilighet": "42 B",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": "OSLO",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
                     "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
+                    "__typename": "Oppholdsadresse"
+                  }
+                ],
+                "kontaktadresser": [
                   {
-                    "type": "Gift",
-                    "relatertVedSivilstand": "21075114491",
-                    "gyldigFraOgMed": "2019-08-03",
-                    "bekreftelsesdato": null,
-                    "master": "Freg",
-                    "kilde": "FREG",
+                    "coAdressenavn": "CO 2",
+                    "semistrukturertAdresse": null,
+                    "strukturertAdresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "kontakt gata 1",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "SVERIGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
                     "erHistorisk": false,
-                    "__typename": "Sivilstand"
+                    "__typename": "Kontaktadresse"
                   },
                   {
-                    "type": "Separert",
-                    "relatertVedSivilstand": "12028536819",
-                    "gyldigFraOgMed": "2013-01-03",
-                    "bekreftelsesdato": null,
-                    "master": "NAV (PDL)",
-                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "coAdressenavn": null,
+                    "semistrukturertAdresse": {
+                      "adresselinje1": null,
+                      "adresselinje2": null,
+                      "adresselinje3": null,
+                      "adresselinje4": null,
+                      "postnummer": "3011",
+                      "poststed": "DRAMMEN",
+                      "land": "NORGE",
+                      "__typename": "SemistrukturertAdresseformat"
+                    },
+                    "strukturertAdresse": null,
+                    "gyldigFraOgMed": null,
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
                     "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "relatertVedSivilstand": null,
-                    "gyldigFraOgMed": "2014-04-09",
-                    "bekreftelsesdato": null,
-                    "master": "NAV (PDL)",
-                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
+                    "__typename": "Kontaktadresse"
                   }
                 ],
                 "__typename": "Personopplysninger"

--- a/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-ny-periode-med-pliktig-bestemmelse-og-delt-grunnlag.json
+++ b/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-ny-periode-med-pliktig-bestemmelse-og-delt-grunnlag.json
@@ -316,7 +316,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -332,13 +332,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -434,7 +434,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -463,7 +463,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -492,7 +492,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -521,7 +521,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -550,7 +550,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -579,7 +579,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -608,7 +608,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -637,7 +637,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -666,7 +666,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -695,7 +695,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -724,7 +724,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -753,7 +753,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -782,7 +782,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -811,7 +811,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -840,7 +840,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -869,7 +869,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -898,7 +898,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -927,7 +927,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1148,11 +1148,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1176,7 +1176,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1855,7 +1856,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1878,7 +1879,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -1904,6 +1905,267 @@
                     "kilde": "Folkeregisteret",
                     "erHistorisk": true,
                     "__typename": "Kontaktadresse"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentAdresser",
+          "variables": {
+            "behandlingID": 44
+          },
+          "query": "query hentAdresser($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      bostedsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      oppholdsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      kontaktadresser {\n        coAdressenavn\n        semistrukturertAdresse {\n          adresselinje1\n          adresselinje2\n          adresselinje3\n          adresselinje4\n          postnummer\n          poststed\n          land\n          __typename\n        }\n        strukturertAdresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "bostedsadresser": [
+                  {
+                    "coAdressenavn": "Co Yo 1",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "bosted gata 3",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "STORBRITANNIA",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1995-06-16",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Bostedsadresse"
+                  },
+                  {
+                    "coAdressenavn": null,
+                    "adresse": {
+                      "tilleggsnavn": "tilleggg navn",
+                      "gatenavn": null,
+                      "husnummerEtasjeLeilighet": null,
+                      "postboks": null,
+                      "postnummer": "2414",
+                      "poststed": "ELVERUM",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1957-09-12",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": true,
+                    "__typename": "Bostedsadresse"
+                  }
+                ],
+                "oppholdsadresser": [
+                  {
+                    "coAdressenavn": "CO 3",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "opphold gata 1",
+                      "husnummerEtasjeLeilighet": "42 B",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": "OSLO",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Oppholdsadresse"
+                  }
+                ],
+                "kontaktadresser": [
+                  {
+                    "coAdressenavn": "CO 2",
+                    "semistrukturertAdresse": null,
+                    "strukturertAdresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "kontakt gata 1",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "SVERIGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": false,
+                    "__typename": "Kontaktadresse"
+                  },
+                  {
+                    "coAdressenavn": null,
+                    "semistrukturertAdresse": {
+                      "adresselinje1": null,
+                      "adresselinje2": null,
+                      "adresselinje3": null,
+                      "adresselinje4": null,
+                      "postnummer": "3011",
+                      "poststed": "DRAMMEN",
+                      "land": "NORGE",
+                      "__typename": "SemistrukturertAdresseformat"
+                    },
+                    "strukturertAdresse": null,
+                    "gyldigFraOgMed": null,
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": true,
+                    "__typename": "Kontaktadresse"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersoninfo",
+          "variables": {
+            "behandlingID": 44
+          },
+          "query": "query hentPersoninfo($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      folkeregisterpersonstatuser {\n        kode\n        tekst\n        master\n        kilde\n        fregGyldighetstidspunkt\n        erHistorisk\n        __typename\n      }\n      foedsel {\n        foedeland\n        foedested\n        foedselsaar\n        foedselsdato\n        __typename\n      }\n      sivilstand {\n        type\n        relatertVedSivilstand\n        gyldigFraOgMed\n        bekreftelsesdato\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "tekst": "Bosatt etter folkeregisterloven",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "1990-01-01",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "tekst": "Midlertidig (D-nummer)",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "2020-10-22",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "tekst": "Utflyttet",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "2012-03-15",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "foedsel": {
+                  "foedeland": "NO",
+                  "foedested": "OSLO",
+                  "foedselsaar": 1969,
+                  "foedselsdato": "1969-05-30",
+                  "__typename": "Foedsel"
+                },
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "relatertVedSivilstand": "12028536819",
+                    "gyldigFraOgMed": "2011-02-02",
+                    "bekreftelsesdato": null,
+                    "master": "Freg",
+                    "kilde": "KILDE_DSF",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "relatertVedSivilstand": "21075114491",
+                    "gyldigFraOgMed": "2019-08-03",
+                    "bekreftelsesdato": null,
+                    "master": "Freg",
+                    "kilde": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "relatertVedSivilstand": "12028536819",
+                    "gyldigFraOgMed": "2013-01-03",
+                    "bekreftelsesdato": null,
+                    "master": "NAV (PDL)",
+                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "relatertVedSivilstand": null,
+                    "gyldigFraOgMed": "2014-04-09",
+                    "bekreftelsesdato": null,
+                    "master": "NAV (PDL)",
+                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
                   }
                 ],
                 "__typename": "Personopplysninger"

--- a/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-ny-skatteforholdsperiode-etter-a-ha-valgt-delt-grunnlag.json
+++ b/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-ny-skatteforholdsperiode-etter-a-ha-valgt-delt-grunnlag.json
@@ -316,7 +316,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -332,13 +332,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -434,7 +434,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -463,7 +463,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -492,7 +492,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -521,7 +521,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -550,7 +550,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -579,7 +579,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -608,7 +608,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -637,7 +637,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -666,7 +666,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -695,7 +695,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -724,7 +724,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -753,7 +753,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -782,7 +782,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -811,7 +811,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -840,7 +840,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -869,7 +869,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -898,7 +898,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -927,7 +927,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1148,11 +1148,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1176,7 +1176,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1865,7 +1866,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1888,152 +1889,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
-                    "gyldigTilOgMed": null,
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "erHistorisk": false,
-                    "__typename": "Kontaktadresse"
-                  },
-                  {
-                    "coAdressenavn": null,
-                    "semistrukturertAdresse": {
-                      "adresselinje1": null,
-                      "adresselinje2": null,
-                      "adresselinje3": null,
-                      "adresselinje4": null,
-                      "postnummer": "3011",
-                      "poststed": "DRAMMEN",
-                      "land": "NORGE",
-                      "__typename": "SemistrukturertAdresseformat"
-                    },
-                    "strukturertAdresse": null,
-                    "gyldigFraOgMed": null,
-                    "gyldigTilOgMed": null,
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "erHistorisk": true,
-                    "__typename": "Kontaktadresse"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentAdresser",
-          "variables": {
-            "behandlingID": 41
-          },
-          "query": "query hentAdresser($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      bostedsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      oppholdsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      kontaktadresser {\n        coAdressenavn\n        semistrukturertAdresse {\n          adresselinje1\n          adresselinje2\n          adresselinje3\n          adresselinje4\n          postnummer\n          poststed\n          land\n          __typename\n        }\n        strukturertAdresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "bostedsadresser": [
-                  {
-                    "coAdressenavn": "Co Yo 1",
-                    "adresse": {
-                      "tilleggsnavn": null,
-                      "gatenavn": "bosted gata 3",
-                      "husnummerEtasjeLeilighet": "42",
-                      "postboks": null,
-                      "postnummer": "0001",
-                      "poststed": null,
-                      "region": null,
-                      "land": "STORBRITANNIA",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "1995-06-16",
-                    "gyldigTilOgMed": null,
-                    "kilde": "Folkeregisteret",
-                    "master": "FREG",
-                    "erHistorisk": false,
-                    "__typename": "Bostedsadresse"
-                  },
-                  {
-                    "coAdressenavn": null,
-                    "adresse": {
-                      "tilleggsnavn": "tilleggg navn",
-                      "gatenavn": null,
-                      "husnummerEtasjeLeilighet": null,
-                      "postboks": null,
-                      "postnummer": "2414",
-                      "poststed": "ELVERUM",
-                      "region": null,
-                      "land": "NORGE",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "1957-09-12",
-                    "gyldigTilOgMed": null,
-                    "kilde": "Folkeregisteret",
-                    "master": "FREG",
-                    "erHistorisk": true,
-                    "__typename": "Bostedsadresse"
-                  }
-                ],
-                "oppholdsadresser": [
-                  {
-                    "coAdressenavn": "CO 3",
-                    "adresse": {
-                      "tilleggsnavn": null,
-                      "gatenavn": "opphold gata 1",
-                      "husnummerEtasjeLeilighet": "42 B",
-                      "postboks": null,
-                      "postnummer": "0001",
-                      "poststed": "OSLO",
-                      "region": null,
-                      "land": "NORGE",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "2016-01-30",
-                    "gyldigTilOgMed": null,
-                    "kilde": "Folkeregisteret",
-                    "master": "FREG",
-                    "erHistorisk": false,
-                    "__typename": "Oppholdsadresse"
-                  }
-                ],
-                "kontaktadresser": [
-                  {
-                    "coAdressenavn": "CO 2",
-                    "semistrukturertAdresse": null,
-                    "strukturertAdresse": {
-                      "tilleggsnavn": null,
-                      "gatenavn": "kontakt gata 1",
-                      "husnummerEtasjeLeilighet": "42",
-                      "postboks": null,
-                      "postnummer": "0001",
-                      "poststed": null,
-                      "region": null,
-                      "land": "SVERIGE",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2289,6 +2145,98 @@
                     "bekreftelsesdato": null,
                     "master": "NAV (PDL)",
                     "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 41
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
                   }

--- a/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-sammenhengende-medlemskapsperiode-innenfor-samme-ar.json
+++ b/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-legge-til-sammenhengende-medlemskapsperiode-innenfor-samme-ar.json
@@ -316,7 +316,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -332,13 +332,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -434,7 +434,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -463,7 +463,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -492,7 +492,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -521,7 +521,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -550,7 +550,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -579,7 +579,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -608,7 +608,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -637,7 +637,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -666,7 +666,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -695,7 +695,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -724,7 +724,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -753,7 +753,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -782,7 +782,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -811,7 +811,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -840,7 +840,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -869,7 +869,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -898,7 +898,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -927,7 +927,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1148,11 +1148,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1176,7 +1176,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1865,7 +1866,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1888,152 +1889,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
-                    "gyldigTilOgMed": null,
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "erHistorisk": false,
-                    "__typename": "Kontaktadresse"
-                  },
-                  {
-                    "coAdressenavn": null,
-                    "semistrukturertAdresse": {
-                      "adresselinje1": null,
-                      "adresselinje2": null,
-                      "adresselinje3": null,
-                      "adresselinje4": null,
-                      "postnummer": "3011",
-                      "poststed": "DRAMMEN",
-                      "land": "NORGE",
-                      "__typename": "SemistrukturertAdresseformat"
-                    },
-                    "strukturertAdresse": null,
-                    "gyldigFraOgMed": null,
-                    "gyldigTilOgMed": null,
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "erHistorisk": true,
-                    "__typename": "Kontaktadresse"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentAdresser",
-          "variables": {
-            "behandlingID": 25
-          },
-          "query": "query hentAdresser($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      bostedsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      oppholdsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      kontaktadresser {\n        coAdressenavn\n        semistrukturertAdresse {\n          adresselinje1\n          adresselinje2\n          adresselinje3\n          adresselinje4\n          postnummer\n          poststed\n          land\n          __typename\n        }\n        strukturertAdresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "bostedsadresser": [
-                  {
-                    "coAdressenavn": "Co Yo 1",
-                    "adresse": {
-                      "tilleggsnavn": null,
-                      "gatenavn": "bosted gata 3",
-                      "husnummerEtasjeLeilighet": "42",
-                      "postboks": null,
-                      "postnummer": "0001",
-                      "poststed": null,
-                      "region": null,
-                      "land": "STORBRITANNIA",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "1995-06-16",
-                    "gyldigTilOgMed": null,
-                    "kilde": "Folkeregisteret",
-                    "master": "FREG",
-                    "erHistorisk": false,
-                    "__typename": "Bostedsadresse"
-                  },
-                  {
-                    "coAdressenavn": null,
-                    "adresse": {
-                      "tilleggsnavn": "tilleggg navn",
-                      "gatenavn": null,
-                      "husnummerEtasjeLeilighet": null,
-                      "postboks": null,
-                      "postnummer": "2414",
-                      "poststed": "ELVERUM",
-                      "region": null,
-                      "land": "NORGE",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "1957-09-12",
-                    "gyldigTilOgMed": null,
-                    "kilde": "Folkeregisteret",
-                    "master": "FREG",
-                    "erHistorisk": true,
-                    "__typename": "Bostedsadresse"
-                  }
-                ],
-                "oppholdsadresser": [
-                  {
-                    "coAdressenavn": "CO 3",
-                    "adresse": {
-                      "tilleggsnavn": null,
-                      "gatenavn": "opphold gata 1",
-                      "husnummerEtasjeLeilighet": "42 B",
-                      "postboks": null,
-                      "postnummer": "0001",
-                      "poststed": "OSLO",
-                      "region": null,
-                      "land": "NORGE",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "2016-01-30",
-                    "gyldigTilOgMed": null,
-                    "kilde": "Folkeregisteret",
-                    "master": "FREG",
-                    "erHistorisk": false,
-                    "__typename": "Oppholdsadresse"
-                  }
-                ],
-                "kontaktadresser": [
-                  {
-                    "coAdressenavn": "CO 2",
-                    "semistrukturertAdresse": null,
-                    "strukturertAdresse": {
-                      "tilleggsnavn": null,
-                      "gatenavn": "kontakt gata 1",
-                      "husnummerEtasjeLeilighet": "42",
-                      "postboks": null,
-                      "postnummer": "0001",
-                      "poststed": null,
-                      "region": null,
-                      "land": "SVERIGE",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2289,98 +2145,6 @@
                     "bekreftelsesdato": null,
                     "master": "NAV (PDL)",
                     "kilde": "Tyske trygdemyndigheter, TYSKLAND",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentPersonopplysninger",
-          "variables": {
-            "behandlingID": 25
-          },
-          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "navn": {
-                  "fornavn": "KARAFFEL",
-                  "mellomnavn": null,
-                  "etternavn": "TRIVIELL",
-                  "__typename": "Navn"
-                },
-                "kjoenn": "MANN",
-                "folkeregisterpersonstatuser": [
-                  {
-                    "kode": "BOSATT",
-                    "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "MIDLERTIDIG",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  }
-                ],
-                "folkeregisteridentifikator": "30056928150",
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
-                    "erHistorisk": false,
-                    "__typename": "Statsborgerskap"
-                  }
-                ],
-                "sivilstand": [
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Separert",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
                   }

--- a/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-utvide-inntektsperiode-innenfor-medlemskapsperiode.json
+++ b/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-utvide-inntektsperiode-innenfor-medlemskapsperiode.json
@@ -316,7 +316,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -332,13 +332,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -434,7 +434,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -463,7 +463,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -492,7 +492,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -521,7 +521,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -550,7 +550,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -579,7 +579,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -608,7 +608,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -637,7 +637,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -666,7 +666,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -695,7 +695,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -724,7 +724,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -753,7 +753,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -782,7 +782,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -811,7 +811,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -840,7 +840,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -869,7 +869,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -898,7 +898,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -927,7 +927,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1148,11 +1148,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1176,7 +1176,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1865,7 +1866,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1888,152 +1889,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
-                    "gyldigTilOgMed": null,
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "erHistorisk": false,
-                    "__typename": "Kontaktadresse"
-                  },
-                  {
-                    "coAdressenavn": null,
-                    "semistrukturertAdresse": {
-                      "adresselinje1": null,
-                      "adresselinje2": null,
-                      "adresselinje3": null,
-                      "adresselinje4": null,
-                      "postnummer": "3011",
-                      "poststed": "DRAMMEN",
-                      "land": "NORGE",
-                      "__typename": "SemistrukturertAdresseformat"
-                    },
-                    "strukturertAdresse": null,
-                    "gyldigFraOgMed": null,
-                    "gyldigTilOgMed": null,
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "erHistorisk": true,
-                    "__typename": "Kontaktadresse"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentAdresser",
-          "variables": {
-            "behandlingID": 46
-          },
-          "query": "query hentAdresser($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      bostedsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      oppholdsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      kontaktadresser {\n        coAdressenavn\n        semistrukturertAdresse {\n          adresselinje1\n          adresselinje2\n          adresselinje3\n          adresselinje4\n          postnummer\n          poststed\n          land\n          __typename\n        }\n        strukturertAdresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "bostedsadresser": [
-                  {
-                    "coAdressenavn": "Co Yo 1",
-                    "adresse": {
-                      "tilleggsnavn": null,
-                      "gatenavn": "bosted gata 3",
-                      "husnummerEtasjeLeilighet": "42",
-                      "postboks": null,
-                      "postnummer": "0001",
-                      "poststed": null,
-                      "region": null,
-                      "land": "STORBRITANNIA",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "1995-06-16",
-                    "gyldigTilOgMed": null,
-                    "kilde": "Folkeregisteret",
-                    "master": "FREG",
-                    "erHistorisk": false,
-                    "__typename": "Bostedsadresse"
-                  },
-                  {
-                    "coAdressenavn": null,
-                    "adresse": {
-                      "tilleggsnavn": "tilleggg navn",
-                      "gatenavn": null,
-                      "husnummerEtasjeLeilighet": null,
-                      "postboks": null,
-                      "postnummer": "2414",
-                      "poststed": "ELVERUM",
-                      "region": null,
-                      "land": "NORGE",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "1957-09-12",
-                    "gyldigTilOgMed": null,
-                    "kilde": "Folkeregisteret",
-                    "master": "FREG",
-                    "erHistorisk": true,
-                    "__typename": "Bostedsadresse"
-                  }
-                ],
-                "oppholdsadresser": [
-                  {
-                    "coAdressenavn": "CO 3",
-                    "adresse": {
-                      "tilleggsnavn": null,
-                      "gatenavn": "opphold gata 1",
-                      "husnummerEtasjeLeilighet": "42 B",
-                      "postboks": null,
-                      "postnummer": "0001",
-                      "poststed": "OSLO",
-                      "region": null,
-                      "land": "NORGE",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "2016-01-30",
-                    "gyldigTilOgMed": null,
-                    "kilde": "Folkeregisteret",
-                    "master": "FREG",
-                    "erHistorisk": false,
-                    "__typename": "Oppholdsadresse"
-                  }
-                ],
-                "kontaktadresser": [
-                  {
-                    "coAdressenavn": "CO 2",
-                    "semistrukturertAdresse": null,
-                    "strukturertAdresse": {
-                      "tilleggsnavn": null,
-                      "gatenavn": "kontakt gata 1",
-                      "husnummerEtasjeLeilighet": "42",
-                      "postboks": null,
-                      "postnummer": "0001",
-                      "poststed": null,
-                      "region": null,
-                      "land": "SVERIGE",
-                      "__typename": "StrukturertAdresseformat"
-                    },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2475,6 +2331,56 @@
                     "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentStatsborgerskap",
+          "variables": {
+            "behandlingID": 46
+          },
+          "query": "query hentStatsborgerskap($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      statsborgerskap {\n        land\n        bekreftelsesdato\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "bekreftelsesdato": null,
+                    "gyldigFraOgMed": "1990-01-01",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
                   }
                 ],
                 "__typename": "Personopplysninger"

--- a/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-utvide-skatteforholdsperiode-innenfor-medlemskapsperiode.json
+++ b/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/kan-utvide-skatteforholdsperiode-innenfor-medlemskapsperiode.json
@@ -316,7 +316,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -332,13 +332,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -434,7 +434,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -463,7 +463,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -492,7 +492,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -521,7 +521,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -550,7 +550,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -579,7 +579,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -608,7 +608,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -637,7 +637,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -666,7 +666,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -695,7 +695,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -724,7 +724,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -753,7 +753,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -782,7 +782,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -811,7 +811,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -840,7 +840,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -869,7 +869,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -898,7 +898,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -927,7 +927,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1148,11 +1148,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1176,7 +1176,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1865,7 +1866,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1888,7 +1889,152 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": false,
+                    "__typename": "Kontaktadresse"
+                  },
+                  {
+                    "coAdressenavn": null,
+                    "semistrukturertAdresse": {
+                      "adresselinje1": null,
+                      "adresselinje2": null,
+                      "adresselinje3": null,
+                      "adresselinje4": null,
+                      "postnummer": "3011",
+                      "poststed": "DRAMMEN",
+                      "land": "NORGE",
+                      "__typename": "SemistrukturertAdresseformat"
+                    },
+                    "strukturertAdresse": null,
+                    "gyldigFraOgMed": null,
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": true,
+                    "__typename": "Kontaktadresse"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentAdresser",
+          "variables": {
+            "behandlingID": 42
+          },
+          "query": "query hentAdresser($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      bostedsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      oppholdsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      kontaktadresser {\n        coAdressenavn\n        semistrukturertAdresse {\n          adresselinje1\n          adresselinje2\n          adresselinje3\n          adresselinje4\n          postnummer\n          poststed\n          land\n          __typename\n        }\n        strukturertAdresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "bostedsadresser": [
+                  {
+                    "coAdressenavn": "Co Yo 1",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "bosted gata 3",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "STORBRITANNIA",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1995-06-16",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Bostedsadresse"
+                  },
+                  {
+                    "coAdressenavn": null,
+                    "adresse": {
+                      "tilleggsnavn": "tilleggg navn",
+                      "gatenavn": null,
+                      "husnummerEtasjeLeilighet": null,
+                      "postboks": null,
+                      "postnummer": "2414",
+                      "poststed": "ELVERUM",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1957-09-12",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": true,
+                    "__typename": "Bostedsadresse"
+                  }
+                ],
+                "oppholdsadresser": [
+                  {
+                    "coAdressenavn": "CO 3",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "opphold gata 1",
+                      "husnummerEtasjeLeilighet": "42 B",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": "OSLO",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Oppholdsadresse"
+                  }
+                ],
+                "kontaktadresser": [
+                  {
+                    "coAdressenavn": "CO 2",
+                    "semistrukturertAdresse": null,
+                    "strukturertAdresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "kontakt gata 1",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "SVERIGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2144,6 +2290,98 @@
                     "bekreftelsesdato": null,
                     "master": "NAV (PDL)",
                     "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 42
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
                   }

--- a/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/skal-vise-legg-til-periode-knappen-for-delt-grunnlag-selv-med-pliktig-bestemmelse.json
+++ b/tests/e2e/recordings/specs/behandle-sak/aarsavregning-delt-grunnlag/skal-vise-legg-til-periode-knappen-for-delt-grunnlag-selv-med-pliktig-bestemmelse.json
@@ -1,0 +1,2631 @@
+{
+  "version": "1.0",
+  "recordedAt": "2025-01-01T00:00:00.000Z",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web-2/tests/e2e/specs/behandle-sak/aarsavregning-delt-grunnlag.spec.ts",
+  "testName": "skal vise 'Legg til periode'-knappen for delt grunnlag selv med pliktig bestemmelse",
+  "exchanges": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/43/aarsak/mottaksdato",
+        "pathname": "/api/behandlinger/43/aarsak/mottaksdato",
+        "normalizedPath": "/api/behandlinger/:behandlingId/aarsak/mottaksdato",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "mottaksdato": "2025-01-01"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/43/aarsavregninger",
+        "pathname": "/api/behandlinger/43/aarsavregninger",
+        "normalizedPath": "/api/behandlinger/:behandlingId/aarsavregninger",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "aarsavregningID": 43,
+          "aar": 2025,
+          "tidligereTrygdeavgiftsGrunnlagsopplysninger": {
+            "trygdeavgiftsgrunnlag": {
+              "avgiftspliktigperioder": [],
+              "skatteforholdsperioder": [],
+              "inntektskperioder": []
+            },
+            "avgift": {
+              "trygdeavgiftsperioder": [],
+              "totalInntekt": 0,
+              "totalAvgift": 0
+            },
+            "tidligereTrygdeavgiftFraAvgiftssystemet": null,
+            "tidligereÅrsavregningManueltAvgiftBeloep": null
+          },
+          "sisteGjeldendeAvgiftspliktigperioder": [],
+          "nyttTrygdeavgiftsGrunnlag": null,
+          "endeligAvgift": null,
+          "avregning": {
+            "beregnetAvgiftBelop": null,
+            "tidligereFakturertBeloep": null,
+            "tilFaktureringBeloep": null,
+            "trygdeavgiftFraAvgiftssystemet": null,
+            "manueltAvgiftBeloep": null
+          },
+          "harTrygdeavgiftFraAvgiftssystemet": true,
+          "endeligAvgiftValg": "OPPLYSNINGER_ENDRET",
+          "harSkjoennsfastsattInntekt": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/43/medlemskapsperioder",
+        "pathname": "/api/behandlinger/43/medlemskapsperioder",
+        "normalizedPath": "/api/behandlinger/:behandlingId/medlemskapsperioder",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/43/medlemskapsperioder",
+        "pathname": "/api/behandlinger/43/medlemskapsperioder",
+        "normalizedPath": "/api/behandlinger/:behandlingId/medlemskapsperioder",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/43/resultat",
+        "pathname": "/api/behandlinger/43/resultat",
+        "normalizedPath": "/api/behandlinger/:behandlingId/resultat",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "behandlingsresultatTypeKode": "IKKE_FASTSATT",
+          "begrunnelseKoder": [],
+          "begrunnelseFritekst": null,
+          "innledningFritekst": null,
+          "trygdeavgiftFritekst": null,
+          "nyVurderingBakgrunn": null,
+          "utfallRegistreringUnntak": null,
+          "utfallUtpeking": null,
+          "vedtakstype": null,
+          "kontrollresultatBegrunnelseKoder": [],
+          "fakturaserieReferanse": null,
+          "aarsavregningID": null
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/43/resultat",
+        "pathname": "/api/behandlinger/43/resultat",
+        "normalizedPath": "/api/behandlinger/:behandlingId/resultat",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "behandlingsresultatTypeKode": "IKKE_FASTSATT",
+          "begrunnelseKoder": [],
+          "begrunnelseFritekst": null,
+          "innledningFritekst": null,
+          "trygdeavgiftFritekst": null,
+          "nyVurderingBakgrunn": null,
+          "utfallRegistreringUnntak": null,
+          "utfallUtpeking": null,
+          "vedtakstype": null,
+          "kontrollresultatBegrunnelseKoder": [],
+          "fakturaserieReferanse": null,
+          "aarsavregningID": 43
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/43",
+        "pathname": "/api/behandlinger/43",
+        "normalizedPath": "/api/behandlinger/:behandlingId",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "behandlingID": 43,
+          "oppsummering": {
+            "behandlingsstatus": {
+              "kode": "UNDER_BEHANDLING",
+              "term": "Behandlingen pågår"
+            },
+            "behandlingstype": {
+              "kode": "ÅRSAVREGNING",
+              "term": "Årsavregning"
+            },
+            "behandlingstema": {
+              "kode": "YRKESAKTIV",
+              "term": "Yrkesaktiv"
+            },
+            "registrertDato": "2025-01-01T00:00:00.000Z",
+            "endretDato": "2025-01-01T00:00:00.000Z",
+            "endretAvNavn": "Lokal Testbruker",
+            "sisteOpplysningerHentetDato": null,
+            "svarFrist": null,
+            "behandlingsfrist": "2025-01-01",
+            "behandlingsresultattype": {
+              "kode": "IKKE_FASTSATT",
+              "term": "Ikke fastsatt"
+            }
+          },
+          "saksopplysninger": {
+            "arbeidsforhold": [],
+            "organisasjoner": [],
+            "medlemskap": {
+              "medlemsperiode": []
+            },
+            "inntekt": {
+              "arbeidsInntektMaanedListe": [],
+              "frilansInntektMaanedListe": []
+            },
+            "sed": {
+              "rinaSaksnummer": null,
+              "rinaDokumentID": null,
+              "fnr": null,
+              "lovvalgsperiode": null,
+              "lovvalgsbestemmelse": null,
+              "lovvalgslandKode": null,
+              "erEndring": false,
+              "sedType": null,
+              "bucType": null
+            }
+          },
+          "redigerbart": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/43",
+        "pathname": "/api/behandlinger/43",
+        "normalizedPath": "/api/behandlinger/:behandlingId",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "behandlingID": 43,
+          "oppsummering": {
+            "behandlingsstatus": {
+              "kode": "UNDER_BEHANDLING",
+              "term": "Behandlingen pågår"
+            },
+            "behandlingstype": {
+              "kode": "ÅRSAVREGNING",
+              "term": "Årsavregning"
+            },
+            "behandlingstema": {
+              "kode": "YRKESAKTIV",
+              "term": "Yrkesaktiv"
+            },
+            "registrertDato": "2025-01-01T00:00:00.000Z",
+            "endretDato": "2025-01-01T00:00:00.000Z",
+            "endretAvNavn": "Lokal Testbruker",
+            "sisteOpplysningerHentetDato": "2025-01-01T00:00:00.000Z",
+            "svarFrist": null,
+            "behandlingsfrist": "2025-01-01",
+            "behandlingsresultattype": {
+              "kode": "IKKE_FASTSATT",
+              "term": "Ikke fastsatt"
+            }
+          },
+          "saksopplysninger": {
+            "arbeidsforhold": [
+              {
+                "arbeidsforholdID": "123",
+                "arbeidsforholdIDnav": 123,
+                "ansettelsesPeriode": {
+                  "fom": "2021-02-17",
+                  "tom": null
+                },
+                "arbeidsforholdstype": "ordinaertArbeidsforhold",
+                "arbeidsavtaler": [
+                  {
+                    "arbeidstidsordning": {
+                      "kode": "ikkeSkift",
+                      "term": "Ikke skift"
+                    },
+                    "avloenningstype": "",
+                    "yrke": {
+                      "kode": "0013008",
+                      "term": "KONSULENT"
+                    },
+                    "gyldighetsperiode": {
+                      "fom": "2021-02-17",
+                      "tom": null
+                    },
+                    "avtaltArbeidstimerPerUke": 37.5,
+                    "stillingsprosent": 100,
+                    "beregnetAntallTimerPrUke": 37.5,
+                    "endringsdatoStillingsprosent": "2021-02-17",
+                    "skipsregister": null,
+                    "skipstype": null,
+                    "maritimArbeidsavtale": false,
+                    "beregnetStillingsprosent": null,
+                    "antallTimerGammeltAa": null,
+                    "fartsomraade": null
+                  }
+                ],
+                "permisjonOgPermittering": [],
+                "utenlandsopphold": [],
+                "arbeidsgivertype": "ORGANISASJON",
+                "arbeidsgiverID": "999999999",
+                "arbeidstakerID": "30056928150",
+                "opplysningspliktigtype": "ORGANISASJON",
+                "opplysningspliktigID": "999999999",
+                "opprettelsestidspunkt": "2025-01-01T00:00:00.000Z",
+                "sistBekreftet": "2025-01-01T00:00:00.000Z",
+                "Aordning": null,
+                "timerTimelonnet": []
+              }
+            ],
+            "organisasjoner": [
+              {
+                "orgnr": "888888888",
+                "navn": "Steinars Stein AS",
+                "oppstartdato": null,
+                "organisasjonsform": "Aksjeselskap",
+                "forretningsadresse": {
+                  "gateadresse": {
+                    "gatenavn": "Adresselinje1",
+                    "gatenummer": null,
+                    "husnummer": null,
+                    "husbokstav": null
+                  },
+                  "postnr": "0010",
+                  "poststed": "Oslo",
+                  "land": "NORGE"
+                },
+                "postadresse": {
+                  "gateadresse": {
+                    "gatenavn": "Adresselinje1",
+                    "gatenummer": null,
+                    "husnummer": null,
+                    "husbokstav": null
+                  },
+                  "postnr": "0010",
+                  "poststed": "Oslo",
+                  "land": "NORGE"
+                }
+              },
+              {
+                "orgnr": "999999999",
+                "navn": "Ståles Stål AS",
+                "oppstartdato": null,
+                "organisasjonsform": "Aksjeselskap",
+                "forretningsadresse": {
+                  "gateadresse": {
+                    "gatenavn": "Adresselinje1",
+                    "gatenummer": null,
+                    "husnummer": null,
+                    "husbokstav": null
+                  },
+                  "postnr": "0010",
+                  "poststed": "Oslo",
+                  "land": "NORGE"
+                },
+                "postadresse": {
+                  "gateadresse": {
+                    "gatenavn": "Adresselinje1",
+                    "gatenummer": null,
+                    "husnummer": null,
+                    "husbokstav": null
+                  },
+                  "postnr": "0010",
+                  "poststed": "Oslo",
+                  "land": "NORGE"
+                }
+              }
+            ],
+            "medlemskap": {
+              "medlemsperiode": []
+            },
+            "inntekt": {
+              "arbeidsInntektMaanedListe": [
+                {
+                  "aarMaaned": "2024-07",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2024-07",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2024-08",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2024-08",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2024-09",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2024-09",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2024-10",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2024-10",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2024-11",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2024-11",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2024-12",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2024-12",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-01",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-01",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-02",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-02",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-03",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-03",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-04",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-04",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-05",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-05",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-06",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-06",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-07",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-07",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-08",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-08",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-09",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-09",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-10",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-10",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-11",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-11",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2025-12",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2025-12",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "frilansInntektMaanedListe": []
+            },
+            "sed": {
+              "rinaSaksnummer": null,
+              "rinaDokumentID": null,
+              "fnr": null,
+              "lovvalgsperiode": null,
+              "lovvalgsbestemmelse": null,
+              "lovvalgslandKode": null,
+              "erEndring": false,
+              "sedType": null,
+              "bucType": null
+            }
+          },
+          "redigerbart": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/brev/utkast/43",
+        "pathname": "/api/brev/utkast/43",
+        "normalizedPath": "/api/brev/utkast/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1043/aarsavregninger",
+        "pathname": "/api/fagsaker/MEL-1043/aarsavregninger",
+        "normalizedPath": "/api/fagsaker/:saksnummer/aarsavregninger",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1043/aarsavregninger?&aar=2025&resultattype=FASTSATT_TRYGDEAVGIFT",
+        "pathname": "/api/fagsaker/MEL-1043/aarsavregninger",
+        "normalizedPath": "/api/fagsaker/:saksnummer/aarsavregninger",
+        "query": {
+          "aar": "2025",
+          "resultattype": "FASTSATT_TRYGDEAVGIFT"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1043/aarsavregninger?&aar=2025&resultattype=IKKE_FASTSATT",
+        "pathname": "/api/fagsaker/MEL-1043/aarsavregninger",
+        "normalizedPath": "/api/fagsaker/:saksnummer/aarsavregninger",
+        "query": {
+          "aar": "2025",
+          "resultattype": "IKKE_FASTSATT"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1043/dokumenter",
+        "pathname": "/api/fagsaker/MEL-1043/dokumenter",
+        "normalizedPath": "/api/fagsaker/:saksnummer/dokumenter",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1043/trygdeavgift/oppsummering",
+        "pathname": "/api/fagsaker/MEL-1043/trygdeavgift/oppsummering",
+        "normalizedPath": "/api/fagsaker/:saksnummer/trygdeavgift/oppsummering",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "harBehandlingMedTrygdeavgift": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1043",
+        "pathname": "/api/fagsaker/MEL-1043",
+        "normalizedPath": "/api/fagsaker/:saksnummer",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "saksnummer": "MEL-1043",
+          "gsakSaksnummer": null,
+          "sakstema": {
+            "kode": "MEDLEMSKAP_LOVVALG",
+            "term": "Medlemskap og lovvalg"
+          },
+          "sakstype": {
+            "kode": "FTRL",
+            "term": "Utenfor avtaleland"
+          },
+          "saksstatus": {
+            "kode": "OPPRETTET",
+            "term": "Saken er opprettet"
+          },
+          "betalingsvalg": null,
+          "registrertDato": "2025-01-01T00:00:00.000Z",
+          "endretDato": "2025-01-01T00:00:00.000Z",
+          "hovedpartRolle": "BRUKER"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
+        "pathname": "/api/featuretoggle",
+        "normalizedPath": "/api/featuretoggle",
+        "query": {
+          "features": "melosys.cdm-4-4"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "melosys.faktureringskomponent.vis_referanse": true,
+          "melosys.pensjonist": true,
+          "melosys.pensjonist_eos": true,
+          "standardvedlegg_eget_vedlegg_avtaleland": true,
+          "melosys.ftrl.begrense_periode_vedtak": true,
+          "melosys.arsavregning": true,
+          "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
+          "melosys.11_3_a_Norge_er_utpekt": true,
+          "melosys.eos_fakturering_av_trygdeavgift": true,
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/ftrl/bestemmelser/?behandlingstema=YRKESAKTIV",
+        "pathname": "/api/ftrl/bestemmelser/",
+        "normalizedPath": "/api/ftrl/bestemmelser/",
+        "query": {
+          "behandlingstema": "YRKESAKTIV"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "bestemmelser": [
+            "FTRL_KAP2_2_1",
+            "FTRL_KAP2_2_2",
+            "FTRL_KAP2_2_3_ANDRE_LEDD",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_A",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_B",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_C",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_D",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_E",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_F",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_G",
+            "FTRL_KAP2_2_7_FØRSTE_LEDD",
+            "FTRL_KAP2_2_7A",
+            "FTRL_KAP2_2_8_FØRSTE_LEDD_A",
+            "FTRL_KAP2_2_8_FØRSTE_LEDD_B",
+            "FTRL_KAP2_2_8_ANDRE_LEDD",
+            "ARKTISK_RÅDS_SEKRETARIAT_ART16",
+            "DET_INTERNASJONALE_BARENTSSEKRETARIATET_ART14",
+            "DEN_NORDATLANTISKE_SJØPATTEDYRKOMMISJON_ART16",
+            "TILLEGGSAVTALE_NATO"
+          ]
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/ftrl/bestemmelser/pliktige",
+        "pathname": "/api/ftrl/bestemmelser/pliktige",
+        "normalizedPath": "/api/ftrl/bestemmelser/pliktige",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "bestemmelser": [
+            "FTRL_KAP2_2_1",
+            "FTRL_KAP2_2_2",
+            "FTRL_KAP2_2_3_ANDRE_LEDD",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_A",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_B",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_C",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_D",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_E",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_F",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_G",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_H",
+            "FTRL_KAP2_2_5_ANDRE_LEDD",
+            "ARKTISK_RÅDS_SEKRETARIAT_ART16",
+            "DET_INTERNASJONALE_BARENTSSEKRETARIATET_ART14",
+            "DEN_NORDATLANTISKE_SJØPATTEDYRKOMMISJON_ART16",
+            "TILLEGGSAVTALE_NATO"
+          ]
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/ftrl/bestemmelser/pliktige",
+        "pathname": "/api/ftrl/bestemmelser/pliktige",
+        "normalizedPath": "/api/ftrl/bestemmelser/pliktige",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "bestemmelser": [
+            "FTRL_KAP2_2_1",
+            "FTRL_KAP2_2_2",
+            "FTRL_KAP2_2_3_ANDRE_LEDD",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_A",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_B",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_C",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_D",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_E",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_F",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_G",
+            "FTRL_KAP2_2_5_FØRSTE_LEDD_H",
+            "FTRL_KAP2_2_5_ANDRE_LEDD",
+            "ARKTISK_RÅDS_SEKRETARIAT_ART16",
+            "DET_INTERNASJONALE_BARENTSSEKRETARIATET_ART14",
+            "DEN_NORDATLANTISKE_SJØPATTEDYRKOMMISJON_ART16",
+            "TILLEGGSAVTALE_NATO"
+          ]
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/medlemskapsperioder/trygdedekning/lovlige-kombinasjoner?bestemmelse=FTRL_KAP2_2_7_F%C3%98RSTE_LEDD",
+        "pathname": "/api/medlemskapsperioder/trygdedekning/lovlige-kombinasjoner",
+        "normalizedPath": "/api/medlemskapsperioder/trygdedekning/lovlige-kombinasjoner",
+        "query": {
+          "bestemmelse": "FTRL_KAP2_2_7_FØRSTE_LEDD"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": ["FULL_DEKNING_FTRL", "FTRL_2_7_TREDJE_LEDD_B_HELSE_SYKE_FORELDREPENGER"]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/mottatteopplysninger/43",
+        "pathname": "/api/mottatteopplysninger/43",
+        "normalizedPath": "/api/mottatteopplysninger/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "soeknadsland": {
+              "landkoder": [],
+              "flereLandUkjentHvilke": false
+            },
+            "periode": {
+              "fom": null,
+              "tom": null
+            },
+            "personOpplysninger": {
+              "utenlandskIdent": [],
+              "medfolgendeFamilie": [],
+              "foedestedOgLand": null
+            },
+            "arbeidPaaLand": {
+              "fysiskeArbeidssteder": [],
+              "erHjemmekontor": null,
+              "erFastArbeidssted": null
+            },
+            "foretakUtland": [],
+            "oppholdUtland": {
+              "oppholdslandkoder": [],
+              "oppholdsPeriode": {
+                "fom": null,
+                "tom": null
+              },
+              "studentFinansieringKode": null,
+              "studentSemester": null,
+              "ektefelleEllerBarnINorge": null
+            },
+            "selvstendigArbeid": {
+              "erSelvstendig": null,
+              "selvstendigForetak": []
+            },
+            "juridiskArbeidsgiverNorge": {
+              "antallAdmAnsatte": null,
+              "antallAnsatte": null,
+              "antallUtsendte": null,
+              "andelOmsetningINorge": null,
+              "andelOppdragINorge": null,
+              "andelKontrakterINorge": null,
+              "andelRekruttertINorge": null,
+              "ekstraArbeidsgivere": [],
+              "erOffentligVirksomhet": null
+            },
+            "maritimtArbeid": [],
+            "luftfartBaser": [],
+            "bosted": {
+              "intensjonOmRetur": null,
+              "antallMaanederINorge": 0,
+              "oppgittAdresse": {
+                "tilleggsnavn": null,
+                "gatenavn": null,
+                "husnummerEtasjeLeilighet": null,
+                "postboks": null,
+                "postnummer": null,
+                "poststed": null,
+                "region": null,
+                "landkode": null
+              }
+            },
+            "trygdedekning": null,
+            "representantIUtlandet": null
+          },
+          "type": "SØKNAD_YRKESAKTIVE_NORGE_ELLER_UTENFOR_EØS",
+          "mottaksdato": "2025-01-01"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/?hovedpart=BRUKER&sakstype=FTRL&sakstema=MEDLEMSKAP_LOVVALG&aktivBehandlingID=43",
+        "pathname": "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "FTRL",
+          "sakstema": "MEDLEMSKAP_LOVVALG",
+          "aktivBehandlingID": "43"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "IKKE_YRKESAKTIV",
+            "term": "Ikke yrkesaktiv"
+          },
+          {
+            "kode": "PENSJONIST",
+            "term": "Pensjonist/uføretrygdet"
+          },
+          {
+            "kode": "UNNTAK_MEDLEMSKAP",
+            "term": "Søknad om unntak fra folketrygdloven"
+          },
+          {
+            "kode": "YRKESAKTIV",
+            "term": "Yrkesaktiv"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/?hovedpart=BRUKER&sakstype=FTRL&saksnummer=MEL-1043",
+        "pathname": "/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "FTRL",
+          "saksnummer": "MEL-1043"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/?saksnummer=MEL-1043",
+        "pathname": "/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/",
+        "query": {
+          "saksnummer": "MEL-1043"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/api/behandlinger/43/aarsavregninger/grunnlagstype",
+        "pathname": "/api/behandlinger/43/aarsavregninger/grunnlagstype",
+        "normalizedPath": "/api/behandlinger/:behandlingId/aarsavregninger/grunnlagstype",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "harTrygdeavgiftFraAvgiftssystemet": true
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "aarsavregningID": 43,
+          "aar": 2025,
+          "tidligereTrygdeavgiftsGrunnlagsopplysninger": {
+            "trygdeavgiftsgrunnlag": {
+              "avgiftspliktigperioder": [],
+              "skatteforholdsperioder": [],
+              "inntektskperioder": []
+            },
+            "avgift": {
+              "trygdeavgiftsperioder": [],
+              "totalInntekt": 0,
+              "totalAvgift": 0
+            },
+            "tidligereTrygdeavgiftFraAvgiftssystemet": null,
+            "tidligereÅrsavregningManueltAvgiftBeloep": null
+          },
+          "sisteGjeldendeAvgiftspliktigperioder": [],
+          "nyttTrygdeavgiftsGrunnlag": null,
+          "endeligAvgift": null,
+          "avregning": {
+            "beregnetAvgiftBelop": null,
+            "tidligereFakturertBeloep": null,
+            "tilFaktureringBeloep": null,
+            "trygdeavgiftFraAvgiftssystemet": null,
+            "manueltAvgiftBeloep": null
+          },
+          "harTrygdeavgiftFraAvgiftssystemet": true,
+          "endeligAvgiftValg": "OPPLYSNINGER_ENDRET",
+          "harSkjoennsfastsattInntekt": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/api/behandlinger/43/aarsavregninger",
+        "pathname": "/api/behandlinger/43/aarsavregninger",
+        "normalizedPath": "/api/behandlinger/:behandlingId/aarsavregninger",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "aar": 2025
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "aarsavregningID": 43,
+          "aar": 2025,
+          "tidligereTrygdeavgiftsGrunnlagsopplysninger": {
+            "trygdeavgiftsgrunnlag": {
+              "avgiftspliktigperioder": [],
+              "skatteforholdsperioder": [],
+              "inntektskperioder": []
+            },
+            "avgift": {
+              "trygdeavgiftsperioder": [],
+              "totalInntekt": 0,
+              "totalAvgift": 0
+            },
+            "tidligereTrygdeavgiftFraAvgiftssystemet": null,
+            "tidligereÅrsavregningManueltAvgiftBeloep": null
+          },
+          "sisteGjeldendeAvgiftspliktigperioder": [],
+          "nyttTrygdeavgiftsGrunnlag": null,
+          "endeligAvgift": null,
+          "avregning": {
+            "beregnetAvgiftBelop": null,
+            "tidligereFakturertBeloep": null,
+            "tilFaktureringBeloep": null,
+            "trygdeavgiftFraAvgiftssystemet": null,
+            "manueltAvgiftBeloep": null
+          },
+          "harTrygdeavgiftFraAvgiftssystemet": null,
+          "endeligAvgiftValg": "OPPLYSNINGER_ENDRET",
+          "harSkjoennsfastsattInntekt": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/api/fagsaker/sok",
+        "pathname": "/api/fagsaker/sok",
+        "normalizedPath": "/api/fagsaker/sok",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "saksnummer": "MEL-1043",
+          "ident": null,
+          "orgnr": null
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "saksnummer": "MEL-1043",
+            "navn": "TRIVIELL KARAFFEL",
+            "sakstema": {
+              "kode": "MEDLEMSKAP_LOVVALG",
+              "term": "Medlemskap og lovvalg"
+            },
+            "sakstype": {
+              "kode": "FTRL",
+              "term": "Utenfor avtaleland"
+            },
+            "saksstatus": {
+              "kode": "OPPRETTET",
+              "term": "Saken er opprettet"
+            },
+            "land": {
+              "landkoder": [],
+              "flereLandUkjentHvilke": false
+            },
+            "periode": {
+              "fom": null,
+              "tom": null
+            },
+            "opprettetDato": "2025-01-01T00:00:00.000Z",
+            "behandlingOversikter": [
+              {
+                "behandlingID": 43,
+                "tittel": "Årsavregning",
+                "behandlingsstatus": {
+                  "kode": "UNDER_BEHANDLING",
+                  "term": "Behandlingen pågår"
+                },
+                "behandlingstype": {
+                  "kode": "ÅRSAVREGNING",
+                  "term": "Årsavregning"
+                },
+                "behandlingstema": {
+                  "kode": "YRKESAKTIV",
+                  "term": "Yrkesaktiv"
+                },
+                "soknadsperiode": {
+                  "fom": null,
+                  "tom": null
+                },
+                "opprettetDato": "2025-01-01T00:00:00.000Z",
+                "behandlingsresultattype": {
+                  "kode": "IKKE_FASTSATT",
+                  "term": "Ikke fastsatt"
+                },
+                "svarFrist": null
+              }
+            ],
+            "hovedpartRolle": "BRUKER"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/api/saksopplysninger/oppfriskning/aarsavregning/43",
+        "pathname": "/api/saksopplysninger/oppfriskning/aarsavregning/43",
+        "normalizedPath": "/api/saksopplysninger/oppfriskning/aarsavregning/:id",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": {}
+      },
+      "response": {
+        "status": 204,
+        "statusText": "No Content",
+        "headers": {},
+        "body": null
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentAdresser",
+          "variables": {
+            "behandlingID": 43
+          },
+          "query": "query hentAdresser($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      bostedsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      oppholdsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      kontaktadresser {\n        coAdressenavn\n        semistrukturertAdresse {\n          adresselinje1\n          adresselinje2\n          adresselinje3\n          adresselinje4\n          postnummer\n          poststed\n          land\n          __typename\n        }\n        strukturertAdresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "bostedsadresser": [
+                  {
+                    "coAdressenavn": "Co Yo 1",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "bosted gata 3",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "STORBRITANNIA",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1995-06-16",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Bostedsadresse"
+                  },
+                  {
+                    "coAdressenavn": null,
+                    "adresse": {
+                      "tilleggsnavn": "tilleggg navn",
+                      "gatenavn": null,
+                      "husnummerEtasjeLeilighet": null,
+                      "postboks": null,
+                      "postnummer": "2414",
+                      "poststed": "ELVERUM",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1957-09-12",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": true,
+                    "__typename": "Bostedsadresse"
+                  }
+                ],
+                "oppholdsadresser": [
+                  {
+                    "coAdressenavn": "CO 3",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "opphold gata 1",
+                      "husnummerEtasjeLeilighet": "42 B",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": "OSLO",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Oppholdsadresse"
+                  }
+                ],
+                "kontaktadresser": [
+                  {
+                    "coAdressenavn": "CO 2",
+                    "semistrukturertAdresse": null,
+                    "strukturertAdresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "kontakt gata 1",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "SVERIGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": false,
+                    "__typename": "Kontaktadresse"
+                  },
+                  {
+                    "coAdressenavn": null,
+                    "semistrukturertAdresse": {
+                      "adresselinje1": null,
+                      "adresselinje2": null,
+                      "adresselinje3": null,
+                      "adresselinje4": null,
+                      "postnummer": "3011",
+                      "poststed": "DRAMMEN",
+                      "land": "NORGE",
+                      "__typename": "SemistrukturertAdresseformat"
+                    },
+                    "strukturertAdresse": null,
+                    "gyldigFraOgMed": null,
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": true,
+                    "__typename": "Kontaktadresse"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentAdresser",
+          "variables": {
+            "behandlingID": 43
+          },
+          "query": "query hentAdresser($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      bostedsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      oppholdsadresser {\n        coAdressenavn\n        adresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        kilde\n        master\n        erHistorisk\n        __typename\n      }\n      kontaktadresser {\n        coAdressenavn\n        semistrukturertAdresse {\n          adresselinje1\n          adresselinje2\n          adresselinje3\n          adresselinje4\n          postnummer\n          poststed\n          land\n          __typename\n        }\n        strukturertAdresse {\n          tilleggsnavn\n          gatenavn\n          husnummerEtasjeLeilighet\n          postboks\n          postnummer\n          poststed\n          region\n          land\n          __typename\n        }\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "bostedsadresser": [
+                  {
+                    "coAdressenavn": "Co Yo 1",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "bosted gata 3",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "STORBRITANNIA",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1995-06-16",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Bostedsadresse"
+                  },
+                  {
+                    "coAdressenavn": null,
+                    "adresse": {
+                      "tilleggsnavn": "tilleggg navn",
+                      "gatenavn": null,
+                      "husnummerEtasjeLeilighet": null,
+                      "postboks": null,
+                      "postnummer": "2414",
+                      "poststed": "ELVERUM",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "1957-09-12",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": true,
+                    "__typename": "Bostedsadresse"
+                  }
+                ],
+                "oppholdsadresser": [
+                  {
+                    "coAdressenavn": "CO 3",
+                    "adresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "opphold gata 1",
+                      "husnummerEtasjeLeilighet": "42 B",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": "OSLO",
+                      "region": null,
+                      "land": "NORGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "kilde": "Folkeregisteret",
+                    "master": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Oppholdsadresse"
+                  }
+                ],
+                "kontaktadresser": [
+                  {
+                    "coAdressenavn": "CO 2",
+                    "semistrukturertAdresse": null,
+                    "strukturertAdresse": {
+                      "tilleggsnavn": null,
+                      "gatenavn": "kontakt gata 1",
+                      "husnummerEtasjeLeilighet": "42",
+                      "postboks": null,
+                      "postnummer": "0001",
+                      "poststed": null,
+                      "region": null,
+                      "land": "SVERIGE",
+                      "__typename": "StrukturertAdresseformat"
+                    },
+                    "gyldigFraOgMed": "2016-02-17",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": false,
+                    "__typename": "Kontaktadresse"
+                  },
+                  {
+                    "coAdressenavn": null,
+                    "semistrukturertAdresse": {
+                      "adresselinje1": null,
+                      "adresselinje2": null,
+                      "adresselinje3": null,
+                      "adresselinje4": null,
+                      "postnummer": "3011",
+                      "poststed": "DRAMMEN",
+                      "land": "NORGE",
+                      "__typename": "SemistrukturertAdresseformat"
+                    },
+                    "strukturertAdresse": null,
+                    "gyldigFraOgMed": null,
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": true,
+                    "__typename": "Kontaktadresse"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersoninfo",
+          "variables": {
+            "behandlingID": 43
+          },
+          "query": "query hentPersoninfo($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      folkeregisterpersonstatuser {\n        kode\n        tekst\n        master\n        kilde\n        fregGyldighetstidspunkt\n        erHistorisk\n        __typename\n      }\n      foedsel {\n        foedeland\n        foedested\n        foedselsaar\n        foedselsdato\n        __typename\n      }\n      sivilstand {\n        type\n        relatertVedSivilstand\n        gyldigFraOgMed\n        bekreftelsesdato\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "tekst": "Bosatt etter folkeregisterloven",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "1990-01-01",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "tekst": "Midlertidig (D-nummer)",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "2020-10-22",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "tekst": "Utflyttet",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "2012-03-15",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "foedsel": {
+                  "foedeland": "NO",
+                  "foedested": "OSLO",
+                  "foedselsaar": 1969,
+                  "foedselsdato": "1969-05-30",
+                  "__typename": "Foedsel"
+                },
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "relatertVedSivilstand": "12028536819",
+                    "gyldigFraOgMed": "2011-02-02",
+                    "bekreftelsesdato": null,
+                    "master": "Freg",
+                    "kilde": "KILDE_DSF",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "relatertVedSivilstand": "21075114491",
+                    "gyldigFraOgMed": "2019-08-03",
+                    "bekreftelsesdato": null,
+                    "master": "Freg",
+                    "kilde": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "relatertVedSivilstand": "12028536819",
+                    "gyldigFraOgMed": "2013-01-03",
+                    "bekreftelsesdato": null,
+                    "master": "NAV (PDL)",
+                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "relatertVedSivilstand": null,
+                    "gyldigFraOgMed": "2014-04-09",
+                    "bekreftelsesdato": null,
+                    "master": "NAV (PDL)",
+                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersoninfo",
+          "variables": {
+            "behandlingID": 43
+          },
+          "query": "query hentPersoninfo($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      folkeregisterpersonstatuser {\n        kode\n        tekst\n        master\n        kilde\n        fregGyldighetstidspunkt\n        erHistorisk\n        __typename\n      }\n      foedsel {\n        foedeland\n        foedested\n        foedselsaar\n        foedselsdato\n        __typename\n      }\n      sivilstand {\n        type\n        relatertVedSivilstand\n        gyldigFraOgMed\n        bekreftelsesdato\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "tekst": "Bosatt etter folkeregisterloven",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "1990-01-01",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "tekst": "Midlertidig (D-nummer)",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "2020-10-22",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "tekst": "Utflyttet",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "2012-03-15",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "foedsel": {
+                  "foedeland": "NO",
+                  "foedested": "OSLO",
+                  "foedselsaar": 1969,
+                  "foedselsdato": "1969-05-30",
+                  "__typename": "Foedsel"
+                },
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "relatertVedSivilstand": "12028536819",
+                    "gyldigFraOgMed": "2011-02-02",
+                    "bekreftelsesdato": null,
+                    "master": "Freg",
+                    "kilde": "KILDE_DSF",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "relatertVedSivilstand": "21075114491",
+                    "gyldigFraOgMed": "2019-08-03",
+                    "bekreftelsesdato": null,
+                    "master": "Freg",
+                    "kilde": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "relatertVedSivilstand": "12028536819",
+                    "gyldigFraOgMed": "2013-01-03",
+                    "bekreftelsesdato": null,
+                    "master": "NAV (PDL)",
+                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "relatertVedSivilstand": null,
+                    "gyldigFraOgMed": "2014-04-09",
+                    "bekreftelsesdato": null,
+                    "master": "NAV (PDL)",
+                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 43
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 43
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 43
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentStatsborgerskap",
+          "variables": {
+            "behandlingID": 43
+          },
+          "query": "query hentStatsborgerskap($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      statsborgerskap {\n        land\n        bekreftelsesdato\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "bekreftelsesdato": null,
+                    "gyldigFraOgMed": "1990-01-01",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentStatsborgerskap",
+          "variables": {
+            "behandlingID": 43
+          },
+          "query": "query hentStatsborgerskap($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      statsborgerskap {\n        land\n        bekreftelsesdato\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "bekreftelsesdato": null,
+                    "gyldigFraOgMed": "1990-01-01",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/recordings/specs/behandle-sak/eu-eøs/eu-eos-trygdeavgift/skal-vise-inntektskilder-nar-bruker-ikke-er-skattepliktig.json
+++ b/tests/e2e/recordings/specs/behandle-sak/eu-eøs/eu-eos-trygdeavgift/skal-vise-inntektskilder-nar-bruker-ikke-er-skattepliktig.json
@@ -518,7 +518,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -534,13 +534,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -636,7 +636,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -665,7 +665,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -694,7 +694,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -723,7 +723,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -752,7 +752,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -781,7 +781,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -810,13 +810,42 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
                           "tom": null
                         },
                         "utbetaltIPeriode": "2026-01",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2026-02",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2026-02",
                         "opplysningspliktigID": "974761076",
                         "virksomhetID": "888888888",
                         "inntektsmottakerID": "30056928150",
@@ -1159,11 +1188,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1187,7 +1216,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1847,7 +1877,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1870,7 +1900,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -1992,7 +2022,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -2015,7 +2045,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2549,56 +2579,6 @@
                     "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentStatsborgerskap",
-          "variables": {
-            "behandlingID": 54
-          },
-          "query": "query hentStatsborgerskap($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      statsborgerskap {\n        land\n        bekreftelsesdato\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
-                    "bekreftelsesdato": null,
-                    "gyldigFraOgMed": "1990-01-01",
-                    "gyldigTilOgMed": null,
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "erHistorisk": false,
-                    "__typename": "Statsborgerskap"
                   }
                 ],
                 "__typename": "Personopplysninger"

--- a/tests/e2e/recordings/specs/behandle-sak/eu-eøs/navigasjon/eu-eos-ikke-yrkesaktiv-bekreft-knapp-forblir-deaktivert-ved-ugyldig-input.json
+++ b/tests/e2e/recordings/specs/behandle-sak/eu-eøs/navigasjon/eu-eos-ikke-yrkesaktiv-bekreft-knapp-forblir-deaktivert-ved-ugyldig-input.json
@@ -246,11 +246,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -274,7 +274,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/behandle-sak/eu-eøs/navigasjon/eu-eos-ikke-yrkesaktiv-navigasjon-frem-og-tilbake.json
+++ b/tests/e2e/recordings/specs/behandle-sak/eu-eøs/navigasjon/eu-eos-ikke-yrkesaktiv-navigasjon-frem-og-tilbake.json
@@ -220,7 +220,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -236,13 +236,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -338,7 +338,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -367,7 +367,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -396,7 +396,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -425,7 +425,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -454,7 +454,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -483,7 +483,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -512,7 +512,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -541,7 +541,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -570,7 +570,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -599,7 +599,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -628,7 +628,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -657,7 +657,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -686,7 +686,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -715,7 +715,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -744,7 +744,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -773,7 +773,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -802,7 +802,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -831,7 +831,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -860,7 +860,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -889,7 +889,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -918,7 +918,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -947,7 +947,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -976,7 +976,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1005,7 +1005,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1034,7 +1034,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1063,7 +1063,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1092,7 +1092,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1121,7 +1121,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1150,7 +1150,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1179,7 +1179,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1208,13 +1208,42 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
                           "tom": null
                         },
                         "utbetaltIPeriode": "2026-01",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2026-02",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2026-02",
                         "opplysningspliktigID": "974761076",
                         "virksomhetID": "888888888",
                         "inntektsmottakerID": "30056928150",
@@ -1420,11 +1449,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1448,7 +1477,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -2348,7 +2378,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -2371,7 +2401,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2493,7 +2523,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -2516,7 +2546,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2797,122 +2827,6 @@
           "authorization": "[REDACTED]"
         },
         "body": {
-          "operationName": "hentPersoninfo",
-          "variables": {
-            "behandlingID": 51
-          },
-          "query": "query hentPersoninfo($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      folkeregisterpersonstatuser {\n        kode\n        tekst\n        master\n        kilde\n        fregGyldighetstidspunkt\n        erHistorisk\n        __typename\n      }\n      foedsel {\n        foedeland\n        foedested\n        foedselsaar\n        foedselsdato\n        __typename\n      }\n      sivilstand {\n        type\n        relatertVedSivilstand\n        gyldigFraOgMed\n        bekreftelsesdato\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "folkeregisterpersonstatuser": [
-                  {
-                    "kode": "BOSATT",
-                    "tekst": "Bosatt etter folkeregisterloven",
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "1990-01-01",
-                    "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "MIDLERTIDIG",
-                    "tekst": "Midlertidig (D-nummer)",
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "2020-10-22",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "tekst": "Utflyttet",
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "2012-03-15",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  }
-                ],
-                "foedsel": {
-                  "foedeland": "NO",
-                  "foedested": "OSLO",
-                  "foedselsaar": 1969,
-                  "foedselsdato": "1969-05-30",
-                  "__typename": "Foedsel"
-                },
-                "sivilstand": [
-                  {
-                    "type": "Gift",
-                    "relatertVedSivilstand": "12028536819",
-                    "gyldigFraOgMed": "2011-02-02",
-                    "bekreftelsesdato": null,
-                    "master": "Freg",
-                    "kilde": "KILDE_DSF",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Gift",
-                    "relatertVedSivilstand": "21075114491",
-                    "gyldigFraOgMed": "2019-08-03",
-                    "bekreftelsesdato": null,
-                    "master": "Freg",
-                    "kilde": "FREG",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Separert",
-                    "relatertVedSivilstand": "12028536819",
-                    "gyldigFraOgMed": "2013-01-03",
-                    "bekreftelsesdato": null,
-                    "master": "NAV (PDL)",
-                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "relatertVedSivilstand": null,
-                    "gyldigFraOgMed": "2014-04-09",
-                    "bekreftelsesdato": null,
-                    "master": "NAV (PDL)",
-                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
           "operationName": "hentPersonopplysninger",
           "variables": {
             "behandlingID": 51
@@ -3166,148 +3080,6 @@
                     "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentPersonopplysninger",
-          "variables": {
-            "behandlingID": 51
-          },
-          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "navn": {
-                  "fornavn": "KARAFFEL",
-                  "mellomnavn": null,
-                  "etternavn": "TRIVIELL",
-                  "__typename": "Navn"
-                },
-                "kjoenn": "MANN",
-                "folkeregisterpersonstatuser": [
-                  {
-                    "kode": "BOSATT",
-                    "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "MIDLERTIDIG",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  }
-                ],
-                "folkeregisteridentifikator": "30056928150",
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
-                    "erHistorisk": false,
-                    "__typename": "Statsborgerskap"
-                  }
-                ],
-                "sivilstand": [
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Separert",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentStatsborgerskap",
-          "variables": {
-            "behandlingID": 51
-          },
-          "query": "query hentStatsborgerskap($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      statsborgerskap {\n        land\n        bekreftelsesdato\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
-                    "bekreftelsesdato": null,
-                    "gyldigFraOgMed": "1990-01-01",
-                    "gyldigTilOgMed": null,
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "erHistorisk": false,
-                    "__typename": "Statsborgerskap"
                   }
                 ],
                 "__typename": "Personopplysninger"

--- a/tests/e2e/recordings/specs/behandle-sak/eu-eøs/navigasjon/eu-eos-ikke-yrkesaktiv-navigasjon-gjennom-steg-med-minimum-input.json
+++ b/tests/e2e/recordings/specs/behandle-sak/eu-eøs/navigasjon/eu-eos-ikke-yrkesaktiv-navigasjon-gjennom-steg-med-minimum-input.json
@@ -220,7 +220,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -236,13 +236,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -338,7 +338,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -367,7 +367,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -396,7 +396,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -425,7 +425,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -454,7 +454,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -483,7 +483,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -512,7 +512,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -541,7 +541,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -570,7 +570,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -599,7 +599,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -628,7 +628,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -657,7 +657,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -686,7 +686,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -715,7 +715,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -744,7 +744,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -773,7 +773,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -802,7 +802,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -831,7 +831,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -860,7 +860,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -889,7 +889,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -918,7 +918,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -947,7 +947,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -976,7 +976,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1005,7 +1005,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1034,7 +1034,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1063,7 +1063,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1092,7 +1092,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1121,7 +1121,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1150,7 +1150,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1179,7 +1179,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1208,13 +1208,42 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
                           "tom": null
                         },
                         "utbetaltIPeriode": "2026-01",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2026-02",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2026-02",
                         "opplysningspliktigID": "974761076",
                         "virksomhetID": "888888888",
                         "inntektsmottakerID": "30056928150",
@@ -1420,11 +1449,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1448,7 +1477,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -2308,7 +2338,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -2331,7 +2361,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2453,7 +2483,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -2476,7 +2506,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -2757,11 +2787,11 @@
           "authorization": "[REDACTED]"
         },
         "body": {
-          "operationName": "hentPersoninfo",
+          "operationName": "hentPersonopplysninger",
           "variables": {
             "behandlingID": 52
           },
-          "query": "query hentPersoninfo($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      folkeregisterpersonstatuser {\n        kode\n        tekst\n        master\n        kilde\n        fregGyldighetstidspunkt\n        erHistorisk\n        __typename\n      }\n      foedsel {\n        foedeland\n        foedested\n        foedselsaar\n        foedselsdato\n        __typename\n      }\n      sivilstand {\n        type\n        relatertVedSivilstand\n        gyldigFraOgMed\n        bekreftelsesdato\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
         }
       },
       "response": {
@@ -2774,450 +2804,384 @@
           "data": {
             "hentSaksopplysninger": {
               "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
                 "folkeregisterpersonstatuser": [
                   {
                     "kode": "BOSATT",
-                    "tekst": "Bosatt etter folkeregisterloven",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 52
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 52
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 52
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentStatsborgerskap",
+          "variables": {
+            "behandlingID": 52
+          },
+          "query": "query hentStatsborgerskap($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      statsborgerskap {\n        land\n        bekreftelsesdato\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "bekreftelsesdato": null,
+                    "gyldigFraOgMed": "1990-01-01",
+                    "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "1990-01-01",
-                    "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "MIDLERTIDIG",
-                    "tekst": "Midlertidig (D-nummer)",
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "2020-10-22",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "tekst": "Utflyttet",
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "fregGyldighetstidspunkt": "2012-03-15",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  }
-                ],
-                "foedsel": {
-                  "foedeland": "NO",
-                  "foedested": "OSLO",
-                  "foedselsaar": 1969,
-                  "foedselsdato": "1969-05-30",
-                  "__typename": "Foedsel"
-                },
-                "sivilstand": [
-                  {
-                    "type": "Gift",
-                    "relatertVedSivilstand": "12028536819",
-                    "gyldigFraOgMed": "2011-02-02",
-                    "bekreftelsesdato": null,
-                    "master": "Freg",
-                    "kilde": "KILDE_DSF",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Gift",
-                    "relatertVedSivilstand": "21075114491",
-                    "gyldigFraOgMed": "2019-08-03",
-                    "bekreftelsesdato": null,
-                    "master": "Freg",
-                    "kilde": "FREG",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Separert",
-                    "relatertVedSivilstand": "12028536819",
-                    "gyldigFraOgMed": "2013-01-03",
-                    "bekreftelsesdato": null,
-                    "master": "NAV (PDL)",
-                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "relatertVedSivilstand": null,
-                    "gyldigFraOgMed": "2014-04-09",
-                    "bekreftelsesdato": null,
-                    "master": "NAV (PDL)",
-                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentPersonopplysninger",
-          "variables": {
-            "behandlingID": 52
-          },
-          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "navn": {
-                  "fornavn": "KARAFFEL",
-                  "mellomnavn": null,
-                  "etternavn": "TRIVIELL",
-                  "__typename": "Navn"
-                },
-                "kjoenn": "MANN",
-                "folkeregisterpersonstatuser": [
-                  {
-                    "kode": "BOSATT",
-                    "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "MIDLERTIDIG",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  }
-                ],
-                "folkeregisteridentifikator": "30056928150",
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
                     "erHistorisk": false,
                     "__typename": "Statsborgerskap"
-                  }
-                ],
-                "sivilstand": [
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Separert",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentPersonopplysninger",
-          "variables": {
-            "behandlingID": 52
-          },
-          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "navn": {
-                  "fornavn": "KARAFFEL",
-                  "mellomnavn": null,
-                  "etternavn": "TRIVIELL",
-                  "__typename": "Navn"
-                },
-                "kjoenn": "MANN",
-                "folkeregisterpersonstatuser": [
-                  {
-                    "kode": "BOSATT",
-                    "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "MIDLERTIDIG",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  }
-                ],
-                "folkeregisteridentifikator": "30056928150",
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
-                    "erHistorisk": false,
-                    "__typename": "Statsborgerskap"
-                  }
-                ],
-                "sivilstand": [
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Separert",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentPersonopplysninger",
-          "variables": {
-            "behandlingID": 52
-          },
-          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "navn": {
-                  "fornavn": "KARAFFEL",
-                  "mellomnavn": null,
-                  "etternavn": "TRIVIELL",
-                  "__typename": "Navn"
-                },
-                "kjoenn": "MANN",
-                "folkeregisterpersonstatuser": [
-                  {
-                    "kode": "BOSATT",
-                    "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "MIDLERTIDIG",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  }
-                ],
-                "folkeregisteridentifikator": "30056928150",
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
-                    "erHistorisk": false,
-                    "__typename": "Statsborgerskap"
-                  }
-                ],
-                "sivilstand": [
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Separert",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentPersonopplysninger",
-          "variables": {
-            "behandlingID": 52
-          },
-          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "navn": {
-                  "fornavn": "KARAFFEL",
-                  "mellomnavn": null,
-                  "etternavn": "TRIVIELL",
-                  "__typename": "Navn"
-                },
-                "kjoenn": "MANN",
-                "folkeregisterpersonstatuser": [
-                  {
-                    "kode": "BOSATT",
-                    "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "MIDLERTIDIG",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  }
-                ],
-                "folkeregisteridentifikator": "30056928150",
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
-                    "erHistorisk": false,
-                    "__typename": "Statsborgerskap"
-                  }
-                ],
-                "sivilstand": [
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Separert",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
                   }
                 ],
                 "__typename": "Personopplysninger"

--- a/tests/e2e/recordings/specs/behandle-sak/ftrl/navigasjon/bekreft-knapp-forblir-deaktivert-ved-ugyldig-input.json
+++ b/tests/e2e/recordings/specs/behandle-sak/ftrl/navigasjon/bekreft-knapp-forblir-deaktivert-ved-ugyldig-input.json
@@ -350,11 +350,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -378,7 +378,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/behandle-sak/ftrl/navigasjon/navigasjon-frem-og-tilbake-mellom-steg.json
+++ b/tests/e2e/recordings/specs/behandle-sak/ftrl/navigasjon/navigasjon-frem-og-tilbake-mellom-steg.json
@@ -332,7 +332,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -348,13 +348,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -450,7 +450,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -479,7 +479,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -508,7 +508,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -537,7 +537,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -566,7 +566,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -595,7 +595,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -624,7 +624,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -653,7 +653,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -682,7 +682,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -711,7 +711,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -740,7 +740,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -769,7 +769,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -798,7 +798,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -827,7 +827,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -856,7 +856,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -885,7 +885,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -914,7 +914,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -943,7 +943,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -972,7 +972,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1001,7 +1001,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1030,7 +1030,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1059,7 +1059,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1088,7 +1088,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1117,7 +1117,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1146,7 +1146,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1175,7 +1175,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1204,7 +1204,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1233,7 +1233,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1262,7 +1262,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1291,7 +1291,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1320,13 +1320,42 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
                           "tom": null
                         },
                         "utbetaltIPeriode": "2026-01",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2026-02",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2026-02",
                         "opplysningspliktigID": "974761076",
                         "virksomhetID": "888888888",
                         "inntektsmottakerID": "30056928150",
@@ -1580,11 +1609,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1608,7 +1637,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -3689,7 +3719,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -3712,7 +3742,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -3834,7 +3864,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -3857,7 +3887,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -4507,148 +4537,6 @@
                     "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentPersonopplysninger",
-          "variables": {
-            "behandlingID": 17
-          },
-          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "navn": {
-                  "fornavn": "KARAFFEL",
-                  "mellomnavn": null,
-                  "etternavn": "TRIVIELL",
-                  "__typename": "Navn"
-                },
-                "kjoenn": "MANN",
-                "folkeregisterpersonstatuser": [
-                  {
-                    "kode": "BOSATT",
-                    "erHistorisk": false,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "MIDLERTIDIG",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  },
-                  {
-                    "kode": "UTFLYTTET",
-                    "erHistorisk": true,
-                    "__typename": "Folkeregisterpersonstatus"
-                  }
-                ],
-                "folkeregisteridentifikator": "30056928150",
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
-                    "erHistorisk": false,
-                    "__typename": "Statsborgerskap"
-                  }
-                ],
-                "sivilstand": [
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Gift",
-                    "erHistorisk": false,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Separert",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  },
-                  {
-                    "type": "Skilt",
-                    "erHistorisk": true,
-                    "__typename": "Sivilstand"
-                  }
-                ],
-                "__typename": "Personopplysninger"
-              },
-              "__typename": "Saksopplysninger"
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/graphql/",
-        "pathname": "/graphql/",
-        "normalizedPath": "/graphql/",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "*/*",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "operationName": "hentStatsborgerskap",
-          "variables": {
-            "behandlingID": 17
-          },
-          "query": "query hentStatsborgerskap($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      statsborgerskap {\n        land\n        bekreftelsesdato\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": {
-          "data": {
-            "hentSaksopplysninger": {
-              "persondata": {
-                "statsborgerskap": [
-                  {
-                    "land": "NORGE",
-                    "bekreftelsesdato": null,
-                    "gyldigFraOgMed": "1990-01-01",
-                    "gyldigTilOgMed": null,
-                    "master": "FREG",
-                    "kilde": "Folkeregisteret",
-                    "erHistorisk": false,
-                    "__typename": "Statsborgerskap"
                   }
                 ],
                 "__typename": "Personopplysninger"

--- a/tests/e2e/recordings/specs/behandle-sak/ftrl/navigasjon/navigasjon-gjennom-alle-steg-med-minimum-input.json
+++ b/tests/e2e/recordings/specs/behandle-sak/ftrl/navigasjon/navigasjon-gjennom-alle-steg-med-minimum-input.json
@@ -195,7 +195,7 @@
         },
         "body": [
           {
-            "id": 3,
+            "id": 1,
             "fomDato": "2024-01-01",
             "tomDato": "2024-12-31",
             "bestemmelse": "FTRL_KAP2_2_5_FØRSTE_LEDD_A",
@@ -617,7 +617,7 @@
                 "arbeidsforholdID": "123",
                 "arbeidsforholdIDnav": 123,
                 "ansettelsesPeriode": {
-                  "fom": "2021-01-30",
+                  "fom": "2021-02-17",
                   "tom": null
                 },
                 "arbeidsforholdstype": "ordinaertArbeidsforhold",
@@ -633,13 +633,13 @@
                       "term": "KONSULENT"
                     },
                     "gyldighetsperiode": {
-                      "fom": "2021-01-30",
+                      "fom": "2021-02-17",
                       "tom": null
                     },
                     "avtaltArbeidstimerPerUke": 37.5,
                     "stillingsprosent": 100,
                     "beregnetAntallTimerPrUke": 37.5,
-                    "endringsdatoStillingsprosent": "2021-01-30",
+                    "endringsdatoStillingsprosent": "2021-02-17",
                     "skipsregister": null,
                     "skipstype": null,
                     "maritimArbeidsavtale": false,
@@ -735,7 +735,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -764,7 +764,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -793,7 +793,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -822,7 +822,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -851,7 +851,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -880,7 +880,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -909,7 +909,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -938,7 +938,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -967,7 +967,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -996,7 +996,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1025,7 +1025,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1054,7 +1054,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1083,7 +1083,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1112,7 +1112,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1141,7 +1141,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1170,7 +1170,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1199,7 +1199,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1228,7 +1228,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1257,7 +1257,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1286,7 +1286,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1315,7 +1315,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1344,7 +1344,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1373,7 +1373,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1402,7 +1402,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1431,7 +1431,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1460,7 +1460,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1489,7 +1489,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1518,7 +1518,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1547,7 +1547,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1576,7 +1576,7 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
@@ -1605,13 +1605,42 @@
                         "inntektskilde": "A-ordningen",
                         "inntektsperiodetype": "Maaned",
                         "inntektsstatus": "LoependeInnrapportert",
-                        "levereringstidspunkt": "2026-01-01T00:00:00",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
                         "opptjeningsland": null,
                         "opptjeningsperiode": {
                           "fom": null,
                           "tom": null
                         },
                         "utbetaltIPeriode": "2026-01",
+                        "opplysningspliktigID": "974761076",
+                        "virksomhetID": "888888888",
+                        "inntektsmottakerID": "30056928150",
+                        "inngaarIGrunnlagForTrekk": true,
+                        "utloeserArbeidsgiveravgift": true,
+                        "informasjonsstatus": "InngaarAlltid",
+                        "beskrivelse": "fastloenn"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "aarMaaned": "2026-02",
+                  "arbeidsInntektInformasjon": {
+                    "inntektListe": [
+                      {
+                        "type": "Loennsinntekt",
+                        "beloep": 50000,
+                        "fordel": "kontantytelse",
+                        "inntektskilde": "A-ordningen",
+                        "inntektsperiodetype": "Maaned",
+                        "inntektsstatus": "LoependeInnrapportert",
+                        "levereringstidspunkt": "2026-02-01T00:00:00",
+                        "opptjeningsland": null,
+                        "opptjeningsperiode": {
+                          "fom": null,
+                          "tom": null
+                        },
+                        "utbetaltIPeriode": "2026-02",
                         "opplysningspliktigID": "974761076",
                         "virksomhetID": "888888888",
                         "inntektsmottakerID": "30056928150",
@@ -1889,11 +1918,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1917,7 +1946,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -3913,7 +3943,7 @@
         },
         "body": [
           {
-            "id": 3,
+            "id": 1,
             "fomDato": "2024-01-01",
             "tomDato": null,
             "bestemmelse": "FTRL_KAP2_2_5_FØRSTE_LEDD_A",
@@ -4456,7 +4486,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -4479,7 +4509,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -4601,7 +4631,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -4624,7 +4654,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -4905,6 +4935,214 @@
           "authorization": "[REDACTED]"
         },
         "body": {
+          "operationName": "hentPersoninfo",
+          "variables": {
+            "behandlingID": 21
+          },
+          "query": "query hentPersoninfo($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      folkeregisterpersonstatuser {\n        kode\n        tekst\n        master\n        kilde\n        fregGyldighetstidspunkt\n        erHistorisk\n        __typename\n      }\n      foedsel {\n        foedeland\n        foedested\n        foedselsaar\n        foedselsdato\n        __typename\n      }\n      sivilstand {\n        type\n        relatertVedSivilstand\n        gyldigFraOgMed\n        bekreftelsesdato\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "tekst": "Bosatt etter folkeregisterloven",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "1990-01-01",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "tekst": "Midlertidig (D-nummer)",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "2020-10-22",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "tekst": "Utflyttet",
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "fregGyldighetstidspunkt": "2012-03-15",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "foedsel": {
+                  "foedeland": "NO",
+                  "foedested": "OSLO",
+                  "foedselsaar": 1969,
+                  "foedselsdato": "1969-05-30",
+                  "__typename": "Foedsel"
+                },
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "relatertVedSivilstand": "12028536819",
+                    "gyldigFraOgMed": "2011-02-02",
+                    "bekreftelsesdato": null,
+                    "master": "Freg",
+                    "kilde": "KILDE_DSF",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "relatertVedSivilstand": "21075114491",
+                    "gyldigFraOgMed": "2019-08-03",
+                    "bekreftelsesdato": null,
+                    "master": "Freg",
+                    "kilde": "FREG",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "relatertVedSivilstand": "12028536819",
+                    "gyldigFraOgMed": "2013-01-03",
+                    "bekreftelsesdato": null,
+                    "master": "NAV (PDL)",
+                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "relatertVedSivilstand": null,
+                    "gyldigFraOgMed": "2014-04-09",
+                    "bekreftelsesdato": null,
+                    "master": "NAV (PDL)",
+                    "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 21
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
           "operationName": "hentPersonopplysninger",
           "variables": {
             "behandlingID": 21
@@ -5158,6 +5396,56 @@
                     "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentStatsborgerskap",
+          "variables": {
+            "behandlingID": 21
+          },
+          "query": "query hentStatsborgerskap($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      statsborgerskap {\n        land\n        bekreftelsesdato\n        gyldigFraOgMed\n        gyldigTilOgMed\n        master\n        kilde\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "bekreftelsesdato": null,
+                    "gyldigFraOgMed": "1990-01-01",
+                    "gyldigTilOgMed": null,
+                    "master": "FREG",
+                    "kilde": "Folkeregisteret",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
                   }
                 ],
                 "__typename": "Personopplysninger"
@@ -5271,8 +5559,8 @@
     {
       "request": {
         "method": "PUT",
-        "url": "http://localhost:3333/api/behandlinger/21/medlemskapsperioder/3",
-        "pathname": "/api/behandlinger/21/medlemskapsperioder/3",
+        "url": "http://localhost:3333/api/behandlinger/21/medlemskapsperioder/1",
+        "pathname": "/api/behandlinger/21/medlemskapsperioder/1",
         "normalizedPath": "/api/behandlinger/:behandlingId/medlemskapsperioder/:id",
         "query": {},
         "headers": {
@@ -5295,7 +5583,7 @@
           "content-type": "application/json"
         },
         "body": {
-          "id": 3,
+          "id": 1,
           "fomDato": "2024-01-01",
           "tomDato": "2024-12-31",
           "bestemmelse": "FTRL_KAP2_2_5_FØRSTE_LEDD_A",

--- a/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/korrekt-validering-for-brevmal-fritekstbrev-til-bruker.json
+++ b/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/korrekt-validering-for-brevmal-fritekstbrev-til-bruker.json
@@ -1073,11 +1073,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1101,7 +1101,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/korrekt-validering-for-brevmal-innhenting-av-inntektsopplysninger-for-arsavregning.json
+++ b/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/korrekt-validering-for-brevmal-innhenting-av-inntektsopplysninger-for-arsavregning.json
@@ -963,11 +963,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -991,7 +991,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1384,7 +1385,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1407,7 +1408,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -1529,7 +1530,7 @@
                       "land": "NORGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "kilde": "Folkeregisteret",
                     "master": "FREG",
@@ -1552,7 +1553,7 @@
                       "land": "SVERIGE",
                       "__typename": "StrukturertAdresseformat"
                     },
-                    "gyldigFraOgMed": "2016-01-30",
+                    "gyldigFraOgMed": "2016-02-17",
                     "gyldigTilOgMed": null,
                     "master": "FREG",
                     "kilde": "Folkeregisteret",
@@ -1808,6 +1809,98 @@
                     "bekreftelsesdato": null,
                     "master": "NAV (PDL)",
                     "kilde": "Tyske trygdemyndigheter, TYSKLAND",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 23
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
                     "erHistorisk": true,
                     "__typename": "Sivilstand"
                   }

--- a/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/korrekt-validering-for-brevmal-melding-om-manglende-opplysninger-til-bruker.json
+++ b/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/korrekt-validering-for-brevmal-melding-om-manglende-opplysninger-til-bruker.json
@@ -1073,11 +1073,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1101,7 +1101,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/send-brev-knappen-blir-enabled-nar-bade-mottaker-og-brevmal-er-valgt.json
+++ b/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/send-brev-knappen-blir-enabled-nar-bade-mottaker-og-brevmal-er-valgt.json
@@ -1073,11 +1073,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1101,7 +1101,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/send-brev-knappen-er-disabled-nar-hverken-mottaker-eller-brevmal-er-valgt.json
+++ b/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/send-brev-knappen-er-disabled-nar-hverken-mottaker-eller-brevmal-er-valgt.json
@@ -1073,11 +1073,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1101,7 +1101,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/send-brev-knappen-er-disabled-nar-mottaker-er-valgt-men-ikke-brevmal.json
+++ b/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/send-brev-knappen-er-disabled-nar-mottaker-er-valgt-men-ikke-brevmal.json
@@ -1073,11 +1073,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -1101,7 +1101,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk/regresjon-avtaleland-med-apen-behandling-viser-varselmelding.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk/regresjon-avtaleland-med-apen-behandling-viser-varselmelding.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,18 +83,19 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -118,7 +119,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1176,7 +1178,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1217,7 +1219,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1264,7 +1266,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1311,7 +1313,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1358,7 +1360,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1405,7 +1407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1452,7 +1454,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1493,7 +1495,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1534,7 +1536,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1575,7 +1577,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1616,7 +1618,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1657,7 +1659,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1698,7 +1700,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1739,7 +1741,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1786,7 +1788,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1827,7 +1829,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1874,7 +1876,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1915,7 +1917,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1962,7 +1964,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -2003,7 +2005,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2050,7 +2052,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2097,7 +2099,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2144,7 +2146,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2191,7 +2193,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2232,7 +2234,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2273,7 +2275,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2314,7 +2316,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2355,7 +2357,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2396,7 +2398,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2437,7 +2439,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2478,7 +2480,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2519,7 +2521,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2560,7 +2562,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2601,7 +2603,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2642,7 +2644,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2683,7 +2685,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2724,7 +2726,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2765,7 +2767,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2812,7 +2814,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2859,7 +2861,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2906,7 +2908,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2953,7 +2955,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -3000,7 +3002,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3047,7 +3049,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3094,7 +3096,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3135,7 +3137,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3176,7 +3178,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3217,7 +3219,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3264,7 +3266,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3311,7 +3313,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3358,7 +3360,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3405,7 +3407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3446,7 +3448,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3487,7 +3489,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3528,7 +3530,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3569,7 +3571,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3610,7 +3612,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3651,7 +3653,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3692,7 +3694,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3733,7 +3735,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3774,7 +3776,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3841,7 +3843,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -3882,7 +3884,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -3929,7 +3931,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -3976,7 +3978,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4023,7 +4025,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4070,7 +4072,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4117,7 +4119,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4158,7 +4160,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4199,7 +4201,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4240,7 +4242,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4281,7 +4283,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4322,7 +4324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4363,7 +4365,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4404,7 +4406,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4451,7 +4453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4492,7 +4494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4539,7 +4541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -4580,7 +4582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4627,7 +4629,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4668,7 +4670,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4715,7 +4717,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -4762,7 +4764,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -4809,7 +4811,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -4856,7 +4858,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -4897,7 +4899,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -4938,7 +4940,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -4979,7 +4981,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5020,7 +5022,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5061,7 +5063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5102,7 +5104,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5143,7 +5145,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5184,7 +5186,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5225,7 +5227,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5266,7 +5268,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5307,7 +5309,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5348,7 +5350,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5389,7 +5391,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5430,7 +5432,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5477,7 +5479,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5524,7 +5526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5571,7 +5573,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5618,7 +5620,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5665,7 +5667,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5712,7 +5714,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -5759,7 +5761,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -5800,7 +5802,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -5841,7 +5843,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -5882,7 +5884,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -5929,7 +5931,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -5976,7 +5978,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6023,7 +6025,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6070,7 +6072,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6111,7 +6113,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6152,7 +6154,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6193,7 +6195,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6234,7 +6236,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6275,7 +6277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6316,7 +6318,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6357,7 +6359,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6398,7 +6400,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6439,7 +6441,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -6619,3868 +6621,6 @@
           {
             "kode": "TRYGDEAVTALE",
             "term": "Avtaleland"
-          }
-        ]
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "url": "http://localhost:3333/api/fagsaker/sok",
-        "pathname": "/api/fagsaker/sok",
-        "normalizedPath": "/api/fagsaker/sok",
-        "query": {},
-        "headers": {
-          "content-type": "application/json",
-          "accept": "application/json",
-          "authorization": "[REDACTED]"
-        },
-        "body": {
-          "ident": "30056928150",
-          "saksnummer": null,
-          "orgnr": null
-        }
-      },
-      "response": {
-        "status": 200,
-        "statusText": "OK",
-        "headers": {
-          "content-type": "application/json"
-        },
-        "body": [
-          {
-            "saksnummer": "MEL-1001",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "LOVVALG_AVKLART",
-              "term": "Lovvalget er avklart"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 1,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "AVSLUTTET",
-                  "term": "Behandlingen er avsluttet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "FASTSATT_LOVVALGSLAND",
-                  "term": "Lovvalgsland er fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1002",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 2,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1003",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 3,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1004",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 4,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1005",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 5,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1006",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 6,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1007",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 7,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1008",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 8,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1009",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 9,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1010",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 10,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1011",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 11,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1012",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 12,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1013",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 13,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1014",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 14,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1015",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "LOVVALG_AVKLART",
-              "term": "Lovvalget er avklart"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 15,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "AVSLUTTET",
-                  "term": "Behandlingen er avsluttet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "MEDLEM_I_FOLKETRYGDEN",
-                  "term": "Medlem i folketrygden"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1016",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "LOVVALG_AVKLART",
-              "term": "Lovvalget er avklart"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 16,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "AVSLUTTET",
-                  "term": "Behandlingen er avsluttet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "MEDLEM_I_FOLKETRYGDEN",
-                  "term": "Medlem i folketrygden"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1017",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": ["SE"],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": "2024-01-01",
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 17,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": "2024-01-01",
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1018",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 18,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1019",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 19,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1020",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 20,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1021",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": ["SE"],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": "2024-01-01",
-              "tom": "2024-12-31"
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 21,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": "2024-01-01",
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1022",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 22,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1023",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 23,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1024",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 24,
-                "tittel": "Årsavregning 2025",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1025",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 25,
-                "tittel": "Årsavregning 2025",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1026",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 26,
-                "tittel": "Årsavregning 2025",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1027",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 27,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1028",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 28,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1029",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 29,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1030",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 30,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1031",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 31,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1032",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 32,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1033",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 33,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1034",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 34,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1035",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 35,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1036",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 36,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1037",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 37,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1038",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 38,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1039",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 39,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1040",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 40,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1041",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 41,
-                "tittel": "Årsavregning 2025",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1042",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 42,
-                "tittel": "Årsavregning 2025",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1043",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 43,
-                "tittel": "Årsavregning 2025",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1044",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 44,
-                "tittel": "Årsavregning 2025",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1045",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 45,
-                "tittel": "Årsavregning 2025",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1046",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 46,
-                "tittel": "Årsavregning 2025",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1047",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 47,
-                "tittel": "Årsavregning 2025",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1048",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 48,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1049",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 49,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1050",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 50,
-                "tittel": "Årsavregning",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "ÅRSAVREGNING",
-                  "term": "Årsavregning"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1051",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": ["SE"],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": "2024-01-01",
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 51,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "IKKE_YRKESAKTIV",
-                  "term": "Ikke yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": "2024-01-01",
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1052",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": ["SE"],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": "2024-01-01",
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 52,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "IKKE_YRKESAKTIV",
-                  "term": "Ikke yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": "2024-01-01",
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1053",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 53,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "IKKE_YRKESAKTIV",
-                  "term": "Ikke yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1054",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "TRYGDEAVGIFT",
-              "term": "Trygdeavgift"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": ["SE"],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": "2026-01-01",
-              "tom": "2026-12-31"
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 54,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "PENSJONIST",
-                  "term": "Pensjonist/uføretrygdet"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1055",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "TRYGDEAVGIFT",
-              "term": "Trygdeavgift"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 55,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "PENSJONIST",
-                  "term": "Pensjonist/uføretrygdet"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1056",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "TRYGDEAVGIFT",
-              "term": "Trygdeavgift"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 56,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "PENSJONIST",
-                  "term": "Pensjonist/uføretrygdet"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1057",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 57,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1058",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 58,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1059",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 59,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1060",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 60,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1061",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 61,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "IKKE_YRKESAKTIV",
-                  "term": "Ikke yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1062",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "TRYGDEAVGIFT",
-              "term": "Trygdeavgift"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 62,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "PENSJONIST",
-                  "term": "Pensjonist/uføretrygdet"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1063",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "HENLAGT",
-              "term": "Saken er henlagt"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 63,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "AVSLUTTET",
-                  "term": "Behandlingen er avsluttet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1064",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 64,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "AVSLUTTET",
-                  "term": "Behandlingen er avsluttet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1065",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 65,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "AVSLUTTET",
-                  "term": "Behandlingen er avsluttet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1066",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 66,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "AVSLUTTET",
-                  "term": "Behandlingen er avsluttet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1067",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 67,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "AVSLUTTET",
-                  "term": "Behandlingen er avsluttet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "IKKE_YRKESAKTIV",
-                  "term": "Ikke yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1068",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "TRYGDEAVGIFT",
-              "term": "Trygdeavgift"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 68,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "AVSLUTTET",
-                  "term": "Behandlingen er avsluttet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "PENSJONIST",
-                  "term": "Pensjonist/uføretrygdet"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1069",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 69,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1070",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 70,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "AVSLUTTET",
-                  "term": "Behandlingen er avsluttet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-1071",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "EU_EOS",
-              "term": "EU/EØS-land"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 71,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "UNDER_BEHANDLING",
-                  "term": "Behandlingen pågår"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "IKKE_YRKESAKTIV",
-                  "term": "Ikke yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
           }
         ]
       }

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk/regresjon-avtaleland-med-ferdigbehandlede-ny-vurdering-og-henvendelse-tilgjengelig.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk/regresjon-avtaleland-med-ferdigbehandlede-ny-vurdering-og-henvendelse-tilgjengelig.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,18 +83,19 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -118,7 +119,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1176,7 +1178,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1217,7 +1219,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1264,7 +1266,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1311,7 +1313,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1358,7 +1360,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1405,7 +1407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1452,7 +1454,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1493,7 +1495,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1534,7 +1536,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1575,7 +1577,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1616,7 +1618,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1657,7 +1659,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1698,7 +1700,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1739,7 +1741,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1786,7 +1788,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1827,7 +1829,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1874,7 +1876,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1915,7 +1917,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1962,7 +1964,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -2003,7 +2005,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2050,7 +2052,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2097,7 +2099,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2144,7 +2146,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2191,7 +2193,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2232,7 +2234,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2273,7 +2275,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2314,7 +2316,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2355,7 +2357,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2396,7 +2398,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2437,7 +2439,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2478,7 +2480,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2519,7 +2521,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2560,7 +2562,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2601,7 +2603,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2642,7 +2644,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2683,7 +2685,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2724,7 +2726,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2765,7 +2767,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2812,7 +2814,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2859,7 +2861,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2906,7 +2908,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2953,7 +2955,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -3000,7 +3002,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3047,7 +3049,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3094,7 +3096,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3135,7 +3137,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3176,7 +3178,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3217,7 +3219,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3264,7 +3266,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3311,7 +3313,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3358,7 +3360,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3405,7 +3407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3446,7 +3448,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3487,7 +3489,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3528,7 +3530,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3569,7 +3571,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3610,7 +3612,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3651,7 +3653,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3692,7 +3694,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3733,7 +3735,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3774,7 +3776,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3841,7 +3843,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -3882,7 +3884,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -3929,7 +3931,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -3976,7 +3978,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4023,7 +4025,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4070,7 +4072,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4117,7 +4119,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4158,7 +4160,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4199,7 +4201,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4240,7 +4242,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4281,7 +4283,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4322,7 +4324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4363,7 +4365,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4404,7 +4406,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4451,7 +4453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4492,7 +4494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4539,7 +4541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -4580,7 +4582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4627,7 +4629,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4668,7 +4670,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4715,7 +4717,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -4762,7 +4764,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -4809,7 +4811,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -4856,7 +4858,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -4897,7 +4899,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -4938,7 +4940,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -4979,7 +4981,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5020,7 +5022,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5061,7 +5063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5102,7 +5104,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5143,7 +5145,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5184,7 +5186,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5225,7 +5227,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5266,7 +5268,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5307,7 +5309,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5348,7 +5350,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5389,7 +5391,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5430,7 +5432,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5477,7 +5479,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5524,7 +5526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5571,7 +5573,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5618,7 +5620,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5665,7 +5667,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5712,7 +5714,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -5759,7 +5761,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -5800,7 +5802,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -5841,7 +5843,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -5882,7 +5884,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -5929,7 +5931,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -5976,7 +5978,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6023,7 +6025,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6070,7 +6072,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6111,7 +6113,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6152,7 +6154,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6193,7 +6195,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6234,7 +6236,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6275,7 +6277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6316,7 +6318,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6357,7 +6359,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6398,7 +6400,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6439,7 +6441,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk/regresjon-avtaleland-med-henlagt-soknad-viser-varselmelding.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk/regresjon-avtaleland-med-henlagt-soknad-viser-varselmelding.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,18 +83,19 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -118,7 +119,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1176,7 +1178,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1217,7 +1219,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1264,7 +1266,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1311,7 +1313,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1358,7 +1360,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1405,7 +1407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1452,7 +1454,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1493,7 +1495,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1534,7 +1536,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1575,7 +1577,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1616,7 +1618,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1657,7 +1659,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1698,7 +1700,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1739,7 +1741,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1786,7 +1788,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1827,7 +1829,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1874,7 +1876,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1915,7 +1917,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1962,7 +1964,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -2003,7 +2005,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2050,7 +2052,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2097,7 +2099,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2144,7 +2146,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2191,7 +2193,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2232,7 +2234,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2273,7 +2275,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2314,7 +2316,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2355,7 +2357,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2396,7 +2398,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2437,7 +2439,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2478,7 +2480,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2519,7 +2521,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2560,7 +2562,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2601,7 +2603,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2642,7 +2644,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2683,7 +2685,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2724,7 +2726,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2765,7 +2767,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2812,7 +2814,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2859,7 +2861,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2906,7 +2908,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2953,7 +2955,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -3000,7 +3002,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3047,7 +3049,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3094,7 +3096,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3135,7 +3137,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3176,7 +3178,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3217,7 +3219,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3264,7 +3266,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3311,7 +3313,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3358,7 +3360,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3405,7 +3407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3446,7 +3448,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3487,7 +3489,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3528,7 +3530,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3569,7 +3571,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3610,7 +3612,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3651,7 +3653,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3692,7 +3694,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3733,7 +3735,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3774,7 +3776,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3841,7 +3843,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -3882,7 +3884,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -3929,7 +3931,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -3976,7 +3978,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4023,7 +4025,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4070,7 +4072,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4117,7 +4119,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4158,7 +4160,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4199,7 +4201,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4240,7 +4242,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4281,7 +4283,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4322,7 +4324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4363,7 +4365,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4404,7 +4406,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4451,7 +4453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4492,7 +4494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4539,7 +4541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -4580,7 +4582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4627,7 +4629,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4668,7 +4670,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4715,7 +4717,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -4762,7 +4764,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -4809,7 +4811,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -4856,7 +4858,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -4897,7 +4899,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -4938,7 +4940,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -4979,7 +4981,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5020,7 +5022,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5061,7 +5063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5102,7 +5104,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5143,7 +5145,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5184,7 +5186,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5225,7 +5227,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5266,7 +5268,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5307,7 +5309,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5348,7 +5350,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5389,7 +5391,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5430,7 +5432,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5477,7 +5479,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5524,7 +5526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5571,7 +5573,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5618,7 +5620,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5665,7 +5667,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5712,7 +5714,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -5759,7 +5761,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -5800,7 +5802,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -5841,7 +5843,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -5882,7 +5884,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -5929,7 +5931,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -5976,7 +5978,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6023,7 +6025,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6070,7 +6072,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6111,7 +6113,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6152,7 +6154,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6193,7 +6195,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6234,7 +6236,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6275,7 +6277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6316,7 +6318,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6357,7 +6359,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6398,7 +6400,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6439,7 +6441,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/alle-behandlinger-avsluttet-alle-behandlingstyper-tilgjengelige.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/alle-behandlinger-avsluttet-alle-behandlingstyper-tilgjengelige.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,7 +83,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1141,7 +1142,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1182,7 +1183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1229,7 +1230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1276,7 +1277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1323,7 +1324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1370,7 +1371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1417,7 +1418,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1458,7 +1459,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1499,7 +1500,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1540,7 +1541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1581,7 +1582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1622,7 +1623,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1663,7 +1664,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1704,7 +1705,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1751,7 +1752,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1792,7 +1793,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1839,7 +1840,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1880,7 +1881,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1927,7 +1928,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1968,7 +1969,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2015,7 +2016,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2062,7 +2063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2109,7 +2110,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2156,7 +2157,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2197,7 +2198,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2238,7 +2239,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2279,7 +2280,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2320,7 +2321,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2361,7 +2362,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2402,7 +2403,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2443,7 +2444,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2484,7 +2485,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2525,7 +2526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2566,7 +2567,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2607,7 +2608,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2648,7 +2649,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2689,7 +2690,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2730,7 +2731,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2777,7 +2778,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2824,7 +2825,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2871,7 +2872,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2918,7 +2919,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2965,7 +2966,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3012,7 +3013,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3059,7 +3060,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3100,7 +3101,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3141,7 +3142,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3182,7 +3183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3229,7 +3230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3276,7 +3277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3323,7 +3324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3370,7 +3371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3411,7 +3412,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3452,7 +3453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3493,7 +3494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3534,7 +3535,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3575,7 +3576,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3616,7 +3617,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3657,7 +3658,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3698,7 +3699,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3739,7 +3740,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/avtaleland-med-apne-behandlinger-viser-varselmelding.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/avtaleland-med-apne-behandlinger-viser-varselmelding.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,7 +83,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1141,7 +1142,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1182,7 +1183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1229,7 +1230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1276,7 +1277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1323,7 +1324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1370,7 +1371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1417,7 +1418,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1458,7 +1459,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1499,7 +1500,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1540,7 +1541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1581,7 +1582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1622,7 +1623,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1663,7 +1664,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1704,7 +1705,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1751,7 +1752,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1792,7 +1793,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1839,7 +1840,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1880,7 +1881,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1927,7 +1928,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1968,7 +1969,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2015,7 +2016,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2062,7 +2063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2109,7 +2110,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2156,7 +2157,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2197,7 +2198,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2238,7 +2239,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2279,7 +2280,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2320,7 +2321,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2361,7 +2362,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2402,7 +2403,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2443,7 +2444,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2484,7 +2485,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2525,7 +2526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2566,7 +2567,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2607,7 +2608,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2648,7 +2649,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2689,7 +2690,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2730,7 +2731,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2777,7 +2778,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2824,7 +2825,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2871,7 +2872,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2918,7 +2919,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2965,7 +2966,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3012,7 +3013,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3059,7 +3060,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3100,7 +3101,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3141,7 +3142,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3182,7 +3183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3229,7 +3230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3276,7 +3277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3323,7 +3324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3370,7 +3371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3411,7 +3412,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3452,7 +3453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3493,7 +3494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3534,7 +3535,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3575,7 +3576,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3616,7 +3617,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3657,7 +3658,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3698,7 +3699,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3739,7 +3740,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/avtaleland-med-avsluttede-behandlinger-alle-behandlingstyper-tilgjengelige.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/avtaleland-med-avsluttede-behandlinger-alle-behandlingstyper-tilgjengelige.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,7 +83,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1141,7 +1142,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1182,7 +1183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1229,7 +1230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1276,7 +1277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1323,7 +1324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1370,7 +1371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1417,7 +1418,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1458,7 +1459,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1499,7 +1500,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1540,7 +1541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1581,7 +1582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1622,7 +1623,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1663,7 +1664,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1704,7 +1705,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1751,7 +1752,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1792,7 +1793,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1839,7 +1840,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1880,7 +1881,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1927,7 +1928,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1968,7 +1969,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2015,7 +2016,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2062,7 +2063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2109,7 +2110,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2156,7 +2157,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2197,7 +2198,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2238,7 +2239,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2279,7 +2280,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2320,7 +2321,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2361,7 +2362,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2402,7 +2403,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2443,7 +2444,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2484,7 +2485,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2525,7 +2526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2566,7 +2567,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2607,7 +2608,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2648,7 +2649,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2689,7 +2690,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2730,7 +2731,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2777,7 +2778,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2824,7 +2825,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2871,7 +2872,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2918,7 +2919,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2965,7 +2966,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3012,7 +3013,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3059,7 +3060,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3100,7 +3101,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3141,7 +3142,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3182,7 +3183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3229,7 +3230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3276,7 +3277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3323,7 +3324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3370,7 +3371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3411,7 +3412,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3452,7 +3453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3493,7 +3494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3534,7 +3535,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3575,7 +3576,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3616,7 +3617,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3657,7 +3658,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3698,7 +3699,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3739,7 +3740,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/eos-pensjonist-med-trygdeavgift-arsavregning-tilgjengelig.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/eos-pensjonist-med-trygdeavgift-arsavregning-tilgjengelig.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,7 +83,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1141,7 +1142,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1182,7 +1183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1229,7 +1230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1276,7 +1277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1323,7 +1324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1370,7 +1371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1417,7 +1418,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1458,7 +1459,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1499,7 +1500,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1540,7 +1541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1581,7 +1582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1622,7 +1623,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1663,7 +1664,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1704,7 +1705,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1751,7 +1752,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1792,7 +1793,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1839,7 +1840,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1880,7 +1881,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1927,7 +1928,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1968,7 +1969,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2015,7 +2016,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2062,7 +2063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2109,7 +2110,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2156,7 +2157,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2197,7 +2198,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2238,7 +2239,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2279,7 +2280,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2320,7 +2321,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2361,7 +2362,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2402,7 +2403,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2443,7 +2444,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2484,7 +2485,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2525,7 +2526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2566,7 +2567,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2607,7 +2608,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2648,7 +2649,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2689,7 +2690,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2730,7 +2731,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2777,7 +2778,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2824,7 +2825,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2871,7 +2872,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2918,7 +2919,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2965,7 +2966,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3012,7 +3013,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3059,7 +3060,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3100,7 +3101,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3141,7 +3142,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3182,7 +3183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3229,7 +3230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3276,7 +3277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3323,7 +3324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3370,7 +3371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3411,7 +3412,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3452,7 +3453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3493,7 +3494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3534,7 +3535,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3575,7 +3576,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3616,7 +3617,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3657,7 +3658,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3698,7 +3699,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3739,7 +3740,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/eos-sak-med-aktive-behandlinger-viser-varselmelding.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/eos-sak-med-aktive-behandlinger-viser-varselmelding.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,7 +83,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1141,7 +1142,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1182,7 +1183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1229,7 +1230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1276,7 +1277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1323,7 +1324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1370,7 +1371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1417,7 +1418,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1458,7 +1459,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1499,7 +1500,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1540,7 +1541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1581,7 +1582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1622,7 +1623,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1663,7 +1664,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1704,7 +1705,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1751,7 +1752,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1792,7 +1793,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1839,7 +1840,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1880,7 +1881,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1927,7 +1928,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1968,7 +1969,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2015,7 +2016,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2062,7 +2063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2109,7 +2110,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2156,7 +2157,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2197,7 +2198,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2238,7 +2239,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2279,7 +2280,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2320,7 +2321,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2361,7 +2362,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2402,7 +2403,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2443,7 +2444,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2484,7 +2485,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2525,7 +2526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2566,7 +2567,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2607,7 +2608,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2648,7 +2649,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2689,7 +2690,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2730,7 +2731,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2777,7 +2778,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2824,7 +2825,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2871,7 +2872,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2918,7 +2919,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2965,7 +2966,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3012,7 +3013,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3059,7 +3060,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3100,7 +3101,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3141,7 +3142,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3182,7 +3183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3229,7 +3230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3276,7 +3277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3323,7 +3324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3370,7 +3371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3411,7 +3412,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3452,7 +3453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3493,7 +3494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3534,7 +3535,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3575,7 +3576,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3616,7 +3617,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3657,7 +3658,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3698,7 +3699,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3739,7 +3740,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/konsistent-oppforsel-ved-navigasjon-mellom-saker.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/konsistent-oppforsel-ved-navigasjon-mellom-saker.json
@@ -103,11 +103,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -131,7 +131,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1189,7 +1190,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1230,7 +1231,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1277,7 +1278,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1324,7 +1325,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1371,7 +1372,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1418,7 +1419,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1465,7 +1466,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1506,7 +1507,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1547,7 +1548,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1588,7 +1589,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1629,7 +1630,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1670,7 +1671,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1711,7 +1712,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1752,7 +1753,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1799,7 +1800,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1840,7 +1841,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1887,7 +1888,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1928,7 +1929,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1975,7 +1976,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -2016,7 +2017,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2063,7 +2064,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2110,7 +2111,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2157,7 +2158,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2204,7 +2205,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2245,7 +2246,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2286,7 +2287,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2327,7 +2328,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2368,7 +2369,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2409,7 +2410,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2450,7 +2451,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2491,7 +2492,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2532,7 +2533,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2573,7 +2574,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2614,7 +2615,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2655,7 +2656,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2696,7 +2697,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2737,7 +2738,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2778,7 +2779,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2825,7 +2826,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2872,7 +2873,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2919,7 +2920,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2966,7 +2967,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -3013,7 +3014,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3060,7 +3061,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3107,7 +3108,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3148,7 +3149,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3189,7 +3190,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3230,7 +3231,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3277,7 +3278,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3324,7 +3325,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3371,7 +3372,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3418,7 +3419,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3459,7 +3460,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3500,7 +3501,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3541,7 +3542,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3582,7 +3583,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3623,7 +3624,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3664,7 +3665,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3705,7 +3706,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3746,7 +3747,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3787,7 +3788,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/utenfor-avtaleland-med-apne-behandlinger-kun-arsavregning-tilgjengelig.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/utenfor-avtaleland-med-apne-behandlinger-kun-arsavregning-tilgjengelig.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,7 +83,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1141,7 +1142,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1182,7 +1183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1229,7 +1230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1276,7 +1277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1323,7 +1324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1370,7 +1371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1417,7 +1418,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1458,7 +1459,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1499,7 +1500,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1540,7 +1541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1581,7 +1582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1622,7 +1623,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1663,7 +1664,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1704,7 +1705,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1751,7 +1752,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1792,7 +1793,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1839,7 +1840,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1880,7 +1881,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1927,7 +1928,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1968,7 +1969,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2015,7 +2016,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2062,7 +2063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2109,7 +2110,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2156,7 +2157,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2197,7 +2198,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2238,7 +2239,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2279,7 +2280,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2320,7 +2321,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2361,7 +2362,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2402,7 +2403,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2443,7 +2444,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2484,7 +2485,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2525,7 +2526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2566,7 +2567,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2607,7 +2608,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2648,7 +2649,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2689,7 +2690,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2730,7 +2731,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2777,7 +2778,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2824,7 +2825,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2871,7 +2872,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2918,7 +2919,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2965,7 +2966,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3012,7 +3013,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3059,7 +3060,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3100,7 +3101,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3141,7 +3142,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3182,7 +3183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3229,7 +3230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3276,7 +3277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3323,7 +3324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3370,7 +3371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3411,7 +3412,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3452,7 +3453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3493,7 +3494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3534,7 +3535,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3575,7 +3576,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3616,7 +3617,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3657,7 +3658,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3698,7 +3699,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3739,7 +3740,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/utenfor-avtaleland-med-apne-behandlinger-viser-behandlingstyper.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/behandlingstype-tilgjengelighet/utenfor-avtaleland-med-apne-behandlinger-viser-behandlingstyper.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,7 +83,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1141,7 +1142,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1182,7 +1183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1229,7 +1230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1276,7 +1277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1323,7 +1324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1370,7 +1371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1417,7 +1418,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1458,7 +1459,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1499,7 +1500,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1540,7 +1541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1581,7 +1582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1622,7 +1623,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1663,7 +1664,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1704,7 +1705,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1751,7 +1752,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1792,7 +1793,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1839,7 +1840,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1880,7 +1881,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1927,7 +1928,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1968,7 +1969,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2015,7 +2016,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2062,7 +2063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2109,7 +2110,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2156,7 +2157,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2197,7 +2198,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2238,7 +2239,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2279,7 +2280,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2320,7 +2321,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2361,7 +2362,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2402,7 +2403,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2443,7 +2444,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2484,7 +2485,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2525,7 +2526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2566,7 +2567,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2607,7 +2608,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2648,7 +2649,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2689,7 +2690,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2730,7 +2731,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2777,7 +2778,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2824,7 +2825,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2871,7 +2872,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2918,7 +2919,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2965,7 +2966,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3012,7 +3013,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3059,7 +3060,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3100,7 +3101,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3141,7 +3142,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3182,7 +3183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3229,7 +3230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3276,7 +3277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3323,7 +3324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3370,7 +3371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3411,7 +3412,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3452,7 +3453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3493,7 +3494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3534,7 +3535,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3575,7 +3576,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3616,7 +3617,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3657,7 +3658,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3698,7 +3699,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3739,7 +3740,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/eos-pensjonist-aarsavregning/knytt-til-eos-pensjonist-sak-med-apne-behandlinger-arsavregning-tilgjengelig.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/eos-pensjonist-aarsavregning/knytt-til-eos-pensjonist-sak-med-apne-behandlinger-arsavregning-tilgjengelig.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,7 +83,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1141,7 +1142,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1182,7 +1183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1229,7 +1230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1276,7 +1277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1323,7 +1324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1370,7 +1371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1417,7 +1418,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1458,7 +1459,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1499,7 +1500,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1540,7 +1541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1581,7 +1582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1622,7 +1623,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1663,7 +1664,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1704,7 +1705,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1751,7 +1752,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1792,7 +1793,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1839,7 +1840,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1880,7 +1881,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1927,7 +1928,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1968,7 +1969,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2015,7 +2016,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2062,7 +2063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2109,7 +2110,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2156,7 +2157,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2197,7 +2198,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2238,7 +2239,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2279,7 +2280,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2320,7 +2321,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2361,7 +2362,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2402,7 +2403,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2443,7 +2444,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2484,7 +2485,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2525,7 +2526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2566,7 +2567,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2607,7 +2608,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2648,7 +2649,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2689,7 +2690,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2730,7 +2731,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2777,7 +2778,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2824,7 +2825,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2871,7 +2872,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2918,7 +2919,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2965,7 +2966,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3012,7 +3013,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3059,7 +3060,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3100,7 +3101,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3141,7 +3142,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3182,7 +3183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3229,7 +3230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3276,7 +3277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3323,7 +3324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3370,7 +3371,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3411,7 +3412,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3452,7 +3453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3493,7 +3494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3534,7 +3535,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3575,7 +3576,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3616,7 +3617,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3657,7 +3658,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3698,7 +3699,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3739,7 +3740,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk/utenfor-avtaleland-med-apen-arsavregning-finner-sak.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk/utenfor-avtaleland-med-apen-arsavregning-finner-sak.json
@@ -103,11 +103,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -131,18 +131,19 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -166,18 +167,19 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -201,7 +203,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1259,7 +1262,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1300,7 +1303,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1347,7 +1350,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1394,7 +1397,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1441,7 +1444,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1488,7 +1491,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1535,7 +1538,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1576,7 +1579,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1617,7 +1620,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1658,7 +1661,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1699,7 +1702,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1740,7 +1743,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1781,7 +1784,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1822,7 +1825,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1869,7 +1872,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1910,7 +1913,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1957,7 +1960,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1998,7 +2001,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -2045,7 +2048,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -2086,7 +2089,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2133,7 +2136,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2180,7 +2183,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2227,7 +2230,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2274,7 +2277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2315,7 +2318,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2356,7 +2359,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2397,7 +2400,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2438,7 +2441,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2479,7 +2482,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2520,7 +2523,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2561,7 +2564,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2602,7 +2605,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2643,7 +2646,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2684,7 +2687,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2725,7 +2728,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2766,7 +2769,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2807,7 +2810,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2848,7 +2851,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2895,7 +2898,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2942,7 +2945,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2989,7 +2992,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -3036,7 +3039,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -3083,7 +3086,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3130,7 +3133,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3177,7 +3180,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3218,7 +3221,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3259,7 +3262,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3300,7 +3303,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3347,7 +3350,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3394,7 +3397,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3441,7 +3444,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3488,7 +3491,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3529,7 +3532,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3570,7 +3573,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3611,7 +3614,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3652,7 +3655,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3693,7 +3696,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3734,7 +3737,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3775,7 +3778,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3816,7 +3819,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3857,7 +3860,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3924,7 +3927,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -3965,7 +3968,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -4012,7 +4015,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -4059,7 +4062,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4106,7 +4109,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4153,7 +4156,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4200,7 +4203,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4241,7 +4244,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4282,7 +4285,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4323,7 +4326,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4364,7 +4367,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4405,7 +4408,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4446,7 +4449,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4487,7 +4490,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4534,7 +4537,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4575,7 +4578,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4622,7 +4625,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -4663,7 +4666,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4710,7 +4713,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4751,7 +4754,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4798,7 +4801,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -4845,7 +4848,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -4892,7 +4895,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -4939,7 +4942,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -4980,7 +4983,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -5021,7 +5024,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -5062,7 +5065,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5103,7 +5106,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5144,7 +5147,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5185,7 +5188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5226,7 +5229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5267,7 +5270,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5308,7 +5311,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5349,7 +5352,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5390,7 +5393,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5431,7 +5434,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5472,7 +5475,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5513,7 +5516,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5560,7 +5563,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5607,7 +5610,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5654,7 +5657,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5701,7 +5704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5748,7 +5751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5795,7 +5798,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -5842,7 +5845,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -5883,7 +5886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -5924,7 +5927,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -5965,7 +5968,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -6012,7 +6015,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -6059,7 +6062,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6106,7 +6109,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6153,7 +6156,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6194,7 +6197,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6235,7 +6238,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6276,7 +6279,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6317,7 +6320,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6358,7 +6361,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6399,7 +6402,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6440,7 +6443,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6481,7 +6484,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6522,7 +6525,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -6589,7 +6592,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -6630,7 +6633,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -6677,7 +6680,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -6724,7 +6727,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -6771,7 +6774,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -6818,7 +6821,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -6865,7 +6868,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -6906,7 +6909,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -6947,7 +6950,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -6988,7 +6991,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -7029,7 +7032,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -7070,7 +7073,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -7111,7 +7114,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -7152,7 +7155,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -7199,7 +7202,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -7240,7 +7243,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -7287,7 +7290,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -7334,7 +7337,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -7375,7 +7378,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -7422,7 +7425,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -7469,7 +7472,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -7516,7 +7519,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -7563,7 +7566,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -7604,7 +7607,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -7645,7 +7648,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -7686,7 +7689,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -7727,7 +7730,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -7768,7 +7771,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -7809,7 +7812,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -7850,7 +7853,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -7891,7 +7894,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -7932,7 +7935,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -7973,7 +7976,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -8014,7 +8017,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -8055,7 +8058,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -8096,7 +8099,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -8137,7 +8140,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -8184,7 +8187,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -8231,7 +8234,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -8278,7 +8281,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -8325,7 +8328,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -8372,7 +8375,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -8419,7 +8422,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -8466,7 +8469,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -8507,7 +8510,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -8548,7 +8551,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -8589,7 +8592,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -8636,7 +8639,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -8683,7 +8686,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -8730,7 +8733,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -8777,7 +8780,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -8818,7 +8821,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -8859,7 +8862,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -8900,7 +8903,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -8941,7 +8944,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -8982,7 +8985,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -9023,7 +9026,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -9064,7 +9067,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -9105,7 +9108,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -9146,7 +9149,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -9213,7 +9216,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -9254,7 +9257,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -9301,7 +9304,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -9348,7 +9351,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -9395,7 +9398,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -9442,7 +9445,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -9489,7 +9492,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -9530,7 +9533,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -9571,7 +9574,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -9612,7 +9615,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -9653,7 +9656,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -9694,7 +9697,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -9735,7 +9738,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -9776,7 +9779,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -9823,7 +9826,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -9870,7 +9873,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -9911,7 +9914,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -9958,7 +9961,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -10005,7 +10008,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -10046,7 +10049,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -10093,7 +10096,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -10140,7 +10143,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -10187,7 +10190,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -10234,7 +10237,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -10275,7 +10278,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -10316,7 +10319,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -10357,7 +10360,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -10398,7 +10401,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -10439,7 +10442,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -10480,7 +10483,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -10521,7 +10524,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -10562,7 +10565,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -10603,7 +10606,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -10644,7 +10647,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -10685,7 +10688,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -10726,7 +10729,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -10767,7 +10770,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -10808,7 +10811,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -10855,7 +10858,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -10902,7 +10905,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -10949,7 +10952,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -10996,7 +10999,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -11043,7 +11046,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -11090,7 +11093,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -11137,7 +11140,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -11178,7 +11181,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -11219,7 +11222,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -11260,7 +11263,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -11307,7 +11310,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -11354,7 +11357,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -11401,7 +11404,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -11448,7 +11451,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -11489,7 +11492,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -11530,7 +11533,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -11571,7 +11574,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -11612,7 +11615,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -11653,7 +11656,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -11694,7 +11697,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -11735,7 +11738,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -11776,7 +11779,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -11817,7 +11820,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -12208,7 +12211,7 @@
           "behandlingstema": "YRKESAKTIV",
           "behandlingstype": "ÅRSAVREGNING",
           "skalTilordnes": false,
-          "mottaksdato": "2026-01-30",
+          "mottaksdato": "2026-02-17",
           "behandlingsaarsakType": "SØKNAD"
         }
       },

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk/utenfor-avtaleland-med-apen-behandling-kun-arsavregning-tilgjengelig.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk/utenfor-avtaleland-med-apen-behandling-kun-arsavregning-tilgjengelig.json
@@ -55,11 +55,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -83,18 +83,19 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -118,7 +119,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1176,7 +1178,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1217,7 +1219,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1264,7 +1266,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1311,7 +1313,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1358,7 +1360,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1405,7 +1407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1452,7 +1454,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1493,7 +1495,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1534,7 +1536,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1575,7 +1577,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1616,7 +1618,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1657,7 +1659,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1698,7 +1700,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1739,7 +1741,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1786,7 +1788,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1827,7 +1829,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1874,7 +1876,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1915,7 +1917,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1962,7 +1964,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -2003,7 +2005,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2050,7 +2052,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2097,7 +2099,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2144,7 +2146,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2191,7 +2193,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2232,7 +2234,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2273,7 +2275,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2314,7 +2316,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2355,7 +2357,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2396,7 +2398,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2437,7 +2439,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2478,7 +2480,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2519,7 +2521,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2560,7 +2562,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2601,7 +2603,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2642,7 +2644,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2683,7 +2685,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2724,7 +2726,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2765,7 +2767,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2812,7 +2814,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2859,7 +2861,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2906,7 +2908,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2953,7 +2955,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -3000,7 +3002,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3047,7 +3049,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3094,7 +3096,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3135,7 +3137,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3176,7 +3178,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3217,7 +3219,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3264,7 +3266,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3311,7 +3313,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3358,7 +3360,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3405,7 +3407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3446,7 +3448,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3487,7 +3489,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3528,7 +3530,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3569,7 +3571,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3610,7 +3612,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3651,7 +3653,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3692,7 +3694,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3733,7 +3735,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3774,7 +3776,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3841,7 +3843,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -3882,7 +3884,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -3929,7 +3931,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -3976,7 +3978,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4023,7 +4025,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4070,7 +4072,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4117,7 +4119,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4158,7 +4160,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4199,7 +4201,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4240,7 +4242,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4281,7 +4283,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4322,7 +4324,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4363,7 +4365,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4404,7 +4406,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4451,7 +4453,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4492,7 +4494,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4539,7 +4541,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -4580,7 +4582,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4627,7 +4629,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4668,7 +4670,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4715,7 +4717,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -4762,7 +4764,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -4809,7 +4811,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -4856,7 +4858,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -4897,7 +4899,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -4938,7 +4940,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -4979,7 +4981,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5020,7 +5022,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5061,7 +5063,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5102,7 +5104,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5143,7 +5145,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5184,7 +5186,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5225,7 +5227,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5266,7 +5268,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5307,7 +5309,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5348,7 +5350,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5389,7 +5391,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5430,7 +5432,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5477,7 +5479,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5524,7 +5526,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5571,7 +5573,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5618,7 +5620,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5665,7 +5667,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5712,7 +5714,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -5759,7 +5761,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -5800,7 +5802,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -5841,7 +5843,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -5882,7 +5884,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -5929,7 +5931,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -5976,7 +5978,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6023,7 +6025,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6070,7 +6072,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6111,7 +6113,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6152,7 +6154,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6193,7 +6195,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6234,7 +6236,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6275,7 +6277,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6316,7 +6318,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6357,7 +6359,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6398,7 +6400,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6439,7 +6441,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk/utenfor-avtaleland-med-avsluttet-behandling-alle-behandlingstyper-tilgjengelige.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/knytt-til-eksisterende/utenfor-avtaleland-behandlingslogikk/utenfor-avtaleland-med-avsluttet-behandling-alle-behandlingstyper-tilgjengelige.json
@@ -398,11 +398,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -426,18 +426,19 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -461,18 +462,19 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -496,7 +498,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1757,7 +1760,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1798,7 +1801,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1845,7 +1848,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1892,7 +1895,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1939,7 +1942,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1986,7 +1989,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -2033,7 +2036,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -2074,7 +2077,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -2115,7 +2118,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -2156,7 +2159,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -2197,7 +2200,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -2238,7 +2241,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -2279,7 +2282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -2320,7 +2323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -2367,7 +2370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -2408,7 +2411,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -2455,7 +2458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -2496,7 +2499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -2543,7 +2546,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -2584,7 +2587,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2631,7 +2634,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2678,7 +2681,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2725,7 +2728,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2772,7 +2775,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2813,7 +2816,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2854,7 +2857,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2895,7 +2898,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2936,7 +2939,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2977,7 +2980,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -3018,7 +3021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -3059,7 +3062,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -3100,7 +3103,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -3141,7 +3144,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -3182,7 +3185,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -3223,7 +3226,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -3264,7 +3267,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -3305,7 +3308,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -3346,7 +3349,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -3393,7 +3396,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -3440,7 +3443,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -3487,7 +3490,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -3534,7 +3537,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -3581,7 +3584,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3628,7 +3631,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3675,7 +3678,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3716,7 +3719,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3757,7 +3760,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3798,7 +3801,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3845,7 +3848,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3892,7 +3895,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3939,7 +3942,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3986,7 +3989,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -4027,7 +4030,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -4068,7 +4071,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -4109,7 +4112,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -4150,7 +4153,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -4191,7 +4194,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -4232,7 +4235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -4273,7 +4276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -4314,7 +4317,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -4355,7 +4358,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -4422,7 +4425,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -4463,7 +4466,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -4510,7 +4513,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -4557,7 +4560,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4604,7 +4607,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4651,7 +4654,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4698,7 +4701,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4739,7 +4742,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4780,7 +4783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4821,7 +4824,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4862,7 +4865,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4903,7 +4906,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4944,7 +4947,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4985,7 +4988,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -5032,7 +5035,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -5073,7 +5076,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -5120,7 +5123,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -5167,7 +5170,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -5208,7 +5211,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -5255,7 +5258,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -5302,7 +5305,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -5349,7 +5352,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -5396,7 +5399,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -5437,7 +5440,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -5478,7 +5481,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -5519,7 +5522,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5560,7 +5563,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5601,7 +5604,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5642,7 +5645,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5683,7 +5686,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5724,7 +5727,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5765,7 +5768,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5806,7 +5809,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5847,7 +5850,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5888,7 +5891,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5929,7 +5932,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5970,7 +5973,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -6017,7 +6020,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -6064,7 +6067,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -6111,7 +6114,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -6158,7 +6161,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -6205,7 +6208,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -6252,7 +6255,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -6299,7 +6302,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -6340,7 +6343,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -6381,7 +6384,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -6422,7 +6425,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -6469,7 +6472,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -6516,7 +6519,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6563,7 +6566,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6610,7 +6613,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6651,7 +6654,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6692,7 +6695,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6733,7 +6736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6774,7 +6777,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6815,7 +6818,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6856,7 +6859,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6897,7 +6900,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6938,7 +6941,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6979,7 +6982,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -7046,7 +7049,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -7087,7 +7090,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -7134,7 +7137,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -7181,7 +7184,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -7228,7 +7231,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -7275,7 +7278,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -7322,7 +7325,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -7363,7 +7366,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -7404,7 +7407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -7445,7 +7448,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -7486,7 +7489,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -7527,7 +7530,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -7568,7 +7571,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -7609,7 +7612,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -7656,7 +7659,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -7703,7 +7706,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -7744,7 +7747,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -7791,7 +7794,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -7838,7 +7841,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -7879,7 +7882,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -7926,7 +7929,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -7973,7 +7976,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -8020,7 +8023,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -8067,7 +8070,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -8108,7 +8111,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -8149,7 +8152,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -8190,7 +8193,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -8231,7 +8234,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -8272,7 +8275,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -8313,7 +8316,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -8354,7 +8357,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -8395,7 +8398,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -8436,7 +8439,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -8477,7 +8480,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -8518,7 +8521,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -8559,7 +8562,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -8600,7 +8603,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -8641,7 +8644,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -8688,7 +8691,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -8735,7 +8738,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -8782,7 +8785,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -8829,7 +8832,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -8876,7 +8879,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -8923,7 +8926,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -8970,7 +8973,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -9011,7 +9014,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -9052,7 +9055,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -9093,7 +9096,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -9140,7 +9143,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -9187,7 +9190,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -9234,7 +9237,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -9281,7 +9284,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -9322,7 +9325,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -9363,7 +9366,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -9404,7 +9407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -9445,7 +9448,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -9486,7 +9489,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -9527,7 +9530,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -9568,7 +9571,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -9609,7 +9612,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -9650,7 +9653,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/alle-pakrevde-felt-utfylt-oppretter-behandling.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/alle-pakrevde-felt-utfylt-oppretter-behandling.json
@@ -7,11 +7,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1134,7 +1135,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1181,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1228,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1275,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1322,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1369,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1410,7 +1411,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1451,7 +1452,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1492,7 +1493,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1533,7 +1534,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1574,7 +1575,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1615,7 +1616,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1656,7 +1657,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -1703,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1750,7 +1751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1791,7 +1792,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1838,7 +1839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1885,7 +1886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1926,7 +1927,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -1973,7 +1974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2020,7 +2021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2067,7 +2068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2114,7 +2115,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2155,7 +2156,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2196,7 +2197,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2237,7 +2238,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2278,7 +2279,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2319,7 +2320,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2360,7 +2361,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2401,7 +2402,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2442,7 +2443,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2483,7 +2484,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2524,7 +2525,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2565,7 +2566,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2606,7 +2607,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2647,7 +2648,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2688,7 +2689,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2735,7 +2736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2782,7 +2783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2829,7 +2830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2876,7 +2877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2923,7 +2924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -2970,7 +2971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3017,7 +3018,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3058,7 +3059,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3099,7 +3100,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3140,7 +3141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3187,7 +3188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3234,7 +3235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3281,7 +3282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3328,7 +3329,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3369,7 +3370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3410,7 +3411,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3451,7 +3452,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3492,7 +3493,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3533,7 +3534,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3574,7 +3575,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3615,7 +3616,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3656,7 +3657,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3697,7 +3698,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3764,7 +3765,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -3805,7 +3806,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -3852,7 +3853,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -3899,7 +3900,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -3946,7 +3947,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -3993,7 +3994,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4040,7 +4041,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4081,7 +4082,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4122,7 +4123,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4163,7 +4164,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4204,7 +4205,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4245,7 +4246,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4286,7 +4287,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4327,7 +4328,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -4374,7 +4375,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4421,7 +4422,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4462,7 +4463,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4509,7 +4510,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4556,7 +4557,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4597,7 +4598,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4644,7 +4645,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -4691,7 +4692,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -4738,7 +4739,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -4785,7 +4786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -4826,7 +4827,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -4867,7 +4868,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -4908,7 +4909,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -4949,7 +4950,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -4990,7 +4991,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5031,7 +5032,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5072,7 +5073,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5113,7 +5114,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5154,7 +5155,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5195,7 +5196,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5236,7 +5237,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5277,7 +5278,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5318,7 +5319,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5359,7 +5360,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5406,7 +5407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5453,7 +5454,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5500,7 +5501,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5547,7 +5548,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5594,7 +5595,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5641,7 +5642,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -5688,7 +5689,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -5729,7 +5730,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -5770,7 +5771,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -5811,7 +5812,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -5858,7 +5859,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -5905,7 +5906,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -5952,7 +5953,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -5999,7 +6000,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6040,7 +6041,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6081,7 +6082,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6122,7 +6123,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6163,7 +6164,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6204,7 +6205,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6245,7 +6246,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6286,7 +6287,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6327,7 +6328,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6368,7 +6369,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -10587,7 +10588,7 @@
           "behandlingstema": "YRKESAKTIV",
           "behandlingstype": "FØRSTEGANG",
           "skalTilordnes": false,
-          "mottaksdato": "2026-01-30",
+          "mottaksdato": "2026-02-17",
           "behandlingsaarsakType": "SØKNAD",
           "hovedpart": "BRUKER",
           "brukerID": "30056928150",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/manglende-pakrevde-felt-viser-feilmeldinger.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/manglende-pakrevde-felt-viser-feilmeldinger.json
@@ -7,11 +7,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1134,7 +1135,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1181,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1228,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1275,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1322,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1369,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1410,7 +1411,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1451,7 +1452,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1492,7 +1493,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1533,7 +1534,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1574,7 +1575,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1615,7 +1616,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1656,7 +1657,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1703,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1744,7 +1745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1791,7 +1792,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "21",
               "prioritet": "NORM",
@@ -1832,7 +1833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1879,7 +1880,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1920,7 +1921,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -1967,7 +1968,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2014,7 +2015,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2061,7 +2062,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2108,7 +2109,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2149,7 +2150,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2190,7 +2191,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2231,7 +2232,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2272,7 +2273,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2313,7 +2314,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2354,7 +2355,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2395,7 +2396,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2436,7 +2437,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2477,7 +2478,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2518,7 +2519,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2559,7 +2560,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2600,7 +2601,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2641,7 +2642,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2682,7 +2683,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2729,7 +2730,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2776,7 +2777,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2823,7 +2824,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2870,7 +2871,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2917,7 +2918,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -2964,7 +2965,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3011,7 +3012,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3052,7 +3053,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3093,7 +3094,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3134,7 +3135,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3181,7 +3182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3228,7 +3229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3275,7 +3276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3322,7 +3323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3363,7 +3364,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3404,7 +3405,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3445,7 +3446,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3486,7 +3487,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3527,7 +3528,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3568,7 +3569,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3609,7 +3610,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3650,7 +3651,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3691,7 +3692,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/opprett-sak-for-sakstype-avtaleland-og-verifiser-at-det-ikke-oppstar-noen-feil.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/opprett-sak-for-sakstype-avtaleland-og-verifiser-at-det-ikke-oppstar-noen-feil.json
@@ -1,17 +1,17 @@
 {
   "version": "1.0",
   "recordedAt": "2025-01-01T00:00:00.000Z",
-  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web-2/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts",
   "testName": "Opprett sak for sakstype \"Avtaleland\" og verifiser at det ikke oppstår noen feil",
   "exchanges": [
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -1140,7 +1141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1181,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1228,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1275,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1322,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1369,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1416,7 +1417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1457,7 +1458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1498,7 +1499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1539,7 +1540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1580,7 +1581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1621,7 +1622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1662,7 +1663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1703,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -1750,7 +1751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1797,7 +1798,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1838,7 +1839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1885,7 +1886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1932,7 +1933,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1973,7 +1974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2020,7 +2021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2067,7 +2068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2114,7 +2115,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2161,7 +2162,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2202,7 +2203,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2243,7 +2244,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2284,7 +2285,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2325,7 +2326,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2366,7 +2367,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2407,7 +2408,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2448,7 +2449,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2489,7 +2490,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2530,7 +2531,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2571,7 +2572,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2612,7 +2613,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2653,7 +2654,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2694,7 +2695,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2735,7 +2736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2782,7 +2783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2829,7 +2830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2876,7 +2877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2923,7 +2924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2970,7 +2971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3017,7 +3018,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3064,7 +3065,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3105,7 +3106,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3146,7 +3147,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3187,7 +3188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3234,7 +3235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3281,7 +3282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3328,7 +3329,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3375,7 +3376,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3416,7 +3417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3457,7 +3458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3498,7 +3499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3539,7 +3540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3580,7 +3581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3621,7 +3622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3662,7 +3663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3703,7 +3704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3744,7 +3745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3782,135 +3783,6 @@
               "land": null,
               "periode": null,
               "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-1071\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "68",
-              "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 74,
-                "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
-                },
-                "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-2",
-              "sakstype": {
-                "kode": "EU_EOS",
-                "term": "EU/EØS-land"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-2\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "69",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 75,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "ARBEID_KUN_NORGE",
-                  "term": "Arbeid kun i Norge"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-3",
-              "sakstype": {
-                "kode": "EU_EOS",
-                "term": "EU/EØS-land"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": {
-                "landkoder": ["NO"],
-                "flereLandUkjentHvilke": false
-              },
-              "periode": {
-                "fom": "2024-01-01",
-                "tom": "2024-12-31"
-              },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-3\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "70",
-              "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 76,
-                "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
-                },
-                "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-4",
-              "sakstype": {
-                "kode": "TRYGDEAVTALE",
-                "term": "Avtaleland"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-4\n",
               "sisteNotat": null
             }
           ]
@@ -3940,7 +3812,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -3987,7 +3859,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -4028,7 +3900,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -4075,7 +3947,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -4122,7 +3994,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4169,7 +4041,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4216,7 +4088,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4263,7 +4135,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4304,7 +4176,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4345,7 +4217,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4386,7 +4258,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4427,7 +4299,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4468,7 +4340,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4509,7 +4381,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4550,7 +4422,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -4597,7 +4469,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4644,7 +4516,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4685,7 +4557,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4732,7 +4604,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4779,7 +4651,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4820,7 +4692,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4867,7 +4739,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -4914,7 +4786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -4961,7 +4833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -5008,7 +4880,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -5049,7 +4921,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -5090,7 +4962,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -5131,7 +5003,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5172,7 +5044,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5213,7 +5085,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5254,7 +5126,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5295,7 +5167,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5336,7 +5208,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5377,7 +5249,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5418,7 +5290,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5459,7 +5331,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5500,7 +5372,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5541,7 +5413,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5582,7 +5454,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5629,7 +5501,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5676,7 +5548,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5723,7 +5595,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5770,7 +5642,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5817,7 +5689,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5864,7 +5736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -5911,7 +5783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -5952,7 +5824,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -5993,7 +5865,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -6034,7 +5906,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -6081,7 +5953,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -6128,7 +6000,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6175,7 +6047,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6222,7 +6094,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6263,7 +6135,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6304,7 +6176,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6345,7 +6217,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6386,7 +6258,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6427,7 +6299,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6468,7 +6340,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6509,7 +6381,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6550,7 +6422,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6591,7 +6463,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -6632,22 +6504,22 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
+              "navn": "TRIVIELL KARAFFEL",
+              "hovedpartIdent": "30056928150",
               "versjon": 1,
               "behandling": {
                 "behandlingID": 74,
                 "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
+                  "kode": "FØRSTEGANG",
+                  "term": "Førstegangsbehandling"
                 },
                 "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
+                  "kode": "ARBEID_KUN_NORGE",
+                  "term": "Arbeid kun i Norge"
                 },
                 "behandlingsstatus": {
                   "kode": "OPPRETTET",
@@ -6667,47 +6539,6 @@
                 "kode": "MEDLEMSKAP_LOVVALG",
                 "term": "Medlemskap og lovvalg"
               },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-2\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "69",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 75,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "ARBEID_KUN_NORGE",
-                  "term": "Arbeid kun i Norge"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-3",
-              "sakstype": {
-                "kode": "EU_EOS",
-                "term": "EU/EØS-land"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
               "land": {
                 "landkoder": ["NO"],
                 "flereLandUkjentHvilke": false
@@ -6716,48 +6547,7 @@
                 "fom": "2024-01-01",
                 "tom": "2024-12-31"
               },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-3\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "70",
-              "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 76,
-                "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
-                },
-                "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-4",
-              "sakstype": {
-                "kode": "TRYGDEAVTALE",
-                "term": "Avtaleland"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-4\n",
+              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-2\n",
               "sisteNotat": null
             }
           ]
@@ -10975,7 +10765,7 @@
             "hovedpartRolle": "BRUKER"
           },
           {
-            "saksnummer": "MEL-3",
+            "saksnummer": "MEL-2",
             "navn": "TRIVIELL KARAFFEL",
             "sakstema": {
               "kode": "MEDLEMSKAP_LOVVALG",
@@ -11000,7 +10790,7 @@
             "opprettetDato": "2025-01-01T00:00:00.000Z",
             "behandlingOversikter": [
               {
-                "behandlingID": 75,
+                "behandlingID": 74,
                 "tittel": "Førstegangsbehandling",
                 "behandlingsstatus": {
                   "kode": "OPPRETTET",
@@ -11047,7 +10837,7 @@
           "behandlingstema": "YRKESAKTIV",
           "behandlingstype": "FØRSTEGANG",
           "skalTilordnes": false,
-          "mottaksdato": "2026-01-19",
+          "mottaksdato": "2026-02-17",
           "behandlingsaarsakType": "SØKNAD",
           "hovedpart": "BRUKER",
           "brukerID": "30056928150",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/opprett-sak-for-sakstype-eu-eos-land-og-verifiser-at-det-ikke-oppstar-noen-feil.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/opprett-sak-for-sakstype-eu-eos-land-og-verifiser-at-det-ikke-oppstar-noen-feil.json
@@ -1,17 +1,17 @@
 {
   "version": "1.0",
   "recordedAt": "2025-01-01T00:00:00.000Z",
-  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web-2/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts",
   "testName": "Opprett sak for sakstype \"EU/EØS-land\" og verifiser at det ikke oppstår noen feil",
   "exchanges": [
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,54 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "67",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 73,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-1",
-              "sakstype": {
-                "kode": "TRYGDEAVTALE",
-                "term": "Avtaleland"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": {
-                "landkoder": [],
-                "flereLandUkjentHvilke": false
-              },
-              "periode": {
-                "fom": null,
-                "tom": null
-              },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-1\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1181,7 +1135,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1228,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1275,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1322,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1369,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1416,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1457,7 +1411,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1498,7 +1452,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1539,7 +1493,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1580,7 +1534,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1621,7 +1575,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1662,7 +1616,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1703,7 +1657,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -1750,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1797,7 +1751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1838,7 +1792,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1885,7 +1839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1932,7 +1886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1973,7 +1927,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2020,7 +1974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2067,7 +2021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2114,7 +2068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2161,7 +2115,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2202,7 +2156,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2243,7 +2197,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2284,7 +2238,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2325,7 +2279,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2366,7 +2320,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2407,7 +2361,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2448,7 +2402,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2489,7 +2443,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2530,7 +2484,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2571,7 +2525,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2612,7 +2566,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2653,7 +2607,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2694,7 +2648,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2735,7 +2689,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2782,7 +2736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2829,7 +2783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2876,7 +2830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2923,7 +2877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2970,7 +2924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3017,7 +2971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3064,7 +3018,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3105,7 +3059,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3146,7 +3100,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3187,7 +3141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3234,7 +3188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3281,7 +3235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3328,7 +3282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3375,7 +3329,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3416,7 +3370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3457,7 +3411,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3498,7 +3452,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3539,7 +3493,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3580,7 +3534,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3621,7 +3575,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3662,7 +3616,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3703,7 +3657,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3744,7 +3698,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3811,7 +3765,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -3858,7 +3812,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -3899,7 +3853,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -3946,7 +3900,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -3993,7 +3947,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4040,7 +3994,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4087,7 +4041,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4134,7 +4088,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4175,7 +4129,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4216,7 +4170,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4257,7 +4211,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4298,7 +4252,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4339,7 +4293,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4380,7 +4334,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4421,7 +4375,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -4468,7 +4422,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4515,7 +4469,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4556,7 +4510,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4603,7 +4557,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4650,7 +4604,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4691,7 +4645,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4738,7 +4692,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -4785,7 +4739,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -4832,7 +4786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -4879,7 +4833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -4920,7 +4874,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -4961,7 +4915,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -5002,7 +4956,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5043,7 +4997,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5084,7 +5038,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5125,7 +5079,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5166,7 +5120,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5207,7 +5161,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5248,7 +5202,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5289,7 +5243,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5330,7 +5284,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5371,7 +5325,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5412,7 +5366,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5453,7 +5407,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5500,7 +5454,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5547,7 +5501,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5594,7 +5548,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5641,7 +5595,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5688,7 +5642,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5735,7 +5689,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -5782,7 +5736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -5823,7 +5777,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -5864,7 +5818,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -5905,7 +5859,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -5952,7 +5906,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -5999,7 +5953,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6046,7 +6000,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6093,7 +6047,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6134,7 +6088,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6175,7 +6129,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6216,7 +6170,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6257,7 +6211,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6298,7 +6252,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6339,7 +6293,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6380,7 +6334,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6421,7 +6375,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6462,7 +6416,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -6500,47 +6454,6 @@
               "land": null,
               "periode": null,
               "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-1071\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "68",
-              "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 74,
-                "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
-                },
-                "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-2",
-              "sakstype": {
-                "kode": "EU_EOS",
-                "term": "EU/EØS-land"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-2\n",
               "sisteNotat": null
             }
           ]
@@ -6863,60 +6776,6 @@
           "content-type": "application/json"
         },
         "body": [
-          {
-            "saksnummer": "MEL-1",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 73,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
           {
             "saksnummer": "MEL-1001",
             "navn": "TRIVIELL KARAFFEL",
@@ -10796,7 +10655,7 @@
           "behandlingstema": "ARBEID_KUN_NORGE",
           "behandlingstype": "FØRSTEGANG",
           "skalTilordnes": false,
-          "mottaksdato": "2026-01-19",
+          "mottaksdato": "2026-02-17",
           "behandlingsaarsakType": "SØKNAD",
           "hovedpart": "BRUKER",
           "brukerID": "30056928150",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/opprett-sak-for-sakstype-eu-eos-land-sakstema-medlemsskap-og-lovvalg-uten-a-velge-fra-til-dato-og-ve.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/opprett-sak-for-sakstype-eu-eos-land-sakstema-medlemsskap-og-lovvalg-uten-a-velge-fra-til-dato-og-ve.json
@@ -1,17 +1,17 @@
 {
   "version": "1.0",
   "recordedAt": "2025-01-01T00:00:00.000Z",
-  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web-2/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts",
   "testName": "Opprett sak for sakstype \"EU/EØS-land\", sakstema \"Medlemsskap og lovvalg\", uten å velge fra- til-dato og verifiser at det ikke oppstår noen feil",
   "exchanges": [
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -1140,7 +1141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1181,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1228,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1275,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1322,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1369,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1416,7 +1417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1457,7 +1458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1498,7 +1499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1539,7 +1540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1580,7 +1581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1621,7 +1622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1662,7 +1663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1703,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -1750,7 +1751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1797,7 +1798,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1838,7 +1839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1885,7 +1886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1932,7 +1933,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1973,7 +1974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2020,7 +2021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2067,7 +2068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2114,7 +2115,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2161,7 +2162,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2202,7 +2203,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2243,7 +2244,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2284,7 +2285,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2325,7 +2326,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2366,7 +2367,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2407,7 +2408,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2448,7 +2449,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2489,7 +2490,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2530,7 +2531,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2571,7 +2572,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2612,7 +2613,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2653,7 +2654,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2694,7 +2695,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2735,7 +2736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2782,7 +2783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2829,7 +2830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2876,7 +2877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2923,7 +2924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2970,7 +2971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3017,7 +3018,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3064,7 +3065,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3105,7 +3106,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3146,7 +3147,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3187,7 +3188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3234,7 +3235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3281,7 +3282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3328,7 +3329,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3375,7 +3376,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3416,7 +3417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3457,7 +3458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3498,7 +3499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3539,7 +3540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3580,7 +3581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3621,7 +3622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3662,7 +3663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3703,7 +3704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3744,7 +3745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3782,94 +3783,6 @@
               "land": null,
               "periode": null,
               "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-1071\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "68",
-              "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 74,
-                "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
-                },
-                "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-2",
-              "sakstype": {
-                "kode": "EU_EOS",
-                "term": "EU/EØS-land"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-2\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "69",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 75,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "ARBEID_KUN_NORGE",
-                  "term": "Arbeid kun i Norge"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-3",
-              "sakstype": {
-                "kode": "EU_EOS",
-                "term": "EU/EØS-land"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": {
-                "landkoder": ["NO"],
-                "flereLandUkjentHvilke": false
-              },
-              "periode": {
-                "fom": "2024-01-01",
-                "tom": "2024-12-31"
-              },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-3\n",
               "sisteNotat": null
             }
           ]
@@ -8072,7 +7985,7 @@
             "hovedpartRolle": "BRUKER"
           },
           {
-            "saksnummer": "MEL-3",
+            "saksnummer": "MEL-2",
             "navn": "TRIVIELL KARAFFEL",
             "sakstema": {
               "kode": "MEDLEMSKAP_LOVVALG",
@@ -8097,7 +8010,7 @@
             "opprettetDato": "2025-01-01T00:00:00.000Z",
             "behandlingOversikter": [
               {
-                "behandlingID": 75,
+                "behandlingID": 74,
                 "tittel": "Førstegangsbehandling",
                 "behandlingsstatus": {
                   "kode": "OPPRETTET",
@@ -8144,7 +8057,7 @@
           "behandlingstema": "ARBEID_KUN_NORGE",
           "behandlingstype": "FØRSTEGANG",
           "skalTilordnes": false,
-          "mottaksdato": "2026-01-19",
+          "mottaksdato": "2026-02-17",
           "behandlingsaarsakType": "SØKNAD",
           "hovedpart": "BRUKER",
           "brukerID": "30056928150",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/opprett-sak-for-sakstype-utenfor-avtaleland-med-behandlingstype-arsavregning-og-verifiser-at-det-ikk.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/opprett-sak-for-sakstype-utenfor-avtaleland-med-behandlingstype-arsavregning-og-verifiser-at-det-ikk.json
@@ -1,17 +1,17 @@
 {
   "version": "1.0",
   "recordedAt": "2025-01-01T00:00:00.000Z",
-  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web-2/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts",
   "testName": "Opprett sak for sakstype \"Utenfor avtaleland\" med behandlingstype \"Årsavregning\" og verifiser at det ikke oppstår noen feil",
   "exchanges": [
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -1140,7 +1141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1181,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1228,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1275,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1322,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1369,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1416,7 +1417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1457,7 +1458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1498,7 +1499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1539,7 +1540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1580,7 +1581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1621,7 +1622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1662,7 +1663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1703,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -1750,7 +1751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1797,7 +1798,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1838,7 +1839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1885,7 +1886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1932,7 +1933,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1973,7 +1974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2020,7 +2021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2067,7 +2068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2114,7 +2115,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2161,7 +2162,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2202,7 +2203,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2243,7 +2244,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2284,7 +2285,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2325,7 +2326,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2366,7 +2367,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2407,7 +2408,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2448,7 +2449,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2489,7 +2490,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2530,7 +2531,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2571,7 +2572,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2612,7 +2613,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2653,7 +2654,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2694,7 +2695,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2735,7 +2736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2782,7 +2783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2829,7 +2830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2876,7 +2877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2923,7 +2924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2970,7 +2971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3017,7 +3018,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3064,7 +3065,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3105,7 +3106,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3146,7 +3147,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3187,7 +3188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3234,7 +3235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3281,7 +3282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3328,7 +3329,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3375,7 +3376,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3416,7 +3417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3457,7 +3458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3498,7 +3499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3539,7 +3540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3580,7 +3581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3621,7 +3622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3662,7 +3663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3703,7 +3704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3744,7 +3745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3785,22 +3786,22 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
+              "navn": "TRIVIELL KARAFFEL",
+              "hovedpartIdent": "30056928150",
               "versjon": 1,
               "behandling": {
                 "behandlingID": 74,
                 "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
+                  "kode": "FØRSTEGANG",
+                  "term": "Førstegangsbehandling"
                 },
                 "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
+                  "kode": "ARBEID_KUN_NORGE",
+                  "term": "Arbeid kun i Norge"
                 },
                 "behandlingsstatus": {
                   "kode": "OPPRETTET",
@@ -3820,47 +3821,6 @@
                 "kode": "MEDLEMSKAP_LOVVALG",
                 "term": "Medlemskap og lovvalg"
               },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-2\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "69",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 75,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "ARBEID_KUN_NORGE",
-                  "term": "Arbeid kun i Norge"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-3",
-              "sakstype": {
-                "kode": "EU_EOS",
-                "term": "EU/EØS-land"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
               "land": {
                 "landkoder": ["NO"],
                 "flereLandUkjentHvilke": false
@@ -3869,142 +3829,7 @@
                 "fom": "2024-01-01",
                 "tom": "2024-12-31"
               },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-3\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "70",
-              "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 76,
-                "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
-                },
-                "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-4",
-              "sakstype": {
-                "kode": "TRYGDEAVTALE",
-                "term": "Avtaleland"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-4\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "71",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 77,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-5",
-              "sakstype": {
-                "kode": "TRYGDEAVTALE",
-                "term": "Avtaleland"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": {
-                "landkoder": [],
-                "flereLandUkjentHvilke": false
-              },
-              "periode": {
-                "fom": null,
-                "tom": null
-              },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-5\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "72",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 78,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-6",
-              "sakstype": {
-                "kode": "FTRL",
-                "term": "Utenfor avtaleland"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": {
-                "landkoder": [],
-                "flereLandUkjentHvilke": false
-              },
-              "periode": {
-                "fom": null,
-                "tom": null
-              },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-6\n",
+              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-2\n",
               "sisteNotat": null
             }
           ]
@@ -4034,7 +3859,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -4081,7 +3906,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -4122,7 +3947,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -4169,7 +3994,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -4216,7 +4041,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4263,7 +4088,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4310,7 +4135,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4357,7 +4182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4398,7 +4223,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4439,7 +4264,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4480,7 +4305,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4521,7 +4346,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4562,7 +4387,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4603,7 +4428,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4644,7 +4469,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -4691,7 +4516,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4738,7 +4563,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4779,7 +4604,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4826,7 +4651,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4873,7 +4698,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4914,7 +4739,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4961,7 +4786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -5008,7 +4833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -5055,7 +4880,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -5102,7 +4927,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -5143,7 +4968,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -5184,7 +5009,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -5225,7 +5050,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5266,7 +5091,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5307,7 +5132,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5348,7 +5173,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5389,7 +5214,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5430,7 +5255,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5471,7 +5296,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5512,7 +5337,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5553,7 +5378,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5594,7 +5419,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5635,7 +5460,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5676,7 +5501,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5723,7 +5548,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5770,7 +5595,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5817,7 +5642,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5864,7 +5689,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5911,7 +5736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5958,7 +5783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -6005,7 +5830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -6046,7 +5871,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -6087,7 +5912,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -6128,7 +5953,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -6175,7 +6000,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -6222,7 +6047,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6269,7 +6094,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6316,7 +6141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6357,7 +6182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6398,7 +6223,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6439,7 +6264,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6480,7 +6305,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6521,7 +6346,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6562,7 +6387,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6603,7 +6428,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6644,7 +6469,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6685,7 +6510,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -6726,22 +6551,22 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
+              "navn": "TRIVIELL KARAFFEL",
+              "hovedpartIdent": "30056928150",
               "versjon": 1,
               "behandling": {
                 "behandlingID": 74,
                 "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
+                  "kode": "FØRSTEGANG",
+                  "term": "Førstegangsbehandling"
                 },
                 "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
+                  "kode": "ARBEID_KUN_NORGE",
+                  "term": "Arbeid kun i Norge"
                 },
                 "behandlingsstatus": {
                   "kode": "OPPRETTET",
@@ -6761,47 +6586,6 @@
                 "kode": "MEDLEMSKAP_LOVVALG",
                 "term": "Medlemskap og lovvalg"
               },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-2\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "69",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 75,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "ARBEID_KUN_NORGE",
-                  "term": "Arbeid kun i Norge"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-3",
-              "sakstype": {
-                "kode": "EU_EOS",
-                "term": "EU/EØS-land"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
               "land": {
                 "landkoder": ["NO"],
                 "flereLandUkjentHvilke": false
@@ -6810,60 +6594,19 @@
                 "fom": "2024-01-01",
                 "tom": "2024-12-31"
               },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-3\n",
+              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-2\n",
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
-              "oppgaveID": "70",
-              "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 76,
-                "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
-                },
-                "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-4",
-              "sakstype": {
-                "kode": "TRYGDEAVTALE",
-                "term": "Avtaleland"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-4\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "71",
+              "oppgaveID": "69",
               "prioritet": "NORM",
               "navn": "TRIVIELL KARAFFEL",
               "hovedpartIdent": "30056928150",
               "versjon": 1,
               "behandling": {
-                "behandlingID": 77,
+                "behandlingID": 75,
                 "behandlingstype": {
                   "kode": "FØRSTEGANG",
                   "term": "Førstegangsbehandling"
@@ -6881,7 +6624,7 @@
                 "endretDato": "2025-01-01T00:00:00.000Z",
                 "svarFrist": null
               },
-              "saksnummer": "MEL-5",
+              "saksnummer": "MEL-3",
               "sakstype": {
                 "kode": "TRYGDEAVTALE",
                 "term": "Avtaleland"
@@ -6898,19 +6641,19 @@
                 "fom": null,
                 "tom": null
               },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-5\n",
+              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-3\n",
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
-              "oppgaveID": "72",
+              "oppgaveID": "70",
               "prioritet": "NORM",
               "navn": "TRIVIELL KARAFFEL",
               "hovedpartIdent": "30056928150",
               "versjon": 1,
               "behandling": {
-                "behandlingID": 78,
+                "behandlingID": 76,
                 "behandlingstype": {
                   "kode": "FØRSTEGANG",
                   "term": "Førstegangsbehandling"
@@ -6928,7 +6671,7 @@
                 "endretDato": "2025-01-01T00:00:00.000Z",
                 "svarFrist": null
               },
-              "saksnummer": "MEL-6",
+              "saksnummer": "MEL-4",
               "sakstype": {
                 "kode": "FTRL",
                 "term": "Utenfor avtaleland"
@@ -6945,7 +6688,7 @@
                 "fom": null,
                 "tom": null
               },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-6\n",
+              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-4\n",
               "sisteNotat": null
             }
           ]
@@ -11204,7 +10947,7 @@
             "hovedpartRolle": "BRUKER"
           },
           {
-            "saksnummer": "MEL-3",
+            "saksnummer": "MEL-2",
             "navn": "TRIVIELL KARAFFEL",
             "sakstema": {
               "kode": "MEDLEMSKAP_LOVVALG",
@@ -11229,7 +10972,7 @@
             "opprettetDato": "2025-01-01T00:00:00.000Z",
             "behandlingOversikter": [
               {
-                "behandlingID": 75,
+                "behandlingID": 74,
                 "tittel": "Førstegangsbehandling",
                 "behandlingsstatus": {
                   "kode": "OPPRETTET",
@@ -11246,114 +10989,6 @@
                 "soknadsperiode": {
                   "fom": "2024-01-01",
                   "tom": "2024-12-31"
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-5",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 77,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-6",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "FTRL",
-              "term": "Utenfor avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 78,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
                 },
                 "opprettetDato": "2025-01-01T00:00:00.000Z",
                 "behandlingsresultattype": {
@@ -11384,7 +11019,7 @@
           "behandlingstema": "YRKESAKTIV",
           "behandlingstype": "ÅRSAVREGNING",
           "skalTilordnes": false,
-          "mottaksdato": "2026-01-19",
+          "mottaksdato": "2026-02-17",
           "behandlingsaarsakType": "SØKNAD",
           "hovedpart": "BRUKER",
           "brukerID": "30056928150",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/opprett-sak-for-sakstype-utenfor-avtaleland-og-verifiser-at-det-ikke-oppstar-noen-feil.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/bruker-sak-validering/opprett-sak-for-sakstype-utenfor-avtaleland-og-verifiser-at-det-ikke-oppstar-noen-feil.json
@@ -1,17 +1,17 @@
 {
   "version": "1.0",
   "recordedAt": "2025-01-01T00:00:00.000Z",
-  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web-2/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts",
   "testName": "Opprett sak for sakstype \"Utenfor avtaleland\" og verifiser at det ikke oppstår noen feil",
   "exchanges": [
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -1140,7 +1141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1181,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1228,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1275,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1322,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1369,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1416,7 +1417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1457,7 +1458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1498,7 +1499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1539,7 +1540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1580,7 +1581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1621,7 +1622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1662,7 +1663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1703,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -1750,7 +1751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1797,7 +1798,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1838,7 +1839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1885,7 +1886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1932,7 +1933,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1973,7 +1974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2020,7 +2021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2067,7 +2068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2114,7 +2115,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2161,7 +2162,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2202,7 +2203,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2243,7 +2244,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2284,7 +2285,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2325,7 +2326,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2366,7 +2367,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2407,7 +2408,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2448,7 +2449,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2489,7 +2490,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2530,7 +2531,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2571,7 +2572,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2612,7 +2613,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2653,7 +2654,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2694,7 +2695,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2735,7 +2736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2782,7 +2783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2829,7 +2830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2876,7 +2877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2923,7 +2924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2970,7 +2971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3017,7 +3018,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3064,7 +3065,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3105,7 +3106,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3146,7 +3147,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3187,7 +3188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3234,7 +3235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3281,7 +3282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3328,7 +3329,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3375,7 +3376,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3416,7 +3417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3457,7 +3458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3498,7 +3499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3539,7 +3540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3580,7 +3581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3621,7 +3622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3662,7 +3663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3703,7 +3704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3744,7 +3745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3785,22 +3786,22 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
+              "navn": "TRIVIELL KARAFFEL",
+              "hovedpartIdent": "30056928150",
               "versjon": 1,
               "behandling": {
                 "behandlingID": 74,
                 "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
+                  "kode": "FØRSTEGANG",
+                  "term": "Førstegangsbehandling"
                 },
                 "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
+                  "kode": "ARBEID_KUN_NORGE",
+                  "term": "Arbeid kun i Norge"
                 },
                 "behandlingsstatus": {
                   "kode": "OPPRETTET",
@@ -3820,47 +3821,6 @@
                 "kode": "MEDLEMSKAP_LOVVALG",
                 "term": "Medlemskap og lovvalg"
               },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-2\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "69",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 75,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "ARBEID_KUN_NORGE",
-                  "term": "Arbeid kun i Norge"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-3",
-              "sakstype": {
-                "kode": "EU_EOS",
-                "term": "EU/EØS-land"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
               "land": {
                 "landkoder": ["NO"],
                 "flereLandUkjentHvilke": false
@@ -3869,95 +3829,7 @@
                 "fom": "2024-01-01",
                 "tom": "2024-12-31"
               },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-3\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "70",
-              "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 76,
-                "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
-                },
-                "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-4",
-              "sakstype": {
-                "kode": "TRYGDEAVTALE",
-                "term": "Avtaleland"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-4\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "71",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 77,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-5",
-              "sakstype": {
-                "kode": "TRYGDEAVTALE",
-                "term": "Avtaleland"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": {
-                "landkoder": [],
-                "flereLandUkjentHvilke": false
-              },
-              "periode": {
-                "fom": null,
-                "tom": null
-              },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-5\n",
+              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-2\n",
               "sisteNotat": null
             }
           ]
@@ -3987,7 +3859,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -4034,7 +3906,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -4075,7 +3947,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -4122,7 +3994,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -4169,7 +4041,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4216,7 +4088,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4263,7 +4135,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4310,7 +4182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4351,7 +4223,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4392,7 +4264,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4433,7 +4305,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4474,7 +4346,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4515,7 +4387,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4556,7 +4428,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4597,7 +4469,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -4644,7 +4516,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4691,7 +4563,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4732,7 +4604,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4779,7 +4651,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4826,7 +4698,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4867,7 +4739,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4914,7 +4786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -4961,7 +4833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -5008,7 +4880,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -5055,7 +4927,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -5096,7 +4968,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -5137,7 +5009,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -5178,7 +5050,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5219,7 +5091,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5260,7 +5132,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5301,7 +5173,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5342,7 +5214,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5383,7 +5255,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5424,7 +5296,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5465,7 +5337,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5506,7 +5378,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5547,7 +5419,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5588,7 +5460,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5629,7 +5501,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5676,7 +5548,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5723,7 +5595,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5770,7 +5642,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5817,7 +5689,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5864,7 +5736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5911,7 +5783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -5958,7 +5830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -5999,7 +5871,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -6040,7 +5912,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -6081,7 +5953,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -6128,7 +6000,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -6175,7 +6047,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6222,7 +6094,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6269,7 +6141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6310,7 +6182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6351,7 +6223,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6392,7 +6264,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6433,7 +6305,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6474,7 +6346,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6515,7 +6387,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6556,7 +6428,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6597,7 +6469,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6638,7 +6510,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -6679,22 +6551,22 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
+              "navn": "TRIVIELL KARAFFEL",
+              "hovedpartIdent": "30056928150",
               "versjon": 1,
               "behandling": {
                 "behandlingID": 74,
                 "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
+                  "kode": "FØRSTEGANG",
+                  "term": "Førstegangsbehandling"
                 },
                 "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
+                  "kode": "ARBEID_KUN_NORGE",
+                  "term": "Arbeid kun i Norge"
                 },
                 "behandlingsstatus": {
                   "kode": "OPPRETTET",
@@ -6714,47 +6586,6 @@
                 "kode": "MEDLEMSKAP_LOVVALG",
                 "term": "Medlemskap og lovvalg"
               },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-2\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "69",
-              "prioritet": "NORM",
-              "navn": "TRIVIELL KARAFFEL",
-              "hovedpartIdent": "30056928150",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 75,
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "ARBEID_KUN_NORGE",
-                  "term": "Arbeid kun i Norge"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-3",
-              "sakstype": {
-                "kode": "EU_EOS",
-                "term": "EU/EØS-land"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
               "land": {
                 "landkoder": ["NO"],
                 "flereLandUkjentHvilke": false
@@ -6763,60 +6594,19 @@
                 "fom": "2024-01-01",
                 "tom": "2024-12-31"
               },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-3\n",
+              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n Arbeid kun i Norge - MEL-2\n",
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-19",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
-              "oppgaveID": "70",
-              "prioritet": "NORM",
-              "navn": "Ståles Stål AS",
-              "hovedpartIdent": "999999999",
-              "versjon": 1,
-              "behandling": {
-                "behandlingID": 76,
-                "behandlingstype": {
-                  "kode": "HENVENDELSE",
-                  "term": "Henvendelse"
-                },
-                "behandlingstema": {
-                  "kode": "VIRKSOMHET",
-                  "term": "Virksomhet"
-                },
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "erUnderOppdatering": false,
-                "registrertDato": "2025-01-01T00:00:00.000Z",
-                "endretDato": "2025-01-01T00:00:00.000Z",
-                "svarFrist": null
-              },
-              "saksnummer": "MEL-4",
-              "sakstype": {
-                "kode": "TRYGDEAVTALE",
-                "term": "Avtaleland"
-              },
-              "sakstema": {
-                "kode": "MEDLEMSKAP_LOVVALG",
-                "term": "Medlemskap og lovvalg"
-              },
-              "land": null,
-              "periode": null,
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-4\n",
-              "sisteNotat": null
-            },
-            {
-              "aktivTil": "2026-04-19",
-              "ansvarligID": "Z123456",
-              "oppgaveID": "71",
+              "oppgaveID": "69",
               "prioritet": "NORM",
               "navn": "TRIVIELL KARAFFEL",
               "hovedpartIdent": "30056928150",
               "versjon": 1,
               "behandling": {
-                "behandlingID": 77,
+                "behandlingID": 75,
                 "behandlingstype": {
                   "kode": "FØRSTEGANG",
                   "term": "Førstegangsbehandling"
@@ -6834,7 +6624,7 @@
                 "endretDato": "2025-01-01T00:00:00.000Z",
                 "svarFrist": null
               },
-              "saksnummer": "MEL-5",
+              "saksnummer": "MEL-3",
               "sakstype": {
                 "kode": "TRYGDEAVTALE",
                 "term": "Avtaleland"
@@ -6851,7 +6641,7 @@
                 "fom": null,
                 "tom": null
               },
-              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-5\n",
+              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-3\n",
               "sisteNotat": null
             }
           ]
@@ -11069,7 +10859,7 @@
             "hovedpartRolle": "BRUKER"
           },
           {
-            "saksnummer": "MEL-3",
+            "saksnummer": "MEL-2",
             "navn": "TRIVIELL KARAFFEL",
             "sakstema": {
               "kode": "MEDLEMSKAP_LOVVALG",
@@ -11094,7 +10884,7 @@
             "opprettetDato": "2025-01-01T00:00:00.000Z",
             "behandlingOversikter": [
               {
-                "behandlingID": 75,
+                "behandlingID": 74,
                 "tittel": "Førstegangsbehandling",
                 "behandlingsstatus": {
                   "kode": "OPPRETTET",
@@ -11111,60 +10901,6 @@
                 "soknadsperiode": {
                   "fom": "2024-01-01",
                   "tom": "2024-12-31"
-                },
-                "opprettetDato": "2025-01-01T00:00:00.000Z",
-                "behandlingsresultattype": {
-                  "kode": "IKKE_FASTSATT",
-                  "term": "Ikke fastsatt"
-                },
-                "svarFrist": null
-              }
-            ],
-            "hovedpartRolle": "BRUKER"
-          },
-          {
-            "saksnummer": "MEL-5",
-            "navn": "TRIVIELL KARAFFEL",
-            "sakstema": {
-              "kode": "MEDLEMSKAP_LOVVALG",
-              "term": "Medlemskap og lovvalg"
-            },
-            "sakstype": {
-              "kode": "TRYGDEAVTALE",
-              "term": "Avtaleland"
-            },
-            "saksstatus": {
-              "kode": "OPPRETTET",
-              "term": "Saken er opprettet"
-            },
-            "land": {
-              "landkoder": [],
-              "flereLandUkjentHvilke": false
-            },
-            "periode": {
-              "fom": null,
-              "tom": null
-            },
-            "opprettetDato": "2025-01-01T00:00:00.000Z",
-            "behandlingOversikter": [
-              {
-                "behandlingID": 77,
-                "tittel": "Førstegangsbehandling",
-                "behandlingsstatus": {
-                  "kode": "OPPRETTET",
-                  "term": "Behandlingen er opprettet"
-                },
-                "behandlingstype": {
-                  "kode": "FØRSTEGANG",
-                  "term": "Førstegangsbehandling"
-                },
-                "behandlingstema": {
-                  "kode": "YRKESAKTIV",
-                  "term": "Yrkesaktiv"
-                },
-                "soknadsperiode": {
-                  "fom": null,
-                  "tom": null
                 },
                 "opprettetDato": "2025-01-01T00:00:00.000Z",
                 "behandlingsresultattype": {
@@ -11195,7 +10931,7 @@
           "behandlingstema": "YRKESAKTIV",
           "behandlingstype": "FØRSTEGANG",
           "skalTilordnes": false,
-          "mottaksdato": "2026-01-19",
+          "mottaksdato": "2026-02-17",
           "behandlingsaarsakType": "SØKNAD",
           "hovedpart": "BRUKER",
           "brukerID": "30056928150",

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/virksomhet-sak-validering/manglende-pakrevde-felt-viser-feilmeldinger.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/virksomhet-sak-validering/manglende-pakrevde-felt-viser-feilmeldinger.json
@@ -7,11 +7,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -1140,7 +1141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1181,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1228,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1275,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1322,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1369,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1416,7 +1417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1457,7 +1458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1498,7 +1499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1539,7 +1540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1580,7 +1581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1621,7 +1622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1662,7 +1663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1703,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -1750,7 +1751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1797,7 +1798,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1838,7 +1839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1885,7 +1886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1932,7 +1933,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1973,7 +1974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2020,7 +2021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2067,7 +2068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2114,7 +2115,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2161,7 +2162,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2202,7 +2203,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2243,7 +2244,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2284,7 +2285,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2325,7 +2326,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2366,7 +2367,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2407,7 +2408,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2448,7 +2449,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2489,7 +2490,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2530,7 +2531,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2571,7 +2572,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2612,7 +2613,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2653,7 +2654,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2694,7 +2695,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2735,7 +2736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2782,7 +2783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2829,7 +2830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2876,7 +2877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2923,7 +2924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2970,7 +2971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3017,7 +3018,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3064,7 +3065,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3105,7 +3106,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3146,7 +3147,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3187,7 +3188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3234,7 +3235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3281,7 +3282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3328,7 +3329,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3375,7 +3376,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3416,7 +3417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3457,7 +3458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3498,7 +3499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3539,7 +3540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3580,7 +3581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3621,7 +3622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3662,7 +3663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3703,7 +3704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3744,7 +3745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3785,7 +3786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
@@ -3832,7 +3833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "69",
               "prioritet": "NORM",
@@ -3879,7 +3880,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "70",
               "prioritet": "NORM",
@@ -3923,6 +3924,53 @@
                 "tom": null
               },
               "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-4\n",
+              "sisteNotat": null
+            },
+            {
+              "aktivTil": "2026-05-18",
+              "ansvarligID": "Z123456",
+              "oppgaveID": "71",
+              "prioritet": "NORM",
+              "navn": "TRIVIELL KARAFFEL",
+              "hovedpartIdent": "30056928150",
+              "versjon": 1,
+              "behandling": {
+                "behandlingID": 77,
+                "behandlingstype": {
+                  "kode": "ÅRSAVREGNING",
+                  "term": "Årsavregning"
+                },
+                "behandlingstema": {
+                  "kode": "YRKESAKTIV",
+                  "term": "Yrkesaktiv"
+                },
+                "behandlingsstatus": {
+                  "kode": "OPPRETTET",
+                  "term": "Behandlingen er opprettet"
+                },
+                "erUnderOppdatering": false,
+                "registrertDato": "2025-01-01T00:00:00.000Z",
+                "endretDato": "2025-01-01T00:00:00.000Z",
+                "svarFrist": null
+              },
+              "saksnummer": "MEL-5",
+              "sakstype": {
+                "kode": "FTRL",
+                "term": "Utenfor avtaleland"
+              },
+              "sakstema": {
+                "kode": "MEDLEMSKAP_LOVVALG",
+                "term": "Medlemskap og lovvalg"
+              },
+              "land": {
+                "landkoder": [],
+                "flereLandUkjentHvilke": false
+              },
+              "periode": {
+                "fom": null,
+                "tom": null
+              },
+              "oppgaveBeskrivelse": "--- 01.01.2025 00:00 (srvmelosys, Melosys) ---\n  - MEL-5\n",
               "sisteNotat": null
             }
           ]

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/virksomhet-sak-validering/opprett-sak-for-sakstype-avtaleland-og-verifiser-at-det-ikke-oppstar-noen-feil.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/virksomhet-sak-validering/opprett-sak-for-sakstype-avtaleland-og-verifiser-at-det-ikke-oppstar-noen-feil.json
@@ -7,11 +7,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -1140,7 +1141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1181,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1228,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1275,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1322,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1369,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1416,7 +1417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1457,7 +1458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1498,7 +1499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1539,7 +1540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1580,7 +1581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1621,7 +1622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1662,7 +1663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1703,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -1750,7 +1751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1797,7 +1798,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1838,7 +1839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1885,7 +1886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1932,7 +1933,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1973,7 +1974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2020,7 +2021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2067,7 +2068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2114,7 +2115,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2161,7 +2162,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2202,7 +2203,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2243,7 +2244,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2284,7 +2285,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2325,7 +2326,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2366,7 +2367,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2407,7 +2408,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2448,7 +2449,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2489,7 +2490,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2530,7 +2531,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2571,7 +2572,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2612,7 +2613,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2653,7 +2654,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2694,7 +2695,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2735,7 +2736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2782,7 +2783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2829,7 +2830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2876,7 +2877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2923,7 +2924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2970,7 +2971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3017,7 +3018,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3064,7 +3065,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3105,7 +3106,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3146,7 +3147,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3187,7 +3188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3234,7 +3235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3281,7 +3282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3328,7 +3329,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3375,7 +3376,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3416,7 +3417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3457,7 +3458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3498,7 +3499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3539,7 +3540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3580,7 +3581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3621,7 +3622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3662,7 +3663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3703,7 +3704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3744,7 +3745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3785,7 +3786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
@@ -3832,7 +3833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "69",
               "prioritet": "NORM",
@@ -3879,7 +3880,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "70",
               "prioritet": "NORM",
@@ -3926,7 +3927,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "71",
               "prioritet": "NORM",
@@ -3973,7 +3974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "72",
               "prioritet": "NORM",
@@ -4040,7 +4041,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -4087,7 +4088,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -4128,7 +4129,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -4175,7 +4176,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -4222,7 +4223,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4269,7 +4270,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4316,7 +4317,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4363,7 +4364,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4404,7 +4405,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4445,7 +4446,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4486,7 +4487,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4527,7 +4528,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4568,7 +4569,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4609,7 +4610,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4650,7 +4651,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -4697,7 +4698,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4744,7 +4745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4785,7 +4786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4832,7 +4833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4879,7 +4880,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4920,7 +4921,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4967,7 +4968,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -5014,7 +5015,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -5061,7 +5062,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -5108,7 +5109,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -5149,7 +5150,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -5190,7 +5191,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -5231,7 +5232,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5272,7 +5273,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5313,7 +5314,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5354,7 +5355,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5395,7 +5396,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5436,7 +5437,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5477,7 +5478,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5518,7 +5519,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5559,7 +5560,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5600,7 +5601,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5641,7 +5642,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5682,7 +5683,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5729,7 +5730,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5776,7 +5777,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5823,7 +5824,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5870,7 +5871,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5917,7 +5918,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5964,7 +5965,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -6011,7 +6012,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -6052,7 +6053,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -6093,7 +6094,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -6134,7 +6135,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -6181,7 +6182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -6228,7 +6229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6275,7 +6276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6322,7 +6323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6363,7 +6364,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6404,7 +6405,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6445,7 +6446,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6486,7 +6487,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6527,7 +6528,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6568,7 +6569,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6609,7 +6610,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6650,7 +6651,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6691,7 +6692,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -6732,7 +6733,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
@@ -6779,7 +6780,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "69",
               "prioritet": "NORM",
@@ -6826,7 +6827,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "70",
               "prioritet": "NORM",
@@ -6873,7 +6874,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "71",
               "prioritet": "NORM",
@@ -6920,7 +6921,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "72",
               "prioritet": "NORM",
@@ -7358,7 +7359,7 @@
           "behandlingstema": "VIRKSOMHET",
           "behandlingstype": "HENVENDELSE",
           "skalTilordnes": false,
-          "mottaksdato": "2026-01-30",
+          "mottaksdato": "2026-02-17",
           "behandlingsaarsakType": "SØKNAD",
           "hovedpart": "VIRKSOMHET",
           "brukerID": null,

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/virksomhet-sak-validering/opprett-sak-for-sakstype-eu-eos-land-og-verifiser-at-det-ikke-oppstar-noen-feil.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ny-sak/virksomhet-sak-validering/opprett-sak-for-sakstype-eu-eos-land-og-verifiser-at-det-ikke-oppstar-noen-feil.json
@@ -7,11 +7,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -1140,7 +1141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1181,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1228,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1275,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1322,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1369,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1416,7 +1417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1457,7 +1458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1498,7 +1499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1539,7 +1540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1580,7 +1581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1621,7 +1622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1662,7 +1663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1703,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -1750,7 +1751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1797,7 +1798,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1838,7 +1839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1885,7 +1886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1932,7 +1933,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1973,7 +1974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2020,7 +2021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2067,7 +2068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2114,7 +2115,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2161,7 +2162,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2202,7 +2203,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2243,7 +2244,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2284,7 +2285,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2325,7 +2326,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2366,7 +2367,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2407,7 +2408,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2448,7 +2449,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2489,7 +2490,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2530,7 +2531,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2571,7 +2572,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2612,7 +2613,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2653,7 +2654,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2694,7 +2695,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2735,7 +2736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2782,7 +2783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2829,7 +2830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2876,7 +2877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2923,7 +2924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2970,7 +2971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3017,7 +3018,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3064,7 +3065,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3105,7 +3106,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3146,7 +3147,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3187,7 +3188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3234,7 +3235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3281,7 +3282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3328,7 +3329,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3375,7 +3376,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3416,7 +3417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3457,7 +3458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3498,7 +3499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3539,7 +3540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3580,7 +3581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3621,7 +3622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3662,7 +3663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3703,7 +3704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3744,7 +3745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3785,7 +3786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
@@ -3832,7 +3833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "69",
               "prioritet": "NORM",
@@ -3879,7 +3880,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "70",
               "prioritet": "NORM",
@@ -3926,7 +3927,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "71",
               "prioritet": "NORM",
@@ -3999,7 +4000,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -4046,7 +4047,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -4087,7 +4088,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -4134,7 +4135,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -4181,7 +4182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -4228,7 +4229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -4275,7 +4276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -4322,7 +4323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -4363,7 +4364,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -4404,7 +4405,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -4445,7 +4446,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -4486,7 +4487,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -4527,7 +4528,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -4568,7 +4569,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -4609,7 +4610,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -4656,7 +4657,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -4703,7 +4704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -4744,7 +4745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -4791,7 +4792,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -4838,7 +4839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -4879,7 +4880,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -4926,7 +4927,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -4973,7 +4974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -5020,7 +5021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -5067,7 +5068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -5108,7 +5109,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -5149,7 +5150,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -5190,7 +5191,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -5231,7 +5232,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -5272,7 +5273,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -5313,7 +5314,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -5354,7 +5355,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -5395,7 +5396,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -5436,7 +5437,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -5477,7 +5478,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -5518,7 +5519,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -5559,7 +5560,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -5600,7 +5601,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -5641,7 +5642,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -5688,7 +5689,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -5735,7 +5736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -5782,7 +5783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -5829,7 +5830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -5876,7 +5877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -5923,7 +5924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -5970,7 +5971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -6011,7 +6012,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -6052,7 +6053,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -6093,7 +6094,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -6140,7 +6141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -6187,7 +6188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -6234,7 +6235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -6281,7 +6282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -6322,7 +6323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -6363,7 +6364,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -6404,7 +6405,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -6445,7 +6446,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -6486,7 +6487,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -6527,7 +6528,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -6568,7 +6569,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -6609,7 +6610,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -6650,7 +6651,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -6691,7 +6692,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
@@ -6738,7 +6739,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "69",
               "prioritet": "NORM",
@@ -6785,7 +6786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "70",
               "prioritet": "NORM",
@@ -6832,7 +6833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "71",
               "prioritet": "NORM",
@@ -7221,7 +7222,7 @@
           "behandlingstema": "VIRKSOMHET",
           "behandlingstype": "HENVENDELSE",
           "skalTilordnes": false,
-          "mottaksdato": "2026-01-30",
+          "mottaksdato": "2026-02-17",
           "behandlingsaarsakType": "SØKNAD",
           "hovedpart": "VIRKSOMHET",
           "brukerID": null,

--- a/tests/e2e/recordings/specs/opprett-ny-sak/ui-grunnleggende/klikk-pa-opprett-ny-sak-behandling-og-verifiser-at-alle-forventede-elementer-er-tilstede.json
+++ b/tests/e2e/recordings/specs/opprett-ny-sak/ui-grunnleggende/klikk-pa-opprett-ny-sak-behandling-og-verifiser-at-alle-forventede-elementer-er-tilstede.json
@@ -7,11 +7,11 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:3333/api/featuretoggle?features=melosys.faktureringskomponent.vis_referanse&features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "normalizedPath": "/api/featuretoggle",
         "query": {
-          "features": "melosys.eos_fakturering_av_trygdeavgift"
+          "features": "melosys.cdm-4-4"
         },
         "headers": {
           "accept": "application/json",
@@ -35,7 +35,8 @@
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
           "melosys.eos_fakturering_av_trygdeavgift": true,
-          "melosys.arsavregning.uten.flyt": false
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
         }
       }
     },
@@ -1093,7 +1094,7 @@
           "journalforing": [],
           "saksbehandling": [
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "67",
               "prioritet": "NORM",
@@ -1140,7 +1141,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "3",
               "prioritet": "NORM",
@@ -1181,7 +1182,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "4",
               "prioritet": "NORM",
@@ -1228,7 +1229,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "5",
               "prioritet": "NORM",
@@ -1275,7 +1276,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "6",
               "prioritet": "NORM",
@@ -1322,7 +1323,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "7",
               "prioritet": "NORM",
@@ -1369,7 +1370,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "8",
               "prioritet": "NORM",
@@ -1416,7 +1417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "9",
               "prioritet": "NORM",
@@ -1457,7 +1458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "10",
               "prioritet": "NORM",
@@ -1498,7 +1499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "11",
               "prioritet": "NORM",
@@ -1539,7 +1540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "12",
               "prioritet": "NORM",
@@ -1580,7 +1581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "13",
               "prioritet": "NORM",
@@ -1621,7 +1622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "14",
               "prioritet": "NORM",
@@ -1662,7 +1663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "15",
               "prioritet": "NORM",
@@ -1703,7 +1704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "66",
               "prioritet": "NORM",
@@ -1750,7 +1751,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "18",
               "prioritet": "NORM",
@@ -1797,7 +1798,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "19",
               "prioritet": "NORM",
@@ -1838,7 +1839,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "20",
               "prioritet": "NORM",
@@ -1885,7 +1886,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "22",
               "prioritet": "NORM",
@@ -1932,7 +1933,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "23",
               "prioritet": "NORM",
@@ -1973,7 +1974,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "24",
               "prioritet": "NORM",
@@ -2020,7 +2021,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "25",
               "prioritet": "NORM",
@@ -2067,7 +2068,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "26",
               "prioritet": "NORM",
@@ -2114,7 +2115,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "27",
               "prioritet": "NORM",
@@ -2161,7 +2162,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "28",
               "prioritet": "NORM",
@@ -2202,7 +2203,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "29",
               "prioritet": "NORM",
@@ -2243,7 +2244,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "30",
               "prioritet": "NORM",
@@ -2284,7 +2285,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "31",
               "prioritet": "NORM",
@@ -2325,7 +2326,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "32",
               "prioritet": "NORM",
@@ -2366,7 +2367,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "33",
               "prioritet": "NORM",
@@ -2407,7 +2408,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "34",
               "prioritet": "NORM",
@@ -2448,7 +2449,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "35",
               "prioritet": "NORM",
@@ -2489,7 +2490,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "36",
               "prioritet": "NORM",
@@ -2530,7 +2531,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "37",
               "prioritet": "NORM",
@@ -2571,7 +2572,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "38",
               "prioritet": "NORM",
@@ -2612,7 +2613,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "39",
               "prioritet": "NORM",
@@ -2653,7 +2654,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "40",
               "prioritet": "NORM",
@@ -2694,7 +2695,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "41",
               "prioritet": "NORM",
@@ -2735,7 +2736,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "42",
               "prioritet": "NORM",
@@ -2782,7 +2783,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "43",
               "prioritet": "NORM",
@@ -2829,7 +2830,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "44",
               "prioritet": "NORM",
@@ -2876,7 +2877,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "45",
               "prioritet": "NORM",
@@ -2923,7 +2924,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "46",
               "prioritet": "NORM",
@@ -2970,7 +2971,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "47",
               "prioritet": "NORM",
@@ -3017,7 +3018,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "48",
               "prioritet": "NORM",
@@ -3064,7 +3065,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "49",
               "prioritet": "NORM",
@@ -3105,7 +3106,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "50",
               "prioritet": "NORM",
@@ -3146,7 +3147,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "51",
               "prioritet": "NORM",
@@ -3187,7 +3188,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "52",
               "prioritet": "NORM",
@@ -3234,7 +3235,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "53",
               "prioritet": "NORM",
@@ -3281,7 +3282,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "54",
               "prioritet": "NORM",
@@ -3328,7 +3329,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "55",
               "prioritet": "NORM",
@@ -3375,7 +3376,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "56",
               "prioritet": "NORM",
@@ -3416,7 +3417,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "57",
               "prioritet": "NORM",
@@ -3457,7 +3458,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "58",
               "prioritet": "NORM",
@@ -3498,7 +3499,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "59",
               "prioritet": "NORM",
@@ -3539,7 +3540,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "60",
               "prioritet": "NORM",
@@ -3580,7 +3581,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "61",
               "prioritet": "NORM",
@@ -3621,7 +3622,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "62",
               "prioritet": "NORM",
@@ -3662,7 +3663,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "63",
               "prioritet": "NORM",
@@ -3703,7 +3704,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "64",
               "prioritet": "NORM",
@@ -3744,7 +3745,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "65",
               "prioritet": "NORM",
@@ -3785,7 +3786,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "68",
               "prioritet": "NORM",
@@ -3832,7 +3833,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "69",
               "prioritet": "NORM",
@@ -3879,7 +3880,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "70",
               "prioritet": "NORM",
@@ -3926,7 +3927,7 @@
               "sisteNotat": null
             },
             {
-              "aktivTil": "2026-04-30",
+              "aktivTil": "2026-05-18",
               "ansvarligID": "Z123456",
               "oppgaveID": "71",
               "prioritet": "NORM",

--- a/tests/e2e/specs/behandle-sak/aarsavregning-delt-grunnlag.spec.ts
+++ b/tests/e2e/specs/behandle-sak/aarsavregning-delt-grunnlag.spec.ts
@@ -228,6 +228,7 @@ test.describe("Årsavregning delt grunnlag - Alle tester", () => {
   test.describe("Legg til periode med pliktig bestemmelse (bugfix)", () => {
     test("skal vise 'Legg til periode'-knappen for delt grunnlag selv med pliktig bestemmelse", async ({
       page,
+      apiRecorder,
     }, testInfo) => {
       test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
       const { aarsavregningPage } = await setupAarsavregningTest(page, "MEL-1043");

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/avtaleland-behandlingslogikk.spec.ts
@@ -92,6 +92,7 @@ test.describe("Avtaleland behandlingslogikk (regresjon)", () => {
 
   test("Regresjon: Avtaleland med ferdigbehandlede - Ny vurdering og Henvendelse tilgjengelig", async ({
     page,
+    apiRecorder,
   }, testInfo) => {
     test.setTimeout(TIMEOUT_FOR_COMPLEX_TESTS);
 

--- a/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/ny-sak/bruker-sak-validering.spec.ts
@@ -55,6 +55,7 @@ test.describe("'Opprett ny sak for bruker", () => {
 
   test('Opprett sak for sakstype "EU/EØS-land" og verifiser at det ikke oppstår noen feil', async ({
     page,
+    apiRecorder,
   }, testInfo) => {
     const opprettNySakPage = await setupOpprettNySakTest(page);
     await opprettNySakPage.fyllInnBrukerId(USER_ID_VALID);
@@ -79,6 +80,7 @@ test.describe("'Opprett ny sak for bruker", () => {
 
   test('Opprett sak for sakstype "EU/EØS-land", sakstema "Medlemsskap og lovvalg", uten å velge fra- til-dato og verifiser at det ikke oppstår noen feil', async ({
     page,
+    apiRecorder,
   }, testInfo) => {
     const opprettNySakPage = await setupOpprettNySakTest(page);
     await opprettNySakPage.fyllInnBrukerId(USER_ID_VALID);

--- a/tests/e2e/specs/opprett-ny-sak/ny-sak/virksomhet-sak-validering.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/ny-sak/virksomhet-sak-validering.spec.ts
@@ -27,6 +27,7 @@ test.describe("'Opprett ny sak for virksomhet", () => {
 
   test('Opprett sak for sakstype "EU/EØS-land" og verifiser at det ikke oppstår noen feil', async ({
     page,
+    apiRecorder,
   }, testInfo) => {
     await opprettNySakPage.velgVirksomhet();
     await opprettNySakPage.fyllInnOrganisasjonsnummer(ORG_NUMBER_VALID);
@@ -47,6 +48,7 @@ test.describe("'Opprett ny sak for virksomhet", () => {
 
   test('Opprett sak for sakstype "Avtaleland" og verifiser at det ikke oppstår noen feil', async ({
     page,
+    apiRecorder,
   }, testInfo) => {
     await opprettNySakPage.velgVirksomhet();
     await opprettNySakPage.fyllInnOrganisasjonsnummer(ORG_NUMBER_VALID);

--- a/tests/e2e/specs/opprett-ny-sak/ui-grunnleggende.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/ui-grunnleggende.spec.ts
@@ -15,6 +15,7 @@ test.describe("'Opprett ny sak/behandling' hovedside", () => {
   });
   test("Klikk på 'Opprett ny sak/behandling' og verifiser at alle forventede elementer er tilstede", async ({
     page,
+    apiRecorder,
   }, testInfo) => {
     await opprettNySakPage.verifiserAlleElementer();
   });


### PR DESCRIPTION
La til manglende apiRecorder fixture i 7 E2E-tester

Tester uten apiRecorder fikk ikke worker-isolasjon mot mock-serveren,
noe som førte til intermitterende feil på CI (bl.a. .informasjonlinje not found).

Ny recording av pw-tester