### PR TITLE
7921 Oppdatere valideringer - med og uten grunnlag

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagForm.tsx
@@ -102,6 +102,7 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
     context: {
       avgiftspliktigperiode,
       medlemskapsTypeErPliktig: medlemskapstypeErPliktig,
+      erHelseutgiftDekkesPeriode,
     },
     mode: "onChange",
     defaultValues: initiellData.formDefaultValues,
@@ -399,7 +400,9 @@ export function AarsavregningMedGrunnlagForm({ initiellData, bekreft, oppdaterSt
               </Nav.ExpansionCard>
             )}
 
-          {arrayValideringsfeil && <Feilmelding type={arrayValideringsfeil} />}
+          {arrayValideringsfeil && (
+            <Feilmelding type={arrayValideringsfeil} erHelseutgiftDekkesPeriode={erHelseutgiftDekkesPeriode} />
+          )}
         </BorderedFormContainer>
       )}
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -17,7 +17,7 @@ const {
 } = MKV.Koder.inntektskildetype;
 const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 const UTENFOR_MEDLEMSKAPSPERIODEN = { melding: "Utenfor medl.periode" };
-const UTENFOR_HELSEDUTGIFTDEKKESPERIODEN = { melding: "Utenfor periode Norge dekker helseutgifter" };
+const UTENFOR_HELSEUTGIFTDEKKESPERIODEN = { melding: "Utenfor periode Norge dekker helseutgifter" };
 
 export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
   !medlemskapsTypeErPliktig && kildetype !== MISJONÆR;
