### PR TITLE
7911 TOGGLE Legg til TWFA-avkrysning for A001 CDM 4.4

### DIFF
--- a/src/@types/dokument.ts
+++ b/src/@types/dokument.ts
@@ -46,6 +46,7 @@ export interface SedPdfData {
   nyttLovvalgsland?: string | null;
   fritekst?: string | null;
   a008Formaal?: string | null; // CDM 4.4: "endringsmelding" | "arbeid_flere_land"
+  erFjernarbeidTWFA?: boolean | null;
 }
 
 export interface TilgjengeligStandardvedlegg {

--- a/src/auth/authUtils.js
+++ b/src/auth/authUtils.js
@@ -6,7 +6,7 @@ const originalFetch = window.fetch;
 
 export const setTokenInterceptor = async (getAccessToken, accounts) => {
   window.fetch = async (...args) => {
-    const [url, options] = args;
+    const [url, options = {}] = args;
     if (!options.headers) {
       options.headers = {};
     }
@@ -24,7 +24,7 @@ export const setTokenInterceptor = async (getAccessToken, accounts) => {
 
 export const setTokenInterceptorForLocalDevelopment = async () => {
   window.fetch = async (...args) => {
-    const [url, options] = args;
+    const [url, options = {}] = args;
     if (!options.headers) {
       options.headers = {};
     }

--- a/src/services/modules/dokumenter-v2.ts
+++ b/src/services/modules/dokumenter-v2.ts
@@ -32,6 +32,7 @@ export interface SedPdfData {
   nyttLovvalgsland?: string | null;
   fritekst?: string | null;
   a008Formaal?: string | null; // CDM 4.4: "endringsmelding" | "arbeid_flere_land"
+  erFjernarbeidTWFA?: boolean | null;
 }
 
 // TODO: Bedre navn?

--- a/src/services/modules/saksflyt/anmodningsperioder.ts
+++ b/src/services/modules/saksflyt/anmodningsperioder.ts
@@ -9,6 +9,7 @@ interface Vedlegg {
 export interface AnmodningOmUnntakBestillingReqDto {
   mottakerinstitusjon: string | null;
   fritekstSed: string | null;
+  erFjernarbeidTWFA?: boolean | null;
   vedlegg: Vedlegg[];
 }
 

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -259,7 +259,7 @@ export const postAsJsonReceiveAsPDF = (url, data = {}, extendResponse = false) =
   methodToJson("POST", url, data, extendResponse, "application/pdf, application/json");
 
 export const fetchAsPDFBlob = (url) =>
-  fetch(url, {})
+  fetch(url, { credentials: "include" })
     .then((response) => response.blob())
     .then((blob) => new Blob([blob], { type: "application/pdf" }));
 

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -260,6 +260,7 @@ export const postAsJsonReceiveAsPDF = (url, data = {}, extendResponse = false) =
 
 export const fetchAsPDFBlob = (url) =>
   fetch(url, { credentials: "include" })
+    .then(sjekkStatuskode)
     .then((response) => response.blob())
     .then((blob) => new Blob([blob], { type: "application/pdf" }));
 

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.test.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { reduxForm } from "redux-form";
+
+import MKV from "../../../../melosyskodeverk";
+import * as KV from "../../../../kodeverk";
+import { VurderingArtikkel16Anmodning } from "./vurderingArtikkel16Anmodning";
+import { renderWithProviders } from "../../../../ducks/test-utils/renderWithProviders";
+
+const mockUseFeatureToggle = vi.fn();
+vi.mock("../../../../featuretoggle", () => ({
+  useFeatureToggle: (...args: unknown[]) => mockUseFeatureToggle(...args),
+}));
+
+vi.mock("../../../../ducks/avklartefakta", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    avklartefaktaSelectors: {
+      ...actual.avklartefaktaSelectors,
+      ArbeidslandKTSelector: () => [{ kode: "SE", term: "Sverige" }],
+    },
+  };
+});
+
+vi.mock("../../../../ducks/dokumenter", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    dokumenterSelectors: {
+      ...actual.dokumenterSelectors,
+      AlleFysiskeDokumentSelector: () => [],
+    },
+  };
+});
+
+vi.mock("../../../../ducks/mottatteOpplysninger", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    mottatteOpplysningerSelectors: {
+      ...actual.mottatteOpplysningerSelectors,
+      MottatteOpplysningerStatusSelector: () => "OK",
+    },
+  };
+});
+
+vi.mock("../../../../ducks/kontroll", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    kontrollSelectors: {
+      ...actual.kontrollSelectors,
+      KontrollFeilSelector: () => [],
+    },
+    kontrollOperations: {
+      ...actual.kontrollOperations,
+      kontrollerAnmodningOmUnntak: vi.fn(),
+      resetKontrollFeil: vi.fn(() => ({ type: "KONTROLL_RESET" })),
+    },
+  };
+});
+
+describe("VurderingArtikkel16Anmodning - TWFA checkbox", () => {
+  let props: any;
+
+  const WrappedComponent = reduxForm({ form: KV.Form.ARTIKKEL_16_ANMODNING })(VurderingArtikkel16Anmodning as any);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    props = {
+      lovvalgsbestemmelse: undefined,
+      formIsValid: true,
+      formValues: {
+        tidligeremedlemskap: [],
+        mottakerinstitusjon: "",
+        kreverMottakerinstitusjon: false,
+        fritekstSed: null,
+      },
+      initialValues: {
+        tidligeremedlemskap: [],
+        mottakerinstitusjon: "",
+        kreverMottakerinstitusjon: false,
+        fritekstSed: null,
+      },
+      tilstand: {
+        unntaksvilkår: {
+          begrunnelseKoder: [],
+          begrunnelseFritekst: "",
+          begrunnelseFritekstEngelsk: "",
+        },
+        muligeBegrunnelseValg: [],
+        erIDirekteTilArtikkel16Flyt: false,
+        harAvklaring: false,
+      },
+      bekreftOgFortsett: vi.fn(),
+      tilbake: vi.fn(),
+      oppdaterData: vi.fn(),
+      slettData: vi.fn(),
+      redigerbart: true,
+      aktivtSteg: true,
+      lagreVilkarHandler: vi.fn(),
+      lagreAnmodningsperioderHandler: vi.fn().mockResolvedValue(undefined),
+      byggAnmodningsperioderHandler: vi.fn().mockResolvedValue(undefined),
+      lagreOgBestillAnmodningsperioder: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it("viser ikke TWFA-checkbox når CDM 4.4 er deaktivert", () => {
+    mockUseFeatureToggle.mockReturnValue(false);
+    renderWithProviders(<WrappedComponent {...props} />);
+    expect(screen.queryByText("Rammeavtale om fjernarbeid (TWFA)")).not.toBeInTheDocument();
+  });
+
+  it("viser ikke TWFA-checkbox når CDM 4.4 er aktivert men annen artikkel er valgt", () => {
+    mockUseFeatureToggle.mockReturnValue(true);
+    renderWithProviders(<WrappedComponent {...props} />);
+    expect(screen.queryByText("Rammeavtale om fjernarbeid (TWFA)")).not.toBeInTheDocument();
+  });
+
+  it("viser ikke TWFA-checkbox når redigerbart er false", () => {
+    mockUseFeatureToggle.mockReturnValue(true);
+    renderWithProviders(<WrappedComponent {...props} redigerbart={false} />);
+    expect(screen.queryByText("Rammeavtale om fjernarbeid (TWFA)")).not.toBeInTheDocument();
+  });
+
+  it("viser TWFA-checkbox når CDM 4.4 er aktivert og artikkel 13(1)(a) er valgt", () => {
+    mockUseFeatureToggle.mockReturnValue(true);
+    renderWithProviders(<WrappedComponent {...props} />, {
+      preloadedState: {
+        anmodningsperioder: {
+          status: "OK",
+          data: [
+            {
+              unntakFraBestemmelse: MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1A,
+              fomDato: "2024-01-01",
+              tomDato: "2024-12-31",
+            },
+          ],
+        },
+      } as any,
+    });
+    expect(screen.getByText("Rammeavtale om fjernarbeid (TWFA)")).toBeInTheDocument();
+  });
+
+  it("kan krysse av og fjerne TWFA-avkrysning", () => {
+    mockUseFeatureToggle.mockReturnValue(true);
+    renderWithProviders(<WrappedComponent {...props} />, {
+      preloadedState: {
+        anmodningsperioder: {
+          status: "OK",
+          data: [
+            {
+              unntakFraBestemmelse: MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1A,
+              fomDato: "2024-01-01",
+              tomDato: "2024-12-31",
+            },
+          ],
+        },
+      } as any,
+    });
+
+    const checkbox = screen.getByRole("checkbox", { name: /Rammeavtale om fjernarbeid/i });
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+});

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.test.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.test.tsx
@@ -55,7 +55,7 @@ vi.mock("../../../../ducks/kontroll", async (importOriginal) => {
     },
     kontrollOperations: {
       ...actual.kontrollOperations,
-      kontrollerAnmodningOmUnntak: vi.fn(),
+      kontrollerAnmodningOmUnntak: vi.fn(() => () => Promise.resolve()),
       resetKontrollFeil: vi.fn(() => ({ type: "KONTROLL_RESET" })),
     },
   };
@@ -109,19 +109,19 @@ describe("VurderingArtikkel16Anmodning - TWFA checkbox", () => {
   it("viser ikke TWFA-checkbox når CDM 4.4 er deaktivert", () => {
     mockUseFeatureToggle.mockReturnValue(false);
     renderWithProviders(<WrappedComponent {...props} />);
-    expect(screen.queryByText("Rammeavtale om fjernarbeid (TWFA)")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Rammeavtale om fjernarbeid/)).not.toBeInTheDocument();
   });
 
   it("viser ikke TWFA-checkbox når CDM 4.4 er aktivert men annen artikkel er valgt", () => {
     mockUseFeatureToggle.mockReturnValue(true);
     renderWithProviders(<WrappedComponent {...props} />);
-    expect(screen.queryByText("Rammeavtale om fjernarbeid (TWFA)")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Rammeavtale om fjernarbeid/)).not.toBeInTheDocument();
   });
 
   it("viser ikke TWFA-checkbox når redigerbart er false", () => {
     mockUseFeatureToggle.mockReturnValue(true);
     renderWithProviders(<WrappedComponent {...props} redigerbart={false} />);
-    expect(screen.queryByText("Rammeavtale om fjernarbeid (TWFA)")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Rammeavtale om fjernarbeid/)).not.toBeInTheDocument();
   });
 
   it("viser TWFA-checkbox når CDM 4.4 er aktivert og artikkel 13(1)(a) er valgt", () => {
@@ -140,7 +140,7 @@ describe("VurderingArtikkel16Anmodning - TWFA checkbox", () => {
         },
       } as any,
     });
-    expect(screen.getByText("Rammeavtale om fjernarbeid (TWFA)")).toBeInTheDocument();
+    expect(screen.getByText(/Rammeavtale om fjernarbeid/)).toBeInTheDocument();
   });
 
   it("kan krysse av og fjerne TWFA-avkrysning", () => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.test.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.test.tsx
@@ -76,12 +76,14 @@ describe("VurderingArtikkel16Anmodning - TWFA checkbox", () => {
         mottakerinstitusjon: "",
         kreverMottakerinstitusjon: false,
         fritekstSed: null,
+        erFjernarbeidTWFA: false,
       },
       initialValues: {
         tidligeremedlemskap: [],
         mottakerinstitusjon: "",
         kreverMottakerinstitusjon: false,
         fritekstSed: null,
+        erFjernarbeidTWFA: false,
       },
       tilstand: {
         unntaksvilkår: {
@@ -118,10 +120,24 @@ describe("VurderingArtikkel16Anmodning - TWFA checkbox", () => {
     expect(screen.queryByText(/Rammeavtale om fjernarbeid/)).not.toBeInTheDocument();
   });
 
-  it("viser ikke TWFA-checkbox når redigerbart er false", () => {
+  it("viser deaktivert TWFA-checkbox når redigerbart er false og artikkel 13(1)(a) er valgt", () => {
     mockUseFeatureToggle.mockReturnValue(true);
-    renderWithProviders(<WrappedComponent {...props} redigerbart={false} />);
-    expect(screen.queryByText(/Rammeavtale om fjernarbeid/)).not.toBeInTheDocument();
+    renderWithProviders(<WrappedComponent {...props} redigerbart={false} />, {
+      preloadedState: {
+        anmodningsperioder: {
+          status: "OK",
+          data: [
+            {
+              unntakFraBestemmelse: MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1A,
+              fomDato: "2024-01-01",
+              tomDato: "2024-12-31",
+            },
+          ],
+        },
+      } as any,
+    });
+    const checkbox = screen.getByRole("checkbox", { name: /Rammeavtale om fjernarbeid/i });
+    expect(checkbox).toBeDisabled();
   });
 
   it("viser TWFA-checkbox når CDM 4.4 er aktivert og artikkel 13(1)(a) er valgt", () => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
@@ -26,6 +26,8 @@ import {
 import * as Mui from "../../../../felleskomponenter/ui";
 import VedleggTable from "../../../../felleskomponenter/vedleggTable";
 import VedleggVelger from "../../../../felleskomponenter/vedleggvelger";
+import { useFeatureToggle } from "../../../../featuretoggle";
+import { MELOSYS_CDM_4_4 } from "../../../../featuretoggle/toggleNavn";
 import { useIsMounted, useDispatch } from "../../../../hooks";
 import * as KV from "../../../../kodeverk";
 import MKV, { MKVUtils } from "../../../../melosyskodeverk";
@@ -109,6 +111,8 @@ function VurderingArtikkel16Anmodning({
 }: Props & PropsFromRedux & InjectedFormProps<FormValuesProps, Props & PropsFromRedux>) {
   const dispatch = useDispatch();
   const isMounted = useIsMounted();
+  const isCdm44Enabled = useFeatureToggle(MELOSYS_CDM_4_4);
+  const [erFjernarbeidTWFA, setErFjernarbeidTWFA] = useState(false);
   const [lovvalgFeilmelding, setLovvalgFeilmelding] = useState<string | undefined>(undefined);
   const [begrunnelseFeilmelding, setBegrunnelseFeilmelding] = useState<string | undefined>(undefined);
   const [fritekstFeilmelding, setFritekstFeilmelding] = useState<string | undefined>(undefined);
@@ -166,6 +170,7 @@ function VurderingArtikkel16Anmodning({
     await byggAnmodningsperioderHandler();
     await lagreAnmodningsperioderHandler();
     setLovvalgFeilmelding(undefined);
+    setErFjernarbeidTWFA(false);
   };
 
   const handleEndretBegrunnelseFritekst = (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -228,6 +233,7 @@ function VurderingArtikkel16Anmodning({
         mottakerinstitusjon: formValues.mottakerinstitusjon || null,
         fritekstSed: formValues.fritekstSed,
         begrunnelseFritekst: unntaksvilkår.begrunnelseFritekst,
+        erFjernarbeidTWFA: erFjernarbeidTWFA || null,
         vedlegg: valgteVedlegg.saksvedlegg.map(({ journalpostID, dokumentID }) => ({ journalpostID, dokumentID })),
       };
 
@@ -258,7 +264,7 @@ function VurderingArtikkel16Anmodning({
             fritekst: unntaksvilkår.begrunnelseFritekst,
           },
         },
-        { sedType: EKV.Koder.sedtyper.A001, sedData: { fritekst: formValues?.fritekstSed } },
+        { sedType: EKV.Koder.sedtyper.A001, sedData: { fritekst: formValues?.fritekstSed, erFjernarbeidTWFA } },
       ]
     : [
         {
@@ -337,6 +343,18 @@ function VurderingArtikkel16Anmodning({
             </Nav.Select>
           </Nav.Column>
         </Nav.Row>
+
+        {isCdm44Enabled &&
+          redigerbart &&
+          unntakFraBestemmelse === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1A && (
+            <Nav.Row>
+              <Nav.Column xs="7">
+                <Nav.Checkbox checked={erFjernarbeidTWFA} onChange={(e) => setErFjernarbeidTWFA(e.target.checked)}>
+                  Rammeavtale om fjernarbeid (TWFA)
+                </Nav.Checkbox>
+              </Nav.Column>
+            </Nav.Row>
+          )}
 
         <Nav.Row>
           <Nav.Column xs="7">

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
@@ -59,6 +59,7 @@ const mapStateToProps = (state: RootState) => ({
     mottakerinstitusjon: "",
     kreverMottakerinstitusjon: false,
     fritekstSed: null,
+    erFjernarbeidTWFA: false,
   },
 });
 
@@ -71,6 +72,7 @@ interface FormValuesProps {
   kreverMottakerinstitusjon: boolean;
   fritekstSed: string | null;
   begrunnelseFritekst: string | null;
+  erFjernarbeidTWFA: boolean;
 }
 
 interface Props {
@@ -101,6 +103,7 @@ export function VurderingArtikkel16Anmodning({
   byggAnmodningsperioderHandler,
   lagreAnmodningsperioderHandler,
   lagreVilkarHandler,
+  change,
   touch,
   formIsValid,
   redigerbart,
@@ -112,7 +115,6 @@ export function VurderingArtikkel16Anmodning({
   const dispatch = useDispatch();
   const isMounted = useIsMounted();
   const isCdm44Enabled = useFeatureToggle(MELOSYS_CDM_4_4);
-  const [erFjernarbeidTWFA, setErFjernarbeidTWFA] = useState(false);
   const [lovvalgFeilmelding, setLovvalgFeilmelding] = useState<string | undefined>(undefined);
   const [begrunnelseFeilmelding, setBegrunnelseFeilmelding] = useState<string | undefined>(undefined);
   const [fritekstFeilmelding, setFritekstFeilmelding] = useState<string | undefined>(undefined);
@@ -132,11 +134,18 @@ export function VurderingArtikkel16Anmodning({
   const medlemskap = useSelector(behandlingerSelectors.MedlemskapSelector);
   const unntakFraBestemmelse = useSelector(anmodningsperioderSelectors.UnntakFraBestemmelseSelector);
   const fysiskeDokumenter = useSelector(dokumenterSelectors.AlleFysiskeDokumentSelector);
+  const erFjernarbeidTWFA = useSelector((state: RootState) => {
+    const values = getFormValues(KV.Form.ARTIKKEL_16_ANMODNING)(state) as FormValuesProps | undefined;
+    return !!values?.erFjernarbeidTWFA;
+  });
   const mottatteOpplysningerStatus = useSelector(
     mottatteOpplysningerSelectors.MottatteOpplysningerStatusSelector,
   ) as string;
   const feltNavnFraBestemmelse =
     lovvalgsbestemmelse === KONV_EFTA_STORBRITANNIA_ART18_1 ? "art18_1_anmodning" : "art16_1_anmodning";
+  const erTWFARelevant =
+    isCdm44Enabled &&
+    unntakFraBestemmelse === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1A;
 
   useEffect(() => {
     oppdaterData(konverterVilkarTilStegData(feltNavnFraBestemmelse, unntaksvilkår));
@@ -170,7 +179,7 @@ export function VurderingArtikkel16Anmodning({
     await byggAnmodningsperioderHandler();
     await lagreAnmodningsperioderHandler();
     setLovvalgFeilmelding(undefined);
-    setErFjernarbeidTWFA(false);
+    change("erFjernarbeidTWFA", false);
   };
 
   const handleEndretBegrunnelseFritekst = (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -233,7 +242,7 @@ export function VurderingArtikkel16Anmodning({
         mottakerinstitusjon: formValues.mottakerinstitusjon || null,
         fritekstSed: formValues.fritekstSed,
         begrunnelseFritekst: unntaksvilkår.begrunnelseFritekst,
-        erFjernarbeidTWFA: isCdm44Enabled && erFjernarbeidTWFA ? true : null,
+        erFjernarbeidTWFA: erTWFARelevant ? erFjernarbeidTWFA : null,
         vedlegg: valgteVedlegg.saksvedlegg.map(({ journalpostID, dokumentID }) => ({ journalpostID, dokumentID })),
       };
 
@@ -268,7 +277,7 @@ export function VurderingArtikkel16Anmodning({
           sedType: EKV.Koder.sedtyper.A001,
           sedData: {
             fritekst: formValues?.fritekstSed,
-            erFjernarbeidTWFA: isCdm44Enabled && erFjernarbeidTWFA ? true : undefined,
+            erFjernarbeidTWFA: erTWFARelevant ? erFjernarbeidTWFA : null,
           },
         },
       ]
@@ -350,17 +359,19 @@ export function VurderingArtikkel16Anmodning({
           </Nav.Column>
         </Nav.Row>
 
-        {isCdm44Enabled &&
-          redigerbart &&
-          unntakFraBestemmelse === MKV.Koder.lovvalgsbestemmelser.lovvalgbestemmelser_883_2004.FO_883_2004_ART13_1A && (
-            <Nav.Row>
-              <Nav.Column xs="7">
-                <Nav.Checkbox checked={erFjernarbeidTWFA} onChange={(e) => setErFjernarbeidTWFA(e.target.checked)}>
-                  Rammeavtale om fjernarbeid
-                </Nav.Checkbox>
-              </Nav.Column>
-            </Nav.Row>
-          )}
+        {erTWFARelevant && (
+          <Nav.Row>
+            <Nav.Column xs="7">
+              <Nav.Checkbox
+                checked={erFjernarbeidTWFA}
+                onChange={(e) => change("erFjernarbeidTWFA", e.target.checked)}
+                disabled={!redigerbart}
+              >
+                Rammeavtale om fjernarbeid
+              </Nav.Checkbox>
+            </Nav.Column>
+          </Nav.Row>
+        )}
 
         <Nav.Row>
           <Nav.Column xs="7">

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
@@ -356,7 +356,7 @@ export function VurderingArtikkel16Anmodning({
             <Nav.Row>
               <Nav.Column xs="7">
                 <Nav.Checkbox checked={erFjernarbeidTWFA} onChange={(e) => setErFjernarbeidTWFA(e.target.checked)}>
-                  Rammeavtale om fjernarbeid {"(TWFA)"}
+                  Rammeavtale om fjernarbeid
                 </Nav.Checkbox>
               </Nav.Column>
             </Nav.Row>

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
@@ -356,7 +356,7 @@ export function VurderingArtikkel16Anmodning({
             <Nav.Row>
               <Nav.Column xs="7">
                 <Nav.Checkbox checked={erFjernarbeidTWFA} onChange={(e) => setErFjernarbeidTWFA(e.target.checked)}>
-                  Rammeavtale om fjernarbeid (TWFA)
+                  Rammeavtale om fjernarbeid
                 </Nav.Checkbox>
               </Nav.Column>
             </Nav.Row>

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
@@ -356,7 +356,7 @@ export function VurderingArtikkel16Anmodning({
             <Nav.Row>
               <Nav.Column xs="7">
                 <Nav.Checkbox checked={erFjernarbeidTWFA} onChange={(e) => setErFjernarbeidTWFA(e.target.checked)}>
-                  Rammeavtale om fjernarbeid
+                  Rammeavtale om fjernarbeid {"(TWFA)"}
                 </Nav.Checkbox>
               </Nav.Column>
             </Nav.Row>

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
@@ -92,7 +92,7 @@ interface Props {
   lagreOgBestillAnmodningsperioder: (bestillAnmodningsperioderBody: any) => Promise<void>;
 }
 
-function VurderingArtikkel16Anmodning({
+export function VurderingArtikkel16Anmodning({
   oppdaterData,
   tilstand: { unntaksvilkår, muligeBegrunnelseValg },
   slettData,
@@ -233,7 +233,7 @@ function VurderingArtikkel16Anmodning({
         mottakerinstitusjon: formValues.mottakerinstitusjon || null,
         fritekstSed: formValues.fritekstSed,
         begrunnelseFritekst: unntaksvilkår.begrunnelseFritekst,
-        erFjernarbeidTWFA: erFjernarbeidTWFA || null,
+        erFjernarbeidTWFA: isCdm44Enabled && erFjernarbeidTWFA ? true : null,
         vedlegg: valgteVedlegg.saksvedlegg.map(({ journalpostID, dokumentID }) => ({ journalpostID, dokumentID })),
       };
 
@@ -264,7 +264,13 @@ function VurderingArtikkel16Anmodning({
             fritekst: unntaksvilkår.begrunnelseFritekst,
           },
         },
-        { sedType: EKV.Koder.sedtyper.A001, sedData: { fritekst: formValues?.fritekstSed, erFjernarbeidTWFA } },
+        {
+          sedType: EKV.Koder.sedtyper.A001,
+          sedData: {
+            fritekst: formValues?.fritekstSed,
+            erFjernarbeidTWFA: isCdm44Enabled && erFjernarbeidTWFA ? true : undefined,
+          },
+        },
       ]
     : [
         {


### PR DESCRIPTION
Legger til TWFA-avkrysning (rammeavtale om fjernarbeid) i bestillingsskjemaet for unntak etter artikkel 16, og sender feltet videre til SED PDF og bestilling.

Rammeavtalen om fjernarbeid (TWFA) må angis på A001 SED når saken gjelder fjernarbeid under artikkel 13(1)(a). Feltet er lagt til bak CDM 4.4 feature toggle.
[MELOSYS-7911](https://jira.adeo.no/browse/MELOSYS-7911)

- Nytt `erFjernarbeidTWFA`-felt i SedPdfData og bestilling-DTO
- TWFA-avkrysning i artikkel 16-bestillingsskjemaet bak feature toggle
- Fiks manglende default-options og credentials i fetch-kall

### Testing
- [x] Enhetstester
- [x] Manuell testing lokalt
- [x] E2E-tester (hvis relevant)