### PR TITLE
7914 Fikset race conditions med manglende await på dispatches

### DIFF
--- a/src/ducks/datalasting/operations.js
+++ b/src/ducks/datalasting/operations.js
@@ -108,32 +108,36 @@ export const lastInnSaksopplysninger = (sakstype, saksnummer, behandlingID) => a
   ]);
 };
 
-export const lastInnSaksopplysningerIngenFlyt = (saksnummer, behandlingID) => (dispatch) => {
-  dispatch(fagsakOperations.hent(saksnummer));
-  dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
-  dispatch(behandlingerOperations.hentBehandling(behandlingID));
-  dispatch(behandlingsresultatOperations.hent(behandlingID));
-};
+export const lastInnSaksopplysningerIngenFlyt = (saksnummer, behandlingID) => (dispatch) =>
+  Promise.all([
+    dispatch(fagsakOperations.hent(saksnummer)),
+    dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer)),
+    dispatch(behandlingerOperations.hentBehandling(behandlingID)),
+    dispatch(behandlingsresultatOperations.hent(behandlingID)),
+  ]);
 
-export const lastInnSaksopplysningerRegistreringUnntaksperioder = (saksnummer, behandlingID) => (dispatch) => {
-  dispatch(fagsakOperations.hent(saksnummer));
-  dispatch(behandlingerOperations.hentBehandling(behandlingID));
-  dispatch(behandlingsresultatOperations.hent(behandlingID));
-  dispatch(avklartefaktaOperations.hent(behandlingID));
-  dispatch(vilkarOperations.hent(behandlingID));
-  dispatch(lovvalgsperioderOperations.hent(behandlingID));
-  dispatch(behandlingsperioderOperations.hentMedlemsPerioder(behandlingID));
-  dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
-};
+export const lastInnSaksopplysningerRegistreringUnntaksperioder = (saksnummer, behandlingID) => (dispatch) =>
+  Promise.all([
+    dispatch(fagsakOperations.hent(saksnummer)),
+    dispatch(behandlingerOperations.hentBehandling(behandlingID)),
+    dispatch(behandlingsresultatOperations.hent(behandlingID)),
+    dispatch(avklartefaktaOperations.hent(behandlingID)),
+    dispatch(vilkarOperations.hent(behandlingID)),
+    dispatch(lovvalgsperioderOperations.hent(behandlingID)),
+    dispatch(behandlingsperioderOperations.hentMedlemsPerioder(behandlingID)),
+    dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer)),
+  ]);
 