@@ -74,7 +74,7 @@ const erInnenforAvgiftspliktigperiodeTest = {
 
       if (!erInnenfor) {
         return this.createError({
-          message: erHelseutgiftDekkesPeriode ? UTENFOR_HELSEDUTGIFTDEKKESPERIODEN : UTENFOR_MEDLEMSKAPSPERIODEN,
+          message: erHelseutgiftDekkesPeriode ? UTENFOR_HELSEUTGIFTDEKKESPERIODEN : UTENFOR_MEDLEMSKAPSPERIODEN,
         });
       }
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.jsx
@@ -17,6 +17,7 @@ const {
 } = MKV.Koder.inntektskildetype;
 const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 const UTENFOR_MEDLEMSKAPSPERIODEN = { melding: "Utenfor medl.periode" };
+const UTENFOR_HELSEDUTGIFTDEKKESPERIODEN = { melding: "Utenfor periode Norge dekker helseutgifter" };
 
 export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
   !medlemskapsTypeErPliktig && kildetype !== MISJONÆR;
@@ -56,13 +57,12 @@ const bruttoInntektFyltUtNårDetKrevesTest = {
 };
 
 const erInnenforAvgiftspliktigperiodeTest = {
-  name: "erInnenforMedlemskapsperiode",
-  message: UTENFOR_MEDLEMSKAPSPERIODEN,
-  test: (datoString, schema) => {
+  name: "erInnenforAvgiftspliktigperiode",
+  test: function (datoString, schema) {
     if (!datoString) return true;
 
     try {
-      const { avgiftspliktigperiode } = schema.options.context;
+      const { avgiftspliktigperiode, erHelseutgiftDekkesPeriode } = schema.options.context;
 
       const avgiftspliktigperiodeFom = Utils.dato.formatterDatoTilISO(avgiftspliktigperiode.fomDato);
       const avgiftspliktigperiodeTom = Utils.dato.formatterDatoTilISO(avgiftspliktigperiode.tomDato);
@@ -70,7 +70,15 @@ const erInnenforAvgiftspliktigperiodeTest = {
 
       if (!isoDatoString) return false;
 
-      return isoDatoString >= avgiftspliktigperiodeFom && isoDatoString <= avgiftspliktigperiodeTom;
+      const erInnenfor = isoDatoString >= avgiftspliktigperiodeFom && isoDatoString <= avgiftspliktigperiodeTom;
+
+      if (!erInnenfor) {
+        return this.createError({
+          message: erHelseutgiftDekkesPeriode ? UTENFOR_HELSEDUTGIFTDEKKESPERIODEN : UTENFOR_MEDLEMSKAPSPERIODEN,
+        });
+      }
+
+      return true;
     } catch (error) {
       return false;
     }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.test.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/aarsavregningMedGrunnlagSchema.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import aarsavregningMedGrunnlagSchema from "./aarsavregningMedGrunnlagSchema";
+import MKV from "../../../../../melosyskodeverk";
+
+const { OPPLYSNINGER_ENDRET } = MKV.Koder.endeligAvgiftValg;
+
+const validate = async (values: Record<string, unknown>, context: Record<string, unknown> = {}) => {
+  try {
+    await aarsavregningMedGrunnlagSchema.validate(values, {
+      abortEarly: false,
+      context,
+    });
+    return null;
+  } catch (e: any) {
+    return e;
+  }
+};
+
+const hasError = (
+  err: {
+    inner?: { path?: string; message?: string | { melding?: string } }[];
+    path?: string;
+    message?: string | { melding?: string };
+  } | null,
+  path: string,
+  message?: string,
+) => {
+  if (!err) return false;
+  const errors = Array.isArray(err.inner) ? err.inner : [err];
+  return errors.some((e) => {
+    const matchesPath = e.path === path;
+    if (!message) return matchesPath;
+
+    const errorMessage = typeof e.message === "string" ? e.message : e.message?.melding;
+    return matchesPath && errorMessage === message;
+  });
+};
+
+describe("aarsavregningMedGrunnlagSchema - erInnenforAvgiftspliktigperiodeTest dynamiske feilmeldinger", () => {
+  const baseContext = {
+    avgiftspliktigperiode: { fomDato: "01.01.2024", tomDato: "30.06.2024" },
+    medlemskapsTypeErPliktig: true,
+    erHelseutgiftDekkesPeriode: false,
+  };
+
+  describe("Skatteforholdsperioder", () => {
+    it("skal vise 'Utenfor medl.periode' når skatteforhold er utenfor medlemskapsperiode", async () => {
+      const values = {
+        endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+        skatteforholdsperioder: [
+          {
+            fomDato: "01.01.2024",
+            tomDato: "31.12.2024",
+            skatteplikttype: "SKATTEPLIKTIG",
+          },
+        ],
+        inntektskilder: [],
+      };
+
+      const err = await validate(values, { ...baseContext, erHelseutgiftDekkesPeriode: false });
+      expect(err).toBeTruthy();
+      expect(hasError(err, "skatteforholdsperioder[0].tomDato", "Utenfor medl.periode")).toBe(true);
+    });
+
+    it("skal vise 'Utenfor periode Norge dekker helseutgifter' når skatteforhold er utenfor helseutgiftdekkesperiode", async () => {
+      const values = {
+        endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+        skatteforholdsperioder: [
+          {
+            fomDato: "01.01.2024",
+            tomDato: "31.12.2024",
+            skatteplikttype: "SKATTEPLIKTIG",
+          },
+        ],
+        inntektskilder: [],
+      };
+
+      const err = await validate(values, { ...baseContext, erHelseutgiftDekkesPeriode: true });
+      expect(err).toBeTruthy();
+      expect(hasError(err, "skatteforholdsperioder[0].tomDato", "Utenfor periode Norge dekker helseutgifter")).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("Inntektskilder", () => {
+    it("skal vise 'Utenfor medl.periode' når inntektskilde er utenfor medlemskapsperiode", async () => {
+      const values = {
+        endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+        skatteforholdsperioder: [
+          {
+            fomDato: "01.01.2024",
+            tomDato: "30.06.2024",
+            skatteplikttype: "IKKE_SKATTEPLIKTIG",
+          },
+        ],
+        inntektskilder: [
+          {
+            kildetype: "NÆRINGSINNTEKT_FRA_NORGE",
+            fomDato: "01.01.2024",
+            tomDato: "31.12.2024",
+            bruttoInntekt: "500000",
+          },
+        ],
+      };
+
+      const err = await validate(values, {
+        ...baseContext,
+        medlemskapsTypeErPliktig: false,
+        erHelseutgiftDekkesPeriode: false,
+      });
+      expect(err).toBeTruthy();
+      expect(hasError(err, "inntektskilder[0].tomDato", "Utenfor medl.periode")).toBe(true);
+    });
+
+    it("skal vise 'Utenfor periode Norge dekker helseutgifter' når inntektskilde er utenfor helseutgiftdekkesperiode", async () => {
+      const values = {
+        endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+        skatteforholdsperioder: [
+          {
+            fomDato: "01.01.2024",
+            tomDato: "30.06.2024",
+            skatteplikttype: "IKKE_SKATTEPLIKTIG",
+          },
+        ],
+        inntektskilder: [
+          {
+            kildetype: "NÆRINGSINNTEKT_FRA_NORGE",
+            fomDato: "01.01.2024",
+            tomDato: "31.12.2024",
+            bruttoInntekt: "500000",
+          },
+        ],
+      };
+
+      const err = await validate(values, {
+        ...baseContext,
+        medlemskapsTypeErPliktig: false,
+        erHelseutgiftDekkesPeriode: true,
+      });
+      expect(err).toBeTruthy();
+      expect(hasError(err, "inntektskilder[0].tomDato", "Utenfor periode Norge dekker helseutgifter")).toBe(true);
+    });
+  });
+});

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.test.tsx
@@ -85,9 +85,26 @@ describe("Feilmelding", () => {
     expect(screen.getByText(/oppholdsperioder/)).toBeDefined();
   });
 
-  it("rendrer inntektskilder dekker ikke", () => {
+  it("rendrer skatteforhold dekker ikke for medlemskapsperiode (default)", () => {
+    render(<Feilmelding type="SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN" />);
+    expect(screen.getByText(/hele medlemskapsperioden\(e\)/)).toBeDefined();
+  });
+
+  it("rendrer skatteforhold dekker ikke for helseutgiftdekkesperiode", () => {
+    render(<Feilmelding type="SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN" erHelseutgiftDekkesPeriode={true} />);
+    expect(screen.getByText(/hele perioden Norge dekker helseutgifter/)).toBeDefined();
+  });
+
+  it("rendrer inntektskilder dekker ikke for medlemskapsperiode (default)", () => {
     render(<Feilmelding type="INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN" />);
-    expect(screen.getByText(/Inntektsperioden/)).toBeDefined();
+    expect(screen.getByText(/hele medlemskapsperioden\(e\)/)).toBeDefined();
+  });
+
+  it("rendrer inntektskilder dekker ikke for helseutgiftdekkesperiode", () => {
+    render(
+      <Feilmelding type="INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN" erHelseutgiftDekkesPeriode={true} />,
+    );
+    expect(screen.getByText(/hele perioden Norge dekker helseutgifter/)).toBeDefined();
   });
 
   it("rendrer default tom div", () => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningMedGrunnlag/valideringsfeil.tsx
@@ -164,12 +164,20 @@ export function finnAktivFeilmelding({
   return undefined;
 }
 
-export function Feilmelding({ type }: { type?: string }) {
+export function Feilmelding({
+  type,
+  erHelseutgiftDekkesPeriode,
+}: {
+  type?: string;
+  erHelseutgiftDekkesPeriode?: boolean;
+}) {
   switch (type) {
     case TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN:
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          Skatteforholdsperioden(e) du har lagt inn dekker ikke hele medlemskapsperioden(e)
+          {erHelseutgiftDekkesPeriode
+            ? "Skatteforholdsperioden(e) du har lagt inn dekker ikke hele perioden Norge dekker helseutgifter"
+            : "Skatteforholdsperioden(e) du har lagt inn dekker ikke hele medlemskapsperioden(e)"}
         </Nav.Alert>
       );
     case TypeFeilmelding.OVERLAPPENDE_SKATTEFORHOLDSPERIODER:
@@ -187,7 +195,9 @@ export function Feilmelding({ type }: { type?: string }) {
     case TypeFeilmelding.INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN:
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          Inntektsperioden(e) du har lagt inn dekker ikke hele medlemskapsperioden(e)
+          {erHelseutgiftDekkesPeriode
+            ? "Inntektsperioden(e) du har lagt inn dekker ikke hele perioden Norge dekker helseutgifter"
+            : "Inntektsperioden(e) du har lagt inn dekker ikke hele medlemskapsperioden(e)"}
         </Nav.Alert>
       );
     case TypeFeilmelding.HAR_OPPHOLDSPERIODER_SKATTEFORHOLD:

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -38,6 +38,7 @@ import { TrygdeavgiftFraAvgiftssystemetInput } from "../komponenter/trygdeavgift
 import {
   beregnTrygdeavgiftsperioder,
   erBrukerSkattepliktigIHelePerioden,
+  erGyldigeMedlemskapsperiodeDatoerForAutoUtfylling,
   hentMedlemskapsFomTomDato,
   validateAarsavregningUtenEllerDeltGrunnlag,
 } from "../utils";
@@ -190,17 +191,22 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     !!initiellData.aarsavregningResponse?.sisteGjeldendeAvgiftspliktigperioder &&
     initiellData.aarsavregningResponse.sisteGjeldendeAvgiftspliktigperioder.length > 0;
 
-  const finnMedlemskapsperiode = useCallback((perioder: MedlemskapsperiodeFieldProps[]) => {
-    const sorterteGyldigePerioder = perioder
-      .filter((periode: MedlemskapsperiodeFieldProps) => periode.fomDato && periode.tomDato)
-      .sort(Utils.dato.sorterEtterNorskFomDato);
-    const medlemskapsperiodeFomTom = hentMedlemskapsFomTomDato(sorterteGyldigePerioder);
+  const finnMedlemskapsperiode = useCallback(
+    (perioder: MedlemskapsperiodeFieldProps[]) => {
+      const sorterteGyldigePerioder = perioder
+        .filter((periode: MedlemskapsperiodeFieldProps) =>
+          erGyldigeMedlemskapsperiodeDatoerForAutoUtfylling(periode.fomDato, periode.tomDato, initiellData.valgtÅr),
+        )
+        .sort(Utils.dato.sorterEtterNorskFomDato);
+      const medlemskapsperiodeFomTom = hentMedlemskapsFomTomDato(sorterteGyldigePerioder);
 
-    return {
-      fomDato: Utils.dato.vaskOgFormatterDatoTilNorsk(medlemskapsperiodeFomTom?.fom),
-      tomDato: Utils.dato.vaskOgFormatterDatoTilNorsk(medlemskapsperiodeFomTom?.tom),
-    };
-  }, []);
+      return {
+        fomDato: Utils.dato.vaskOgFormatterDatoTilNorsk(medlemskapsperiodeFomTom?.fom),
+        tomDato: Utils.dato.vaskOgFormatterDatoTilNorsk(medlemskapsperiodeFomTom?.tom),
+      };
+    },
+    [initiellData.valgtÅr],
+  );
 
   const medlemskapsperiode = useMemo(() => {
     return finnMedlemskapsperiode(medlemskapsperioder);
@@ -233,6 +239,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
       type: periode.type,
       trygdedekning: erMedlemskapsperiodeEllerLovvalgsperiode(periode) ? periode.trygdedekning : "",
       medlemskapstype: erMedlemskapsperiodeEllerLovvalgsperiode(periode) ? periode.medlemskapstype : "PLIKTIG",
+      bostedLandkode: erHelseutgiftdekkesperiode(periode) ? periode.bostedLandkode : "",
     })),
     trygdeavgiftFraAvgiftssystemet: trygdeavgiftFraAvgiftssystemetParam,
     endeligAvgiftValg: endeligAvgiftValgFormState,

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -304,7 +304,6 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
     },
     [medlemskapstypeErPliktig, setFeilmelding, setAarsavregningResponse],
   );
-
   const debouncedBeregning = useCallback(() => {
     setDebouncedBeregningPagaar(false);
     if (
@@ -902,7 +901,9 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
               </Nav.ExpansionCard>
             )}
 
-          {arrayValideringsfeil && <Feilmelding type={arrayValideringsfeil} />}
+          {arrayValideringsfeil && (
+            <Feilmelding type={arrayValideringsfeil} erHelseutgiftDekkesPeriode={erHelseutgift} />
+          )}
         </BorderedFormContainer>
       )}
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
@@ -18,6 +18,7 @@ const {
   PENSJON_UFØRETRYGD_KILDESKATT,
 } = MKV.Koder.inntektskildetype;
 const UTENFOR_MEDLEMSKAPSPERIODEN = { melding: "Utenfor medlemskapsperiode" };
+const UTENFOR_HELSEDUTGIFTDEKKESPERIODEN = { melding: "Utenfor periode Norge dekker helseutgifter" };
 const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
 export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
@@ -100,10 +101,9 @@ const åpenTomTest = {
 };
 
 // Simple test for checking if a date is within medlemskapsperiode range
-const erInnenforMedlemskapsperiodeTest = {
-  name: "erInnenforMedlemskapsperiode",
-  message: UTENFOR_MEDLEMSKAPSPERIODEN,
-  test: (datoString, schema) => {
+const erInnenforAvgiftspliktigperiodeTest = {
+  name: "erInnenforAvgiftspliktigperiode",
+  test: function (datoString, schema) {
     if (Utils._isEmpty(datoString)) return true;
 
     // MELOSYS-7612: Valider kun komplette datoer for å unngå valideringsfeil under typing
@@ -121,12 +121,22 @@ const erInnenforMedlemskapsperiodeTest = {
     const fom = sortertePerioder[0].fomDato;
     const tom = sortertePerioder[sortertePerioder.length - 1].tomDato;
 
-    return Utils.dato.erIPeriode(
+    const erInnenfor = Utils.dato.erIPeriode(
       Utils.dato.vaskOgFormatterTilISO(fom),
       Utils.dato.vaskOgFormatterTilISO(tom),
       Utils.dato.vaskOgFormatterTilISO(datoString),
       "[]",
     );
+
+    if (!erInnenfor) {
+      const erHelseutgift =
+        avgiftspliktigperioder.length > 0 && avgiftspliktigperioder.every((p) => p.type === "HELSEUTGIFTDEKKESPERIODE");
+      return this.createError({
+        message: erHelseutgift ? UTENFOR_HELSEDUTGIFTDEKKESPERIODEN : UTENFOR_MEDLEMSKAPSPERIODEN,
+      });
+    }
+
+    return true;
   },
 };
 
@@ -150,13 +160,13 @@ const skatteforholdsperiodeSchema = object().shape({
     .required(MAA_FYLLES_UT)
     .erGyldigDato()
     .test(erInnenforValgtAarTest)
-    .test(erInnenforMedlemskapsperiodeTest),
+    .test(erInnenforAvgiftspliktigperiodeTest),
   tomDato: string()
     .required(MAA_FYLLES_UT)
     .erGyldigDato()
     .test(åpenTomTest)
     .test(erInnenforValgtAarTest)
-    .test(erInnenforMedlemskapsperiodeTest)
+    .test(erInnenforAvgiftspliktigperiodeTest)
     .erEtterDatofelt("fomDato"),
   skatteplikttype: string().required(MAA_FYLLES_UT),
 });
@@ -165,11 +175,11 @@ const inntektskildeSchema = object().shape({
   kildetype: string().required(MAA_FYLLES_UT),
   arbAvgBetales: string().test(arbAvgBetalesFyltUtNårDetKrevesTest).nullable(),
   bruttoInntekt: string().test(bruttoInntektFyltUtNårDetKrevesTest),
-  fomDato: string().required(MAA_FYLLES_UT).erGyldigDato().test(erInnenforMedlemskapsperiodeTest),
+  fomDato: string().required(MAA_FYLLES_UT).erGyldigDato().test(erInnenforAvgiftspliktigperiodeTest),
   tomDato: string()
     .required(MAA_FYLLES_UT)
     .erGyldigDato()
-    .test(erInnenforMedlemskapsperiodeTest)
+    .test(erInnenforAvgiftspliktigperiodeTest)
     .erEtterDatofelt("fomDato"),
 });
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
@@ -153,6 +153,11 @@ const medlemskapsperiodeSchema = object().shape({
     then: (schema) => schema.nullable().notRequired(),
     otherwise: (schema) => schema.required(MAA_FYLLES_UT),
   }),
+  bostedLandkode: string().when("type", {
+    is: (type) => type === "HELSEUTGIFTDEKKESPERIODE",
+    then: (schema) => schema.required(MAA_FYLLES_UT),
+    otherwise: (schema) => schema.nullable().notRequired(),
+  }),
 });
 
 const skatteforholdsperiodeSchema = object().shape({

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
@@ -18,7 +18,7 @@ const {
   PENSJON_UFØRETRYGD_KILDESKATT,
 } = MKV.Koder.inntektskildetype;
 const UTENFOR_MEDLEMSKAPSPERIODEN = { melding: "Utenfor medlemskapsperiode" };
-const UTENFOR_HELSEDUTGIFTDEKKESPERIODEN = { melding: "Utenfor periode Norge dekker helseutgifter" };
+const UTENFOR_HELSEUTGIFTDEKKESPERIODEN = { melding: "Utenfor periode Norge dekker helseutgifter" };
 const { OPPLYSNINGER_ENDRET, MANUELL_ENDELIG_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 
 export const arbAvgBetalesKreves = (kildetype, medlemskapsTypeErPliktig) =>
@@ -132,7 +132,7 @@ const erInnenforAvgiftspliktigperiodeTest = {
       const erHelseutgift =
         avgiftspliktigperioder.length > 0 && avgiftspliktigperioder.every((p) => p.type === "HELSEUTGIFTDEKKESPERIODE");
       return this.createError({
-        message: erHelseutgift ? UTENFOR_HELSEDUTGIFTDEKKESPERIODEN : UTENFOR_MEDLEMSKAPSPERIODEN,
+        message: erHelseutgift ? UTENFOR_HELSEUTGIFTDEKKESPERIODEN : UTENFOR_MEDLEMSKAPSPERIODEN,
       });
     }
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.test.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.test.ts
@@ -369,3 +369,145 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
     });
   });
 });
+
+describe("aarsavregningUtenEllerDeltGrunnlagSchema - erInnenforAvgiftspliktigperiodeTest dynamiske feilmeldinger", () => {
+  describe("Skatteforholdsperioder", () => {
+    it("skal vise 'Utenfor medlemskapsperiode' når skatteforhold er utenfor medlemskapsperiode", async () => {
+      const values = {
+        endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+        bestemmelse: "FTRL_2_7",
+        avgiftspliktigperioder: [
+          {
+            id: 1,
+            fomDato: "01.01.2024",
+            tomDato: "30.06.2024",
+            trygdedekning: "FULL_DEKNING",
+            medlemskapstype: PLIKTIG,
+            type: "MEDLEMSKAPSPERIODE",
+          },
+        ],
+        skatteforholdsperioder: [
+          {
+            id: 1,
+            fomDato: "01.01.2024",
+            tomDato: "31.12.2024",
+            skatteplikttype: "SKATTEPLIKTIG",
+          },
+        ],
+        inntektskilder: [],
+      };
+
+      const err = await validate(values, { aar: 2024 });
+      expect(err).toBeTruthy();
+      expect(hasError(err, "skatteforholdsperioder[0].tomDato", "Utenfor medlemskapsperiode")).toBe(true);
+    });
+
+    it("skal vise 'Utenfor periode Norge dekker helseutgifter' når skatteforhold er utenfor helseutgiftdekkesperiode", async () => {
+      const values = {
+        endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+        avgiftspliktigperioder: [
+          {
+            id: 1,
+            fomDato: "01.01.2024",
+            tomDato: "30.06.2024",
+            trygdedekning: "",
+            medlemskapstype: PLIKTIG,
+            type: "HELSEUTGIFTDEKKESPERIODE",
+          },
+        ],
+        skatteforholdsperioder: [
+          {
+            id: 1,
+            fomDato: "01.01.2024",
+            tomDato: "31.12.2024",
+            skatteplikttype: "SKATTEPLIKTIG",
+          },
+        ],
+        inntektskilder: [],
+      };
+
+      const err = await validate(values, { aar: 2024 });
+      expect(err).toBeTruthy();
+      expect(hasError(err, "skatteforholdsperioder[0].tomDato", "Utenfor periode Norge dekker helseutgifter")).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("Inntektskilder", () => {
+    it("skal vise 'Utenfor medlemskapsperiode' når inntektskilde er utenfor medlemskapsperiode", async () => {
+      const values = {
+        endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+        bestemmelse: "FTRL_2_7",
+        avgiftspliktigperioder: [
+          {
+            id: 1,
+            fomDato: "01.01.2024",
+            tomDato: "30.06.2024",
+            trygdedekning: "FULL_DEKNING",
+            medlemskapstype: "FRIVILLIG",
+            type: "MEDLEMSKAPSPERIODE",
+          },
+        ],
+        skatteforholdsperioder: [
+          {
+            id: 1,
+            fomDato: "01.01.2024",
+            tomDato: "30.06.2024",
+            skatteplikttype: "SKATTEPLIKTIG",
+          },
+        ],
+        inntektskilder: [
+          {
+            id: 1,
+            kildetype: "NÆRINGSINNTEKT_FRA_NORGE",
+            fomDato: "01.01.2024",
+            tomDato: "31.12.2024",
+            bruttoInntekt: "500000",
+          },
+        ],
+      };
+
+      const err = await validate(values, { aar: 2024 });
+      expect(err).toBeTruthy();
+      expect(hasError(err, "inntektskilder[0].tomDato", "Utenfor medlemskapsperiode")).toBe(true);
+    });
+
+    it("skal vise 'Utenfor periode Norge dekker helseutgifter' når inntektskilde er utenfor helseutgiftdekkesperiode", async () => {
+      const values = {
+        endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+        avgiftspliktigperioder: [
+          {
+            id: 1,
+            fomDato: "01.01.2024",
+            tomDato: "30.06.2024",
+            trygdedekning: "",
+            medlemskapstype: PLIKTIG,
+            type: "HELSEUTGIFTDEKKESPERIODE",
+          },
+        ],
+        skatteforholdsperioder: [
+          {
+            id: 1,
+            fomDato: "01.01.2024",
+            tomDato: "30.06.2024",
+            skatteplikttype: "IKKE_SKATTEPLIKTIG",
+          },
+        ],
+        inntektskilder: [
+          {
+            id: 1,
+            kildetype: "NÆRINGSINNTEKT_FRA_NORGE",
+            fomDato: "01.01.2024",
+            tomDato: "31.12.2024",
+            bruttoInntekt: "500000",
+          },
+        ],
+      };
+
+      const err = await validate(values, { aar: 2024 });
+      expect(err).toBeTruthy();
+      expect(hasError(err, "inntektskilder[0].tomDato", "Utenfor periode Norge dekker helseutgifter")).toBe(true);
+    });
+  });
+});

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.test.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.test.ts
@@ -370,6 +370,77 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
   });
 });
 
+describe("aarsavregningUtenEllerDeltGrunnlagSchema - bostedLandkode validering", () => {
+  it("skal kreve bostedLandkode for HELSEUTGIFTDEKKESPERIODE", async () => {
+    const values = {
+      endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+      avgiftspliktigperioder: [
+        {
+          id: 1,
+          fomDato: "01.01.2024",
+          tomDato: "31.12.2024",
+          type: "HELSEUTGIFTDEKKESPERIODE",
+          bostedLandkode: "",
+        },
+      ],
+      skatteforholdsperioder: [
+        { id: 1, fomDato: "01.01.2024", tomDato: "31.12.2024", skatteplikttype: "SKATTEPLIKTIG" },
+      ],
+      inntektskilder: [],
+    };
+
+    const err = await validate(values, { aar: 2024 });
+    expect(err).toBeTruthy();
+    expect(hasError(err, "avgiftspliktigperioder[0].bostedLandkode", "Må fylles ut")).toBe(true);
+  });
+
+  it("skal godta utfylt bostedLandkode for HELSEUTGIFTDEKKESPERIODE", async () => {
+    const values = {
+      endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+      avgiftspliktigperioder: [
+        {
+          id: 1,
+          fomDato: "01.01.2024",
+          tomDato: "31.12.2024",
+          type: "HELSEUTGIFTDEKKESPERIODE",
+          bostedLandkode: "SE",
+        },
+      ],
+      skatteforholdsperioder: [
+        { id: 1, fomDato: "01.01.2024", tomDato: "31.12.2024", skatteplikttype: "SKATTEPLIKTIG" },
+      ],
+      inntektskilder: [],
+    };
+
+    const err = await validate(values, { aar: 2024 });
+    expect(err).toBeNull();
+  });
+
+  it("skal ikke kreve bostedLandkode for MEDLEMSKAPSPERIODE", async () => {
+    const values = {
+      endeligAvgiftValg: OPPLYSNINGER_ENDRET,
+      bestemmelse: "FTRL_2_7",
+      avgiftspliktigperioder: [
+        {
+          id: 1,
+          fomDato: "01.01.2024",
+          tomDato: "31.12.2024",
+          trygdedekning: "FULL_DEKNING",
+          medlemskapstype: PLIKTIG,
+          type: "MEDLEMSKAPSPERIODE",
+        },
+      ],
+      skatteforholdsperioder: [
+        { id: 1, fomDato: "01.01.2024", tomDato: "31.12.2024", skatteplikttype: "SKATTEPLIKTIG" },
+      ],
+      inntektskilder: [],
+    };
+
+    const err = await validate(values, { aar: 2024 });
+    expect(err).toBeNull();
+  });
+});
+
 describe("aarsavregningUtenEllerDeltGrunnlagSchema - erInnenforAvgiftspliktigperiodeTest dynamiske feilmeldinger", () => {
   describe("Skatteforholdsperioder", () => {
     it("skal vise 'Utenfor medlemskapsperiode' når skatteforhold er utenfor medlemskapsperiode", async () => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.test.tsx
@@ -89,9 +89,26 @@ describe("Feilmelding", () => {
     expect(screen.getByText(/kan ikke overlappe/)).toBeDefined();
   });
 
-  it("rendrer skatteforhold dekker ikke", () => {
+  it("rendrer skatteforhold dekker ikke for medlemskapsperiode (default)", () => {
     render(<Feilmelding type="SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN" />);
-    expect(screen.getByText(/dekker ikke hele/)).toBeDefined();
+    expect(screen.getByText(/hele medlemskapsperioden\(e\)/)).toBeDefined();
+  });
+
+  it("rendrer skatteforhold dekker ikke for helseutgiftdekkesperiode", () => {
+    render(<Feilmelding type="SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN" erHelseutgiftDekkesPeriode={true} />);
+    expect(screen.getByText(/hele perioden Norge dekker helseutgifter/)).toBeDefined();
+  });
+
+  it("rendrer inntektskilder dekker ikke for medlemskapsperiode (default)", () => {
+    render(<Feilmelding type="INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN" />);
+    expect(screen.getByText(/hele medlemskapsperioden\(e\)/)).toBeDefined();
+  });
+
+  it("rendrer inntektskilder dekker ikke for helseutgiftdekkesperiode", () => {
+    render(
+      <Feilmelding type="INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN" erHelseutgiftDekkesPeriode={true} />,
+    );
+    expect(screen.getByText(/hele perioden Norge dekker helseutgifter/)).toBeDefined();
   });
 
   it("rendrer default tom div", () => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/valideringsfeil.tsx
@@ -190,7 +190,13 @@ export function finnAktivFeilmelding({
   return undefined;
 }
 
-export function Feilmelding({ type }: { type?: string }) {
+export function Feilmelding({
+  type,
+  erHelseutgiftDekkesPeriode,
+}: {
+  type?: string;
+  erHelseutgiftDekkesPeriode?: boolean;
+}) {
   switch (type) {
     case TypeFeilmelding.OVERLAPPENDE_MEDLEMSKAPSPERIODER:
       return (
@@ -207,7 +213,9 @@ export function Feilmelding({ type }: { type?: string }) {
     case TypeFeilmelding.SKATTEFORHOLD_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN:
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          Skatteforholdsperioden(e) du har lagt inn dekker ikke hele avgiftsperioden(e)
+          {erHelseutgiftDekkesPeriode
+            ? "Skatteforholdsperioden(e) du har lagt inn dekker ikke hele perioden Norge dekker helseutgifter"
+            : "Skatteforholdsperioden(e) du har lagt inn dekker ikke hele medlemskapsperioden(e)"}
         </Nav.Alert>
       );
     case TypeFeilmelding.OVERLAPPENDE_SKATTEFORHOLDSPERIODER:
@@ -225,7 +233,9 @@ export function Feilmelding({ type }: { type?: string }) {
     case TypeFeilmelding.INNTEKTSKILDER_DEKKER_IKKE_HELE_MEDLEMSKAPSPERIODEN:
       return (
         <Nav.Alert variant="error" className="alertstripe_feilmelding">
-          Inntektsperioden(e) du har lagt inn dekker ikke hele avgiftsperioden(e)
+          {erHelseutgiftDekkesPeriode
+            ? "Inntektsperioden(e) du har lagt inn dekker ikke hele perioden Norge dekker helseutgifter"
+            : "Inntektsperioden(e) du har lagt inn dekker ikke hele medlemskapsperioden(e)"}
         </Nav.Alert>
       );
     default:

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
@@ -6,10 +6,7 @@ import MKV from "../../../../../melosyskodeverk";
 import * as Api from "../../../../../services/api";
 import { Inntektskilde } from "../../../../../felleskomponenter/trygdeavgift/komponenter/types";
 import * as Utils from "../../../../../utils";
-import {
-  erUlagretPeriode,
-  ULAGRET_MEDLEMSKAPSPERIODE_ID,
-} from "../aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
+import { ULAGRET_MEDLEMSKAPSPERIODE_ID } from "../aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
 import { MedlemskapsperiodeFieldProps } from "../aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlag";
 
 interface BestemmelseSelectProps {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/bestemmelseSelect.tsx
@@ -49,7 +49,11 @@ function BestemmelseSelect({
         setTrygdedekninger(trygdedekningerResponse);
 
         try {
-          if (avgiftspliktigperioder.some((periode: MedlemskapsperiodeFieldProps) => erUlagretPeriode(periode.id))) {
+          if (
+            avgiftspliktigperioder.some(
+              (periode: MedlemskapsperiodeFieldProps) => periode.id !== ULAGRET_MEDLEMSKAPSPERIODE_ID,
+            )
+          ) {
             await Api.MedlemAvFolketrygden.Medlemskapsperioder.slettMedlemskapsperioder(behandlingID!);
           }
         } catch (error) {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.less
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.less
@@ -4,6 +4,15 @@
   .trygdedekning {
     min-width: 7.5rem;
   }
+
+  .dato--helseutgift-label {
+    width: auto;
+
+    .navds-label--small {
+      white-space: nowrap;
+      width: auto;
+    }
+  }
 }
 
 .medlemskapsperiode-display {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/medlemskapsperiodeSkjema.tsx
@@ -129,12 +129,12 @@ export function AvgiftspliktigperiodeSkjema({
     }
   }, [trygdedekninger, index, setValue, erHelseutgift]);
 
-  const periodeLabelTekst = erHelseutgift ? "Helseutgiftdekkes" : "Medlemskapsperiode";
+  const periodeLabelTekst = erHelseutgift ? `Periode Norge dekker helseutgifter` : "Medlemskapsperiode";
 
   return (
     <>
       <Nav.Row className="periode__rad medlemskapsperiode__rad" key={field.id}>
-        <Nav.Column className="dato">
+        <Nav.Column className={`dato${erHelseutgift && index === 0 ? " dato--helseutgift-label" : ""}`}>
           <Forms.Datovelger
             label={index === 0 ? periodeLabelTekst : ""}
             control={control}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
@@ -118,8 +118,8 @@ export function beregnTrygdeavgiftsperioder(
 export const hentMedlemskapsFomTomDato = (medlemskapsperioder?: BasePeriode[]) => {
   if (medlemskapsperioder && !Utils._isEmpty(medlemskapsperioder)) {
     const sorted = [...medlemskapsperioder].sort(Utils.dato.sorterEtterNorskFomDato);
-    const fomISO = Utils.dato.formatterDatoTilISO(sorted[0].fomDato);
-    const tomISO = Utils.dato.formatterDatoTilISO(sorted[sorted.length - 1].tomDato);
+    const fomISO = Utils.dato.vaskOgFormatterTilISO(sorted[0].fomDato);
+    const tomISO = Utils.dato.vaskOgFormatterTilISO(sorted[sorted.length - 1].tomDato);
     return { fom: fomISO, tom: tomISO };
   }
   return {};

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/utils.ts
@@ -252,7 +252,6 @@ export const validateAarsavregningUtenEllerDeltGrunnlag = async (
     return { isValid: true, errors: {} };
   } catch (err) {
     const validationErrors: Record<string, string> = {};
-
     if (err instanceof ValidationError) {
       if (err.inner && err.inner.length > 0) {
         err.inner.forEach((error) => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -89,17 +89,9 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
 
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
-  const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const saksnummer = useSelector(fagsakSelectors.SaksnummerSelector) as any;
-  const sakstype = useSelector(fagsakSelectors.SakstypeSelector);
-  const sakstema = useSelector(fagsakSelectors.SakstemaSelector);
   const { oppfriskOgLastInnSaksopplysningerForAarsavregning } = useContext(FellesHandlersContext) as any;
   const dispatch = useDispatch();
-
-  const erEøsPensjonist =
-    sakstype?.kode === MKV.Koder.sakstyper.EU_EOS &&
-    sakstema?.kode === MKV.Koder.sakstemaer.TRYGDEAVGIFT &&
-    behandlingstema === MKV.Koder.behandlinger.behandlingstema.PENSJONIST;
 
   /**
    * Utleder harTrygdeavgiftFraAvgiftssystemet når verdien er null (bakoverkompatibilitet).

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -89,9 +89,17 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
 
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector) as boolean;
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as any;
+  const behandlingstema = useSelector(behandlingerSelectors.BehandlingstemaKodeSelector);
   const saksnummer = useSelector(fagsakSelectors.SaksnummerSelector) as any;
+  const sakstype = useSelector(fagsakSelectors.SakstypeSelector);
+  const sakstema = useSelector(fagsakSelectors.SakstemaSelector);
   const { oppfriskOgLastInnSaksopplysningerForAarsavregning } = useContext(FellesHandlersContext) as any;
   const dispatch = useDispatch();
+
+  const erEøsPensjonist =
+    sakstype?.kode === MKV.Koder.sakstyper.EU_EOS &&
+    sakstema?.kode === MKV.Koder.sakstemaer.TRYGDEAVGIFT &&
+    behandlingstema === MKV.Koder.behandlinger.behandlingstema.PENSJONIST;
 
   /**
    * Utleder harTrygdeavgiftFraAvgiftssystemet når verdien er null (bakoverkompatibilitet).


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7921

- Fikset autoutfylling av datoer i skatteforhold og inntekt ved å bruke vaskOgFormatterTilISO i stedet for formatterDatoTilISO, slik at råe datoinput (f.eks. 31012025) parses korrekt.
- Forhindret at autoutfylling trigges på ufullstendige datoer ved å validere med erGyldigeMedlemskapsperiodeDatoerForAutoUtfylling før perioden brukes.
- Lagt til valideringer og feilmeldinger for EØS-pensjonist (helseutgiftdekkesperiode) i både med-grunnlag og uten/delt-grunnlag skjemaene.
- Lagt til tester for skjemavalidering, valideringsfeil og datovalidering for årsavregning.
