### PR TITLE
NOJIRA G4P Prodsetting dato for 11.3.b

### DIFF
--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -12,7 +12,11 @@ import momentTZ from "moment-timezone";
  */
 const MAX_AR_FREM_I_TID = 10;
 
-const FLYT_PRODUKSJON_DATO_EØS_11_3_B = moment("2025-11-15T00:00:00Z");
+/**
+ * Z indikerer at datoen er i UTC tidssone, i vinteren er det 1 time forskjell mellom UTC og norsk tid.
+ * 08:00 er derfor kl 09:00 i norsk tid.
+ */
+const FLYT_PRODUKSJON_DATO_EØS_11_3_B = moment("2026-02-26T08:00:00Z");
 
 /** Gjør et beste forsøk på å vaske inputdato. Dersom vask ikke er mulig (feks ved helt feil datoformat eller
  * ugyldig dato, returner false.


### PR DESCRIPTION
Vi har visnings logikker i 11.3.b flyten som er baserer seg på datoen flyten blir prodsatt.
Oppdaterer datoen/tiden til der den prodsettes. 