### PR TITLE
7636 DAPI Årsavregning uten eller delt grunnlag for eøs pensjonister

### DIFF
--- a/src/services/modules/aarsavregning/periodeApiAdapter.ts
+++ b/src/services/modules/aarsavregning/periodeApiAdapter.ts
@@ -1,0 +1,201 @@
+/**
+ * Adapter for CRUD-operasjoner på årsavregningsperioder.
+ *
+ * Ruter kall til riktig backend-endepunkt basert på Avgiftspliktigperiode.type:
+ * - MEDLEMSKAPSPERIODE       → medlemskapsperioder-API
+ * - LOVVALGSPERIODE          → lovvalgsperioder-API
+ * - HELSEUTGIFTDEKKESPERIODE → helseutgiftDekkesPeriode-API
+ *
+ * Mapper response-DTO-er tilbake til Avgiftspliktigperiode-unionen.
+ */
+
+import * as MedlemskapsperioderApi from "../medlemavfolketrygden/medlemskapsperioder";
+import * as LovvalgsperioderApi from "../lovvalgsperioder";
+import * as HelseutgiftApi from "../helseutgiftDekkesPeriode/helseutgiftDekkesPeriode";
+import type {
+  AarsavregningsPeriodeType,
+  Avgiftspliktigperiode,
+  MedlemskapsperiodeForAvgift,
+  LovvalgsperiodeForAvgift,
+  HelseutgiftdekkesperiodeForAvgift,
+  MedlemskapsperiodeDto,
+} from "../types/periodeTyper";
+import type { Lovvalgsperiode } from "../lovvalgsperioder";
+import type { HelseutgiftDekkesPeriodeDto } from "../helseutgiftDekkesPeriode/helseutgiftDekkesPeriode";
+
+const mapMedlemskapsperiodeDto = (dto: MedlemskapsperiodeDto): MedlemskapsperiodeForAvgift => ({
+  ...dto,
+  type: "MEDLEMSKAPSPERIODE",
+});
+
+const mapLovvalgsperiodeDto = (dto: Lovvalgsperiode): LovvalgsperiodeForAvgift => ({
+  fomDato: dto.fomDato,
+  tomDato: dto.tomDato ?? "",
+  id: dto.periodeID ? Number(dto.periodeID) : 0,
+  type: "LOVVALGSPERIODE",
+  bestemmelse: dto.lovvalgsbestemmelse ?? "",
+  innvilgelsesResultat: dto.innvilgelsesResultat,
+  trygdedekning: dto.trygdeDekning,
+  medlemskapstype: dto.medlemskapstype,
+});
+
+const HELSEUTGIFT_SENTINEL_ID = 0;
+
+const mapHelseutgiftDekkesPeriodeDto = (dto: HelseutgiftDekkesPeriodeDto): HelseutgiftdekkesperiodeForAvgift => ({
+  fomDato: dto.fomDato,
+  tomDato: dto.tomDato,
+  id: HELSEUTGIFT_SENTINEL_ID,
+  type: "HELSEUTGIFTDEKKESPERIODE",
+  bostedLandkode: dto.bostedLandkode,
+});
+
+const tilMedlemskapsperiodeRequest = (
+  periode: MedlemskapsperiodeForAvgift,
+  bestemmelse: string,
+): MedlemskapsperioderApi.OppdaterMedlemskapsperiode => ({
+  fomDato: periode.fomDato,
+  tomDato: periode.tomDato,
+  trygdedekning: periode.trygdedekning,
+  bestemmelse,
+  innvilgelsesResultat: periode.innvilgelsesResultat,
+});
+
+const tilLovvalgsperiodeRequest = (periode: LovvalgsperiodeForAvgift): LovvalgsperioderApi.OpprettLovvalgsperiode => ({
+  fomDato: periode.fomDato,
+  tomDato: periode.tomDato,
+  lovvalgsbestemmelse: periode.bestemmelse,
+  trygdedekning: periode.trygdedekning,
+  innvilgelsesResultat: periode.innvilgelsesResultat,
+});
+
+const tilHelseutgiftRequest = (
+  periode: HelseutgiftdekkesperiodeForAvgift,
+  bostedLandkode: string,
+): HelseutgiftDekkesPeriodeDto => ({
+  fomDato: periode.fomDato,
+  tomDato: periode.tomDato,
+  bostedLandkode,
+});
+
+export const hentPerioder = async (
+  periodeType: AarsavregningsPeriodeType,
+  behandlingID: number,
+): Promise<Avgiftspliktigperiode[]> => {
+  switch (periodeType) {
+    case "MEDLEMSKAPSPERIODE": {
+      const perioder = await MedlemskapsperioderApi.hentMedlemskapsperioder(behandlingID);
+      return perioder.map(mapMedlemskapsperiodeDto);
+    }
+    case "LOVVALGSPERIODE": {
+      const perioder = await LovvalgsperioderApi.hent(behandlingID);
+      return perioder.map(mapLovvalgsperiodeDto);
+    }
+    case "HELSEUTGIFTDEKKESPERIODE": {
+      try {
+        const periode = await HelseutgiftApi.hentHelseutgiftDekkesPeriode(behandlingID);
+        return [mapHelseutgiftDekkesPeriodeDto(periode)];
+      } catch {
+        return [];
+      }
+    }
+  }
+};
+
+export const opprettPeriode = async (
+  periodeType: AarsavregningsPeriodeType,
+  behandlingID: number,
+  periode: Avgiftspliktigperiode,
+  bestemmelse: string,
+): Promise<Avgiftspliktigperiode> => {
+  switch (periodeType) {
+    case "MEDLEMSKAPSPERIODE": {
+      const request = tilMedlemskapsperiodeRequest(periode as MedlemskapsperiodeForAvgift, bestemmelse);
+      const response = await MedlemskapsperioderApi.opprettMedlemskapsperioder(behandlingID, request);
+      return mapMedlemskapsperiodeDto(response);
+    }
+    case "LOVVALGSPERIODE": {
+      const request = tilLovvalgsperiodeRequest(periode as LovvalgsperiodeForAvgift);
+      const perioder = await LovvalgsperioderApi.opprettLovvalgsperiode(behandlingID, request);
+      const nyeste = perioder[perioder.length - 1];
+      return mapLovvalgsperiodeDto(nyeste);
+    }
+    case "HELSEUTGIFTDEKKESPERIODE": {
+      const typed = periode as HelseutgiftdekkesperiodeForAvgift;
+      const request = tilHelseutgiftRequest(typed, typed.bostedLandkode);
+      await HelseutgiftApi.opprettHelseutgiftDekkesPeriode(behandlingID, request);
+      return { ...typed, id: HELSEUTGIFT_SENTINEL_ID };
+    }
+  }
+};
+
+export const oppdaterPeriode = async (
+  periodeType: AarsavregningsPeriodeType,
+  behandlingID: number,
+  periode: Avgiftspliktigperiode,
+  bestemmelse: string,
+): Promise<Avgiftspliktigperiode> => {
+  switch (periodeType) {
+    case "MEDLEMSKAPSPERIODE": {
+      const typed = periode as MedlemskapsperiodeForAvgift;
+      const request = tilMedlemskapsperiodeRequest(typed, bestemmelse);
+      const response = await MedlemskapsperioderApi.oppdaterMedlemskapsperioder(behandlingID, typed.id, request);
+      return mapMedlemskapsperiodeDto(response);
+    }
+    case "LOVVALGSPERIODE": {
+      const typed = periode as LovvalgsperiodeForAvgift;
+      const fullLovvalgsperiode: Lovvalgsperiode = {
+        periodeID: String(typed.id),
+        fomDato: typed.fomDato,
+        tomDato: typed.tomDato,
+        lovvalgsbestemmelse: typed.bestemmelse,
+        lovvalgsland: "",
+        innvilgelsesResultat: typed.innvilgelsesResultat,
+        trygdeDekning: typed.trygdedekning,
+        medlemskapstype: typed.medlemskapstype,
+      };
+      const response = await LovvalgsperioderApi.oppdaterLovvalgsperiode(behandlingID, typed.id, fullLovvalgsperiode);
+      return mapLovvalgsperiodeDto(response);
+    }
+    case "HELSEUTGIFTDEKKESPERIODE":
+      throw new Error("Oppdatering av helseutgiftdekkesperiode er ikke støttet — bruk opprettPeriode");
+  }
+};
+
+export const slettPeriode = async (
+  periodeType: AarsavregningsPeriodeType,
+  behandlingID: number,
+  periodeId: number,
+): Promise<void> => {
+  switch (periodeType) {
+    case "MEDLEMSKAPSPERIODE":
+      await MedlemskapsperioderApi.slettMedlemskapsperiode(behandlingID, periodeId);
+      return;
+    case "LOVVALGSPERIODE":
+      await LovvalgsperioderApi.slettLovvalgsperiode(behandlingID, periodeId);
+      return;
+    case "HELSEUTGIFTDEKKESPERIODE":
+      throw new Error("Sletting av helseutgiftdekkesperiode er ikke støttet");
+  }
+};
+
+export const slettAllePerioder = async (
+  periodeType: AarsavregningsPeriodeType,
+  behandlingID: number,
+): Promise<void> => {
+  switch (periodeType) {
+    case "MEDLEMSKAPSPERIODE":
+      await MedlemskapsperioderApi.slettMedlemskapsperioder(behandlingID);
+      return;
+    case "LOVVALGSPERIODE": {
+      const perioder = await LovvalgsperioderApi.hent(behandlingID);
+      for (const periode of perioder) {
+        if (periode.periodeID) {
+          await LovvalgsperioderApi.slettLovvalgsperiode(behandlingID, Number(periode.periodeID));
+        }
+      }
+      return;
+    }
+    case "HELSEUTGIFTDEKKESPERIODE":
+      throw new Error("Sletting av helseutgiftdekkesperiode er ikke støttet");
+  }
+};

--- a/src/services/modules/aarsavregning/periodeApiAdapter.ts
+++ b/src/services/modules/aarsavregning/periodeApiAdapter.ts
@@ -10,33 +10,21 @@
  */
 
 import * as MedlemskapsperioderApi from "../medlemavfolketrygden/medlemskapsperioder";
-import * as LovvalgsperioderApi from "../lovvalgsperioder";
 import * as HelseutgiftApi from "../helseutgiftDekkesPeriode/helseutgiftDekkesPeriode";
-import type {
-  AarsavregningsPeriodeType,
-  Avgiftspliktigperiode,
-  MedlemskapsperiodeForAvgift,
-  LovvalgsperiodeForAvgift,
-  HelseutgiftdekkesperiodeForAvgift,
-  MedlemskapsperiodeDto,
+import {
+  type AarsavregningsPeriodeType,
+  type Avgiftspliktigperiode,
+  type MedlemskapsperiodeForAvgift,
+  type HelseutgiftdekkesperiodeForAvgift,
+  type MedlemskapsperiodeDto,
+  erHelseutgiftdekkesperiode,
+  erMedlemskapsperiode,
 } from "../types/periodeTyper";
-import type { Lovvalgsperiode } from "../lovvalgsperioder";
 import type { HelseutgiftDekkesPeriodeDto } from "../helseutgiftDekkesPeriode/helseutgiftDekkesPeriode";
 
 const mapMedlemskapsperiodeDto = (dto: MedlemskapsperiodeDto): MedlemskapsperiodeForAvgift => ({
   ...dto,
   type: "MEDLEMSKAPSPERIODE",
-});
-
-const mapLovvalgsperiodeDto = (dto: Lovvalgsperiode): LovvalgsperiodeForAvgift => ({
-  fomDato: dto.fomDato,
-  tomDato: dto.tomDato ?? "",
-  id: dto.periodeID ? Number(dto.periodeID) : 0,
-  type: "LOVVALGSPERIODE",
-  bestemmelse: dto.lovvalgsbestemmelse ?? "",
-  innvilgelsesResultat: dto.innvilgelsesResultat,
-  trygdedekning: dto.trygdeDekning,
-  medlemskapstype: dto.medlemskapstype,
 });
 
 const HELSEUTGIFT_SENTINEL_ID = 0;
@@ -60,14 +48,6 @@ const tilMedlemskapsperiodeRequest = (
   innvilgelsesResultat: periode.innvilgelsesResultat,
 });
 
