### PR TITLE
7921 Testfiler med cleanup problemer

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { VurderingVedtak } from "./vurderingVedtak";
 import { renderWithProvidersAsync } from "../../../../ducks/test-utils/renderWithProviders";
 import MKV from "../../../../melosyskodeverk";
@@ -39,6 +39,15 @@ vi.mock("../../../../services/api", () => ({
     },
   },
 }));
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
 
 const { BEREGNET_AVGIFT } = MKV.Koder.endeligAvgiftValg;
 const { FULLMEKTIG_TRYGDEAVGIFT } = MKV.Koder.fullmaktstype;


### PR DESCRIPTION
https://github.com/navikt/melosys-web/actions/runs/23141973011

Problemet var at lodash debounce-timeren trigget etter at test-miljøet var revet ned. Fikset med vi.useFakeTimers() i beforeEach og vi.runOnlyPendingTimers() + vi.useRealTimers() i afterEach, slik at alle ventende timers kjøres kontrollert før cleanup.