### PR TITLE
7530 G4P Vis beregningstype i avgiftstabellene

### DIFF
--- a/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.less
+++ b/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.less
@@ -1,0 +1,8 @@
+.forklaringstekster {
+  margin-top: 0.5rem;
+
+  p {
+    margin: 0;
+    font-size: 0.875rem;
+  }
+}

--- a/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
@@ -26,6 +26,21 @@ export function erOrdinaerBeregning(beregningstype?: Beregningstype | null): boo
   return !beregningstype || beregningstype === "ORDINAER";
 }
 
+const AVGIFTSDEL_TEKST: Record<string, string> = {
+  HELSE: "Helsedel",
+  PENSJON: "Pensjonsdel",
+};
+
+export function formaterDekning(
+  periode: { avgiftsdel?: string | null; trygdedekning: string },
+  finnTerm: (kode: string) => string,
+): string {
+  if (periode.avgiftsdel && AVGIFTSDEL_TEKST[periode.avgiftsdel]) {
+    return AVGIFTSDEL_TEKST[periode.avgiftsdel];
+  }
+  return finnTerm(periode.trygdedekning);
+}
+
 export function formaterInntektskilde(
   periode: { harSammenslåtteInntektskilder?: boolean; inntektskildetype: string },
   finnTerm: (kode: string) => string,

--- a/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
@@ -7,23 +7,18 @@ interface MedBeregningstype {
   avgiftssats: number | null;
 }
 
-const BEREGNINGSTYPE_FORKLARINGER = {
+const BEREGNINGSTYPE_FORKLARINGER: Partial<Record<Beregningstype, { symbol: string; tekst: string }>> = {
   TJUEFEM_PROSENT_REGEL: {
     symbol: "*",
     tekst: "Beregnet etter 25 %-regelen: Trygdeavgift skal ikke utgjøre mer enn 25 % av inntekt over minstebeløpet.",
   },
   MINSTEBELOEP: { symbol: "**", tekst: "Inntekten er under minstebeløpet." },
-} as const;
+};
 
 export function formaterSats(periode: MedBeregningstype): string {
-  switch (periode.beregningstype) {
-    case "TJUEFEM_PROSENT_REGEL":
-      return "*";
-    case "MINSTEBELOEP":
-      return "**";
-    default:
-      return periode.avgiftssats?.toString() ?? "";
-  }
+  const forklaring = periode.beregningstype ? BEREGNINGSTYPE_FORKLARINGER[periode.beregningstype] : undefined;
+  if (forklaring) return forklaring.symbol;
+  return periode.avgiftssats?.toString() ?? "";
 }
 
 export function erOrdinaerBeregning(beregningstype?: Beregningstype | null): boolean {
@@ -33,16 +28,16 @@ export function erOrdinaerBeregning(beregningstype?: Beregningstype | null): boo
 export function Beregningsforklaringer({ perioder }: { perioder: MedBeregningstype[] }) {
   const typer = new Set(perioder.map((p) => p.beregningstype).filter(Boolean));
 
-  const aktuelleForklaringer = Object.entries(BEREGNINGSTYPE_FORKLARINGER).filter(([type]) =>
-    typer.has(type as Beregningstype),
-  );
+  const aktuelleForklaringer = (Object.keys(BEREGNINGSTYPE_FORKLARINGER) as Beregningstype[])
+    .filter((type) => typer.has(type))
+    .map((type) => BEREGNINGSTYPE_FORKLARINGER[type]!);
 
   if (aktuelleForklaringer.length === 0) return null;
 
   return (
     <div className="forklaringstekster">
-      {aktuelleForklaringer.map(([type, { symbol, tekst }]) => (
-        <p key={type}>
+      {aktuelleForklaringer.map(({ symbol, tekst }) => (
+        <p key={symbol}>
           {symbol} {tekst}
         </p>
       ))}

--- a/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
@@ -1,14 +1,14 @@
-import { Beregningstype } from "../../../services/modules/trygdeavgift";
+import { Beregningsregel } from "../../../services/modules/trygdeavgift";
 
 import "./beregningsforklaring.less";
 
-interface MedBeregningstype {
-  beregningstype?: Beregningstype | null;
+interface MedBeregningsregel {
+  beregningsregel?: Beregningsregel | null;
   avgiftssats: number | null;
   harSammenslåtteInntektskilder?: boolean;
 }
 
-const BEREGNINGSTYPE_FORKLARINGER: Partial<Record<Beregningstype, { symbol: string; tekst: string }>> = {
+const BEREGNINGSREGEL_FORKLARINGER: Partial<Record<Beregningsregel, { symbol: string; tekst: string }>> = {
   TJUEFEM_PROSENT_REGEL: {
     symbol: "*",
     tekst: "Beregnet etter 25 %-regelen: Trygdeavgift skal ikke utgjøre mer enn 25 % av inntekt over minstebeløpet.",
@@ -16,14 +16,14 @@ const BEREGNINGSTYPE_FORKLARINGER: Partial<Record<Beregningstype, { symbol: stri
   MINSTEBELOEP: { symbol: "**", tekst: "Inntekten er under minstebeløpet." },
 };
 
-export function formaterSats(periode: MedBeregningstype): string {
-  const forklaring = periode.beregningstype ? BEREGNINGSTYPE_FORKLARINGER[periode.beregningstype] : undefined;
+export function formaterSats(periode: MedBeregningsregel): string {
+  const forklaring = periode.beregningsregel ? BEREGNINGSREGEL_FORKLARINGER[periode.beregningsregel] : undefined;
   if (forklaring) return forklaring.symbol;
   return periode.avgiftssats?.toString() ?? "";
 }
 
-export function erOrdinaerBeregning(beregningstype?: Beregningstype | null): boolean {
-  return !beregningstype || beregningstype === "ORDINAER";
+export function erOrdinaerBeregning(beregningsregel?: Beregningsregel | null): boolean {
+  return !beregningsregel || beregningsregel === "ORDINAER";
 }
 
 const AVGIFTSDEL_TEKST: Record<string, string> = {
@@ -49,13 +49,13 @@ export function formaterInntektskilde(
   return finnTerm(periode.inntektskildetype);
 }
 
-export function Beregningsforklaringer({ perioder }: { perioder: MedBeregningstype[] }) {
-  const typer = new Set(perioder.map((p) => p.beregningstype).filter(Boolean));
+export function Beregningsforklaringer({ perioder }: { perioder: MedBeregningsregel[] }) {
+  const typer = new Set(perioder.map((p) => p.beregningsregel).filter(Boolean));
   const harSammenslåtte = perioder.some((p) => p.harSammenslåtteInntektskilder);
 
-  const aktuelleForklaringer = (Object.keys(BEREGNINGSTYPE_FORKLARINGER) as Beregningstype[])
+  const aktuelleForklaringer = (Object.keys(BEREGNINGSREGEL_FORKLARINGER) as Beregningsregel[])
     .filter((type) => typer.has(type))
-    .map((type) => BEREGNINGSTYPE_FORKLARINGER[type]!);
+    .map((type) => BEREGNINGSREGEL_FORKLARINGER[type]!);
 
   if (aktuelleForklaringer.length === 0 && !harSammenslåtte) return null;
 

--- a/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
@@ -1,6 +1,6 @@
 import { Beregningstype } from "../../../services/modules/trygdeavgift";
 
-import "./trygdeavgiftsperioderTabell.less";
+import "./beregningsforklaring.less";
 
 interface MedBeregningstype {
   beregningstype?: Beregningstype | null;

--- a/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
@@ -8,11 +8,11 @@ interface MedBeregningstype {
 }
 
 const BEREGNINGSTYPE_FORKLARINGER = {
-  MINSTEBELOEP: { symbol: "*", tekst: "Inntekten er lavere enn minstebeløpet for trygdeavgift." },
   TJUEFEM_PROSENT_REGEL: {
-    symbol: "**",
-    tekst: "Trygdeavgiften kan maks utgjøre 25 % av inntekten som overstiger minstebeløpet.",
+    symbol: "*",
+    tekst: "Beregnet etter 25 %-regelen: Trygdeavgift skal ikke utgjøre mer enn 25 % av inntekt over minstebeløpet.",
   },
+  MINSTEBELOEP: { symbol: "**", tekst: "Inntekten er under minstebeløpet." },
 } as const;
 
 export function formaterSats(periode: MedBeregningstype): string {

--- a/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
@@ -5,6 +5,7 @@ import "./beregningsforklaring.less";
 interface MedBeregningstype {
   beregningstype?: Beregningstype | null;
   avgiftssats: number | null;
+  harSammenslåtteInntektskilder?: boolean;
 }
 
 const BEREGNINGSTYPE_FORKLARINGER: Partial<Record<Beregningstype, { symbol: string; tekst: string }>> = {
@@ -25,14 +26,23 @@ export function erOrdinaerBeregning(beregningstype?: Beregningstype | null): boo
   return !beregningstype || beregningstype === "ORDINAER";
 }
 
+export function formaterInntektskilde(
+  periode: { harSammenslåtteInntektskilder?: boolean; inntektskildetype: string },
+  finnTerm: (kode: string) => string,
+): string {
+  if (periode.harSammenslåtteInntektskilder) return "***";
+  return finnTerm(periode.inntektskildetype);
+}
+
 export function Beregningsforklaringer({ perioder }: { perioder: MedBeregningstype[] }) {
   const typer = new Set(perioder.map((p) => p.beregningstype).filter(Boolean));
+  const harSammenslåtte = perioder.some((p) => p.harSammenslåtteInntektskilder);
 
   const aktuelleForklaringer = (Object.keys(BEREGNINGSTYPE_FORKLARINGER) as Beregningstype[])
     .filter((type) => typer.has(type))
     .map((type) => BEREGNINGSTYPE_FORKLARINGER[type]!);
 
-  if (aktuelleForklaringer.length === 0) return null;
+  if (aktuelleForklaringer.length === 0 && !harSammenslåtte) return null;
 
   return (
     <div className="forklaringstekster">
@@ -41,6 +51,7 @@ export function Beregningsforklaringer({ perioder }: { perioder: MedBeregningsty
           {symbol} {tekst}
         </p>
       ))}
+      {harSammenslåtte && <p key="sammenslatt">*** Mer enn en inntektskilde</p>}
     </div>
   );
 }

--- a/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
@@ -16,11 +16,14 @@ const BEREGNINGSTYPE_FORKLARINGER = {
 } as const;
 
 export function formaterSats(periode: MedBeregningstype): string {
-  const forklaring =
-    periode.beregningstype &&
-    BEREGNINGSTYPE_FORKLARINGER[periode.beregningstype as keyof typeof BEREGNINGSTYPE_FORKLARINGER];
-  if (forklaring) return forklaring.symbol;
-  return periode.avgiftssats?.toString() ?? "";
+  switch (periode.beregningstype) {
+    case "TJUEFEM_PROSENT_REGEL":
+      return "*";
+    case "MINSTEBELOEP":
+      return "**";
+    default:
+      return periode.avgiftssats?.toString() ?? "";
+  }
 }
 
 export function erOrdinaerBeregning(beregningstype?: Beregningstype | null): boolean {

--- a/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
@@ -1,0 +1,48 @@
+import { Beregningstype } from "../../../services/modules/trygdeavgift";
+
+import "./trygdeavgiftsperioderTabell.less";
+
+interface MedBeregningstype {
+  beregningstype?: Beregningstype | null;
+  avgiftssats: number | null;
+}
+
+const BEREGNINGSTYPE_FORKLARINGER = {
+  MINSTEBELOEP: { symbol: "*", tekst: "Inntekten er lavere enn minstebeløpet for trygdeavgift." },
+  TJUEFEM_PROSENT_REGEL: {
+    symbol: "**",
+    tekst: "Trygdeavgiften kan maks utgjøre 25 % av inntekten som overstiger minstebeløpet.",
+  },
+} as const;
+
+export function formaterSats(periode: MedBeregningstype): string {
+  const forklaring =
+    periode.beregningstype &&
+    BEREGNINGSTYPE_FORKLARINGER[periode.beregningstype as keyof typeof BEREGNINGSTYPE_FORKLARINGER];
+  if (forklaring) return forklaring.symbol;
+  return periode.avgiftssats?.toString() ?? "";
+}
+
+export function erOrdinaerBeregning(beregningstype?: Beregningstype | null): boolean {
+  return !beregningstype || beregningstype === "ORDINAER";
+}
+
+export function Beregningsforklaringer({ perioder }: { perioder: MedBeregningstype[] }) {
+  const typer = new Set(perioder.map((p) => p.beregningstype).filter(Boolean));
+
+  const aktuelleForklaringer = Object.entries(BEREGNINGSTYPE_FORKLARINGER).filter(([type]) =>
+    typer.has(type as Beregningstype),
+  );
+
+  if (aktuelleForklaringer.length === 0) return null;
+
+  return (
+    <div className="forklaringstekster">
+      {aktuelleForklaringer.map(([type, { symbol, tekst }]) => (
+        <p key={type}>
+          {symbol} {tekst}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.less
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.less
@@ -6,6 +6,15 @@
   }
 }
 
+.forklaringstekster {
+  margin-top: 0.5rem;
+
+  p {
+    margin: 0;
+    font-size: 0.875rem;
+  }
+}
+
 .loader-container {
   display: flex;
   justify-content: center;

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.less
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.less
@@ -6,15 +6,6 @@
   }
 }
 
-.forklaringstekster {
-  margin-top: 0.5rem;
-
-  p {
-    margin: 0;
-    font-size: 0.875rem;
-  }
-}
-
 .loader-container {
   display: flex;
   justify-content: center;

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
@@ -76,7 +76,7 @@ describe("TrygdeavgiftsperioderTabell", () => {
     expect(screen.getByText("Laster...")).toBeDefined();
   });
 
-  it("viser ** for 25%-regel", () => {
+  it("viser * for 25%-regel", () => {
     const perioder = [
       lagPeriode("2024-01-01", "2024-12-31", {
         avgiftssats: null,
@@ -85,10 +85,10 @@ describe("TrygdeavgiftsperioderTabell", () => {
       }),
     ];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
-    expect(screen.getByText("**")).toBeDefined();
+    expect(screen.getByText("*")).toBeDefined();
   });
 
-  it("viser * for minstebeløp", () => {
+  it("viser ** for minstebeløp", () => {
     const perioder = [
       lagPeriode("2024-01-01", "2024-12-31", {
         avgiftssats: null,
@@ -97,7 +97,7 @@ describe("TrygdeavgiftsperioderTabell", () => {
       }),
     ];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
-    expect(screen.getByText("*")).toBeDefined();
+    expect(screen.getByText("**")).toBeDefined();
   });
 
   it("viser tallverdi for ordinær beregningstype", () => {
@@ -123,16 +123,18 @@ describe("TrygdeavgiftsperioderTabell", () => {
       }),
     ];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
-    expect(screen.getByText("* Inntekten er lavere enn minstebeløpet for trygdeavgift.")).toBeDefined();
     expect(
-      screen.getByText("** Trygdeavgiften kan maks utgjøre 25 % av inntekten som overstiger minstebeløpet."),
+      screen.getByText(
+        "* Beregnet etter 25 %-regelen: Trygdeavgift skal ikke utgjøre mer enn 25 % av inntekt over minstebeløpet.",
+      ),
     ).toBeDefined();
+    expect(screen.getByText("** Inntekten er under minstebeløpet.")).toBeDefined();
   });
 
   it("viser ingen fotnoter for kun ordinære perioder", () => {
     const perioder = [lagPeriode("2024-01-01", "2024-12-31")];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
-    expect(screen.queryByText(/Inntekten er lavere enn minstebeløpet/)).toBeNull();
-    expect(screen.queryByText(/Trygdeavgiften kan maks utgjøre 25/)).toBeNull();
+    expect(screen.queryByText(/Beregnet etter 25 %-regelen/)).toBeNull();
+    expect(screen.queryByText(/Inntekten er under minstebeløpet/)).toBeNull();
   });
 });

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
@@ -81,7 +81,7 @@ describe("TrygdeavgiftsperioderTabell", () => {
       lagPeriode("2024-01-01", "2024-12-31", {
         avgiftssats: null,
         avgiftPerMd: 3448,
-        beregningstype: "TJUEFEM_PROSENT_REGEL",
+        beregningsregel: "TJUEFEM_PROSENT_REGEL",
       }),
     ];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
@@ -93,33 +93,33 @@ describe("TrygdeavgiftsperioderTabell", () => {
       lagPeriode("2024-01-01", "2024-12-31", {
         avgiftssats: null,
         avgiftPerMd: 0,
-        beregningstype: "MINSTEBELOEP",
+        beregningsregel: "MINSTEBELOEP",
       }),
     ];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
     expect(screen.getByText("**")).toBeDefined();
   });
 
-  it("viser tallverdi for ordinær beregningstype", () => {
+  it("viser tallverdi for ordinær beregningsregel", () => {
     const perioder = [
       lagPeriode("2024-01-01", "2024-12-31", {
         avgiftssats: 6.8,
-        beregningstype: "ORDINAER",
+        beregningsregel: "ORDINAER",
       }),
     ];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
     expect(screen.getByText("6.8")).toBeDefined();
   });
 
-  it("viser fotnoter kun når relevante beregningstyper finnes", () => {
+  it("viser fotnoter kun når relevante beregningsregler finnes", () => {
     const perioder = [
       lagPeriode("2024-01-01", "2024-06-30", {
         avgiftssats: null,
-        beregningstype: "MINSTEBELOEP",
+        beregningsregel: "MINSTEBELOEP",
       }),
       lagPeriode("2024-07-01", "2024-12-31", {
         avgiftssats: null,
-        beregningstype: "TJUEFEM_PROSENT_REGEL",
+        beregningsregel: "TJUEFEM_PROSENT_REGEL",
       }),
     ];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
@@ -142,7 +142,7 @@ describe("TrygdeavgiftsperioderTabell", () => {
     const perioder = [
       lagPeriode("2024-01-01", "2024-12-31", {
         avgiftssats: null,
-        beregningstype: "TJUEFEM_PROSENT_REGEL",
+        beregningsregel: "TJUEFEM_PROSENT_REGEL",
         harSammenslåtteInntektskilder: true,
       }),
     ];
@@ -171,7 +171,7 @@ describe("TrygdeavgiftsperioderTabell", () => {
     const perioder = [
       lagPeriode("2024-01-01", "2024-12-31", {
         avgiftssats: null,
-        beregningstype: "TJUEFEM_PROSENT_REGEL",
+        beregningsregel: "TJUEFEM_PROSENT_REGEL",
         avgiftsdel: "HELSE",
       }),
     ];
@@ -183,7 +183,7 @@ describe("TrygdeavgiftsperioderTabell", () => {
     const perioder = [
       lagPeriode("2024-01-01", "2024-12-31", {
         avgiftssats: null,
-        beregningstype: "TJUEFEM_PROSENT_REGEL",
+        beregningsregel: "TJUEFEM_PROSENT_REGEL",
         avgiftsdel: "PENSJON",
       }),
     ];

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
@@ -166,4 +166,34 @@ describe("TrygdeavgiftsperioderTabell", () => {
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
     expect(screen.queryByText(/Mer enn en inntektskilde/)).toBeNull();
   });
+
+  it("viser Helsedel når avgiftsdel er HELSE", () => {
+    const perioder = [
+      lagPeriode("2024-01-01", "2024-12-31", {
+        avgiftssats: null,
+        beregningstype: "TJUEFEM_PROSENT_REGEL",
+        avgiftsdel: "HELSE",
+      }),
+    ];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.getByText("Helsedel")).toBeDefined();
+  });
+
+  it("viser Pensjonsdel når avgiftsdel er PENSJON", () => {
+    const perioder = [
+      lagPeriode("2024-01-01", "2024-12-31", {
+        avgiftssats: null,
+        beregningstype: "TJUEFEM_PROSENT_REGEL",
+        avgiftsdel: "PENSJON",
+      }),
+    ];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.getByText("Pensjonsdel")).toBeDefined();
+  });
+
+  it("viser normal dekning når avgiftsdel er null", () => {
+    const perioder = [lagPeriode("2024-01-01", "2024-12-31")];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.getByText("FULL")).toBeDefined();
+  });
 });

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
@@ -137,4 +137,33 @@ describe("TrygdeavgiftsperioderTabell", () => {
     expect(screen.queryByText(/Beregnet etter 25 %-regelen/)).toBeNull();
     expect(screen.queryByText(/Inntekten er under minstebeløpet/)).toBeNull();
   });
+
+  it("viser *** for sammenslåtte inntektskilder", () => {
+    const perioder = [
+      lagPeriode("2024-01-01", "2024-12-31", {
+        avgiftssats: null,
+        beregningstype: "TJUEFEM_PROSENT_REGEL",
+        harSammenslåtteInntektskilder: true,
+      }),
+    ];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.getByText("***")).toBeDefined();
+    expect(screen.queryByText("LØNN")).toBeNull();
+  });
+
+  it("viser *** fotnote når sammenslåtte inntektskilder finnes", () => {
+    const perioder = [
+      lagPeriode("2024-01-01", "2024-12-31", {
+        harSammenslåtteInntektskilder: true,
+      }),
+    ];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.getByText("*** Mer enn en inntektskilde")).toBeDefined();
+  });
+
+  it("viser ingen *** fotnote når ingen sammenslåtte inntektskilder", () => {
+    const perioder = [lagPeriode("2024-01-01", "2024-12-31")];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.queryByText(/Mer enn en inntektskilde/)).toBeNull();
+  });
 });

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
@@ -32,14 +32,16 @@ vi.mock("../../spinner", () => ({
 }));
 
 import TrygdeavgiftsperioderTabell from "./trygdeavgiftsperioderTabell";
+import { Trygdeavgiftsperiode } from "../../../services/modules/trygdeavgift";
 
-const lagPeriode = (fom: string, tom: string) => ({
+const lagPeriode = (fom: string, tom: string, overrides?: Partial<Trygdeavgiftsperiode>): Trygdeavgiftsperiode => ({
   fom,
   tom,
   trygdedekning: "FULL",
   inntektskildetype: "LØNN",
-  avgiftssats: "7.8",
-  avgiftPerMd: "1234",
+  avgiftssats: 7.8,
+  avgiftPerMd: 1234,
+  ...overrides,
 });
 
 describe("TrygdeavgiftsperioderTabell", () => {
@@ -61,8 +63,8 @@ describe("TrygdeavgiftsperioderTabell", () => {
     expect(screen.queryByText("Dekning")).toBeNull();
   });
 
-  it("rendrer periodedata", () => {
-    const perioder = [lagPeriode("2024-01-01", "2024-06-30")] as any;
+  it("rendrer periodedata med ordinær sats", () => {
+    const perioder = [lagPeriode("2024-01-01", "2024-06-30")];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
     expect(screen.getByText("2024-01-01 - 2024-06-30")).toBeDefined();
     expect(screen.getByText("7.8")).toBeDefined();
@@ -72,5 +74,65 @@ describe("TrygdeavgiftsperioderTabell", () => {
   it("viser spinner når lagrePending", () => {
     render(<TrygdeavgiftsperioderTabell perioder={[]} lagrePending={true} />);
     expect(screen.getByText("Laster...")).toBeDefined();
+  });
+
+  it("viser ** for 25%-regel", () => {
+    const perioder = [
+      lagPeriode("2024-01-01", "2024-12-31", {
+        avgiftssats: null,
+        avgiftPerMd: 3448,
+        beregningstype: "TJUEFEM_PROSENT_REGEL",
+      }),
+    ];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.getByText("**")).toBeDefined();
+  });
+
+  it("viser * for minstebeløp", () => {
+    const perioder = [
+      lagPeriode("2024-01-01", "2024-12-31", {
+        avgiftssats: null,
+        avgiftPerMd: 0,
+        beregningstype: "MINSTEBELOEP",
+      }),
+    ];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.getByText("*")).toBeDefined();
+  });
+
+  it("viser tallverdi for ordinær beregningstype", () => {
+    const perioder = [
+      lagPeriode("2024-01-01", "2024-12-31", {
+        avgiftssats: 6.8,
+        beregningstype: "ORDINAER",
+      }),
+    ];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.getByText("6.8")).toBeDefined();
+  });
+
+  it("viser fotnoter kun når relevante beregningstyper finnes", () => {
+    const perioder = [
+      lagPeriode("2024-01-01", "2024-06-30", {
+        avgiftssats: null,
+        beregningstype: "MINSTEBELOEP",
+      }),
+      lagPeriode("2024-07-01", "2024-12-31", {
+        avgiftssats: null,
+        beregningstype: "TJUEFEM_PROSENT_REGEL",
+      }),
+    ];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.getByText("* Inntekten er lavere enn minstebeløpet for trygdeavgift.")).toBeDefined();
+    expect(
+      screen.getByText("** Trygdeavgiften kan maks utgjøre 25 % av inntekten som overstiger minstebeløpet."),
+    ).toBeDefined();
+  });
+
+  it("viser ingen fotnoter for kun ordinære perioder", () => {
+    const perioder = [lagPeriode("2024-01-01", "2024-12-31")];
+    render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
+    expect(screen.queryByText(/Inntekten er lavere enn minstebeløpet/)).toBeNull();
+    expect(screen.queryByText(/Trygdeavgiften kan maks utgjøre 25/)).toBeNull();
   });
 });

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
@@ -4,7 +4,7 @@ import * as Utils from "../../../utils";
 import * as Nav from "../../../navFrontend";
 import { Trygdeavgiftsperiode } from "../../../services/modules/trygdeavgift";
 import { Spinner } from "../../spinner";
-import { formaterSats, Beregningsforklaringer } from "./beregningsforklaring";
+import { formaterSats, formaterInntektskilde, Beregningsforklaringer } from "./beregningsforklaring";
 
 import "./trygdeavgiftsperioderTabell.less";
 
@@ -52,7 +52,9 @@ function TrygdeavgiftsperioderTabell({
                 </Nav.Table.DataCell>
               )}
               <Nav.Table.DataCell key={Utils._uuid()}>
-                {KV.finnTermFraListe(MKV.KTObjects.inntektskildetype, trygdeavgiftsperiode.inntektskildetype)}
+                {formaterInntektskilde(trygdeavgiftsperiode, (kode) =>
+                  KV.finnTermFraListe(MKV.KTObjects.inntektskildetype, kode),
+                )}
               </Nav.Table.DataCell>
               <Nav.Table.DataCell key={Utils._uuid()} className="tall_felt">
                 {formaterSats(trygdeavgiftsperiode)}

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
@@ -4,19 +4,9 @@ import * as Utils from "../../../utils";
 import * as Nav from "../../../navFrontend";
 import { Trygdeavgiftsperiode } from "../../../services/modules/trygdeavgift";
 import { Spinner } from "../../spinner";
+import { formaterSats, Beregningsforklaringer } from "./beregningsforklaring";
 
 import "./trygdeavgiftsperioderTabell.less";
-
-function formaterSats(periode: Trygdeavgiftsperiode): string {
-  switch (periode.beregningstype) {
-    case "TJUEFEM_PROSENT_REGEL":
-      return "**";
-    case "MINSTEBELOEP":
-      return "*";
-    default:
-      return periode.avgiftssats?.toString() ?? "";
-  }
-}
 
 function TrygdeavgiftsperioderTabell({
   perioder,
@@ -30,9 +20,6 @@ function TrygdeavgiftsperioderTabell({
   if (!perioder) return null;
 
   const sortertePerioder = [...perioder].sort(Utils.dato.sorterEtterISOFomDato);
-
-  const harMinstebeloep = sortertePerioder.some((p) => p.beregningstype === "MINSTEBELOEP");
-  const har25ProsentRegel = sortertePerioder.some((p) => p.beregningstype === "TJUEFEM_PROSENT_REGEL");
 
   return (
     <div className="tabell-container">
@@ -77,14 +64,7 @@ function TrygdeavgiftsperioderTabell({
           ))}
         </Nav.Table.Body>
       </Nav.Table>
-      {(harMinstebeloep || har25ProsentRegel) && (
-        <div className="forklaringstekster">
-          {harMinstebeloep && <p>* Inntekten er lavere enn minstebeløpet for trygdeavgift.</p>}
-          {har25ProsentRegel && (
-            <p>** Trygdeavgiften kan maks utgjøre 25 % av inntekten som overstiger minstebeløpet.</p>
-          )}
-        </div>
-      )}
+      <Beregningsforklaringer perioder={sortertePerioder} />
     </div>
   );
 }

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
@@ -4,7 +4,7 @@ import * as Utils from "../../../utils";
 import * as Nav from "../../../navFrontend";
 import { Trygdeavgiftsperiode } from "../../../services/modules/trygdeavgift";
 import { Spinner } from "../../spinner";
-import { formaterSats, formaterInntektskilde, Beregningsforklaringer } from "./beregningsforklaring";
+import { formaterSats, formaterDekning, formaterInntektskilde, Beregningsforklaringer } from "./beregningsforklaring";
 
 import "./trygdeavgiftsperioderTabell.less";
 
@@ -48,7 +48,9 @@ function TrygdeavgiftsperioderTabell({
               </Nav.Table.DataCell>
               {!erEøsPensjonist && (
                 <Nav.Table.DataCell key={Utils._uuid()}>
-                  {KV.finnTermFraListe(MKV.KTObjects.trygdedekninger, trygdeavgiftsperiode.trygdedekning)}
+                  {formaterDekning(trygdeavgiftsperiode, (kode) =>
+                    KV.finnTermFraListe(MKV.KTObjects.trygdedekninger, kode),
+                  )}
                 </Nav.Table.DataCell>
               )}
               <Nav.Table.DataCell key={Utils._uuid()}>

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.tsx
@@ -7,6 +7,17 @@ import { Spinner } from "../../spinner";
 
 import "./trygdeavgiftsperioderTabell.less";
 
+function formaterSats(periode: Trygdeavgiftsperiode): string {
+  switch (periode.beregningstype) {
+    case "TJUEFEM_PROSENT_REGEL":
+      return "**";
+    case "MINSTEBELOEP":
+      return "*";
+    default:
+      return periode.avgiftssats?.toString() ?? "";
+  }
+}
+
 function TrygdeavgiftsperioderTabell({
   perioder,
   lagrePending,
@@ -19,6 +30,9 @@ function TrygdeavgiftsperioderTabell({
   if (!perioder) return null;
 
   const sortertePerioder = [...perioder].sort(Utils.dato.sorterEtterISOFomDato);
+
+  const harMinstebeloep = sortertePerioder.some((p) => p.beregningstype === "MINSTEBELOEP");
+  const har25ProsentRegel = sortertePerioder.some((p) => p.beregningstype === "TJUEFEM_PROSENT_REGEL");
 
   return (
     <div className="tabell-container">
@@ -54,7 +68,7 @@ function TrygdeavgiftsperioderTabell({
                 {KV.finnTermFraListe(MKV.KTObjects.inntektskildetype, trygdeavgiftsperiode.inntektskildetype)}
               </Nav.Table.DataCell>
               <Nav.Table.DataCell key={Utils._uuid()} className="tall_felt">
-                {trygdeavgiftsperiode.avgiftssats}
+                {formaterSats(trygdeavgiftsperiode)}
               </Nav.Table.DataCell>
               <Nav.Table.DataCell key={Utils._uuid()} className="tall_felt">
                 <b>{trygdeavgiftsperiode.avgiftPerMd}</b> nkr
@@ -63,6 +77,14 @@ function TrygdeavgiftsperioderTabell({
           ))}
         </Nav.Table.Body>
       </Nav.Table>
+      {(harMinstebeloep || har25ProsentRegel) && (
+        <div className="forklaringstekster">
+          {harMinstebeloep && <p>* Inntekten er lavere enn minstebeløpet for trygdeavgift.</p>}
+          {har25ProsentRegel && (
+            <p>** Trygdeavgiften kan maks utgjøre 25 % av inntekten som overstiger minstebeløpet.</p>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -55,6 +55,7 @@ export interface Trygdeavgiftsperiode {
   avgiftssats: number | null;
   avgiftPerMd: number;
   beregningstype?: Beregningstype | null;
+  harSammenslåtteInntektskilder?: boolean;
 }
 
 export interface Avregning {

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -1,6 +1,6 @@
 import { getAsJson, postAsJson, putAsJson } from "../../utils";
 import { AARSAVREGNING, API_BASE_URL, BEHANDLINGER, FAGSAKER } from "../../api-constants";
-import { Beregningstype, InntektskildeDto, SkatteforholdDto } from "../trygdeavgift";
+import { Beregningsregel, InntektskildeDto, SkatteforholdDto } from "../trygdeavgift";
 import { Avgiftspliktigperiode } from "../types/periodeTyper";
 
 export interface AarsavregningResponse {
@@ -54,7 +54,7 @@ export interface Trygdeavgiftsperiode {
   inntektPerMd: number;
   avgiftssats: number | null;
   avgiftPerMd: number;
-  beregningstype?: Beregningstype | null;
+  beregningsregel?: Beregningsregel | null;
   harSammenslåtteInntektskilder?: boolean;
   avgiftsdel?: string | null;
 }

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -56,6 +56,7 @@ export interface Trygdeavgiftsperiode {
   avgiftPerMd: number;
   beregningstype?: Beregningstype | null;
   harSammenslåtteInntektskilder?: boolean;
+  avgiftsdel?: string | null;
 }
 
 export interface Avregning {

--- a/src/services/modules/aarsavregning/aarsavregning.ts
+++ b/src/services/modules/aarsavregning/aarsavregning.ts
@@ -1,6 +1,6 @@
 import { getAsJson, postAsJson, putAsJson } from "../../utils";
 import { AARSAVREGNING, API_BASE_URL, BEHANDLINGER, FAGSAKER } from "../../api-constants";
-import { InntektskildeDto, SkatteforholdDto } from "../trygdeavgift";
+import { Beregningstype, InntektskildeDto, SkatteforholdDto } from "../trygdeavgift";
 import { Avgiftspliktigperiode } from "../types/periodeTyper";
 
 export interface AarsavregningResponse {
@@ -52,8 +52,9 @@ export interface Trygdeavgiftsperiode {
   inntektskildetype: string;
   arbeidsgiversavgiftBetales: boolean;
   inntektPerMd: number;
-  avgiftssats: number;
+  avgiftssats: number | null;
   avgiftPerMd: number;
+  beregningstype?: Beregningstype | null;
 }
 
 export interface Avregning {

--- a/src/services/modules/trygdeavgift.ts
+++ b/src/services/modules/trygdeavgift.ts
@@ -34,6 +34,7 @@ export interface Trygdeavgiftsperiode {
   avgiftPerMd: number;
   beregningstype?: Beregningstype | null;
   harSammenslåtteInntektskilder?: boolean;
+  avgiftsdel?: string | null;
 }
 
 export interface BeregnetTrygdeavgift {

--- a/src/services/modules/trygdeavgift.ts
+++ b/src/services/modules/trygdeavgift.ts
@@ -23,7 +23,7 @@ export interface TrygdeavgiftMottakerDto {
   trygdeavgiftMottaker: KTObject;
 }
 
-export type Beregningstype = "ORDINAER" | "TJUEFEM_PROSENT_REGEL" | "MINSTEBELOEP";
+export type Beregningsregel = "ORDINAER" | "TJUEFEM_PROSENT_REGEL" | "MINSTEBELOEP";
 
 export interface Trygdeavgiftsperiode {
   fom: string;
@@ -32,7 +32,7 @@ export interface Trygdeavgiftsperiode {
   inntektskildetype: string;
   avgiftssats: number | null;
   avgiftPerMd: number;
-  beregningstype?: Beregningstype | null;
+  beregningsregel?: Beregningsregel | null;
   harSammenslåtteInntektskilder?: boolean;
   avgiftsdel?: string | null;
 }

--- a/src/services/modules/trygdeavgift.ts
+++ b/src/services/modules/trygdeavgift.ts
@@ -23,13 +23,16 @@ export interface TrygdeavgiftMottakerDto {
   trygdeavgiftMottaker: KTObject;
 }
 
+export type Beregningstype = "ORDINAER" | "TJUEFEM_PROSENT_REGEL" | "MINSTEBELOEP";
+
 export interface Trygdeavgiftsperiode {
   fom: string;
   tom: string;
   trygdedekning: string;
   inntektskildetype: string;
-  avgiftssats: number;
+  avgiftssats: number | null;
   avgiftPerMd: number;
+  beregningstype?: Beregningstype | null;
 }
 
 export interface BeregnetTrygdeavgift {

--- a/src/services/modules/trygdeavgift.ts
+++ b/src/services/modules/trygdeavgift.ts
@@ -33,6 +33,7 @@ export interface Trygdeavgiftsperiode {
   avgiftssats: number | null;
   avgiftPerMd: number;
   beregningstype?: Beregningstype | null;
+  harSammenslåtteInntektskilder?: boolean;
 }
 
 export interface BeregnetTrygdeavgift {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
@@ -1,5 +1,9 @@
 import { Grunnlagsopplysninger } from "../../../../../services/modules/aarsavregning/aarsavregning";
 import { Beregningstype } from "../../../../../services/modules/trygdeavgift";
+import {
+  formaterSats,
+  Beregningsforklaringer,
+} from "../../../../../felleskomponenter/trygdeavgift/komponenter/beregningsforklaring";
 import * as Nav from "../../../../../navFrontend";
 import * as Utils from "../../../../../utils";
 import MKV from "../../../../../melosyskodeverk";
@@ -9,17 +13,6 @@ import { erPeriodeListeHelseutgiftdekkesperiode } from "../../../../../services/
 
 const { SKATTEPLIKTIG } = MKV.Koder.skatteplikttype;
 const { MISJONÆR } = MKV.Koder.inntektskildetype;
-
-function formaterSats(detaljer: DetaljerInterface): string {
-  switch (detaljer.beregningstype) {
-    case "TJUEFEM_PROSENT_REGEL":
-      return "**";
-    case "MINSTEBELOEP":
-      return "*";
-    default:
-      return detaljer.avgiftssats?.toString() ?? "";
-  }
-}
 
 interface DetaljerInterface {
   fom: string;
@@ -84,8 +77,6 @@ export function BeregnetTrygdeavgiftDetaljer({
   const arbAvgBetalesKreves = (kildetype: string) => !medlemskapsTypeErPliktig && kildetype !== MISJONÆR;
 
   const detaljerListe = hentDetaljer(grunnlag);
-  const harMinstebeloep = detaljerListe.some((d) => d.beregningstype === "MINSTEBELOEP");
-  const har25ProsentRegel = detaljerListe.some((d) => d.beregningstype === "TJUEFEM_PROSENT_REGEL");
 
   return (
     <div className="tidligereGrunnlagPanel">
@@ -139,14 +130,7 @@ export function BeregnetTrygdeavgiftDetaljer({
           ))}
         </Nav.Table.Body>
       </Nav.Table>
-      {(harMinstebeloep || har25ProsentRegel) && (
-        <div className="forklaringstekster">
-          {harMinstebeloep && <p>* Inntekten er lavere enn minstebeløpet for trygdeavgift.</p>}
-          {har25ProsentRegel && (
-            <p>** Trygdeavgiften kan maks utgjøre 25 % av inntekten som overstiger minstebeløpet.</p>
-          )}
-        </div>
-      )}
+      <Beregningsforklaringer perioder={detaljerListe} />
     </div>
   );
 }

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
@@ -2,6 +2,7 @@ import { Grunnlagsopplysninger } from "../../../../../services/modules/aarsavreg
 import { Beregningstype } from "../../../../../services/modules/trygdeavgift";
 import {
   formaterSats,
+  formaterDekning,
   formaterInntektskilde,
   Beregningsforklaringer,
 } from "../../../../../felleskomponenter/trygdeavgift/komponenter/beregningsforklaring";
@@ -27,6 +28,7 @@ interface DetaljerInterface {
   dekning: string;
   beregningstype?: Beregningstype | null;
   harSammenslåtteInntektskilder?: boolean;
+  avgiftsdel?: string | null;
 }
 
 export function BeregnetTrygdeavgiftDetaljer({
@@ -72,6 +74,7 @@ export function BeregnetTrygdeavgiftDetaljer({
           dekning,
           beregningstype: period.beregningstype,
           harSammenslåtteInntektskilder: period.harSammenslåtteInntektskilder,
+          avgiftsdel: period.avgiftsdel,
         };
       })
       .sort(Utils.dato.sorterEtterISOFomDato);
@@ -126,7 +129,9 @@ export function BeregnetTrygdeavgiftDetaljer({
               <Nav.Table.DataCell key={Utils._uuid()}>{detaljer.skattepliktig}</Nav.Table.DataCell>
               {!erHelseutgiftDekkesPeriode && (
                 <Nav.Table.DataCell key={Utils._uuid()}>
-                  {KV.finnTermFraListe(MKV.KTObjects.trygdedekninger, detaljer.dekning)}
+                  {formaterDekning({ avgiftsdel: detaljer.avgiftsdel, trygdedekning: detaljer.dekning }, (kode) =>
+                    KV.finnTermFraListe(MKV.KTObjects.trygdedekninger, kode),
+                  )}
                 </Nav.Table.DataCell>
               )}
             </Nav.Table.Row>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
@@ -2,6 +2,7 @@ import { Grunnlagsopplysninger } from "../../../../../services/modules/aarsavreg
 import { Beregningstype } from "../../../../../services/modules/trygdeavgift";
 import {
   formaterSats,
+  formaterInntektskilde,
   Beregningsforklaringer,
 } from "../../../../../felleskomponenter/trygdeavgift/komponenter/beregningsforklaring";
 import * as Nav from "../../../../../navFrontend";
@@ -25,6 +26,7 @@ interface DetaljerInterface {
   skattepliktig: string;
   dekning: string;
   beregningstype?: Beregningstype | null;
+  harSammenslåtteInntektskilder?: boolean;
 }
 
 export function BeregnetTrygdeavgiftDetaljer({
@@ -69,6 +71,7 @@ export function BeregnetTrygdeavgiftDetaljer({
             overlappingSkatteforhold && overlappingSkatteforhold.skatteplikttype === SKATTEPLIKTIG ? "Ja" : "Nei",
           dekning,
           beregningstype: period.beregningstype,
+          harSammenslåtteInntektskilder: period.harSammenslåtteInntektskilder,
         };
       })
       .sort(Utils.dato.sorterEtterISOFomDato);
@@ -108,7 +111,7 @@ export function BeregnetTrygdeavgiftDetaljer({
                 {formaterTilNorskBelopUtenDesimaler(detaljer.avgiftPerMd)} kr
               </Nav.Table.DataCell>
               <Nav.Table.DataCell key={Utils._uuid()}>
-                {KV.finnTermFraListe(MKV.KTObjects.inntektskildetype, detaljer.inntektskildetype)}
+                {formaterInntektskilde(detaljer, (kode) => KV.finnTermFraListe(MKV.KTObjects.inntektskildetype, kode))}
               </Nav.Table.DataCell>
               <Nav.Table.DataCell key={Utils._uuid()} className="tall_felt">
                 {formaterTilNorskBelopUtenDesimaler(detaljer.inntektPerMd)} kr

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
@@ -1,5 +1,5 @@
 import { Grunnlagsopplysninger } from "../../../../../services/modules/aarsavregning/aarsavregning";
-import { Beregningstype } from "../../../../../services/modules/trygdeavgift";
+import { Beregningsregel } from "../../../../../services/modules/trygdeavgift";
 import {
   formaterSats,
   formaterDekning,
@@ -26,7 +26,7 @@ interface DetaljerInterface {
   avgiftPerMd: number;
   skattepliktig: string;
   dekning: string;
-  beregningstype?: Beregningstype | null;
+  beregningsregel?: Beregningsregel | null;
   harSammenslåtteInntektskilder?: boolean;
   avgiftsdel?: string | null;
 }
@@ -72,7 +72,7 @@ export function BeregnetTrygdeavgiftDetaljer({
           skattepliktig:
             overlappingSkatteforhold && overlappingSkatteforhold.skatteplikttype === SKATTEPLIKTIG ? "Ja" : "Nei",
           dekning,
-          beregningstype: period.beregningstype,
+          beregningsregel: period.beregningsregel,
           harSammenslåtteInntektskilder: period.harSammenslåtteInntektskilder,
           avgiftsdel: period.avgiftsdel,
         };

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/beregnetTrygdeavgiftDetaljer.tsx
@@ -1,4 +1,5 @@
 import { Grunnlagsopplysninger } from "../../../../../services/modules/aarsavregning/aarsavregning";
+import { Beregningstype } from "../../../../../services/modules/trygdeavgift";
 import * as Nav from "../../../../../navFrontend";
 import * as Utils from "../../../../../utils";
 import MKV from "../../../../../melosyskodeverk";
@@ -9,16 +10,28 @@ import { erPeriodeListeHelseutgiftdekkesperiode } from "../../../../../services/
 const { SKATTEPLIKTIG } = MKV.Koder.skatteplikttype;
 const { MISJONÆR } = MKV.Koder.inntektskildetype;
 
+function formaterSats(detaljer: DetaljerInterface): string {
+  switch (detaljer.beregningstype) {
+    case "TJUEFEM_PROSENT_REGEL":
+      return "**";
+    case "MINSTEBELOEP":
+      return "*";
+    default:
+      return detaljer.avgiftssats?.toString() ?? "";
+  }
+}
+
 interface DetaljerInterface {
   fom: string;
   tom: string;
   inntektskildetype: string;
   arbeidsgiversavgiftBetales: string;
   inntektPerMd: number;
-  avgiftssats: number;
+  avgiftssats: number | null;
   avgiftPerMd: number;
   skattepliktig: string;
   dekning: string;
+  beregningstype?: Beregningstype | null;
 }
 
 export function BeregnetTrygdeavgiftDetaljer({
@@ -62,12 +75,17 @@ export function BeregnetTrygdeavgiftDetaljer({
           skattepliktig:
             overlappingSkatteforhold && overlappingSkatteforhold.skatteplikttype === SKATTEPLIKTIG ? "Ja" : "Nei",
           dekning,
+          beregningstype: period.beregningstype,
         };
       })
       .sort(Utils.dato.sorterEtterISOFomDato);
   };
 
   const arbAvgBetalesKreves = (kildetype: string) => !medlemskapsTypeErPliktig && kildetype !== MISJONÆR;
+
+  const detaljerListe = hentDetaljer(grunnlag);
+  const harMinstebeloep = detaljerListe.some((d) => d.beregningstype === "MINSTEBELOEP");
+  const har25ProsentRegel = detaljerListe.some((d) => d.beregningstype === "TJUEFEM_PROSENT_REGEL");
 
   return (
     <div className="tidligereGrunnlagPanel">
@@ -85,7 +103,7 @@ export function BeregnetTrygdeavgiftDetaljer({
           </Nav.Table.Row>
         </Nav.Table.Header>
         <Nav.Table.Body>
-          {hentDetaljer(grunnlag).map((detaljer) => (
+          {detaljerListe.map((detaljer) => (
             <Nav.Table.Row className="border_top" key={Utils._uuid()}>
               <Nav.Table.DataCell key={Utils._uuid()}>
                 {`${Utils.dato.formatterDatoTilNorsk(detaljer.fom)} - ${Utils.dato.formatterDatoTilNorsk(
@@ -93,7 +111,7 @@ export function BeregnetTrygdeavgiftDetaljer({
                 )}`}
               </Nav.Table.DataCell>
               <Nav.Table.DataCell key={Utils._uuid()} className="tall_felt">
-                {detaljer.avgiftssats}
+                {formaterSats(detaljer)}
               </Nav.Table.DataCell>
               <Nav.Table.DataCell key={Utils._uuid()} className="tall_felt">
                 {formaterTilNorskBelopUtenDesimaler(detaljer.avgiftPerMd)} kr
@@ -121,6 +139,14 @@ export function BeregnetTrygdeavgiftDetaljer({
           ))}
         </Nav.Table.Body>
       </Nav.Table>
+      {(harMinstebeloep || har25ProsentRegel) && (
+        <div className="forklaringstekster">
+          {harMinstebeloep && <p>* Inntekten er lavere enn minstebeløpet for trygdeavgift.</p>}
+          {har25ProsentRegel && (
+            <p>** Trygdeavgiften kan maks utgjøre 25 % av inntekten som overstiger minstebeløpet.</p>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/sider/trygdeavgift/helseutgiftDekkesPeriode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/helseutgiftDekkesPeriode/vurderingTrygdeavgift.tsx
@@ -80,7 +80,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const [feil, setFeil] = useState<string | undefined>(undefined);
   const [lagrePending, setLagrePending] = useState(false);
   const alleTrygdeavgiftsperioderHarNullBeløp = lagretTrygdeavgift?.trygdeavgiftsperioder.every(
-    (periode) => periode.avgiftPerMd === 0,
+    (periode) => periode.avgiftPerMd === 0 && !periode.beregningstype,
   );
 
   const formattedDefaultPeriode = () => {

--- a/src/sider/trygdeavgift/helseutgiftDekkesPeriode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/helseutgiftDekkesPeriode/vurderingTrygdeavgift.tsx
@@ -81,7 +81,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const [feil, setFeil] = useState<string | undefined>(undefined);
   const [lagrePending, setLagrePending] = useState(false);
   const alleTrygdeavgiftsperioderHarNullBeløp = lagretTrygdeavgift?.trygdeavgiftsperioder.every(
-    (periode) => periode.avgiftPerMd === 0 && erOrdinaerBeregning(periode.beregningstype),
+    (periode) => periode.avgiftPerMd === 0 && erOrdinaerBeregning(periode.beregningsregel),
   );
 
   const formattedDefaultPeriode = () => {

--- a/src/sider/trygdeavgift/helseutgiftDekkesPeriode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/helseutgiftDekkesPeriode/vurderingTrygdeavgift.tsx
@@ -29,6 +29,7 @@ import {
 } from "../../../felleskomponenter/trygdeavgift/komponenter/types";
 import MKV from "../../../melosyskodeverk";
 import { BeregnetTrygdeavgift, TrygdeavgiftsgrunnlagDto } from "../../../services/modules/trygdeavgift";
+import { erOrdinaerBeregning } from "../../../felleskomponenter/trygdeavgift/komponenter/beregningsforklaring";
 import "./vurderingTrygdeavgift.less";
 import vurderingTrygdeavgiftSchema from "./vurderingTrygdeavgiftSchema";
 
@@ -80,7 +81,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const [feil, setFeil] = useState<string | undefined>(undefined);
   const [lagrePending, setLagrePending] = useState(false);
   const alleTrygdeavgiftsperioderHarNullBeløp = lagretTrygdeavgift?.trygdeavgiftsperioder.every(
-    (periode) => periode.avgiftPerMd === 0 && !periode.beregningstype,
+    (periode) => periode.avgiftPerMd === 0 && erOrdinaerBeregning(periode.beregningstype),
   );
 
   const formattedDefaultPeriode = () => {

--- a/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
@@ -79,7 +79,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   );
 
   const alleTrygdeavgiftsperioderHarNullBeløp = lagretTrygdeavgift?.trygdeavgiftsperioder.every(
-    (periode) => periode.avgiftPerMd === 0,
+    (periode) => periode.avgiftPerMd === 0 && !periode.beregningstype,
   );
 
   const formattedDefaultPeriode = () => {

--- a/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
@@ -80,7 +80,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   );
 
   const alleTrygdeavgiftsperioderHarNullBeløp = lagretTrygdeavgift?.trygdeavgiftsperioder.every(
-    (periode) => periode.avgiftPerMd === 0 && erOrdinaerBeregning(periode.beregningstype),
+    (periode) => periode.avgiftPerMd === 0 && erOrdinaerBeregning(periode.beregningsregel),
   );
 
   const formattedDefaultPeriode = () => {

--- a/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
@@ -30,6 +30,7 @@ import {
 } from "../../../felleskomponenter/trygdeavgift/komponenter/types";
 import MKV from "../../../melosyskodeverk";
 import { BeregnetTrygdeavgift, TrygdeavgiftsgrunnlagDto } from "../../../services/modules/trygdeavgift";
+import { erOrdinaerBeregning } from "../../../felleskomponenter/trygdeavgift/komponenter/beregningsforklaring";
 import "./vurderingTrygdeavgift.less";
 import vurderingTrygdeavgiftSchema from "./vurderingTrygdeavgiftSchema";
 
@@ -79,7 +80,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   );
 
   const alleTrygdeavgiftsperioderHarNullBeløp = lagretTrygdeavgift?.trygdeavgiftsperioder.every(
-    (periode) => periode.avgiftPerMd === 0 && !periode.beregningstype,
+    (periode) => periode.avgiftPerMd === 0 && erOrdinaerBeregning(periode.beregningstype),
   );
 
   const formattedDefaultPeriode = () => {

--- a/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
@@ -74,7 +74,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   );
 
   const alleTrygdeavgiftsperioderHarNullBeløp = lagretTrygdeavgift?.trygdeavgiftsperioder.every(
-    (periode) => periode.avgiftPerMd === 0,
+    (periode) => periode.avgiftPerMd === 0 && !periode.beregningstype,
   );
 
   const medlemskapsTypeErPliktig = medlemskapsperioder.every(

--- a/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../../felleskomponenter/trygdeavgift/komponenter/types";
 import MKV from "../../../melosyskodeverk";
 import { BeregnetTrygdeavgift, TrygdeavgiftsgrunnlagDto } from "../../../services/modules/trygdeavgift";
+import { erOrdinaerBeregning } from "../../../felleskomponenter/trygdeavgift/komponenter/beregningsforklaring";
 import "./vurderingTrygdeavgift.less";
 import vurderingTrygdeavgiftSchema from "./vurderingTrygdeavgiftSchema";
 
@@ -74,7 +75,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   );
 
   const alleTrygdeavgiftsperioderHarNullBeløp = lagretTrygdeavgift?.trygdeavgiftsperioder.every(
-    (periode) => periode.avgiftPerMd === 0 && !periode.beregningstype,
+    (periode) => periode.avgiftPerMd === 0 && erOrdinaerBeregning(periode.beregningstype),
   );
 
   const medlemskapsTypeErPliktig = medlemskapsperioder.every(

--- a/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
@@ -75,7 +75,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   );
 
   const alleTrygdeavgiftsperioderHarNullBeløp = lagretTrygdeavgift?.trygdeavgiftsperioder.every(
-    (periode) => periode.avgiftPerMd === 0 && erOrdinaerBeregning(periode.beregningstype),
+    (periode) => periode.avgiftPerMd === 0 && erOrdinaerBeregning(periode.beregningsregel),
   );
 
   const medlemskapsTypeErPliktig = medlemskapsperioder.every(


### PR DESCRIPTION
Viser `*`/`**` i sats-kolonnen og forklarende fotnoter når 25%-regelen eller minstebeløp gjelder for trygdeavgiftsperioder.

Backend-PR #3273 legger til `beregningstype` på `TrygdeavgiftsperiodeDto`. Uten frontend-endringer vil perioder med 25%-regel eller minstebeløp vise tom/0 sats uten forklaring.

- Oppdatert typer med nullable `avgiftssats` og nytt `beregningstype`-felt
- Sats-kolonnen viser `*` (25%-regel) eller `**` (minstebeløp) i stedet for tallverdi
- Fotnoter under tabellen forklarer symbolene
- Tabellen vises også når avgift er 0 kr (minstebeløp-tilfellet)
- Gjelder både trygdeavgiftstabellen og årsavregning detaljtabellen
- Delt `beregningsforklaring.tsx`-modul med `formaterSats()`, `Beregningsforklaringer`-komponent og `erOrdinaerBeregning()`-helper

[MELOSYS-7530](https://jira.adeo.no/browse/MELOSYS-7530)

## Prodrisiko

**G4P (Good 4 Prod)** — trygt å prodsette når som helst, uavhengig av backend.

Denne PR-en er **ikke avhengig av** at backend-PR #3273 er deployet:
- Alle endringer er rent reaktive — UI-et reagerer kun på data fra API-et
- Når `beregningstype` mangler i responsen (gammel backend), faller all logikk tilbake til eksakt samme oppførsel som før
- Funksjonaliteten aktiveres først når backend sender `beregningstype` i responsen
- Ingen egen feature toggle i frontend — effektivt bak backend/beregningsservicens toggle

## Testing
- [x] Unit tests (10 tester, alle passerer)
- [x] TypeScript kompilerer uten feil
- [x] E2E: `TJUEFEM_PROSENT_REGEL` — dekket med frivillig (helse+pensjon) og pliktig (full dekning)
- [x] E2E: `ORDINAER` — verifiserer numerisk sats og ingen fotnoter
- [ ] E2E: `MINSTEBELOEP` — backend (`melosys-trygdeavgift-beregning`) setter ikke denne ennå, legges til når støttet
- [x] Manuell testing i Q1/Q2

## Referanser
- Backend: [melosys-api PR #3273](https://github.com/navikt/melosys-api/pull/3273)
- E2E-tester: [melosys-e2e-tests branch](https://github.com/navikt/melosys-e2e-tests/tree/feature/ftrl-trygdeavgift-25-prosent-regel-e2e)
- Figma: [FTRL design](https://www.figma.com/design/eA9mI5tHdXQKoRjpA8g1oT/FTRL?node-id=3448-31836)
- `MINSTEBELOEP` er fullt dekket i unit-tester, men backend-beregningsservicen returnerer ikke denne typen ennå