### PR TITLE
G4P Fiks race condition i bekreftOgFortsett steg-overgang

### DIFF
--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -153,8 +153,8 @@ class Stegvelger extends Component {
     return Api.Fagsaker.aktoer.hent(saksnummer, MKV.Koder.aktoersroller.FULLMEKTIG);
   };
 
-  bekreftOgFortsett = () => {
-    this.publiserStegdata();
+  bekreftOgFortsett = async () => {
+    await this.publiserStegdata();
     this.validerSoknadOgGaTilSteg(this.beregnNesteSteg());
   };
 

--- a/src/felleskomponenter/stegvelger/stegMotor/typer.ts
+++ b/src/felleskomponenter/stegvelger/stegMotor/typer.ts
@@ -69,7 +69,7 @@ export interface PropsLight {
   vilkar?: unknown[];
   stegErGyldig?: boolean;
   tilgjengeligeHandlers: {
-    bekreftOgFortsett: () => void;
+    bekreftOgFortsett: () => Promise<void>;
     tilbake: () => void;
     byggLovvalgsperioder: () => void;
     oppdaterStegData: (stegId: string, felt: string, verdi: unknown) => void;


### PR DESCRIPTION
Legger til manglende `await` på `publiserStegdata()` i `bekreftOgFortsett()` i Stegvelger.jsx.

`publiserStegdata()` er `async` og oppdaterer Redux-state via `Promise.all` (vilkår, avklartefakta, lovvalgsperioder m.m.), men ble kalt uten `await`. Dette førte til at `validerSoknadOgGaTilSteg()` kjørte med gammel Redux-state før API-kallene var ferdige.

På CI med raskere nettverkstiming ga dette en ~60% feilrate der steg-wizarden ikke re-rendret til neste steg etter klikk på "Bekreft og fortsett" — API svarte OK men React viste fortsatt forrige heading ("Yrkessituasjon"). Funnet via systematisk stabilitetstesting av E2E-tester (repeat_each=5, disable_retries=true) over 3 iterasjoner.

- Legger til `async/await` på `bekreftOgFortsett` i Stegvelger.jsx
- Oppdaterer TypeScript-type fra `() => void` til `() => Promise<void>` i typer.ts

## Testing
- [x] Alle 78 eksisterende enhetstester passerer
- [x] TypeScript kompilerer uten feil
- [x] Lint og prettier passerer (pre-commit hooks)
- [x] E2E-tester med ny melosys-web image

## Notes
Relatert E2E-test PR: https://github.com/navikt/melosys-e2e-tests/pull/236