### PR TITLE
7926 Fjern Kosovo fra advarselsbanner for ukjent statsborgerskap

### DIFF
--- a/src/felleskomponenter/alertmeldinger/statsborgerskapFeil.test.tsx
+++ b/src/felleskomponenter/alertmeldinger/statsborgerskapFeil.test.tsx
@@ -59,4 +59,10 @@ describe("StatsborgerskapFeil", () => {
     render(<StatsborgerskapFeil className="test" />);
     expect(screen.getByRole("alert")).toBeDefined();
   });
+
+  it("returnerer null for Kosovo statsborgerskap", () => {
+    mockPersonopplysninger = { statsborgerskap: ["Kosovo"] };
+    const { container } = render(<StatsborgerskapFeil className="test" />);
+    expect(container.innerHTML).toBe("");
+  });
 });

--- a/src/felleskomponenter/alertmeldinger/statsborgerskapFeil.tsx
+++ b/src/felleskomponenter/alertmeldinger/statsborgerskapFeil.tsx
@@ -4,7 +4,7 @@ import { behandlingerSelectors } from "../../ducks/behandlinger";
 import * as Utils from "../../utils";
 import * as Nav from "../../navFrontend";
 
-const uoppgittEllerUkjenteLand = ["UOPPGITT", "UKJENT", "KOSOVO"];
+const uoppgittEllerUkjenteLand = ["UOPPGITT", "UKJENT"];
 
 function StatsborgerskapFeil({ className }: { className: string }) {
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector);


### PR DESCRIPTION
Fjerner Kosovo fra listen over land som trigger advarselbanneret om ukjent statsborgerskap.

Med CDM 4.4 støtter RINA nå Kosovo-statsborgerskap (XXK), så banneret som ble innført
under CDM 4.3 (da Kosovo ble mappet som "ukjent" i SED) er ikke lenger nødvendig.
[MELOSYS-7926](https://jira.adeo.no/browse/MELOSYS-7926)

- Fjernet "KOSOVO" fra `uoppgittEllerUkjenteLand`-listen i `statsborgerskapFeil.tsx`
- Lagt til test for at Kosovo-statsborgerskap ikke viser banneret

## Testing
- [x] Enhetstester
- [x] Manuell testing lokalt (verifisert med Playwright mot behandling med Kosovo-person)