-export const lastInnSaksopplysningerBehandleMottattAOU = (saksnummer, behandlingID) => (dispatch, getState) => {
-  dispatch(behandlingerOperations.hentBehandling(behandlingID));
-  dispatch(behandlingsresultatOperations.hent(behandlingID));
-  dispatch(anmodningsperioderOperations.hent(behandlingID)).then(() => {
-    const anmodningsperiodeID = anmodningsperioderSelectors.AnmodningsperiodeIDSelector(getState());
-    dispatch(anmodningsperiodesvarOperations.hent(anmodningsperiodeID));
-  });
-  dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer));
+export const lastInnSaksopplysningerBehandleMottattAOU = (saksnummer, behandlingID) => async (dispatch, getState) => {
+  await Promise.all([
+    dispatch(behandlingerOperations.hentBehandling(behandlingID)),
+    dispatch(behandlingsresultatOperations.hent(behandlingID)),
+    dispatch(anmodningsperioderOperations.hent(behandlingID)).then(() => {
+      const anmodningsperiodeID = anmodningsperioderSelectors.AnmodningsperiodeIDSelector(getState());
+      return dispatch(anmodningsperiodesvarOperations.hent(anmodningsperiodeID));
+    }),
+    dispatch(dokumenterOperations.hentDokumentOversikt(saksnummer)),
+  ]);
 };
 
 export const resetSaksopplysninger = () => (dispatch) => {

--- a/src/ducks/datalasting/operations.test.ts
+++ b/src/ducks/datalasting/operations.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  lastInnSaksopplysningerIngenFlyt,
+  lastInnSaksopplysningerRegistreringUnntaksperioder,
+  lastInnSaksopplysningerBehandleMottattAOU,
+} from "./operations";
+
+describe("datalasting operations", () => {
+  const mockDispatch = vi.fn(() => Promise.resolve());
+  const mockGetState = vi.fn(() => ({
+    anmodningsperioder: {
+      data: [{ anmodningsperiodeID: 42 }],
+    },
+  }));
+
+  beforeEach(() => {
+    mockDispatch.mockClear();
+    mockGetState.mockClear();
+  });
+
+  describe("lastInnSaksopplysningerIngenFlyt", () => {
+    it("returnerer thunk", () => {
+      expect(typeof lastInnSaksopplysningerIngenFlyt("SAK-1", 123)).toBe("function");
+    });
+
+    it("returnerer Promise ved dispatch (ikke undefined)", () => {
+      const thunk = lastInnSaksopplysningerIngenFlyt("SAK-1", 123);
+      const result = thunk(mockDispatch);
+      expect(result).toBeInstanceOf(Promise);
+    });
+
+    it("dispatcher 4 operations", () => {
+      const thunk = lastInnSaksopplysningerIngenFlyt("SAK-1", 123);
+      thunk(mockDispatch);
+      expect(mockDispatch).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("lastInnSaksopplysningerRegistreringUnntaksperioder", () => {
+    it("returnerer thunk", () => {
+      expect(typeof lastInnSaksopplysningerRegistreringUnntaksperioder("SAK-1", 123)).toBe("function");
+    });
+
+    it("returnerer Promise ved dispatch (ikke undefined)", () => {
+      const thunk = lastInnSaksopplysningerRegistreringUnntaksperioder("SAK-1", 123);
+      const result = thunk(mockDispatch);
+      expect(result).toBeInstanceOf(Promise);
+    });
+
+    it("dispatcher 8 operations", () => {
+      const thunk = lastInnSaksopplysningerRegistreringUnntaksperioder("SAK-1", 123);
+      thunk(mockDispatch);
+      expect(mockDispatch).toHaveBeenCalledTimes(8);
+    });
+  });
+
+  describe("lastInnSaksopplysningerBehandleMottattAOU", () => {
+    it("returnerer thunk", () => {
+      expect(typeof lastInnSaksopplysningerBehandleMottattAOU("SAK-1", 123)).toBe("function");
+    });
+
+    it("returnerer Promise ved dispatch (ikke undefined)", async () => {
+      const thunk = lastInnSaksopplysningerBehandleMottattAOU("SAK-1", 123);
+      const result = thunk(mockDispatch, mockGetState);
+      expect(result).toBeInstanceOf(Promise);
+      await result;
+    });
+
+    it("dispatcher behandling, resultat, anmodningsperioder og dokumenter", async () => {
+      const thunk = lastInnSaksopplysningerBehandleMottattAOU("SAK-1", 123);
+      await thunk(mockDispatch, mockGetState);
+      // 4 initielle dispatches + 1 dispatch av anmodningsperiodesvar i .then()
+      expect(mockDispatch).toHaveBeenCalledTimes(5);
+    });
+  });
+});

--- a/src/sider/aarsavregning/saksbehandling.tsx
+++ b/src/sider/aarsavregning/saksbehandling.tsx
@@ -84,8 +84,10 @@ function Saksbehandling({ match, location }: Props) {
         return false;
       }
 
-      await dispatch(mottatteOpplysningerOperations.hent(behandlingId));
-      await dispatch(dokumenterOperations.hentDokumentOversikt(saksnr));
+      await Promise.all([
+        dispatch(mottatteOpplysningerOperations.hent(behandlingId)),
+        dispatch(dokumenterOperations.hentDokumentOversikt(saksnr)),
+      ]);
       setSaksopplysningerLastet(true);
       return true;
     } catch (e) {

--- a/src/sider/aarsavregning/saksbehandling.tsx
+++ b/src/sider/aarsavregning/saksbehandling.tsx
@@ -77,15 +77,15 @@ function Saksbehandling({ match, location }: Props) {
       const behandling = response.data;
       if (!behandling) return false;
 
-      dispatch(behandlingsresultatOperations.hent(behandlingId));
+      await dispatch(behandlingsresultatOperations.hent(behandlingId));
 
       if (behandlingOppfriskes) {
         visOppfriskModal();
         return false;
       }
 
-      dispatch(mottatteOpplysningerOperations.hent(behandlingId));
-      dispatch(dokumenterOperations.hentDokumentOversikt(saksnr));
+      await dispatch(mottatteOpplysningerOperations.hent(behandlingId));
+      await dispatch(dokumenterOperations.hentDokumentOversikt(saksnr));
       setSaksopplysningerLastet(true);
       return true;
     } catch (e) {


### PR DESCRIPTION
Fikser race conditions i årsavregning ved å legge til manglende `await` på dispatch-kall.

Tre dispatch-kall i årsavregning saksbehandling manglet `await`, noe som førte til at
datalasting ikke ble fullført før komponenten brukte dataene. Dette kunne gi feil
ved årsavregning med 25%-regel.
[MELOSYS-7914](https://jira.adeo.no/browse/MELOSYS-7914)

- Lagt til `await` på 3 dispatch-kall i `saksbehandling.tsx`
- Konvertert `lastInnSaksopplysninger*`-funksjoner til `Promise.all`
- Lagt til enhetstester for datalasting operations

## Testing
- [x] Enhetstester (3171 bestått)
- [x] TypeScript-sjekk (`tsc --noEmit`)