### PR TITLE
7938 Fiks race condition ved vedtaksfatting (SaksopplysningKilde)

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
@@ -238,6 +238,7 @@ export function VurderingArbeidTjenestepersonEllerFlyVedtak({
   }, [aktivtSteg, formValues?.vedtakstype, formValues?.kopiTilArbeidsgiver, mottatteOpplysningerStatus]);
 
   const onSubmit = async () => {
+    debouncedKontrollerBehandling.cancel?.();
     await validerMottatteOpplysninger();
     fattVedtak(behandlingID, lagFattVedtakEOSReqDto());
   };

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak_Legacy/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak_Legacy/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
@@ -298,15 +298,15 @@ export function VurderingArbeidTjenestepersonEllerFlyVedtak({
       );
     }
 
-    try {
-      await validerMottatteOpplysninger();
-      const res = await fattVedtak(behandlingID, lagFattVedtakEOSReqDto());
-      if (res.data?.data?.error) {
-        setVedtakPending(false);
-      }
-    } catch {
-      setVedtakPending(false);
-    }
+    validerMottatteOpplysninger()
+      .then(() => {
+        fattVedtak(behandlingID, lagFattVedtakEOSReqDto()).then((res) => {
+          if (res.data?.data?.error) {
+            setVedtakPending(false);
+          }
+        });
+      })
+      .catch(() => setVedtakPending(false));
   };
 
   const fom = Utils.dato.formatterDatoTilNorsk(

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak_Legacy/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak_Legacy/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
@@ -287,6 +287,8 @@ export function VurderingArbeidTjenestepersonEllerFlyVedtak({
   }, [aktivtSteg, formIsValid, formValues?.kopiTilArbeidsgiver, mottatteOpplysningerStatus]);
 
   const onSubmit = async (values, dispatch, props) => {
+    debouncedKontrollerBehandling.cancel?.();
+
     setVedtakPending(true);
 
     if (values.forkortLovvalgsperiode) {
@@ -296,15 +298,15 @@ export function VurderingArbeidTjenestepersonEllerFlyVedtak({
       );
     }
 
-    validerMottatteOpplysninger()
-      .then(() => {
-        fattVedtak(behandlingID, lagFattVedtakEOSReqDto()).then((res) => {
-          if (res.data?.data?.error) {
-            setVedtakPending(false);
-          }
-        });
-      })
-      .catch(() => setVedtakPending(false));
+    try {
+      await validerMottatteOpplysninger();
+      const res = await fattVedtak(behandlingID, lagFattVedtakEOSReqDto());
+      if (res.data?.data?.error) {
+        setVedtakPending(false);
+      }
+    } catch {
+      setVedtakPending(false);
+    }
   };
 
   const fom = Utils.dato.formatterDatoTilNorsk(

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
@@ -146,17 +146,19 @@ export function VurderingArtikkel13_x_vedtak({
   };
 
   const onSubmit = async () => {
+    debouncedKontrollerBehandling.cancel?.();
+
     setVedtakPending(true);
 
-    validerMottatteOpplysninger()
-      .then(() => {
-        fattVedtak(behandlingID, lagFattVedtakEOSReqDto()).then((res) => {
-          if (res.data?.data?.error) {
-            setVedtakPending(false);
-          }
-        });
-      })
-      .catch(() => setVedtakPending(false));
+    try {
+      await validerMottatteOpplysninger();
+      const res = await fattVedtak(behandlingID, lagFattVedtakEOSReqDto());
+      if (res.data?.data?.error) {
+        setVedtakPending(false);
+      }
+    } catch {
+      setVedtakPending(false);
+    }
   };
 
   const stegErGyldig = redigerbart && formIsValid && !harFeilmeldinger;

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
@@ -150,15 +150,15 @@ export function VurderingArtikkel13_x_vedtak({
 
     setVedtakPending(true);
 
-    try {
-      await validerMottatteOpplysninger();
-      const res = await fattVedtak(behandlingID, lagFattVedtakEOSReqDto());
-      if (res.data?.data?.error) {
-        setVedtakPending(false);
-      }
-    } catch {
-      setVedtakPending(false);
-    }
+    validerMottatteOpplysninger()
+      .then(() => {
+        fattVedtak(behandlingID, lagFattVedtakEOSReqDto()).then((res) => {
+          if (res.data?.data?.error) {
+            setVedtakPending(false);
+          }
+        });
+      })
+      .catch(() => setVedtakPending(false));
   };
 
   const stegErGyldig = redigerbart && formIsValid && !harFeilmeldinger;

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/vurderingArtikkel16Vedtak.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/vurderingArtikkel16Vedtak.tsx
@@ -170,6 +170,8 @@ export function VurderingArtikkel16Vedtak({
   };
 
   const vedKlikk = async () => {
+    debouncedKontrollerBehandling.cancel?.();
+
     if (!validerForm()) return;
 
     if (formValues.forkortLovvalgsperiode) {
@@ -178,24 +180,26 @@ export function VurderingArtikkel16Vedtak({
 
     setVedtakPending(true);
 
-    validerMottatteOpplysninger()
-      .then(() => {
-        const request = {
-          behandlingsresultatTypeKode: FASTSATT_LOVVALGSLAND,
-          fritekst: formValues.vedtaksbrevFritekst,
-          begrunnelseFritekst: formValues.vedtaksbrevFritekst,
-          fritekstSed: null,
-          mottakerinstitusjoner: null,
-          vedtakstype: formValues.vedtakstype || FØRSTEGANGSVEDTAK,
-          nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
-        };
-        dispatch(vedtakOperations.fatt(behandlingID, request)).then((res) => {
-          if (res.data?.data?.error) {
-            setVedtakPending(false);
-          }
-        });
-      })
-      .catch(() => setVedtakPending(false));
+    try {
+      await validerMottatteOpplysninger();
+
+      const request = {
+        behandlingsresultatTypeKode: FASTSATT_LOVVALGSLAND,
+        fritekst: formValues.vedtaksbrevFritekst,
+        begrunnelseFritekst: formValues.vedtaksbrevFritekst,
+        fritekstSed: null,
+        mottakerinstitusjoner: null,
+        vedtakstype: formValues.vedtakstype || FØRSTEGANGSVEDTAK,
+        nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
+      };
+
+      const res = await dispatch(vedtakOperations.fatt(behandlingID, request));
+      if (res.data?.data?.error) {
+        setVedtakPending(false);
+      }
+    } catch {
+      setVedtakPending(false);
+    }
   };
 
   const { anmodningsperiodeSvarType } = anmodningsperiodesvar;

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/vurderingArtikkel16Vedtak.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/vurderingArtikkel16Vedtak.tsx
@@ -180,26 +180,24 @@ export function VurderingArtikkel16Vedtak({
 
     setVedtakPending(true);
 
-    try {
-      await validerMottatteOpplysninger();
-
-      const request = {
-        behandlingsresultatTypeKode: FASTSATT_LOVVALGSLAND,
-        fritekst: formValues.vedtaksbrevFritekst,
-        begrunnelseFritekst: formValues.vedtaksbrevFritekst,
-        fritekstSed: null,
-        mottakerinstitusjoner: null,
-        vedtakstype: formValues.vedtakstype || FØRSTEGANGSVEDTAK,
-        nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
-      };
-
-      const res = await dispatch(vedtakOperations.fatt(behandlingID, request));
-      if (res.data?.data?.error) {
-        setVedtakPending(false);
-      }
-    } catch {
-      setVedtakPending(false);
-    }
+    validerMottatteOpplysninger()
+      .then(() => {
+        const request = {
+          behandlingsresultatTypeKode: FASTSATT_LOVVALGSLAND,
+          fritekst: formValues.vedtaksbrevFritekst,
+          begrunnelseFritekst: formValues.vedtaksbrevFritekst,
+          fritekstSed: null,
+          mottakerinstitusjoner: null,
+          vedtakstype: formValues.vedtakstype || FØRSTEGANGSVEDTAK,
+          nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
+        };
+        dispatch(vedtakOperations.fatt(behandlingID, request)).then((res) => {
+          if (res.data?.data?.error) {
+            setVedtakPending(false);
+          }
+        });
+      })
+      .catch(() => setVedtakPending(false));
   };
 
   const { anmodningsperiodeSvarType } = anmodningsperiodesvar;

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -244,27 +244,25 @@ function VurderingVedtak({
 
     setVedtakPending(true);
 
-    try {
-      await validerMottatteOpplysninger();
-
-      const vedtakRequest = {
-        behandlingsresultatTypeKode: FASTSATT_LOVVALGSLAND,
-        vedtakstype: formValues.vedtakstype || FØRSTEGANGSVEDTAK,
-        fritekst: formValues.vedtaksbrevFritekst,
-        begrunnelseFritekst: formValues.vedtaksbrevFritekst,
-        fritekstSed: formValues.fritekstSed,
-        kopiTilArbeidsgiver: formValues.kopiTilArbeidsgiver,
-        mottakerinstitusjoner: visMottakerinstitusjoner ? [formValues.mottakerinstitusjon] : [],
-        nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
-      };
-
-      const res = await dispatch(vedtakOperations.fatt(behandlingID, vedtakRequest));
-      if (res.data?.data?.error) {
-        setVedtakPending(false);
-      }
-    } catch {
-      setVedtakPending(false);
-    }
+    validerMottatteOpplysninger()
+      .then(() => {
+        const vedtakRequest = {
+          behandlingsresultatTypeKode: FASTSATT_LOVVALGSLAND,
+          vedtakstype: formValues.vedtakstype || FØRSTEGANGSVEDTAK,
+          fritekst: formValues.vedtaksbrevFritekst,
+          begrunnelseFritekst: formValues.vedtaksbrevFritekst,
+          fritekstSed: formValues.fritekstSed,
+          kopiTilArbeidsgiver: formValues.kopiTilArbeidsgiver,
+          mottakerinstitusjoner: visMottakerinstitusjoner ? [formValues.mottakerinstitusjon] : [],
+          nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
+        };
+        dispatch(vedtakOperations.fatt(behandlingID, vedtakRequest)).then((res) => {
+          if (res.data?.data?.error) {
+            setVedtakPending(false);
+          }
+        });
+      })
+      .catch(() => setVedtakPending(false));
   };
 
   const { fomDato, tomDato, lovvalgsbestemmelse, tilleggBestemmelse } = lovvalgsperiode;

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -236,29 +236,35 @@ function VurderingVedtak({
   };
 
   const onSubmit = async () => {
+    // Cancel any pending debounced kontroll to prevent concurrent HTTP requests
+    // that race with vedtak/fatt on SaksopplysningKilde entities
+    debouncedKontrollerBehandling.cancel?.();
+
     if (!validerForm()) return;
 
     setVedtakPending(true);
 
-    validerMottatteOpplysninger()
-      .then(() => {
-        const vedtakRequest = {
-          behandlingsresultatTypeKode: FASTSATT_LOVVALGSLAND,
-          vedtakstype: formValues.vedtakstype || FØRSTEGANGSVEDTAK,
-          fritekst: formValues.vedtaksbrevFritekst,
-          begrunnelseFritekst: formValues.vedtaksbrevFritekst,
-          fritekstSed: formValues.fritekstSed,
-          kopiTilArbeidsgiver: formValues.kopiTilArbeidsgiver,
-          mottakerinstitusjoner: visMottakerinstitusjoner ? [formValues.mottakerinstitusjon] : [],
-          nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
-        };
-        dispatch(vedtakOperations.fatt(behandlingID, vedtakRequest)).then((res) => {
-          if (res.data?.data?.error) {
-            setVedtakPending(false);
-          }
-        });
-      })
-      .catch(() => setVedtakPending(false));
+    try {
+      await validerMottatteOpplysninger();
+
+      const vedtakRequest = {
+        behandlingsresultatTypeKode: FASTSATT_LOVVALGSLAND,
+        vedtakstype: formValues.vedtakstype || FØRSTEGANGSVEDTAK,
+        fritekst: formValues.vedtaksbrevFritekst,
+        begrunnelseFritekst: formValues.vedtaksbrevFritekst,
+        fritekstSed: formValues.fritekstSed,
+        kopiTilArbeidsgiver: formValues.kopiTilArbeidsgiver,
+        mottakerinstitusjoner: visMottakerinstitusjoner ? [formValues.mottakerinstitusjon] : [],
+        nyVurderingBakgrunn: formValues.vedtakstypebegrunnelse,
+      };
+
+      const res = await dispatch(vedtakOperations.fatt(behandlingID, vedtakRequest));
+      if (res.data?.data?.error) {
+        setVedtakPending(false);
+      }
+    } catch {
+      setVedtakPending(false);
+    }
   };
 
   const { fomDato, tomDato, lovvalgsbestemmelse, tilleggBestemmelse } = lovvalgsperiode;


### PR DESCRIPTION
[MELOSYS-7938](https://jira.adeo.no/browse/MELOSYS-7938)

## Sammendrag

Cancel debounced `kontrollerFerdigbehandling` i `onSubmit` i alle vedtak-komponenter for å forhindre at den overlapper med `vedtak/fatt`-kallet.

### Problem

Vedtak-komponenter har en debounced `kontrollerFerdigbehandling` (500ms) som trigges av useEffect på form-endringer. Når bruker klikker "Fatt vedtak", kan denne kontroll-requesten være in-flight eller pending. Både `kontroll/ferdigbehandling` og `vedtak/fatt` kaller `RegisteropplysningerService.hentOgLagreOpplysninger()` for samme behandling, som gir `OptimisticLockingFailureException` på `SaksopplysningKilde`.

Dette forårsaker ~47% flaky rate på "arbeid i flere land"-tester i E2E.

### Løsning

Lagt til `debouncedKontrollerBehandling.cancel?.()` i `onSubmit` i alle vedtak-komponenter. Beholder eksisterende `.then()`-mønster per review-tilbakemelding.

`vedtak/fatt` → `EosVedtakService.fattVedtak()` kjører allerede `kontrollerVedtakMedRegisteropplysninger` internt, så den debounced kontroll er **redundant** ved submit.

### Endrede filer

- `vurderingVedtak.tsx` (EU/EOS)
- `vurderingArtikkel13_x_vedtak.jsx`
- `vurderingArtikkel16Vedtak.tsx`
- `vurderingArbeidTjenestepersonEllerFlyVedtak.jsx` (begge varianter)

### Sikkerhetsanalyse

**Edge case:** Hvis bruker klikker "Fatt vedtak" innenfor 500ms etter navigering til vedtak-steget, cancelles den første kontroll-kallet (som viser warning-bannere). Men vedtak-endepunktets interne kontroll fanger de samme feilene og returnerer `ValideringException` — bruker får samme tilbakemelding uansett.

### Validering

Validert sammen med backend-fix (lock + debounce i RegisteropplysningerService):
- 4 konsekutive CI-kjøringer med `repeat_each=20`: **0/320 feil** (fix-7)
- fix-9 (denne koden + cancel i alle komponenter) under validering

Frontend-fix alene (uten backend-fix) reduserte rate fra ~47% til ~17% — begge trengs.

### Relatert

- Backend-fix i melosys-api: [PR #3233](https://github.com/navikt/melosys-api/pull/3233) (lock + debounce i RegisteropplysningerService)
- [Komplett rapport](https://github.com/navikt/melosys-e2e-tests/blob/feature/api-recording-system/docs/reports/saksopplysningkilde-complete-fix-2026-02-25.md)

## Testing
- [x] Lokal test bestått
- [x] CI: 0/320 feil over 4 kjøringer (fix-7, sammen med backend-fix)
- [ ] CI: fix-9 validering pågår (run 22487928800)