-const tilLovvalgsperiodeRequest = (periode: LovvalgsperiodeForAvgift): LovvalgsperioderApi.OpprettLovvalgsperiode => ({
-  fomDato: periode.fomDato,
-  tomDato: periode.tomDato,
-  lovvalgsbestemmelse: periode.bestemmelse,
-  trygdedekning: periode.trygdedekning,
-  innvilgelsesResultat: periode.innvilgelsesResultat,
-});
-
 const tilHelseutgiftRequest = (
   periode: HelseutgiftdekkesperiodeForAvgift,
   bostedLandkode: string,
@@ -87,77 +67,48 @@ export const hentPerioder = async (
       return perioder.map(mapMedlemskapsperiodeDto);
     }
     case "LOVVALGSPERIODE": {
-      const perioder = await LovvalgsperioderApi.hent(behandlingID);
-      return perioder.map(mapLovvalgsperiodeDto);
+      throw new Error("Lovvalgsperioder er ikke støttet enda");
     }
     case "HELSEUTGIFTDEKKESPERIODE": {
-      try {
-        const periode = await HelseutgiftApi.hentHelseutgiftDekkesPeriode(behandlingID);
-        return [mapHelseutgiftDekkesPeriodeDto(periode)];
-      } catch {
-        return [];
-      }
+      const periode = await HelseutgiftApi.hentHelseutgiftDekkesPeriode(behandlingID);
+      return [mapHelseutgiftDekkesPeriodeDto(periode)];
     }
   }
 };
 
 export const opprettPeriode = async (
-  periodeType: AarsavregningsPeriodeType,
   behandlingID: number,
   periode: Avgiftspliktigperiode,
   bestemmelse: string,
 ): Promise<Avgiftspliktigperiode> => {
-  switch (periodeType) {
-    case "MEDLEMSKAPSPERIODE": {
-      const request = tilMedlemskapsperiodeRequest(periode as MedlemskapsperiodeForAvgift, bestemmelse);
-      const response = await MedlemskapsperioderApi.opprettMedlemskapsperioder(behandlingID, request);
-      return mapMedlemskapsperiodeDto(response);
-    }
-    case "LOVVALGSPERIODE": {
-      const request = tilLovvalgsperiodeRequest(periode as LovvalgsperiodeForAvgift);
-      const perioder = await LovvalgsperioderApi.opprettLovvalgsperiode(behandlingID, request);
-      const nyeste = perioder[perioder.length - 1];
-      return mapLovvalgsperiodeDto(nyeste);
-    }
-    case "HELSEUTGIFTDEKKESPERIODE": {
-      const typed = periode as HelseutgiftdekkesperiodeForAvgift;
-      const request = tilHelseutgiftRequest(typed, typed.bostedLandkode);
-      await HelseutgiftApi.opprettHelseutgiftDekkesPeriode(behandlingID, request);
-      return { ...typed, id: HELSEUTGIFT_SENTINEL_ID };
-    }
+  if (erHelseutgiftdekkesperiode(periode)) {
+    const request = tilHelseutgiftRequest(periode, periode.bostedLandkode);
+    await HelseutgiftApi.opprettHelseutgiftDekkesPeriode(behandlingID, request);
+    return { ...periode, id: HELSEUTGIFT_SENTINEL_ID };
+  } else if (erMedlemskapsperiode(periode)) {
+    const request = tilMedlemskapsperiodeRequest(periode, bestemmelse);
+    const response = await MedlemskapsperioderApi.opprettMedlemskapsperioder(behandlingID, request);
+    return mapMedlemskapsperiodeDto(response);
+  } else {
+    throw new Error("Lovvalgsperioder er ikke støttet enda");
   }
 };
 
 export const oppdaterPeriode = async (
-  periodeType: AarsavregningsPeriodeType,
   behandlingID: number,
   periode: Avgiftspliktigperiode,
   bestemmelse: string,
 ): Promise<Avgiftspliktigperiode> => {
-  switch (periodeType) {
-    case "MEDLEMSKAPSPERIODE": {
-      const typed = periode as MedlemskapsperiodeForAvgift;
-      const request = tilMedlemskapsperiodeRequest(typed, bestemmelse);
-      const response = await MedlemskapsperioderApi.oppdaterMedlemskapsperioder(behandlingID, typed.id, request);
-      return mapMedlemskapsperiodeDto(response);
-    }
-    case "LOVVALGSPERIODE": {
-      const typed = periode as LovvalgsperiodeForAvgift;
-      const fullLovvalgsperiode: Lovvalgsperiode = {
-        periodeID: String(typed.id),
-        fomDato: typed.fomDato,
-        tomDato: typed.tomDato,
-        lovvalgsbestemmelse: typed.bestemmelse,
-        lovvalgsland: "",
-        innvilgelsesResultat: typed.innvilgelsesResultat,
-        trygdeDekning: typed.trygdedekning,
-        medlemskapstype: typed.medlemskapstype,
-      };
-      const response = await LovvalgsperioderApi.oppdaterLovvalgsperiode(behandlingID, typed.id, fullLovvalgsperiode);
-      return mapLovvalgsperiodeDto(response);
-    }
-    case "HELSEUTGIFTDEKKESPERIODE":
-      throw new Error("Oppdatering av helseutgiftdekkesperiode er ikke støttet — bruk opprettPeriode");
+  if (erMedlemskapsperiode(periode)) {
+    const request = tilMedlemskapsperiodeRequest(periode, bestemmelse);
+    const response = await MedlemskapsperioderApi.oppdaterMedlemskapsperioder(behandlingID, periode.id, request);
+    return mapMedlemskapsperiodeDto(response);
+  } else if (erHelseutgiftdekkesperiode(periode)) {
+    const request = tilHelseutgiftRequest(periode, periode.bostedLandkode);
+    await HelseutgiftApi.oppdaterHelseutgiftDekkesPeriode(behandlingID, request);
+    return { ...periode, id: HELSEUTGIFT_SENTINEL_ID };
+  } else {
+    throw new Error("Lovvalgsperioder er ikke støttet enda");
   }
 };
 
@@ -171,8 +122,7 @@ export const slettPeriode = async (
       await MedlemskapsperioderApi.slettMedlemskapsperiode(behandlingID, periodeId);
       return;
     case "LOVVALGSPERIODE":
-      await LovvalgsperioderApi.slettLovvalgsperiode(behandlingID, periodeId);
-      return;
+      throw new Error("Lovvalgsperioder er ikke støttet enda");
     case "HELSEUTGIFTDEKKESPERIODE":
       throw new Error("Sletting av helseutgiftdekkesperiode er ikke støttet");
   }
@@ -187,13 +137,7 @@ export const slettAllePerioder = async (
       await MedlemskapsperioderApi.slettMedlemskapsperioder(behandlingID);
       return;
     case "LOVVALGSPERIODE": {
-      const perioder = await LovvalgsperioderApi.hent(behandlingID);
-      for (const periode of perioder) {
-        if (periode.periodeID) {
-          await LovvalgsperioderApi.slettLovvalgsperiode(behandlingID, Number(periode.periodeID));
-        }
-      }
-      return;
+      throw new Error("Lovvalgsperioder er ikke støttet enda");
     }
     case "HELSEUTGIFTDEKKESPERIODE":
       throw new Error("Sletting av helseutgiftdekkesperiode er ikke støttet");

--- a/src/services/modules/types/periodeTyper.test.ts
+++ b/src/services/modules/types/periodeTyper.test.ts
@@ -41,6 +41,7 @@ const lagHelseutgiftdekkesperiode = (
   type: "HELSEUTGIFTDEKKESPERIODE",
   fomDato: "2024-01-01",
   tomDato: "2024-12-31",
+  bostedLandkode: "NO",
   ...overrides,
 });
 

--- a/src/services/modules/types/periodeTyper.ts
+++ b/src/services/modules/types/periodeTyper.ts
@@ -28,11 +28,10 @@ export interface MedlemskapsperiodeForAvgift extends BasePeriode {
   medlemskapstype: string;
 }
 
-// Helseutgiftdekkesperiode i årsavregning-kontekst - kun datoer
-// NB: HelseutgiftDekkesPeriodeDto (egen fil) brukes for CRUD og har bostedLandkode
 export interface HelseutgiftdekkesperiodeForAvgift extends BasePeriode {
   id: number;
   type: "HELSEUTGIFTDEKKESPERIODE";
+  bostedLandkode: string;
 }
 
 // Lovvalgsperiode - backend har også lovvalgsland og tilleggsbestemmelse, men ikke eksponert i AvgiftspliktigPeriodeDto
@@ -77,3 +76,9 @@ export const erMedlemskapsperiodeEllerLovvalgsperiode = (
 ): periode is MedlemskapsperiodeForAvgift | LovvalgsperiodeForAvgift => {
   return erMedlemskapsperiode(periode) || erLovvalgsperiode(periode);
 };
+
+/**
+ * Periodetype-diskriminator for årsavregningsperioder.
+ * Bestemmer hvilken CRUD-modul som brukes og hvilke felter som er relevante i skjemaet.
+ */
+export type AarsavregningsPeriodeType = "MEDLEMSKAPSPERIODE" | "HELSEUTGIFTDEKKESPERIODE" | "LOVVALGSPERIODE";

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -2,44 +2,52 @@ import * as Api from "../../../../../services/api";
 import "../vurderingAarsavregningInngang.less";
 import { useCallback, useEffect, useState } from "react";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
+import * as PeriodeAdapter from "../../../../../services/modules/aarsavregning/periodeApiAdapter";
 import { useDispatch, useSelector } from "react-redux";
 import { behandlingerSelectors } from "../../../../../ducks/behandlinger";
 import { redigerbartSelectors } from "../../../../../ducks/redigerbart";
+import { fagsakSelectors } from "../../../../../ducks/fagsaker";
 import { FieldValue } from "react-hook-form";
 import { FormValuesProps } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
 import * as Utils from "../../../../../utils";
 import MKV from "../../../../../melosyskodeverk";
 import { OK } from "../../../../../ducks/aarsavregning/types";
 
-import { medlemskapsperioderTypes } from "../../../../../ducks/medlemskapsperioder";
 import { mapTilInntektskilderProps, mapTilSkatteforholdProps } from "../utils";
 import {
   Avgiftspliktigperiode,
-  MedlemskapsperiodeDto,
+  AarsavregningsPeriodeType,
   MedlemskapsperiodeForAvgift,
-  erMedlemskapsperiode,
+  LovvalgsperiodeForAvgift,
   erMedlemskapsperiodeEllerLovvalgsperiode,
 } from "../../../../../services/modules/types/periodeTyper";
-import { OppdaterMedlemskapsperiode } from "../../../../../services/modules/medlemavfolketrygden/medlemskapsperioder";
 import { AarsavregningUtenEllerDeltGrunnlagForm } from "./aarsavregningUtenEllerDeltGrunnlagForm";
 
 const { DELVIS_INNVILGET, INNVILGET } = MKV.Koder.innvilgelsesResultat;
 
 /**
- * Props for medlemskapsperiode-felt i årsavregning-skjema.
- * Utvider Medlemskapsperiode med:
- * - redigerbar: true = kan endres (nye perioder), false = fra grunnlag
+ * FieldProps for avgiftspliktige perioder i årsavregning-skjema.
+ * Utvider Avgiftspliktigperiode (discriminated union) med:
+ * - redigerbar: true = kan endres (nye perioder), false = fra grunnlag (låst)
  * - feil: valideringsfeilmelding
  */
-export type MedlemskapsperiodeFieldProps = MedlemskapsperiodeDto & {
+export type AvgiftspliktigperiodeFieldProps = Avgiftspliktigperiode & {
   redigerbar: boolean;
   feil?: string;
 };
 
-export const ULAGRET_MEDLEMSKAPSPERIODE_ID = -1;
+/** @deprecated Bruk AvgiftspliktigperiodeFieldProps */
+export type MedlemskapsperiodeFieldProps = AvgiftspliktigperiodeFieldProps;
 
-export const DEFAULT_MEDLEMSKAPSPERIODE: MedlemskapsperiodeFieldProps = {
+export const ULAGRET_MEDLEMSKAPSPERIODE_ID = -1;
+export const ULAGRET_HELSEUTGIFTDEKKESPERIODE_ID = -2;
+
+export const erUlagretPeriode = (id: number): boolean =>
+  id === ULAGRET_MEDLEMSKAPSPERIODE_ID || id === ULAGRET_HELSEUTGIFTDEKKESPERIODE_ID;
+
+export const DEFAULT_MEDLEMSKAPSPERIODE: AvgiftspliktigperiodeFieldProps = {
   id: ULAGRET_MEDLEMSKAPSPERIODE_ID,
+  type: "MEDLEMSKAPSPERIODE",
   fomDato: "",
   tomDato: "",
   innvilgelsesResultat: "",
@@ -49,30 +57,64 @@ export const DEFAULT_MEDLEMSKAPSPERIODE: MedlemskapsperiodeFieldProps = {
   redigerbar: true,
 };
 
-export const mapTilMedlemskapsperiodeFieldProps = (
-  medlemskapsperiode: MedlemskapsperiodeDto,
+export const lagDefaultPeriode = (periodeType: AarsavregningsPeriodeType): AvgiftspliktigperiodeFieldProps => {
+  switch (periodeType) {
+    case "MEDLEMSKAPSPERIODE":
+      return DEFAULT_MEDLEMSKAPSPERIODE;
+    case "LOVVALGSPERIODE":
+      return {
+        id: -1,
+        type: "LOVVALGSPERIODE",
+        fomDato: "",
+        tomDato: "",
+        innvilgelsesResultat: "",
+        medlemskapstype: "",
+        trygdedekning: "",
+        bestemmelse: "",
+        redigerbar: true,
+      };
+    case "HELSEUTGIFTDEKKESPERIODE":
+      return {
+        id: ULAGRET_HELSEUTGIFTDEKKESPERIODE_ID,
+        type: "HELSEUTGIFTDEKKESPERIODE",
+        fomDato: "",
+        tomDato: "",
+        bostedLandkode: "",
+        redigerbar: true,
+      };
+  }
+};
+
+export const mapTilFieldProps = (
+  periode: Avgiftspliktigperiode,
   sistGjeldendeAvgiftspliktigePerioder?: Avgiftspliktigperiode[],
-): MedlemskapsperiodeFieldProps => {
-  const medlemskapsperiodeErFraGrunnlag = sistGjeldendeAvgiftspliktigePerioder?.some(
-    (periode) => periode.fomDato === medlemskapsperiode.fomDato && periode.tomDato === medlemskapsperiode.tomDato,
+): AvgiftspliktigperiodeFieldProps => {
+  const erFraGrunnlag = sistGjeldendeAvgiftspliktigePerioder?.some(
+    (grunnlagPeriode) => grunnlagPeriode.fomDato === periode.fomDato && grunnlagPeriode.tomDato === periode.tomDato,
   );
 
   return {
-    ...medlemskapsperiode,
-    fomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsperiode.fomDato),
-    tomDato: Utils.dato.formatterDatoTilNorsk(medlemskapsperiode.tomDato),
+    ...periode,
+    fomDato: Utils.dato.formatterDatoTilNorsk(periode.fomDato),
+    tomDato: Utils.dato.formatterDatoTilNorsk(periode.tomDato),
     feil: undefined,
-    redigerbar: !medlemskapsperiodeErFraGrunnlag,
+    redigerbar: !erFraGrunnlag,
   };
 };
 
-export const mapMedlemskapsperioder = (
-  perioder: MedlemskapsperiodeDto[],
+/** @deprecated Bruk mapTilFieldProps */
+export const mapTilMedlemskapsperiodeFieldProps = mapTilFieldProps;
+
+export const mapPerioder = (
+  perioder: Avgiftspliktigperiode[],
   sistGjeldendeAvgiftspliktigePerioder?: Avgiftspliktigperiode[],
-): MedlemskapsperiodeFieldProps[] =>
+): AvgiftspliktigperiodeFieldProps[] =>
   [...perioder]
     .sort((a, b) => Utils.dato.sorterEtterISOFomDato(a, b))
-    .map((periode) => mapTilMedlemskapsperiodeFieldProps(periode, sistGjeldendeAvgiftspliktigePerioder));
+    .map((periode) => mapTilFieldProps(periode, sistGjeldendeAvgiftspliktigePerioder));
+
+/** @deprecated Bruk mapPerioder */
+export const mapMedlemskapsperioder = mapPerioder;
 
 interface Props {
   bekreft: () => void;
@@ -88,6 +130,7 @@ export interface MedlemskapTomFomDatoer {
 }
 
 export interface AarsavregningFormValuesProps extends FormValuesProps {
+  avgiftspliktigperioder: MedlemskapsperiodeFieldProps[];
   trygdeavgiftFraAvgiftssystemet?: string;
   bestemmelse?: string;
   endeligAvgiftValg: string;
@@ -107,11 +150,13 @@ export function AarsavregningUtenEllerDeltGrunnlag({
     bestemmelser: string[];
     formDefaultValues: FieldValue<AarsavregningFormValuesProps>;
     trygdedekninger?: string[];
+    periodeType: AarsavregningsPeriodeType;
   }>({
     bestemmelser: [],
+    periodeType: "MEDLEMSKAPSPERIODE",
     formDefaultValues: {
       bestemmelse: "",
-      medlemskapsperioder: [DEFAULT_MEDLEMSKAPSPERIODE],
+      avgiftspliktigperioder: [DEFAULT_MEDLEMSKAPSPERIODE],
       skatteforholdsperioder: [{}],
       inntektskilder: [{}],
       trygdeavgiftFraAvgiftssystemet: "",
@@ -123,85 +168,72 @@ export function AarsavregningUtenEllerDeltGrunnlag({
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
   const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
+  const sakstype = useSelector(fagsakSelectors.SakstypeSelector);
+  const sakstema = useSelector(fagsakSelectors.SakstemaSelector);
   const dispatch = useDispatch();
 
-  const opprettMedlemskapsperiode = async (medlemskapsperiode: Avgiftspliktigperiode) => {
-    if (!erMedlemskapsperiode(medlemskapsperiode)) {
-      throw new Error(`Cannot create membership period from type ${medlemskapsperiode.type}`);
-    }
+  const erEøsPensjonist =
+    sakstype?.kode === MKV.Koder.sakstyper.EU_EOS &&
+    sakstema?.kode === MKV.Koder.sakstemaer.TRYGDEAVGIFT &&
+    behandlingstema === MKV.Koder.behandlinger.behandlingstema.PENSJONIST;
 
-    const periodeRequest = {
-      fomDato: medlemskapsperiode.fomDato,
-      tomDato: medlemskapsperiode.tomDato,
-      trygdedekning: medlemskapsperiode.trygdedekning,
-      bestemmelse: medlemskapsperiode.bestemmelse,
-      innvilgelsesResultat: MKV.Koder.innvilgelsesResultat.INNVILGET,
-    } as OppdaterMedlemskapsperiode;
-
-    const response: any = await Api.MedlemAvFolketrygden.Medlemskapsperioder.opprettMedlemskapsperioder(
-      behandlingID,
-      periodeRequest,
-    );
-
-    return response.type !== medlemskapsperioderTypes.FEILET;
-  };
-
-  const getMappedMedlemskapsperioder = async (
+  const hentMappedPerioder = async (
     aarsavregningRes: AarsavregningResponse,
-  ): Promise<MedlemskapsperiodeFieldProps[]> => {
-    const medlemskapsperioderRes =
-      await Api.MedlemAvFolketrygden.Medlemskapsperioder.hentMedlemskapsperioder(behandlingID);
+    periodeType: AarsavregningsPeriodeType,
+  ): Promise<AvgiftspliktigperiodeFieldProps[]> => {
+    const perioderRes = await PeriodeAdapter.hentPerioder(periodeType, behandlingID);
 
-    const innvilgedeMedlemskapsperioder = medlemskapsperioderRes.filter(
-      (periode) => periode.innvilgelsesResultat === INNVILGET || periode.innvilgelsesResultat === DELVIS_INNVILGET,
-    );
+    const erInnvilget = (periode: Avgiftspliktigperiode) =>
+      periode.type === "HELSEUTGIFTDEKKESPERIODE" ||
+      (erMedlemskapsperiodeEllerLovvalgsperiode(periode) &&
+        (periode.innvilgelsesResultat === INNVILGET || periode.innvilgelsesResultat === DELVIS_INNVILGET));
+
+    const innvilgedePerioder = perioderRes.filter(erInnvilget);
 
     if (
       redigerbart &&
       harTrygdeavgiftFraAvgiftssystemet &&
-      innvilgedeMedlemskapsperioder.length === 0 &&
-      aarsavregningRes?.sisteGjeldendeAvgiftspliktigperioder
+      innvilgedePerioder.length === 0 &&
+      aarsavregningRes?.sisteGjeldendeAvgiftspliktigperioder &&
+      periodeType !== "HELSEUTGIFTDEKKESPERIODE"
     ) {
-      // Initiell innlasting for delt grunnlag
-      const medlemskapsperioderFraGrunnlag = aarsavregningRes.sisteGjeldendeAvgiftspliktigperioder;
-      const innvilgedeMedlemskapsperioderFraGrunnlag = medlemskapsperioderFraGrunnlag.filter(
-        (periode): periode is MedlemskapsperiodeForAvgift =>
-          periode.type === "MEDLEMSKAPSPERIODE" &&
-          (periode.innvilgelsesResultat === INNVILGET || periode.innvilgelsesResultat === DELVIS_INNVILGET),
+      const perioderFraGrunnlag = aarsavregningRes.sisteGjeldendeAvgiftspliktigperioder.filter(
+        (periode) => periode.type === periodeType && erInnvilget(periode),
       );
 
-      for (const periode of innvilgedeMedlemskapsperioderFraGrunnlag) {
-        await opprettMedlemskapsperiode(periode);
+      for (const periode of perioderFraGrunnlag) {
+        const bestemmelse = erMedlemskapsperiodeEllerLovvalgsperiode(periode) ? periode.bestemmelse : "";
+        await PeriodeAdapter.opprettPeriode(periodeType, behandlingID, periode, bestemmelse);
       }
 
-      // Henter medlemskapsperioder fra behandlingsresultat
-      const oppdaterteMedlemskapsperioder =
-        await Api.MedlemAvFolketrygden.Medlemskapsperioder.hentMedlemskapsperioder(behandlingID);
+      const oppdatertePerioder = await PeriodeAdapter.hentPerioder(periodeType, behandlingID);
+      const oppdaterteInnvilgede = oppdatertePerioder.filter(erInnvilget);
 
-      const oppdaterteInnvilgedeMedlemskapsperioder = oppdaterteMedlemskapsperioder.filter(
-        (periode) => periode.innvilgelsesResultat === INNVILGET || periode.innvilgelsesResultat === DELVIS_INNVILGET,
-      );
-
-      return mapMedlemskapsperioder(
-        oppdaterteInnvilgedeMedlemskapsperioder,
-        aarsavregningRes.sisteGjeldendeAvgiftspliktigperioder,
-      );
+      return mapPerioder(oppdaterteInnvilgede, aarsavregningRes.sisteGjeldendeAvgiftspliktigperioder);
     }
-    // Vanlig innlastning. Delt og uten grunnlag
-    return mapMedlemskapsperioder(innvilgedeMedlemskapsperioder, aarsavregningRes.sisteGjeldendeAvgiftspliktigperioder);
+
+    return mapPerioder(innvilgedePerioder, aarsavregningRes.sisteGjeldendeAvgiftspliktigperioder);
   };
 
-  const getBestemmelse = (mappedMedlemskapsperioder: MedlemskapsperiodeFieldProps[]) => {
-    if (mappedMedlemskapsperioder.length > 0) {
-      const førsteBestemmelse = mappedMedlemskapsperioder[0].bestemmelse;
-      const medlemskapsperioderHarSammeBestemmelse = mappedMedlemskapsperioder.every(
-        (period) => period.bestemmelse === førsteBestemmelse,
+  const getBestemmelse = (perioder: AvgiftspliktigperiodeFieldProps[], periodeType: AarsavregningsPeriodeType) => {
+    if (periodeType === "HELSEUTGIFTDEKKESPERIODE") {
+      return "";
+    }
+
+    if (perioder.length > 0) {
+      const perioderMedBestemmelse = perioder.filter(
+        (p): p is (MedlemskapsperiodeForAvgift | LovvalgsperiodeForAvgift) & { redigerbar: boolean; feil?: string } =>
+          erMedlemskapsperiodeEllerLovvalgsperiode(p),
       );
-      if (medlemskapsperioderHarSammeBestemmelse) {
+      if (perioderMedBestemmelse.length === 0) return "";
+
+      const førsteBestemmelse = perioderMedBestemmelse[0].bestemmelse;
+      const harSammeBestemmelse = perioderMedBestemmelse.every((periode) => periode.bestemmelse === førsteBestemmelse);
+      if (harSammeBestemmelse) {
         return førsteBestemmelse;
       }
       throw new Error(
-        "Kan ikke laste inn årsavregning fordi grunnlag eller behandlingsresultat har innvilgede medlemskapsperioder med ulik bestemmelse",
+        "Kan ikke laste inn årsavregning fordi grunnlag eller behandlingsresultat har innvilgede perioder med ulik bestemmelse",
       );
     }
     return "";
@@ -239,6 +271,10 @@ export function AarsavregningUtenEllerDeltGrunnlag({
           }
         }
 
+        const periodeType: AarsavregningsPeriodeType =
+          aarsavregningRes?.sisteGjeldendeAvgiftspliktigperioder?.[0]?.type ??
+          (erEøsPensjonist ? "HELSEUTGIFTDEKKESPERIODE" : "MEDLEMSKAPSPERIODE");
+
         const deltGrunnlagAarsavregningHarIkkeNyttGrunnlag =
           harTrygdeavgiftFraAvgiftssystemet && aarsavregningRes && !aarsavregningRes.nyttTrygdeavgiftsGrunnlag;
 
@@ -259,8 +295,8 @@ export function AarsavregningUtenEllerDeltGrunnlag({
           eventuellNyBestemmelse &&
           bestemmelseFraTidligereAvgiftsgrunnlag === eventuellNyBestemmelse;
 
-        const mappedMedlemskapsperioder = await getMappedMedlemskapsperioder(aarsavregningRes!);
-        const bestemmelse = getBestemmelse(mappedMedlemskapsperioder);
+        const mappedPerioder = await hentMappedPerioder(aarsavregningRes!, periodeType);
+        const bestemmelse = getBestemmelse(mappedPerioder, periodeType);
         const trygdedekninger = await getTrygdedekninger(bestemmelse);
 
         const trygdeavgiftFraAvgiftssystemet =
@@ -274,10 +310,10 @@ export function AarsavregningUtenEllerDeltGrunnlag({
             ? aarsavregningRes?.avregning?.manueltAvgiftBeloep
             : "";
 
+        const defaultPeriode = lagDefaultPeriode(periodeType);
+
         const formDefaultValues: FieldValue<AarsavregningFormValuesProps> = {
-          medlemskapsperioder: mappedMedlemskapsperioder.length
-            ? mappedMedlemskapsperioder
-            : [DEFAULT_MEDLEMSKAPSPERIODE],
+          avgiftspliktigperioder: mappedPerioder.length ? mappedPerioder : [defaultPeriode],
           bestemmelse,
           trygdeavgiftFraAvgiftssystemet,
           endeligAvgiftValg: aarsavregningRes?.endeligAvgiftValg || "",
@@ -287,13 +323,13 @@ export function AarsavregningUtenEllerDeltGrunnlag({
               ? aarsavregningRes?.tidligereTrygdeavgiftsGrunnlagsopplysninger?.trygdeavgiftsgrunnlag
                   .skatteforholdsperioder
               : aarsavregningRes?.nyttTrygdeavgiftsGrunnlag?.trygdeavgiftsgrunnlag.skatteforholdsperioder,
-            mappedMedlemskapsperioder,
+            mappedPerioder,
           ),
           inntektskilder: mapTilInntektskilderProps(
             skalHenteGrunnlagFraTidligereTrygdeavgiftsgrunnlag
               ? aarsavregningRes?.tidligereTrygdeavgiftsGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.inntektskperioder
               : aarsavregningRes?.nyttTrygdeavgiftsGrunnlag?.trygdeavgiftsgrunnlag.inntektskperioder,
-            mappedMedlemskapsperioder,
+            mappedPerioder,
           ),
         };
 
@@ -303,6 +339,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({
           bestemmelser: bestemmelsesRes.bestemmelser,
           formDefaultValues,
           trygdedekninger,
+          periodeType,
         });
 
         setIsLoading(false);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag.tsx
@@ -62,17 +62,7 @@ export const lagDefaultPeriode = (periodeType: AarsavregningsPeriodeType): Avgif
     case "MEDLEMSKAPSPERIODE":
       return DEFAULT_MEDLEMSKAPSPERIODE;
     case "LOVVALGSPERIODE":
-      return {
-        id: -1,
-        type: "LOVVALGSPERIODE",
-        fomDato: "",
-        tomDato: "",
-        innvilgelsesResultat: "",
-        medlemskapstype: "",
-        trygdedekning: "",
-        bestemmelse: "",
-        redigerbar: true,
-      };
+      throw new Error("Lovvalgsperioder er ikke støttet enda");
     case "HELSEUTGIFTDEKKESPERIODE":
       return {
         id: ULAGRET_HELSEUTGIFTDEKKESPERIODE_ID,
@@ -203,7 +193,7 @@ export function AarsavregningUtenEllerDeltGrunnlag({
 
       for (const periode of perioderFraGrunnlag) {
         const bestemmelse = erMedlemskapsperiodeEllerLovvalgsperiode(periode) ? periode.bestemmelse : "";
-        await PeriodeAdapter.opprettPeriode(periodeType, behandlingID, periode, bestemmelse);
+        await PeriodeAdapter.opprettPeriode(behandlingID, periode, bestemmelse);
       }
 
       const oppdatertePerioder = await PeriodeAdapter.hentPerioder(periodeType, behandlingID);

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -15,9 +15,16 @@ import MKV from "../../../../../melosyskodeverk";
 import * as Nav from "../../../../../navFrontend";
 import * as Api from "../../../../../services/api";
 import { AarsavregningResponse } from "../../../../../services/modules/aarsavregning/aarsavregning";
-import type { BasePeriode } from "../../../../../services/modules/types/periodeTyper";
-import type { MedlemskapsperiodeDto } from "../../../../../services/modules/types/periodeTyper";
-import { OppdaterMedlemskapsperiode } from "../../../../../services/modules/medlemavfolketrygden/medlemskapsperioder";
+import * as PeriodeAdapter from "../../../../../services/modules/aarsavregning/periodeApiAdapter";
+import type {
+  BasePeriode,
+  AarsavregningsPeriodeType,
+  Avgiftspliktigperiode,
+} from "../../../../../services/modules/types/periodeTyper";
+import {
+  erMedlemskapsperiodeEllerLovvalgsperiode,
+  erHelseutgiftdekkesperiode,
+} from "../../../../../services/modules/types/periodeTyper";
 import * as Utils from "../../../../../utils";
 import { Aarsavregningsmeldinger } from "../komponenter/aarsavregningsmeldinger";
 import { BeregnetTrygdeavgiftDetaljer } from "../komponenter/beregnetTrygdeavgiftDetaljer";
@@ -25,7 +32,7 @@ import BestemmelseSelect from "../komponenter/bestemmelseSelect";
 import { BorderedFormContainer } from "../komponenter/borderedFormContainer";
 import { EndeligAvgiftValgRadioGroup } from "../komponenter/endeligAvgiftValgRadioGroup";
 import { ManuellAvgiftFormPart } from "../komponenter/manuellAvgiftFormPart";
-import { MedlemskapsperiodeSkjema } from "../komponenter/medlemskapsperiodeSkjema";
+import { AvgiftspliktigperiodeSkjema } from "../komponenter/medlemskapsperiodeSkjema";
 import { SumArsavregningTabell } from "../komponenter/sumArsavregningTabell";
 import { TrygdeavgiftFraAvgiftssystemetInput } from "../komponenter/trygdeavgiftFraAvgiftssystemetInput";
 import {
@@ -37,8 +44,9 @@ import {
 import {
   AarsavregningFormValuesProps,
   DEFAULT_MEDLEMSKAPSPERIODE,
+  lagDefaultPeriode,
   MedlemskapsperiodeFieldProps,
-  ULAGRET_MEDLEMSKAPSPERIODE_ID,
+  erUlagretPeriode,
 } from "./aarsavregningUtenEllerDeltGrunnlag";
 import aarsavregningUtenEllerDeltGrunnlagSchema from "./aarsavregningUtenEllerDeltGrunnlagSchema";
 import { Feilmelding, finnAktivFeilmelding, finnAktivFeilmeldingForMedlemskapsperioder } from "./valideringsfeil";
@@ -81,6 +89,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     bestemmelser: string[];
     formDefaultValues: FieldValue<AarsavregningFormValuesProps>;
     trygdedekninger?: string[];
+    periodeType: AarsavregningsPeriodeType;
   };
   bekreft: () => void;
   oppdaterStatus: (isValid: boolean) => void;
@@ -100,7 +109,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const [endrerBestemmelse, setEndrerBestemmelse] = useState(false);
   const [lagreMedlemskapsperioderPaagar, setLagreMedlemskapsperioderPaagar] = useState(false);
   const [lagredeMedlemskapsperioder, setLagredeMedlemskapsperioder] = useState<MedlemskapsperiodeFieldProps[]>(
-    initiellData.formDefaultValues.medlemskapsperioder || [],
+    initiellData.formDefaultValues.avgiftspliktigperioder || [],
   );
 
   // Redux selectors
@@ -130,7 +139,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     fields: medlemskapsperioderFields,
     append: medlemskapsperioderAppend,
     remove: medlemskapsperioderRemove,
-  } = useFieldArray({ control, name: "medlemskapsperioder" });
+  } = useFieldArray({ control, name: "avgiftspliktigperioder" });
 
   const {
     fields: skattFields,
@@ -147,7 +156,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
   const formValues = watch();
   const bestemmelse = useWatch({ control, name: "bestemmelse" });
-  const medlemskapsperioder = useWatch({ control, name: "medlemskapsperioder" });
+  const medlemskapsperioder = useWatch({ control, name: "avgiftspliktigperioder" });
   const medlemskapsperioderForrigeAntall = useRef(medlemskapsperioder.length);
   const trygdeavgiftFraAvgiftssystemet = useWatch({ control, name: "trygdeavgiftFraAvgiftssystemet" });
   const skatteforholdsperioder = useWatch({ control, name: "skatteforholdsperioder" });
@@ -159,11 +168,19 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   const forrigetrygdeavgiftFraAvgiftssystemet = useRef(trygdeavgiftFraAvgiftssystemet);
   const previousDepsRef = useRef<Record<string, unknown> | null>(null);
 
+  const periodeType = initiellData.periodeType;
+  const erHelseutgift = periodeType === "HELSEUTGIFTDEKKESPERIODE";
   const medlemskapstypeErPliktig = useMemo(() => {
+    if (erHelseutgift) return true;
+
     return medlemskapsperioder
-      .filter((periode: MedlemskapsperiodeFieldProps) => periode.id !== ULAGRET_MEDLEMSKAPSPERIODE_ID)
-      .every((periode: MedlemskapsperiodeFieldProps) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG);
-  }, [medlemskapsperioder]);
+      .filter((periode: MedlemskapsperiodeFieldProps) => !erUlagretPeriode(periode.id))
+      .every(
+        (periode: MedlemskapsperiodeFieldProps) =>
+          erMedlemskapsperiodeEllerLovvalgsperiode(periode) &&
+          periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG,
+      );
+  }, [medlemskapsperioder, erHelseutgift]);
 
   const erDeltGrunnlag =
     harTrygdeavgiftFraAvgiftssystemet &&
@@ -210,11 +227,12 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       arbAvgBetales: inntektskilde.arbAvgBetales,
       erMaanedsbelop: inntektskilde.erMaanedsbelop,
     })),
-    medlemskapsperioder: medlemskapsperioderFormState.map((periode: MedlemskapsperiodeFieldProps) => ({
+    avgiftspliktigperioder: medlemskapsperioderFormState.map((periode: MedlemskapsperiodeFieldProps) => ({
       fomDato: periode.fomDato,
       tomDato: periode.tomDato,
-      trygdedekning: periode.trygdedekning,
-      medlemskapstype: periode.medlemskapstype,
+      type: periode.type,
+      trygdedekning: erMedlemskapsperiodeEllerLovvalgsperiode(periode) ? periode.trygdedekning : "",
+      medlemskapstype: erMedlemskapsperiodeEllerLovvalgsperiode(periode) ? periode.medlemskapstype : "PLIKTIG",
     })),
     trygdeavgiftFraAvgiftssystemet: trygdeavgiftFraAvgiftssystemetParam,
     endeligAvgiftValg: endeligAvgiftValgFormState,
@@ -226,35 +244,45 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     lagredePerioder: MedlemskapsperiodeFieldProps[],
     index: number,
   ) => {
-    const periodeRequest = {
+    const periodeMedIsoDatoer: MedlemskapsperiodeFieldProps = {
+      ...periode,
       fomDato: Utils.dato.vaskOgFormatterTilISO(periode.fomDato, "") as string,
       tomDato: Utils.dato.vaskOgFormatterTilISO(periode.tomDato, "") as string,
-      trygdedekning: periode.trygdedekning,
-      bestemmelse: getValues("bestemmelse"),
-      innvilgelsesResultat: MKV.Koder.innvilgelsesResultat.INNVILGET,
-    } as OppdaterMedlemskapsperiode;
+    };
+    if (erMedlemskapsperiodeEllerLovvalgsperiode(periodeMedIsoDatoer)) {
+      periodeMedIsoDatoer.innvilgelsesResultat = MKV.Koder.innvilgelsesResultat.INNVILGET;
+    }
 
     const lagretMedlemskapsperiode = lagredePerioder[index];
+    const trygdedekningNå = erMedlemskapsperiodeEllerLovvalgsperiode(periode) ? periode.trygdedekning : "";
+    const trygdedekningLagret =
+      lagretMedlemskapsperiode && erMedlemskapsperiodeEllerLovvalgsperiode(lagretMedlemskapsperiode)
+        ? lagretMedlemskapsperiode.trygdedekning
+        : "";
+    const bostedLandkodeNå = erHelseutgiftdekkesperiode(periode) ? periode.bostedLandkode : "";
+    const bostedLandkodeLagret =
+      lagretMedlemskapsperiode && erHelseutgiftdekkesperiode(lagretMedlemskapsperiode)
+        ? lagretMedlemskapsperiode.bostedLandkode
+        : "";
     const harEndringer =
       !lagretMedlemskapsperiode ||
-      periode.id === ULAGRET_MEDLEMSKAPSPERIODE_ID ||
+      erUlagretPeriode(periode.id) ||
       periode.fomDato !== lagretMedlemskapsperiode.fomDato ||
       periode.tomDato !== lagretMedlemskapsperiode.tomDato ||
-      periode.trygdedekning !== lagretMedlemskapsperiode.trygdedekning;
+      trygdedekningNå !== trygdedekningLagret ||
+      bostedLandkodeNå !== bostedLandkodeLagret;
 
     if (harEndringer) {
       try {
-        return await (periode.id === ULAGRET_MEDLEMSKAPSPERIODE_ID
-          ? Api.MedlemAvFolketrygden.Medlemskapsperioder.opprettMedlemskapsperioder(behandlingID, periodeRequest)
-          : Api.MedlemAvFolketrygden.Medlemskapsperioder.oppdaterMedlemskapsperioder(
-              behandlingID,
-              periode.id,
-              periodeRequest,
-            ));
+        const bestemmelse = getValues("bestemmelse") ?? "";
+        const skalOpprette = erHelseutgift || erUlagretPeriode(periode.id);
+        return await (skalOpprette
+          ? PeriodeAdapter.opprettPeriode(periodeType, behandlingID, periodeMedIsoDatoer, bestemmelse)
+          : PeriodeAdapter.oppdaterPeriode(periodeType, behandlingID, periodeMedIsoDatoer, bestemmelse));
       } catch (error) {
-        setFeilmelding("Feil ved lagring av medlemskapsperiode");
+        setFeilmelding("Feil ved lagring av periode");
         /* eslint-disable-next-line no-console */
-        console.error("Feil ved lagring av medlemskapsperiode:", error);
+        console.error("Feil ved lagring av periode:", error);
         return undefined;
       }
     }
@@ -268,6 +296,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       await beregnTrygdeavgiftsperioder(formVerdier, {
         behandlingID,
         medlemskapstypeErPliktig,
+        erEøsPensjonist: erHelseutgift,
         setFeilmelding,
         setAarsavregningResponse,
       });
@@ -289,7 +318,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       return;
     }
 
-    const medlemskapsperioderFormState = getValues("medlemskapsperioder");
+    const medlemskapsperioderFormState = getValues("avgiftspliktigperioder");
     const formState = mapFormState(
       getValues("skatteforholdsperioder"),
       getValues("inntektskilder"),
@@ -305,7 +334,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         skatteforholdsperioder: formState.skatteforholdsperioder,
         inntektskilder: formState.inntektskilder,
         medlemskapsperiodeFomTom,
-        medlemskapsperioder: medlemskapsperioderFormState,
+        avgiftspliktigperioder: medlemskapsperioderFormState,
         medlemskapstypeErPliktig,
       });
 
@@ -338,11 +367,11 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
   const lagreMedlemskapsperioder = useCallback(
     async (medlemskapsperioderFormValues: MedlemskapsperiodeFieldProps[]) => {
-      type LagretMedlemskapsperiodeMedIndex = MedlemskapsperiodeDto & {
+      type LagretPeriodeMedIndex = Avgiftspliktigperiode & {
         formValuesIndex: number;
       };
 
-      const endredeMedlemskapsperioder: LagretMedlemskapsperiodeMedIndex[] = [];
+      const endredeMedlemskapsperioder: LagretPeriodeMedIndex[] = [];
       for (const [index, periode] of medlemskapsperioderFormValues.entries()) {
         const lagretPeriode = await lagreMedlemskapsperiodeHvisEndret(periode, lagredeMedlemskapsperioder, index);
         if (lagretPeriode)
@@ -363,7 +392,9 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
           if (lagretPeriodeMedID) {
             return {
               ...periode,
-              medlemskapstype: lagretPeriodeMedID.medlemskapstype,
+              ...(erMedlemskapsperiodeEllerLovvalgsperiode(lagretPeriodeMedID)
+                ? { medlemskapstype: lagretPeriodeMedID.medlemskapstype }
+                : {}),
               id: lagretPeriodeMedID.id,
             };
           }
@@ -371,7 +402,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         });
 
         setLagredeMedlemskapsperioder(oppdaterteMedlemskapsperioder);
-        setValue("medlemskapsperioder", oppdaterteMedlemskapsperioder);
+        setValue("avgiftspliktigperioder", oppdaterteMedlemskapsperioder);
       }
     },
     [setValue, setLagredeMedlemskapsperioder, lagredeMedlemskapsperioder],
@@ -396,13 +427,15 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     const nåværendeListeMedRelevanteFelter = medlemskapsperioderNå.map((periode) => ({
       fomDato: periode.fomDato,
       tomDato: periode.tomDato,
-      trygdedekning: periode.trygdedekning,
+      trygdedekning: erMedlemskapsperiodeEllerLovvalgsperiode(periode) ? periode.trygdedekning : "",
+      bostedLandkode: erHelseutgiftdekkesperiode(periode) ? periode.bostedLandkode : "",
     }));
 
     const forrigeListeMedRelevanteFelter = medlemskapsperioderTidlgere.map((periode) => ({
       fomDato: periode.fomDato,
       tomDato: periode.tomDato,
-      trygdedekning: periode.trygdedekning,
+      trygdedekning: erMedlemskapsperiodeEllerLovvalgsperiode(periode) ? periode.trygdedekning : "",
+      bostedLandkode: erHelseutgiftdekkesperiode(periode) ? periode.bostedLandkode : "",
     }));
 
     const sorterEtterFomDato = (a: BasePeriode, b: BasePeriode) => {
@@ -436,9 +469,9 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         const { isValid: erGyldigSkjema } = await validateAarsavregningUtenEllerDeltGrunnlag(
           getValues(),
           context,
-          "medlemskapsperioder",
+          "avgiftspliktigperioder",
         );
-        if (!erGyldigSkjema || !bestemmelse) {
+        if (!erGyldigSkjema || (!erHelseutgift && !bestemmelse)) {
           return;
         }
 
@@ -465,13 +498,13 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
       const completeFormData = {
         ...getValues(),
-        medlemskapsperioder: oppdaterteMedlemskapsperioder,
+        avgiftspliktigperioder: oppdaterteMedlemskapsperioder,
       };
       const context = {
         aar: initiellData.valgtÅr,
         harTrygdeavgiftFraAvgiftssystemet,
       };
-      validateAarsavregningUtenEllerDeltGrunnlag(completeFormData, context, "medlemskapsperioder")
+      validateAarsavregningUtenEllerDeltGrunnlag(completeFormData, context, "avgiftspliktigperioder")
         .then(async ({ isValid }) => {
           if (isValid) {
             await lagreMedlemskapsperioder(oppdaterteMedlemskapsperioder);
@@ -483,7 +516,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
   );
 
   const leggTilDefaultMedlemskapsperiode = () => {
-    medlemskapsperioderAppend(DEFAULT_MEDLEMSKAPSPERIODE);
+    medlemskapsperioderAppend(lagDefaultPeriode(periodeType));
   };
 
   const slettMedlemskapsperiode = async (index: number) => {
@@ -491,18 +524,20 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
 
     try {
       setLagreMedlemskapsperioderPaagar(true);
-      if (periode.id === ULAGRET_MEDLEMSKAPSPERIODE_ID) {
+      if (erUlagretPeriode(periode.id)) {
         medlemskapsperioderRemove(index);
       } else {
-        await Api.MedlemAvFolketrygden.Medlemskapsperioder.slettMedlemskapsperiode(behandlingID, periode.id);
+        await PeriodeAdapter.slettPeriode(periodeType, behandlingID, periode.id);
         medlemskapsperioderRemove(index);
-        dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
+        if (periodeType === "MEDLEMSKAPSPERIODE") {
+          dispatch(medlemskapsperioderOperations.hentMedlemskapsperioder(behandlingID));
+        }
       }
       setLagreMedlemskapsperioderPaagar(false);
     } catch (error) {
       /* eslint-disable-next-line no-console */
-      console.error("Feil ved sletting av medlemskapsperiode:", error);
-      setFeilmelding("Feil ved sletting av medlemskapsperiode");
+      console.error("Feil ved sletting av periode:", error);
+      setFeilmelding("Feil ved sletting av periode");
     }
   };
 
@@ -602,7 +637,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       const currentFormState = mapFormState(
         getValues("skatteforholdsperioder"),
         getValues("inntektskilder"),
-        getValues("medlemskapsperioder"),
+        getValues("avgiftspliktigperioder"),
         getValues("trygdeavgiftFraAvgiftssystemet"),
         getValues("endeligAvgiftValg"),
         getValues("bestemmelse"),
@@ -611,7 +646,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       if (!redigerbart || !aarsavregningID || endrerBestemmelse || beregningPaagar || lagreMedlemskapsperioderPaagar) {
         return;
       }
-
       if (!Utils._isEqual(currentFormState, previousFormState)) {
         const context = {
           aar: initiellData.valgtÅr,
@@ -774,22 +808,24 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
             Inntekts- og skatteopplysninger for endelig trygdeavgift
           </Nav.Heading>
 
-          <BestemmelseSelect
-            control={control}
-            setValue={setValue}
-            bestemmelser={initiellData.bestemmelser}
-            behandlingID={behandlingID}
-            redigerbart={skjemaErRedigerbart}
-            setTrygdedekninger={setTrygdedekninger}
-            setFeilmelding={setFeilmelding}
-            setEndrerBestemmelse={setEndrerBestemmelse}
-            lagreMedlemskapsperioderHvisGyldig={lagreMedlemskapsperioderEtterBestemmelseEndringHvisGyldig}
-            harLaasteMedlemskapsperioder={harLaasteMedlemskapsperioder}
-          />
+          {!erHelseutgift && (
+            <BestemmelseSelect
+              control={control}
+              setValue={setValue}
+              bestemmelser={initiellData.bestemmelser}
+              behandlingID={behandlingID}
+              redigerbart={skjemaErRedigerbart}
+              setTrygdedekninger={setTrygdedekninger}
+              setFeilmelding={setFeilmelding}
+              setEndrerBestemmelse={setEndrerBestemmelse}
+              lagreMedlemskapsperioderHvisGyldig={lagreMedlemskapsperioderEtterBestemmelseEndringHvisGyldig}
+              harLaasteMedlemskapsperioder={harLaasteMedlemskapsperioder}
+            />
+          )}
 
           <div className="perioder">
             {medlemskapsperioderFields.map((field, index: number) => (
-              <MedlemskapsperiodeSkjema
+              <AvgiftspliktigperiodeSkjema
                 key={field.id}
                 redigerbart={skjemaErRedigerbart}
                 control={control}
@@ -798,12 +834,13 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
                 remove={slettMedlemskapsperiode}
                 formValues={formValues}
                 handleLeggTil={leggTilDefaultMedlemskapsperiode}
-                visLeggTil
+                visLeggTil={!erHelseutgift}
                 maxDate={maxDate}
                 minDate={minDate}
-                trygdedekninger={trygdedekninger}
+                trygdedekninger={erHelseutgift ? [] : trygdedekninger}
                 setValue={setValue}
                 erDeltGrunnlag={erDeltGrunnlag}
+                periodeType={periodeType}
               />
             ))}
           </div>
@@ -834,6 +871,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
               bestemmelse={bestemmelse}
               minDate={minDate}
               maxDate={maxDate}
+              erHelseutgiftDekkesPeriode={erHelseutgift}
             />
           )}
           {formIsValid && trygdeAvgiftSkalIkkeBetalesTilNav && (

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -277,8 +277,8 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         const bestemmelse = getValues("bestemmelse") ?? "";
         const skalOpprette = erHelseutgift || erUlagretPeriode(periode.id);
         return await (skalOpprette
-          ? PeriodeAdapter.opprettPeriode(periodeType, behandlingID, periodeMedIsoDatoer, bestemmelse)
-          : PeriodeAdapter.oppdaterPeriode(periodeType, behandlingID, periodeMedIsoDatoer, bestemmelse));
+          ? PeriodeAdapter.opprettPeriode(behandlingID, periodeMedIsoDatoer, bestemmelse)
+          : PeriodeAdapter.oppdaterPeriode(behandlingID, periodeMedIsoDatoer, bestemmelse));
       } catch (error) {
         setFeilmelding("Feil ved lagring av periode");
         /* eslint-disable-next-line no-console */

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
@@ -4,7 +4,7 @@ import * as KV from "../../../../../kodeverk";
 import * as Utils from "../../../../../utils";
 import { BOOLSK_STRING } from "../../../../../constants";
 import * as Datoutils from "../../../../../utils/dato";
-import { ULAGRET_MEDLEMSKAPSPERIODE_ID } from "./aarsavregningUtenEllerDeltGrunnlag";
+import { erUlagretPeriode } from "./aarsavregningUtenEllerDeltGrunnlag";
 
 import { erBrukerSkattepliktigIHelePerioden } from "../utils";
 
@@ -25,8 +25,11 @@ export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
 
 const erMedlemskapsTypePliktig = (medlemskapsperioder) => {
   const medlemskapsTypeErPliktig = medlemskapsperioder
-    .filter((periode) => periode.id !== ULAGRET_MEDLEMSKAPSPERIODE_ID)
-    .every((periode) => periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG);
+    .filter((periode) => !erUlagretPeriode(periode.id))
+    .every((periode) => {
+      if (periode.type === "HELSEUTGIFTDEKKESPERIODE") return true;
+      return periode.medlemskapstype === MKV.Koder.medlemskapstyper.PLIKTIG;
+    });
 
   return medlemskapsTypeErPliktig;
 };
@@ -37,8 +40,8 @@ const arbAvgBetalesFyltUtNårDetKrevesTest = {
   test: (arbAvgBetales, schema) => {
     const { kildetype } = schema.from[0].value;
 
-    const { medlemskapsperioder } = schema.from[1].value;
-    const medlemskapsTypeErPliktig = erMedlemskapsTypePliktig(medlemskapsperioder);
+    const { avgiftspliktigperioder } = schema.from[1].value;
+    const medlemskapsTypeErPliktig = erMedlemskapsTypePliktig(avgiftspliktigperioder);
 
     return !(arbAvgBetalesKreves(kildetype, medlemskapsTypeErPliktig) && Utils._isEmpty(arbAvgBetales));
   },
@@ -108,11 +111,10 @@ const erInnenforMedlemskapsperiodeTest = {
     const vasketDato = Utils.dato.vaskInputDato(datoString);
     if (!vasketDato || vasketDato.length < 10) return true;
 
-    // Get medlemskapsperioder directly from form values
-    const { medlemskapsperioder } = schema.from[1].value;
-    if (!medlemskapsperioder || medlemskapsperioder.length === 0) return true;
+    const { avgiftspliktigperioder } = schema.from[1].value;
+    if (!avgiftspliktigperioder || avgiftspliktigperioder.length === 0) return true;
 
-    const gyldigePerioder = medlemskapsperioder.filter((p) => p.fomDato && p.tomDato);
+    const gyldigePerioder = avgiftspliktigperioder.filter((p) => p.fomDato && p.tomDato);
     if (gyldigePerioder.length === 0) return true;
 
     const sortertePerioder = [...gyldigePerioder].sort(Utils.dato.sorterEtterNorskFomDato);
@@ -136,7 +138,11 @@ const medlemskapsperiodeSchema = object().shape({
     .erEtterDatofelt("fomDato")
     .test(åpenTomTest)
     .test(erInnenforValgtAarTest),
-  trygdedekning: string().required(MAA_FYLLES_UT),
+  trygdedekning: string().when("type", {
+    is: (type) => type === "HELSEUTGIFTDEKKESPERIODE",
+    then: (schema) => schema.nullable().notRequired(),
+    otherwise: (schema) => schema.required(MAA_FYLLES_UT),
+  }),
 });
 
 const skatteforholdsperiodeSchema = object().shape({
@@ -168,19 +174,31 @@ const inntektskildeSchema = object().shape({
 });
 
 const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
-  bestemmelse: string().when(["endeligAvgiftValg"], {
-    is: (endeligAvgiftValg) => endeligAvgiftValg === OPPLYSNINGER_ENDRET,
+  bestemmelse: string().when(["endeligAvgiftValg", "avgiftspliktigperioder"], {
+    is: (endeligAvgiftValg, avgiftspliktigperioder) => {
+      if (endeligAvgiftValg !== OPPLYSNINGER_ENDRET) return false;
+      const erHelseutgift =
+        avgiftspliktigperioder?.length > 0 &&
+        avgiftspliktigperioder.every((p) => p.type === "HELSEUTGIFTDEKKESPERIODE");
+      return !erHelseutgift;
+    },
     then: (schema) => schema.required(MAA_FYLLES_UT),
     otherwise: (schema) => schema.nullable(),
   }),
   endeligAvgiftValg: string().required(MAA_FYLLES_UT),
-  medlemskapsperioder: array().when(["endeligAvgiftValg"], {
+  avgiftspliktigperioder: array().when(["endeligAvgiftValg"], {
     is: (endeligAvgiftValg) => endeligAvgiftValg === OPPLYSNINGER_ENDRET,
     then: (schema) => schema.min(1, "Minst en medlemskapsperiode").of(medlemskapsperiodeSchema),
     otherwise: (schema) => schema,
   }),
-  trygdeavgiftFraAvgiftssystemet: string().when(["$harTrygdeavgiftFraAvgiftssystemet"], {
-    is: true,
+  trygdeavgiftFraAvgiftssystemet: string().when(["$harTrygdeavgiftFraAvgiftssystemet", "avgiftspliktigperioder"], {
+    is: (harTrygdeavgiftFraAvgiftssystemet, avgiftspliktigperioder) => {
+      if (!harTrygdeavgiftFraAvgiftssystemet) return false;
+      const erHelseutgift =
+        avgiftspliktigperioder?.length > 0 &&
+        avgiftspliktigperioder.every((p) => p.type === "HELSEUTGIFTDEKKESPERIODE");
+      return !erHelseutgift;
+    },
     then: (schema) => schema.required(MAA_FYLLES_UT),
     otherwise: (schema) => schema.nullable(),
   }),
@@ -189,10 +207,10 @@ const aarsavregningUtenEllerDeltGrunnlagSchema = object().shape({
     then: (schema) => schema.min(1, "Minst en skatteforholdsperiode").of(skatteforholdsperiodeSchema),
     otherwise: (schema) => schema,
   }),
-  inntektskilder: array().when(["medlemskapsperioder", "skatteforholdsperioder", "endeligAvgiftValg"], {
-    is: (medlemskapsperioder, skatteforholdsperioder, endeligAvgiftValg) => {
+  inntektskilder: array().when(["avgiftspliktigperioder", "skatteforholdsperioder", "endeligAvgiftValg"], {
+    is: (avgiftspliktigperioder, skatteforholdsperioder, endeligAvgiftValg) => {
       if (endeligAvgiftValg !== OPPLYSNINGER_ENDRET) return false;
-      const medlemskapsTypeErPliktig = erMedlemskapsTypePliktig(medlemskapsperioder);
+      const medlemskapsTypeErPliktig = erMedlemskapsTypePliktig(avgiftspliktigperioder);
 
       return !(medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(skatteforholdsperioder));
     },

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.test.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.test.ts
@@ -44,7 +44,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "dd11ss",
@@ -59,15 +59,15 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
 
       const err = await validate(values, { aar: 2024 });
       expect(err).toBeTruthy();
-      expect(hasError(err, "medlemskapsperioder[0].fomDato", "Skriv inn en gyldig dato")).toBe(true);
-      expect(hasError(err, "medlemskapsperioder[0].fomDato", "Utenfor valgt år")).toBe(false);
+      expect(hasError(err, "avgiftspliktigperioder[0].fomDato", "Skriv inn en gyldig dato")).toBe(true);
+      expect(hasError(err, "avgiftspliktigperioder[0].fomDato", "Utenfor valgt år")).toBe(false);
     });
 
     it("skal vise 'Skriv inn en gyldig dato' for ugyldig input som '99.99.9999'", async () => {
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "99.99.9999",
@@ -82,15 +82,15 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
 
       const err = await validate(values, { aar: 2024 });
       expect(err).toBeTruthy();
-      expect(hasError(err, "medlemskapsperioder[0].fomDato", "Skriv inn en gyldig dato")).toBe(true);
-      expect(hasError(err, "medlemskapsperioder[0].fomDato", "Utenfor valgt år")).toBe(false);
+      expect(hasError(err, "avgiftspliktigperioder[0].fomDato", "Skriv inn en gyldig dato")).toBe(true);
+      expect(hasError(err, "avgiftspliktigperioder[0].fomDato", "Utenfor valgt år")).toBe(false);
     });
 
     it("skal vise 'Utenfor valgt år' for gyldig dato utenfor året", async () => {
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "01.01.2023",
@@ -105,15 +105,15 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
 
       const err = await validate(values, { aar: 2024 });
       expect(err).toBeTruthy();
-      expect(hasError(err, "medlemskapsperioder[0].fomDato", "Utenfor valgt år")).toBe(true);
-      expect(hasError(err, "medlemskapsperioder[0].fomDato", "Skriv inn en gyldig dato")).toBe(false);
+      expect(hasError(err, "avgiftspliktigperioder[0].fomDato", "Utenfor valgt år")).toBe(true);
+      expect(hasError(err, "avgiftspliktigperioder[0].fomDato", "Skriv inn en gyldig dato")).toBe(false);
     });
 
     it("skal godta gyldig dato innenfor året", async () => {
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "01.01.2024",
@@ -143,7 +143,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "01.01.2024",
@@ -158,15 +158,15 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
 
       const err = await validate(values, { aar: 2024 });
       expect(err).toBeTruthy();
-      expect(hasError(err, "medlemskapsperioder[0].tomDato", "Skriv inn en gyldig dato")).toBe(true);
-      expect(hasError(err, "medlemskapsperioder[0].tomDato", "Utenfor valgt år")).toBe(false);
+      expect(hasError(err, "avgiftspliktigperioder[0].tomDato", "Skriv inn en gyldig dato")).toBe(true);
+      expect(hasError(err, "avgiftspliktigperioder[0].tomDato", "Utenfor valgt år")).toBe(false);
     });
 
     it("skal vise 'Utenfor valgt år' for gyldig dato utenfor året", async () => {
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "01.01.2024",
@@ -181,7 +181,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
 
       const err = await validate(values, { aar: 2024 });
       expect(err).toBeTruthy();
-      expect(hasError(err, "medlemskapsperioder[0].tomDato", "Utenfor valgt år")).toBe(true);
+      expect(hasError(err, "avgiftspliktigperioder[0].tomDato", "Utenfor valgt år")).toBe(true);
     });
   });
 
@@ -190,7 +190,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "01.01.2024",
@@ -220,7 +220,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "01.01.2024",
@@ -251,7 +251,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "01.01.2024",
@@ -288,7 +288,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "01.01.2024",
@@ -327,7 +327,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "",
@@ -343,14 +343,14 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
       const err = await validate(values, { aar: 2024 });
       expect(err).toBeTruthy();
       // Skal feile på required, ikke på erInnenforValgtAarTest
-      expect(hasError(err, "medlemskapsperioder[0].fomDato", "Må fylles ut")).toBe(true);
+      expect(hasError(err, "avgiftspliktigperioder[0].fomDato", "Må fylles ut")).toBe(true);
     });
 
     it("skal håndtere delvis utfylt dato", async () => {
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
-        medlemskapsperioder: [
+        avgiftspliktigperioder: [
           {
             id: 1,
             fomDato: "01.01",
@@ -365,7 +365,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
 
       const err = await validate(values, { aar: 2024 });
       expect(err).toBeTruthy();
-      expect(hasError(err, "medlemskapsperioder[0].fomDato", "Skriv inn en gyldig dato")).toBe(true);
+      expect(hasError(err, "avgiftspliktigperioder[0].fomDato", "Skriv inn en gyldig dato")).toBe(true);
     });
   });
 });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/mapMedlemskapsperioder.test.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/mapMedlemskapsperioder.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { mapTilMedlemskapsperiodeFieldProps, mapMedlemskapsperioder } from "./aarsavregningUtenEllerDeltGrunnlag";
-import { MedlemskapsperiodeDto } from "../../../../../services/modules/types/periodeTyper";
+import { MedlemskapsperiodeForAvgift } from "../../../../../services/modules/types/periodeTyper";
+
+type MedlemskapsperiodeFieldPropsNarrowed = MedlemskapsperiodeForAvgift & { redigerbar: boolean; feil?: string };
 
 describe("mapTilMedlemskapsperiodeFieldProps", () => {
-  const lagMedlemskapsperiodeDto = (overrides?: Partial<MedlemskapsperiodeDto>): MedlemskapsperiodeDto => ({
+  const lagMedlemskapsperiode = (overrides?: Partial<MedlemskapsperiodeForAvgift>): MedlemskapsperiodeForAvgift => ({
     id: 1,
+    type: "MEDLEMSKAPSPERIODE",
     fomDato: "2023-01-01",
     tomDato: "2023-12-31",
     bestemmelse: "FTRL_2_7",
@@ -15,24 +18,24 @@ describe("mapTilMedlemskapsperiodeFieldProps", () => {
   });
 
   it("skal konvertere ISO-datoer til norsk format", () => {
-    const dto = lagMedlemskapsperiodeDto({
+    const periode = lagMedlemskapsperiode({
       fomDato: "2023-01-01",
       tomDato: "2023-12-31",
     });
 
-    const resultat = mapTilMedlemskapsperiodeFieldProps(dto);
+    const resultat = mapTilMedlemskapsperiodeFieldProps(periode);
 
     expect(resultat.fomDato).toBe("01.01.2023");
     expect(resultat.tomDato).toBe("31.12.2023");
   });
 
   it("skal ikke returnere blanke datoer for gyldige ISO-datoer", () => {
-    const dto = lagMedlemskapsperiodeDto({
+    const periode = lagMedlemskapsperiode({
       fomDato: "2024-06-15",
       tomDato: "2024-11-30",
     });
 
-    const resultat = mapTilMedlemskapsperiodeFieldProps(dto);
+    const resultat = mapTilMedlemskapsperiodeFieldProps(periode);
 
     expect(resultat.fomDato).not.toBe("");
     expect(resultat.tomDato).not.toBe("");
@@ -40,16 +43,16 @@ describe("mapTilMedlemskapsperiodeFieldProps", () => {
     expect(resultat.tomDato).toBe("30.11.2024");
   });
 
-  it("skal ikke ha type-felt (MedlemskapsperiodeDto har ikke type)", () => {
-    const dto = lagMedlemskapsperiodeDto();
+  it("skal beholde type-felt fra Avgiftspliktigperiode", () => {
+    const periode = lagMedlemskapsperiode();
 
-    const resultat = mapTilMedlemskapsperiodeFieldProps(dto);
+    const resultat = mapTilMedlemskapsperiodeFieldProps(periode);
 
-    expect((resultat as any).type).toBeUndefined();
+    expect(resultat.type).toBe("MEDLEMSKAPSPERIODE");
   });
 
-  it("skal beholde alle felt fra MedlemskapsperiodeDto", () => {
-    const dto = lagMedlemskapsperiodeDto({
+  it("skal beholde alle felt fra MedlemskapsperiodeForAvgift", () => {
+    const periode = lagMedlemskapsperiode({
       id: 42,
       bestemmelse: "FTRL_2_9",
       medlemskapstype: "FRIVILLIG",
@@ -57,7 +60,7 @@ describe("mapTilMedlemskapsperiodeFieldProps", () => {
       trygdedekning: "FULL_DEKNING_FTRL",
     });
 
-    const resultat = mapTilMedlemskapsperiodeFieldProps(dto);
+    const resultat = mapTilMedlemskapsperiodeFieldProps(periode) as MedlemskapsperiodeFieldPropsNarrowed;
 
     expect(resultat.id).toBe(42);
     expect(resultat.bestemmelse).toBe("FTRL_2_9");
@@ -67,7 +70,7 @@ describe("mapTilMedlemskapsperiodeFieldProps", () => {
   });
 
   it("skal sette redigerbar=true når periode ikke finnes i sisteGjeldendeAvgiftspliktigePerioder", () => {
-    const dto = lagMedlemskapsperiodeDto({
+    const periode = lagMedlemskapsperiode({
       fomDato: "2023-01-01",
       tomDato: "2023-06-30",
     });
@@ -84,13 +87,13 @@ describe("mapTilMedlemskapsperiodeFieldProps", () => {
       },
     ];
 
-    const resultat = mapTilMedlemskapsperiodeFieldProps(dto, sisteGjeldende);
+    const resultat = mapTilMedlemskapsperiodeFieldProps(periode, sisteGjeldende);
 
     expect(resultat.redigerbar).toBe(true);
   });
 
   it("skal sette redigerbar=false når periode finnes i sisteGjeldendeAvgiftspliktigePerioder", () => {
-    const dto = lagMedlemskapsperiodeDto({
+    const periode = lagMedlemskapsperiode({
       fomDato: "2023-01-01",
       tomDato: "2023-12-31",
     });
@@ -107,15 +110,15 @@ describe("mapTilMedlemskapsperiodeFieldProps", () => {
       },
     ];
 
-    const resultat = mapTilMedlemskapsperiodeFieldProps(dto, sisteGjeldende);
+    const resultat = mapTilMedlemskapsperiodeFieldProps(periode, sisteGjeldende);
 
     expect(resultat.redigerbar).toBe(false);
   });
 
   it("skal sette redigerbar=true når sisteGjeldendeAvgiftspliktigePerioder er undefined", () => {
-    const dto = lagMedlemskapsperiodeDto();
+    const periode = lagMedlemskapsperiode();
 
-    const resultat = mapTilMedlemskapsperiodeFieldProps(dto, undefined);
+    const resultat = mapTilMedlemskapsperiodeFieldProps(periode, undefined);
 
     expect(resultat.redigerbar).toBe(true);
   });
@@ -123,9 +126,10 @@ describe("mapTilMedlemskapsperiodeFieldProps", () => {
 
 describe("mapMedlemskapsperioder", () => {
   it("skal sortere perioder kronologisk og konvertere datoer", () => {
-    const perioder: MedlemskapsperiodeDto[] = [
+    const perioder: MedlemskapsperiodeForAvgift[] = [
       {
         id: 2,
+        type: "MEDLEMSKAPSPERIODE",
         fomDato: "2023-07-01",
         tomDato: "2023-12-31",
         bestemmelse: "FTRL_2_7",
@@ -135,6 +139,7 @@ describe("mapMedlemskapsperioder", () => {
       },
       {
         id: 1,
+        type: "MEDLEMSKAPSPERIODE",
         fomDato: "2023-01-01",
         tomDato: "2023-06-30",
         bestemmelse: "FTRL_2_7",
@@ -153,10 +158,11 @@ describe("mapMedlemskapsperioder", () => {
     expect(resultat[1].tomDato).toBe("31.12.2023");
   });
 
-  it("skal ikke ha type-felt på noen perioder", () => {
-    const perioder: MedlemskapsperiodeDto[] = [
+  it("skal beholde type-felt på alle perioder", () => {
+    const perioder: MedlemskapsperiodeForAvgift[] = [
       {
         id: 1,
+        type: "MEDLEMSKAPSPERIODE",
         fomDato: "2023-01-01",
         tomDato: "2023-12-31",
         bestemmelse: "FTRL_2_7",
@@ -168,7 +174,7 @@ describe("mapMedlemskapsperioder", () => {
 
     const resultat = mapMedlemskapsperioder(perioder);
 
-    expect(resultat.every((p) => (p as any).type === undefined)).toBe(true);
+    expect(resultat.every((p) => p.type === "MEDLEMSKAPSPERIODE")).toBe(true);
   });
 
   it("skal håndtere tom array", () => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.test.tsx
@@ -50,7 +50,7 @@ describe("finnAktivFeilmelding", () => {
     skatteforholdsperioder: [] as any[],
     inntektskilder: [] as any[],
     medlemskapsperiodeFomTom: { fomDato: "2024-01-01", tomDato: "2024-12-31" },
-    medlemskapsperioder: [{ fomDato: "2024-01-01", tomDato: "2024-12-31" }] as any[],
+    avgiftspliktigperioder: [{ fomDato: "2024-01-01", tomDato: "2024-12-31" }] as any[],
     medlemskapstypeErPliktig: true,
   };
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
@@ -124,7 +124,7 @@ interface AarsavregningValidationParams {
   skatteforholdsperioder: Skatteforhold[];
   inntektskilder: Inntektskilde[];
   medlemskapsperiodeFomTom: BasePeriode;
-  medlemskapsperioder: BasePeriode[];
+  avgiftspliktigperioder: BasePeriode[];
   medlemskapstypeErPliktig: boolean;
 }
 
@@ -148,14 +148,14 @@ export function finnAktivFeilmelding({
   inntektskilder,
   medlemskapsperiodeFomTom,
   medlemskapstypeErPliktig,
-  medlemskapsperioder,
+  avgiftspliktigperioder,
 }: AarsavregningValidationParams): string | undefined {
-  const medlemskapsperioderFeilmelding = finnAktivFeilmeldingForMedlemskapsperioder(medlemskapsperioder);
+  const medlemskapsperioderFeilmelding = finnAktivFeilmeldingForMedlemskapsperioder(avgiftspliktigperioder);
   if (medlemskapsperioderFeilmelding) {
     return medlemskapsperioderFeilmelding;
   }
 
-  const vaskedeMedlemskapsperioder = Utils.dato.vaskOgFormaterDatoerTilIso(medlemskapsperioder);
+  const vaskedeMedlemskapsperioder = Utils.dato.vaskOgFormaterDatoerTilIso(avgiftspliktigperioder);
   const vaskedeSkatteforholdsperioder = Utils.dato.vaskOgFormaterDatoerTilIso(skatteforholdsperioder);
   const vaskedeInntektskilder = Utils.dato.vaskOgFormaterDatoerTilIso(inntektskilder);
 
@@ -195,19 +195,19 @@ export function Feilmelding({ type }: { type?: string }) {
     case TypeFeilmelding.OVERLAPPENDE_MEDLEMSKAPSPERIODER:
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          Medlemskapsperiodene kan ikke overlappe
+          Avgiftsperiodene kan ikke overlappe
         </Nav.Alert>
       );
     case TypeFeilmelding.HAR_OPPHOLDSPERIODER_MEDLEMSKAPSPERIODER:
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          Det er opphold i medlemskapsperiodene.
+          Det er opphold i avgiftsperiodene.
         </Nav.Alert>
       );
     case TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN:
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          Skatteforholdsperioden(e) du har lagt inn dekker ikke hele medlemskapsperioden(e)
+          Skatteforholdsperioden(e) du har lagt inn dekker ikke hele avgiftsperiodene(e)
         </Nav.Alert>
       );
     case TypeFeilmelding.OVERLAPPENDE_SKATTEFORHOLDSPERIODER:
@@ -225,7 +225,7 @@ export function Feilmelding({ type }: { type?: string }) {
     case TypeFeilmelding.INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN:
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          Inntektsperioden(e) du har lagt inn dekker ikke hele medlemskapsperioden(e)
+          Inntektsperioden(e) du har lagt inn dekker ikke hele avgiftsperiodene(e)
         </Nav.Alert>
       );
     default:

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
@@ -207,7 +207,7 @@ export function Feilmelding({ type }: { type?: string }) {
     case TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN:
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          Skatteforholdsperioden(e) du har lagt inn dekker ikke hele avgiftsperiodene(e)
+          Skatteforholdsperioden(e) du har lagt inn dekker ikke hele avgiftsperioden(e)
         </Nav.Alert>
       );
     case TypeFeilmelding.OVERLAPPENDE_SKATTEFORHOLDSPERIODER:
@@ -225,7 +225,7 @@ export function Feilmelding({ type }: { type?: string }) {
     case TypeFeilmelding.INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN:
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          Inntektsperioden(e) du har lagt inn dekker ikke hele avgiftsperiodene(e)
+          Inntektsperioden(e) du har lagt inn dekker ikke hele avgiftsperioden(e)
         </Nav.Alert>
       );
     default:

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
@@ -34,7 +34,7 @@ function BestemmelseSelect({
   lagreMedlemskapsperioderHvisGyldig,
   harLaasteMedlemskapsperioder,
 }: BestemmelseSelectProps) {
-  const medlemskapsperioder = useWatch({ control, name: "avgiftspliktigperioder" });
+  const avgiftspliktigperioder = useWatch({ control, name: "avgiftspliktigperioder" });
   const inntektskilder = useWatch({ control, name: "inntektskilder" });
 
   const handleBestemmelseChange = useCallback(
@@ -47,7 +47,7 @@ function BestemmelseSelect({
 
         try {
           if (
-            medlemskapsperioder.some(
+            avgiftspliktigperioder.some(
               (periode: MedlemskapsperiodeFieldProps) => periode.id !== ULAGRET_MEDLEMSKAPSPERIODE_ID,
             )
           ) {
@@ -61,7 +61,7 @@ function BestemmelseSelect({
 
         const defaultTrygdedekning = trygdedekningerResponse.length === 1 ? trygdedekningerResponse[0] : "";
 
-        const oppdaterteMedlemskapsperioder = medlemskapsperioder.map((periode: MedlemskapsperiodeFieldProps) => ({
+        const oppdaterteMedlemskapsperioder = avgiftspliktigperioder.map((periode: MedlemskapsperiodeFieldProps) => ({
           ...periode,
           trygdedekning: defaultTrygdedekning,
           id: ULAGRET_MEDLEMSKAPSPERIODE_ID,
@@ -86,7 +86,7 @@ function BestemmelseSelect({
       }
     },
     [
-      medlemskapsperioder,
+      avgiftspliktigperioder,
       inntektskilder,
       setValue,
       setTrygdedekninger,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
@@ -34,7 +34,7 @@ function BestemmelseSelect({
   lagreMedlemskapsperioderHvisGyldig,
   harLaasteMedlemskapsperioder,
 }: BestemmelseSelectProps) {
-  const medlemskapsperioder = useWatch({ control, name: "medlemskapsperioder" });
+  const medlemskapsperioder = useWatch({ control, name: "avgiftspliktigperioder" });
   const inntektskilder = useWatch({ control, name: "inntektskilder" });
 
   const handleBestemmelseChange = useCallback(
@@ -66,7 +66,7 @@ function BestemmelseSelect({
           trygdedekning: defaultTrygdedekning,
           id: ULAGRET_MEDLEMSKAPSPERIODE_ID,
         }));
-        setValue("medlemskapsperioder", oppdaterteMedlemskapsperioder);
+        setValue("avgiftspliktigperioder", oppdaterteMedlemskapsperioder);
 
         setValue(
           "inntektskilder",

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
@@ -6,7 +6,10 @@ import MKV from "../../../../../melosyskodeverk";
 import * as Api from "../../../../../services/api";
 import { Inntektskilde } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
 import * as Utils from "../../../../../utils";
-import { ULAGRET_MEDLEMSKAPSPERIODE_ID } from "../aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
+import {
+  erUlagretPeriode,
+  ULAGRET_MEDLEMSKAPSPERIODE_ID,
+} from "../aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
 import { MedlemskapsperiodeFieldProps } from "../aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
 
 interface BestemmelseSelectProps {
@@ -46,11 +49,7 @@ function BestemmelseSelect({
         setTrygdedekninger(trygdedekningerResponse);
 
         try {
-          if (
-            avgiftspliktigperioder.some(
-              (periode: MedlemskapsperiodeFieldProps) => periode.id !== ULAGRET_MEDLEMSKAPSPERIODE_ID,
-            )
-          ) {
+          if (avgiftspliktigperioder.some((periode: MedlemskapsperiodeFieldProps) => erUlagretPeriode(periode.id))) {
             await Api.MedlemAvFolketrygden.Medlemskapsperioder.slettMedlemskapsperioder(behandlingID!);
           }
         } catch (error) {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
@@ -12,6 +12,10 @@ import {
   ULAGRET_MEDLEMSKAPSPERIODE_ID,
   MedlemskapsperiodeFieldProps,
 } from "../aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
+import type {
+  AarsavregningsPeriodeType,
+  HelseutgiftdekkesperiodeForAvgift,
+} from "../../../../../services/modules/types/periodeTyper";
 
 import { useEffect } from "react";
 import { FormValuesProps } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
@@ -69,9 +73,10 @@ export interface PeriodeElementerProps {
   trygdedekninger?: string[];
   setValue: (name: string, value: unknown, options?: { shouldValidate?: boolean; shouldDirty?: boolean }) => void;
   erDeltGrunnlag?: boolean;
+  periodeType?: AarsavregningsPeriodeType;
 }
 
-export function MedlemskapsperiodeSkjema({
+export function AvgiftspliktigperiodeSkjema({
   redigerbart,
   field,
   control,
@@ -85,13 +90,15 @@ export function MedlemskapsperiodeSkjema({
   trygdedekninger = [],
   setValue,
   erDeltGrunnlag = false,
+  periodeType,
 }: PeriodeElementerProps) {
+  const erHelseutgift = periodeType === "HELSEUTGIFTDEKKESPERIODE";
   const pliktigeBestemmelser = usePliktigeBestemmelser();
   const erPliktigBestemmelse = formValues.bestemmelse && pliktigeBestemmelser.includes(formValues.bestemmelse);
 
-  const medlemskapsperioder = formValues.medlemskapsperioder as MedlemskapsperiodeFieldProps[];
+  const medlemskapsperioder = formValues.avgiftspliktigperioder as MedlemskapsperiodeFieldProps[];
   const erPeriodeFraGrunnlag = !medlemskapsperioder[index]?.redigerbar;
-  const kanViseSletteKolonne = redigerbart && medlemskapsperioder.length > 1;
+  const kanViseSletteKolonne = !erHelseutgift && redigerbart && medlemskapsperioder.length > 1;
   const tilOgMedDatoForrigePeriode =
     medlemskapsperioder[index - 1] !== undefined
       ? Utils.dato.norskStringTilDate(medlemskapsperioder[index - 1]?.tomDato)
@@ -117,21 +124,23 @@ export function MedlemskapsperiodeSkjema({
   const erDennePeriodenSlettbar = kanPeriodeSlettes(gjeldendePeriodeForRad, medlemskapsperioder);
 
   useEffect(() => {
-    if (trygdedekninger?.length === 1) {
-      setValue(`medlemskapsperioder[${index}].trygdedekning`, trygdedekninger[0], { shouldValidate: true });
+    if (!erHelseutgift && trygdedekninger?.length === 1) {
+      setValue(`avgiftspliktigperioder[${index}].trygdedekning`, trygdedekninger[0], { shouldValidate: true });
     }
-  }, [trygdedekninger, index, setValue]);
+  }, [trygdedekninger, index, setValue, erHelseutgift]);
+
+  const periodeLabelTekst = erHelseutgift ? "Helseutgiftdekkes" : "Medlemskapsperiode";
 
   return (
     <>
       <Nav.Row className="periode__rad medlemskapsperiode__rad" key={field.id}>
         <Nav.Column className="dato">
           <Forms.Datovelger
-            label={index === 0 ? "Medlemskapsperiode" : ""}
+            label={index === 0 ? periodeLabelTekst : ""}
             control={control}
             minDate={safeMinDateForFom}
             maxDate={maxDate}
-            name={`medlemskapsperioder[${index}].fomDato`}
+            name={`avgiftspliktigperioder[${index}].fomDato`}
             aria-label={`Fra og med periode ${index + 1}`}
             readOnly={!redigerbart || erPeriodeFraGrunnlag}
           />
@@ -140,29 +149,50 @@ export function MedlemskapsperiodeSkjema({
           <Forms.Datovelger
             label={index === 0 ? <span className="invisible" /> : ""}
             control={control}
-            name={`medlemskapsperioder[${index}].tomDato`}
+            name={`avgiftspliktigperioder[${index}].tomDato`}
             aria-label={`Til og med periode ${index + 1}`}
             minDate={Utils.dato.norskStringTilDate(medlemskapsperioder[index].fomDato) || minDate}
             maxDate={maxDate}
             readOnly={!redigerbart || erPeriodeFraGrunnlag}
           />
         </Nav.Column>
-        <Nav.Column className="trygdedekning">
-          <Forms.Select
-            name={`medlemskapsperioder[${index}].trygdedekning`}
-            label={index === 0 ? "Dekning" : ""}
-            hideLabel={index !== 0}
-            aria-label={`Trygdedekning periode ${index + 1}`}
-            control={control}
-            readOnly={!redigerbart || erPeriodeFraGrunnlag || kunEnTrygdedekning}
-          >
-            {trygdedekninger?.map((dekning) => (
-              <option key={dekning} value={dekning}>
-                {KV.kodeTilTerm(dekning, MKV.KTObjects.trygdedekninger)}
-              </option>
-            ))}
-          </Forms.Select>
-        </Nav.Column>
+        {!erHelseutgift && (
+          <Nav.Column className="trygdedekning">
+            <Forms.Select
+              name={`avgiftspliktigperioder[${index}].trygdedekning`}
+              label={index === 0 ? "Dekning" : ""}
+              hideLabel={index !== 0}
+              aria-label={`Trygdedekning periode ${index + 1}`}
+              control={control}
+              readOnly={!redigerbart || erPeriodeFraGrunnlag || kunEnTrygdedekning}
+            >
+              {trygdedekninger?.map((dekning) => (
+                <option key={dekning} value={dekning}>
+                  {KV.kodeTilTerm(dekning, MKV.KTObjects.trygdedekninger)}
+                </option>
+              ))}
+            </Forms.Select>
+          </Nav.Column>
+        )}
+        {erHelseutgift && (
+          <Nav.Column className="trygdedekning">
+            <Forms.Select
+              name={`avgiftspliktigperioder[${index}].bostedLandkode`}
+              label={index === 0 ? "Bostedsland" : ""}
+              hideLabel={index !== 0}
+              aria-label={`Bostedsland periode ${index + 1}`}
+              control={control}
+              readOnly={!redigerbart || erPeriodeFraGrunnlag}
+              emptyFieldDisabled={!!(medlemskapsperioder[index] as HelseutgiftdekkesperiodeForAvgift)?.bostedLandkode}
+            >
+              {MKV.KTObjects.landkoder.map((item: any) => (
+                <option key={item.kode} value={item.kode}>
+                  {Utils.land.landTekstFormat(item)}
+                </option>
+              ))}
+            </Forms.Select>
+          </Nav.Column>
+        )}
         {kanViseSletteKolonne && (
           <Nav.Column className={index === 0 ? "slett__knapp slett__first" : "slett__knapp"}>
             <Mui.IkonKnapp
@@ -174,7 +204,7 @@ export function MedlemskapsperiodeSkjema({
           </Nav.Column>
         )}
       </Nav.Row>
-      {medlemskapsperioder.length === index + 1 && (!erPliktigBestemmelse || erDeltGrunnlag) && (
+      {!erHelseutgift && medlemskapsperioder.length === index + 1 && (!erPliktigBestemmelse || erDeltGrunnlag) && (
         <div className="legg-til__rad">
           <Mui.Lenkeknapp onClick={handleLeggTil} ikon={Ikoner.Add} disabled={!redigerbart || !visLeggTil}>
             Legg til periode

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.test.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.test.ts
@@ -11,10 +11,12 @@ import {
   mapTilInntektskilderProps,
   mapTilSkatteforholdProps,
 } from "./utils";
-import { Avgiftspliktigperiode } from "../../../../services/modules/types/periodeTyper";
+import { MedlemskapsperiodeForAvgift } from "../../../../services/modules/types/periodeTyper";
 
 // Helper function to create mock Medlemskapsperiode
-const createMockMedlemskapsperiode = (overrides?: Partial<Avgiftspliktigperiode>): Avgiftspliktigperiode => ({
+const createMockMedlemskapsperiode = (
+  overrides?: Partial<MedlemskapsperiodeForAvgift>,
+): MedlemskapsperiodeForAvgift => ({
   type: "MEDLEMSKAPSPERIODE",
   id: 1,
   fomDato: "01.01.2023",

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
@@ -70,16 +70,18 @@ export function beregnTrygdeavgiftsperioder(
   options: {
     behandlingID: number;
     medlemskapstypeErPliktig?: boolean;
+    erEøsPensjonist?: boolean;
     setFeilmelding: (error: string | string[] | undefined) => void;
     setAarsavregningResponse: (response: AarsavregningResponse) => void;
   },
 ) {
-  const { behandlingID, medlemskapstypeErPliktig, setFeilmelding, setAarsavregningResponse } = options;
+  const { behandlingID, medlemskapstypeErPliktig, erEøsPensjonist, setFeilmelding, setAarsavregningResponse } = options;
 
   setFeilmelding(undefined);
   const erBrukerPliktigMedlemOgSkattepliktig =
     medlemskapstypeErPliktig && erBrukerSkattepliktigIHelePerioden(formVerdier.skatteforholdsperioder);
-  return Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
+
+  const trygdeavgiftsgrunnlag = {
     skatteforholdsperioder: formVerdier.skatteforholdsperioder.map((skatteforhold: Skatteforhold) => ({
       fomDato: Utils.dato.formatterDatoTilISO(skatteforhold.fomDato),
       tomDato: Utils.dato.formatterDatoTilISO(skatteforhold.tomDato, null),
@@ -95,7 +97,13 @@ export function beregnTrygdeavgiftsperioder(
           erMaanedsbelop: Utils.streng.uppercaseStrengTilBool(inntektskilde.erMaanedsbelop) || false,
         }))
       : [],
-  })
+  };
+
+  const beregnTrygdeavgiftsperioder = erEøsPensjonist
+    ? Api.Trygdeavgift.eøsPensjonistBeregnTrygdeavgiftsperioder
+    : Api.Trygdeavgift.beregnTrygdeavgiftsperioder;
+
+  return beregnTrygdeavgiftsperioder(behandlingID, trygdeavgiftsgrunnlag)
     .then(() => {
       setFeilmelding(undefined);
       return Api.Aarsavregning.hentAarsavregning(behandlingID).then((response: AarsavregningResponse) => {
@@ -271,7 +279,6 @@ export const validateAarsavregningUtenEllerDeltGrunnlag = async (
         }
       }
     }
-
     // Returner basert på om vi fant relevante feil
     const hasErrors = Object.keys(validationErrors).length > 0;
     return { isValid: !hasErrors, errors: validationErrors };

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -301,7 +301,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
           {aarsavregningResponse && harTidligereTrygdeavgiftsgrunnlag === false && (
             <Nav.Alert variant="info" className="alertstripe_feilmelding">
               <Nav.BodyLong size="small">
-                Det er ingen informasjon om perioder med medlemskap og forskuddsvis fakturert trygdeavgift i Melosys.
+                Det er ingen informasjon om forskuddsvis fakturert trygdeavgift i Melosys.
               </Nav.BodyLong>
             </Nav.Alert>
           )}

--- a/tests/e2e/pages/behandling/aarsavregning.page.ts
+++ b/tests/e2e/pages/behandling/aarsavregning.page.ts
@@ -117,9 +117,9 @@ export class AarsavregningPage extends BehandlingPage {
 
   async getAntallMedlemskapsperioder(): Promise<number> {
     // Vent på at minst ett trygdedekning-felt er synlig før telling
-    const firstSelect = this.page.locator('select[name^="medlemskapsperioder["][name$="].trygdedekning"]').first();
+    const firstSelect = this.page.locator('select[name^="avgiftspliktigperioder["][name$="].trygdedekning"]').first();
     await expect(firstSelect, `${this.ctx}: Første trygdedekning-select skal være synlig`).toBeVisible();
-    return await this.page.locator('select[name^="medlemskapsperioder["][name$="].trygdedekning"]').count();
+    return await this.page.locator('select[name^="avgiftspliktigperioder["][name$="].trygdedekning"]').count();
   }
 
   // Skatteforholdsperiode operasjoner


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7636

Lagt til støtte for flere periodetyper (medlemskapsperiode, helseutgiftdekkesperiode, lovvalgsperiode) i årsavregning uten/delt grunnlag, med ny periodeApiAdapter som abstraherer CRUD-operasjoner per periodetype.
Refaktorert react-hook-form feltnavn fra medlemskapsperioder til avgiftspliktigperioder gjennom skjema, validering og tester for å reflektere at feltet nå håndterer alle periodetyper.