### PR TITLE
7916 Fakturainformasjon-tabell flyter over ved zooming

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/fakturainformasjon/fakturainformasjon.less
+++ b/src/felleskomponenter/menypanel/menypunkter/fakturainformasjon/fakturainformasjon.less
@@ -1,6 +1,7 @@
 @import "../../../../constants.less";
 
 .fakturainformasjon {
+  overflow-x: auto;
   .fakturainformasjon-tabell {
     padding: 1em 0 2em 0em;
     .fakturaseksjon {

--- a/src/felleskomponenter/menypanel/menypunkter/fakturainformasjon/fakturainformasjon.less
+++ b/src/felleskomponenter/menypanel/menypunkter/fakturainformasjon/fakturainformasjon.less
@@ -3,7 +3,7 @@
 .fakturainformasjon {
   overflow-x: auto;
   .fakturainformasjon-tabell {
-    padding: 1em 0 2em 0em;
+    padding: 1em 0 2em 0;
     .fakturaseksjon {
       padding-bottom: 3em;
       .headerseksjon {
@@ -22,7 +22,7 @@
         padding: 0.3em 0;
 
         &:last-child {
-          border-bottom: 0px solid @navGra60;
+          border-bottom: 0 solid @navGra60;
         }
 
         > * {
@@ -67,7 +67,7 @@
 
   .fakturalinje {
     .uten-border {
-      border-bottom: 0px;
+      border-bottom: 0;
     }
   }
   .mellomrom-tekst-tabell {


### PR DESCRIPTION
Summary

  - La til overflow-x: auto på .fakturainformasjon-containeren slik at tabellen får horisontal scrollbar ved smal skjerm/zooming, i stedet for å flyte over elementer på høyre side
  - Fjernet redundante px-enheter på 0-verdier (lint-opprydding)

  Test plan

  - Åpne en sak med fakturainformasjon-data
  - Zoom inn (Cmd+Plus) til tabellen er bredere enn tilgjengelig plass
  - Verifiser at horisontal scrollbar vises i stedet for overlapping med høyre panel
