### PR TITLE
7946 VAKT: Vis warning ved videresending når arbeidsland ikke er kjent

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
@@ -21,6 +21,7 @@ import { behandlingerSelectors } from "../../../../ducks/behandlinger";
 import { avklartefaktaSelectors } from "../../../../ducks/avklartefakta";
 import { dokumenterSelectors } from "../../../../ducks/dokumenter";
 import { feiletResponsOperations } from "../../../../ducks/feiletRespons";
+import { mottatteOpplysningerSelectors } from "../../../../ducks/mottatteOpplysninger";
 import { useFeatureToggle } from "../../../../featuretoggle";
 import { MELOSYS_CDM_4_4 } from "../../../../featuretoggle/toggleNavn";
 
@@ -32,6 +33,7 @@ export function VurderingVideresend({
   redigerbart,
   behandlingID,
   bostedsland = { kode: "", term: "" },
+  flereLandUkjentHvilke,
   fysiskeDokument,
   handleSubmit,
   form,
@@ -102,6 +104,15 @@ export function VurderingVideresend({
         <Nav.Heading level="1" className="stegvelgertittel">
           Videresending av søknad
         </Nav.Heading>
+        {flereLandUkjentHvilke && (
+          <Nav.Row>
+            <Nav.Column xs="8">
+              <Nav.Alert variant="warning" className="videresendSoknad__warning">
+                Land er ikke satt under «Periode og land». Arbeidsland vil ikke bli inkludert i SED A008.
+              </Nav.Alert>
+            </Nav.Column>
+          </Nav.Row>
+        )}
         <Nav.Row>
           <Nav.Column xs="8">
             <Skjema.Textarea
@@ -190,6 +201,7 @@ VurderingVideresend.propTypes = {
   videresendSoknad: PT.func.isRequired,
   tilbake: PT.func.isRequired,
   bostedsland: MPT.Kodeverk,
+  flereLandUkjentHvilke: PT.bool,
   handleSubmit: PT.func.isRequired,
   form: PT.string.isRequired,
   formValues: PT.object,
@@ -208,6 +220,7 @@ const VurderingVideresendForm = reduxForm({
 const mapStateToProps = (state) => ({
   behandlingID: behandlingerSelectors.BehandlingIDSelector(state),
   bostedsland: avklartefaktaSelectors.BostedslandSelector(state),
+  flereLandUkjentHvilke: mottatteOpplysningerSelectors.SoknadslandFlereLandUkjentHvilkeSelector(state),
   fysiskeDokument: dokumenterSelectors.AlleFysiskeDokumentSelector(state),
   formValues: getFormValues(KV.Form.VURDERING_VIDERESEND)(state),
   initialValues: {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
@@ -108,11 +108,19 @@ export function VurderingVideresend({
           <Nav.Row>
             <Nav.Column xs="8">
               <Nav.Alert variant="warning" className="videresendSoknad__warning">
-                Land er ikke satt under «Periode og land». Arbeidsland vil ikke bli inkludert i SED A008.
+                <span>
+                  Land er satt til{" "}
+                  <i>
+                    <b>Flere land. Ikke kjent hvilke.</b>
+                  </i>{" "}
+                  Arbeidsland vil derfor ikke bli oppgitt i SED A008. Du kan endre dette under sidemenypunkt “Periode og
+                  land”.
+                </span>
               </Nav.Alert>
             </Nav.Column>
           </Nav.Row>
         )}
+
         <Nav.Row>
           <Nav.Column xs="8">
             <Skjema.Textarea

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.jsx
@@ -104,17 +104,17 @@ export function VurderingVideresend({
         <Nav.Heading level="1" className="stegvelgertittel">
           Videresending av søknad
         </Nav.Heading>
-        {flereLandUkjentHvilke && (
+        {isA008Cdm44Enabled && redigerbart && flereLandUkjentHvilke && (
           <Nav.Row>
             <Nav.Column xs="8">
               <Nav.Alert variant="warning" className="videresendSoknad__warning">
                 <span>
                   Land er satt til{" "}
-                  <i>
-                    <b>Flere land. Ikke kjent hvilke.</b>
-                  </i>{" "}
-                  Arbeidsland vil derfor ikke bli oppgitt i SED A008. Du kan endre dette under sidemenypunkt “Periode og
-                  land”.
+                  <em>
+                    <strong>Flere land. Ikke kjent hvilke.</strong>
+                  </em>{" "}
+                  Arbeidsland vil derfor ikke bli oppgitt i SED A008. Du kan endre dette under sidemenypunkt "Periode og
+                  land".
                 </span>
               </Nav.Alert>
             </Nav.Column>

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.less
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVideresend/vurderingVideresend.less
@@ -3,6 +3,10 @@
     margin-top: 1em;
   }
 
+  &__warning {
+    margin-bottom: 1em;
+  }
+
   .mottakerinstitusjoner {
     .skjemaelement__label {
       font-weight: bold;


### PR DESCRIPTION
Viser en warning-alert på siste steget «Videresending av søknad» når land under «Periode og land» er satt til «Flere land. Ikke kjent hvilke». Saksbehandler blir informert om at arbeidsland ikke vil bli inkludert i SED A008, men er ikke blokkert fra å videresende.