### PR TITLE
7911 TOGGLE Inkluder erFjernarbeidTWFA i SED-forhåndsvisning

### DIFF
--- a/src/ducks/dokumenter/operations.ts
+++ b/src/ducks/dokumenter/operations.ts
@@ -41,6 +41,7 @@ export async function forhandsvisSed(behandlingID: number, sedType: string, data
     begrunnelseUtenlandskMyndighet: data.begrunnelseUtenlandskMyndighet || null,
     vilSendeAnmodningOmMerInformasjon,
     ...(data.a008Formaal && { a008Formaal: data.a008Formaal }),
+    ...(data.erFjernarbeidTWFA != null && { erFjernarbeidTWFA: data.erFjernarbeidTWFA }),
   };
 
   const response = await Api.Dokumenter.pdf.forhandsvisSed(behandlingID, sedType, utfyltdata);


### PR DESCRIPTION
Inkluder erFjernarbeidTWFA-feltet i utfyltdata-objektet som sendes til
backend ved forhåndsvisning av SED PDF.

Feltet ble satt korrekt i pdfDokumenter fra vurderingArtikkel16Anmodning-
komponenten, men forhandsvisSed-funksjonen filtrerte det bort når den
bygget request-objektet. Dette førte til at forhåndsvisning av A001
alltid viste "Rammeavtale for fjernarbeid: Nei" selv når TWFA var valgt.
[MELOSYS-7911](https://jira.adeo.no/browse/MELOSYS-7911)

- Inkluder `erFjernarbeidTWFA` i utfyltdata i `forhandsvisSed`

## Testing
- [x] Manuell testing lokalt