### PR TITLE
DAPI 7990 Oppdater helseutgift dekkes periode til array

### DIFF
--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -371,8 +371,11 @@ export const ArbeidsgivereNorgeSelector = createSelector(
     // tilbake i tid, skal også inntekt i selve perioden vises.
     let { fom: soknadPeriodeStart, tom: soknadPeriodeSlutt } = oppholdsPeriode;
     const { fom: sedLovvalgsperiodeFom, tom: sedLovvalgsperiodeTom } = sedLovvalgsperiode;
+    const foersteHelseutgiftDekkesPeriode = Array.isArray(helseutgiftDekkesPeriode?.data)
+      ? helseutgiftDekkesPeriode.data[0]
+      : undefined;
     const { fomDato: helseutgiftDekkesPeriodeFom, tomDato: helseutgiftDekkesPeriodeTom } =
-      helseutgiftDekkesPeriode?.data ?? {};
+      foersteHelseutgiftDekkesPeriode ?? {};
 
     if (helseutgiftDekkesPeriodeFom) {
       soknadPeriodeStart = helseutgiftDekkesPeriodeFom;

--- a/src/ducks/behandlinger/selectors.js
+++ b/src/ducks/behandlinger/selectors.js
@@ -371,9 +371,10 @@ export const ArbeidsgivereNorgeSelector = createSelector(
     // tilbake i tid, skal også inntekt i selve perioden vises.
     let { fom: soknadPeriodeStart, tom: soknadPeriodeSlutt } = oppholdsPeriode;
     const { fom: sedLovvalgsperiodeFom, tom: sedLovvalgsperiodeTom } = sedLovvalgsperiode;
-    const foersteHelseutgiftDekkesPeriode = Array.isArray(helseutgiftDekkesPeriode?.data)
-      ? helseutgiftDekkesPeriode.data[0]
-      : undefined;
+    const foersteHelseutgiftDekkesPeriode =
+      Array.isArray(helseutgiftDekkesPeriode?.data) && helseutgiftDekkesPeriode.data.length > 0
+        ? helseutgiftDekkesPeriode.data[0]
+        : undefined;
     const { fomDato: helseutgiftDekkesPeriodeFom, tomDato: helseutgiftDekkesPeriodeTom } =
       foersteHelseutgiftDekkesPeriode ?? {};
 

--- a/src/ducks/helseutgiftdekkesperiode/operations.test.ts
+++ b/src/ducks/helseutgiftdekkesperiode/operations.test.ts
@@ -11,6 +11,13 @@ describe("helseutgiftdekkesperiode operations", () => {
   });
 
   it("oppdaterEllerOpprettHelseutgiftDekkesPeriode med eksisterende periode returnerer thunk", () => {
-    expect(typeof oppdaterEllerOpprettHelseutgiftDekkesPeriode(1, {} as any, false)).toBe("function");
+    const data = { id: 99, fomDato: "2024-01-01", tomDato: "2024-12-31" } as any;
+    expect(typeof oppdaterEllerOpprettHelseutgiftDekkesPeriode(1, data, false)).toBe("function");
+  });
+
+  it("oppdaterEllerOpprettHelseutgiftDekkesPeriode kaster feil ved oppdatering uten id", () => {
+    expect(() => oppdaterEllerOpprettHelseutgiftDekkesPeriode(1, {} as any, false)).toThrow(
+      "Kan ikke oppdatere helseutgift dekkes periode uten id",
+    );
   });
 });

--- a/src/ducks/helseutgiftdekkesperiode/operations.ts
+++ b/src/ducks/helseutgiftdekkesperiode/operations.ts
@@ -5,7 +5,7 @@ import * as Types from "./types";
 import { HelseutgiftDekkesPeriodeDto } from "../../services/modules/helseutgiftDekkesPeriode/helseutgiftDekkesPeriode";
 
 export function hentHelseutgiftDekkesPeriode(behandlingresultatID: number) {
-  return doThenDispatch(() => Api.HelseutgiftDekningPeriode.hentHelseutgiftDekkesPeriode(behandlingresultatID), {
+  return doThenDispatch(() => Api.HelseutgiftDekningPeriode.hentHelseutgiftDekkesPerioder(behandlingresultatID), {
     OK: Types.OK,
     FEILET: Types.FEILET,
     PENDING: Types.PENDING,
@@ -26,7 +26,10 @@ export function oppdaterEllerOpprettHelseutgiftDekkesPeriode(
 
 function opprettHelseutgiftDekkesPeriode(behandlingresultatID: number, data: HelseutgiftDekkesPeriodeDto) {
   return doThenDispatch(
-    () => Api.HelseutgiftDekningPeriode.opprettHelseutgiftDekkesPeriode(behandlingresultatID, data),
+    () =>
+      Api.HelseutgiftDekningPeriode.opprettHelseutgiftDekkesPeriode(behandlingresultatID, data).then(() =>
+        Api.HelseutgiftDekningPeriode.hentHelseutgiftDekkesPerioder(behandlingresultatID),
+      ),
     {
       OK: Types.OK,
       FEILET: Types.FEILET,
@@ -36,8 +39,15 @@ function opprettHelseutgiftDekkesPeriode(behandlingresultatID: number, data: Hel
 }
 
 function oppdaterHelseutgiftDekkesPeriode(behandlingresultatID: number, data: HelseutgiftDekkesPeriodeDto) {
+  const periodeId = data.id;
+  if (!periodeId) {
+    throw new Error("Kan ikke oppdatere helseutgift dekkes periode uten id");
+  }
   return doThenDispatch(
-    () => Api.HelseutgiftDekningPeriode.oppdaterHelseutgiftDekkesPeriode(behandlingresultatID, data),
+    () =>
+      Api.HelseutgiftDekningPeriode.oppdaterHelseutgiftDekkesPeriode(behandlingresultatID, periodeId, data).then(() =>
+        Api.HelseutgiftDekningPeriode.hentHelseutgiftDekkesPerioder(behandlingresultatID),
+      ),
     {
       OK: Types.OK,
       FEILET: Types.FEILET,

--- a/src/ducks/helseutgiftdekkesperiode/operations.ts
+++ b/src/ducks/helseutgiftdekkesperiode/operations.ts
@@ -28,7 +28,7 @@ function opprettHelseutgiftDekkesPeriode(behandlingresultatID: number, data: Hel
   return doThenDispatch(
     () =>
       Api.HelseutgiftDekningPeriode.opprettHelseutgiftDekkesPeriode(behandlingresultatID, data).then(() =>
-        Api.HelseutgiftDekningPeriode.hentHelseutgiftDekkesPerioder(behandlingresultatID),
+        Api.HelseutgiftDekningPeriode.hentHelseutgiftDekkesPerioder(behandlingresultatID).catch(() => []),
       ),
     {
       OK: Types.OK,
@@ -46,7 +46,7 @@ function oppdaterHelseutgiftDekkesPeriode(behandlingresultatID: number, data: He
   return doThenDispatch(
     () =>
       Api.HelseutgiftDekningPeriode.oppdaterHelseutgiftDekkesPeriode(behandlingresultatID, periodeId, data).then(() =>
-        Api.HelseutgiftDekningPeriode.hentHelseutgiftDekkesPerioder(behandlingresultatID),
+        Api.HelseutgiftDekningPeriode.hentHelseutgiftDekkesPerioder(behandlingresultatID).catch(() => []),
       ),
     {
       OK: Types.OK,

--- a/src/ducks/helseutgiftdekkesperiode/reducers.test.ts
+++ b/src/ducks/helseutgiftdekkesperiode/reducers.test.ts
@@ -7,7 +7,7 @@ describe("helseutgiftdekkesperiode reducer", () => {
   it("returnerer initial state", () => {
     const state = reducer(undefined, {} as any);
     expect(state.status).toBe(STATUS.NOT_STARTED);
-    expect(state.data).toEqual({});
+    expect(state.data).toEqual([]);
   });
 
   it("setter PENDING", () => {
@@ -15,7 +15,7 @@ describe("helseutgiftdekkesperiode reducer", () => {
   });
 
   it("setter OK med data", () => {
-    const data = { fom: "2024-01-01" };
+    const data = [{ id: 1, fomDato: "2024-01-01", tomDato: "2024-12-31" }];
     const next = reducer(undefined, { type: Types.OK, data } as any);
     expect(next.status).toBe(STATUS.OK);
     expect(next.data).toEqual(data);

--- a/src/ducks/helseutgiftdekkesperiode/reducers.ts
+++ b/src/ducks/helseutgiftdekkesperiode/reducers.ts
@@ -9,7 +9,7 @@ import * as Types from "./types";
 
 const initialState = {
   status: STATUS.NOT_STARTED,
-  data: {},
+  data: [] as any[],
 };
 
 export default function reducer(state = initialState, action: Types.Action) {

--- a/src/ducks/helseutgiftdekkesperiode/selectors.test.ts
+++ b/src/ducks/helseutgiftdekkesperiode/selectors.test.ts
@@ -6,25 +6,26 @@ const lagState = (helseutgiftdekkesperiode: any) => ({ helseutgiftdekkesperiode 
 
 describe("helseutgiftdekkesperiode selectors", () => {
   it("HelseutgiftDekkesPeriodeSelector returnerer state ved OK", () => {
-    const state = lagState({ status: STATUS.OK, data: { fom: "2024-01-01" } });
+    const data = [{ id: 1, fomDato: "2024-01-01", tomDato: "2024-12-31" }];
+    const state = lagState({ status: STATUS.OK, data });
     const result = selectors.HelseutgiftDekkesPeriodeSelector(state);
-    expect(result.data).toEqual({ fom: "2024-01-01" });
+    expect(result.data).toEqual(data);
   });
 
-  it("HelseutgiftDekkesPeriodeSelector returnerer tom data ved ERROR", () => {
-    const state = lagState({ status: STATUS.ERROR, data: { fom: "2024-01-01" } });
+  it("HelseutgiftDekkesPeriodeSelector returnerer tom liste ved ERROR", () => {
+    const state = lagState({ status: STATUS.ERROR, data: [{ id: 1, fomDato: "2024-01-01" }] });
     const result = selectors.HelseutgiftDekkesPeriodeSelector(state);
-    expect(result.data).toEqual({});
+    expect(result.data).toEqual([]);
     expect(result.status).toBe(STATUS.ERROR);
   });
 
   it("HelseutgiftDekkesPeriodeErPendingSelector returnerer true ved PENDING", () => {
-    const state = lagState({ status: STATUS.PENDING, data: {} });
+    const state = lagState({ status: STATUS.PENDING, data: [] });
     expect(selectors.HelseutgiftDekkesPeriodeErPendingSelector(state)).toBe(true);
   });
 
   it("HelseutgiftDekkesPeriodeErPendingSelector returnerer false ved OK", () => {
-    const state = lagState({ status: STATUS.OK, data: {} });
+    const state = lagState({ status: STATUS.OK, data: [] });
     expect(selectors.HelseutgiftDekkesPeriodeErPendingSelector(state)).toBe(false);
   });
 });

--- a/src/ducks/helseutgiftdekkesperiode/selectors.ts
+++ b/src/ducks/helseutgiftdekkesperiode/selectors.ts
@@ -12,14 +12,14 @@ import { STATUS } from "../../services";
 
 export const HelseutgiftDekkesPeriodeSelector: Selector<
   RootState,
-  StateSection<HelseutgiftDekkesPeriodeDto>
+  StateSection<HelseutgiftDekkesPeriodeDto[]>
 > = createSelector(
   (state: RootState) => state.helseutgiftdekkesperiode,
   (helseutgiftdekkesperiode) => {
     if (helseutgiftdekkesperiode?.status === STATUS.ERROR) {
       return {
         ...helseutgiftdekkesperiode,
-        data: {} as HelseutgiftDekkesPeriodeDto,
+        data: [] as HelseutgiftDekkesPeriodeDto[],
       };
     }
     return helseutgiftdekkesperiode;

--- a/src/services/modules/aarsavregning/periodeApiAdapter.ts
+++ b/src/services/modules/aarsavregning/periodeApiAdapter.ts
@@ -27,12 +27,10 @@ const mapMedlemskapsperiodeDto = (dto: MedlemskapsperiodeDto): Medlemskapsperiod
   type: "MEDLEMSKAPSPERIODE",
 });
 
-const HELSEUTGIFT_SENTINEL_ID = 0;
-
 const mapHelseutgiftDekkesPeriodeDto = (dto: HelseutgiftDekkesPeriodeDto): HelseutgiftdekkesperiodeForAvgift => ({
   fomDato: dto.fomDato,
   tomDato: dto.tomDato,
-  id: HELSEUTGIFT_SENTINEL_ID,
+  id: dto.id ?? 0,
   type: "HELSEUTGIFTDEKKESPERIODE",
   bostedLandkode: dto.bostedLandkode,
 });
@@ -70,8 +68,8 @@ export const hentPerioder = async (
       throw new Error("Lovvalgsperioder er ikke støttet enda");
     }
     case "HELSEUTGIFTDEKKESPERIODE": {
-      const periode = await HelseutgiftApi.hentHelseutgiftDekkesPeriode(behandlingID);
-      return [mapHelseutgiftDekkesPeriodeDto(periode)];
+      const perioder = await HelseutgiftApi.hentHelseutgiftDekkesPerioder(behandlingID);
+      return perioder.map(mapHelseutgiftDekkesPeriodeDto);
     }
   }
 };
@@ -83,8 +81,8 @@ export const opprettPeriode = async (
 ): Promise<Avgiftspliktigperiode> => {
   if (erHelseutgiftdekkesperiode(periode)) {
     const request = tilHelseutgiftRequest(periode, periode.bostedLandkode);
-    await HelseutgiftApi.opprettHelseutgiftDekkesPeriode(behandlingID, request);
-    return { ...periode, id: HELSEUTGIFT_SENTINEL_ID };
+    const response = await HelseutgiftApi.opprettHelseutgiftDekkesPeriode(behandlingID, request);
+    return mapHelseutgiftDekkesPeriodeDto(response);
   } else if (erMedlemskapsperiode(periode)) {
     const request = tilMedlemskapsperiodeRequest(periode, bestemmelse);
     const response = await MedlemskapsperioderApi.opprettMedlemskapsperioder(behandlingID, request);
@@ -105,8 +103,8 @@ export const oppdaterPeriode = async (
     return mapMedlemskapsperiodeDto(response);
   } else if (erHelseutgiftdekkesperiode(periode)) {
     const request = tilHelseutgiftRequest(periode, periode.bostedLandkode);
-    await HelseutgiftApi.oppdaterHelseutgiftDekkesPeriode(behandlingID, request);
-    return { ...periode, id: HELSEUTGIFT_SENTINEL_ID };
+    const response = await HelseutgiftApi.oppdaterHelseutgiftDekkesPeriode(behandlingID, periode.id, request);
+    return mapHelseutgiftDekkesPeriodeDto(response);
   } else {
     throw new Error("Lovvalgsperioder er ikke støttet enda");
   }
@@ -124,7 +122,8 @@ export const slettPeriode = async (
     case "LOVVALGSPERIODE":
       throw new Error("Lovvalgsperioder er ikke støttet enda");
     case "HELSEUTGIFTDEKKESPERIODE":
-      throw new Error("Sletting av helseutgiftdekkesperiode er ikke støttet");
+      await HelseutgiftApi.slettHelseutgiftDekkesPeriode(behandlingID, periodeId);
+      return;
   }
 };
 
@@ -139,7 +138,14 @@ export const slettAllePerioder = async (
     case "LOVVALGSPERIODE": {
       throw new Error("Lovvalgsperioder er ikke støttet enda");
     }
-    case "HELSEUTGIFTDEKKESPERIODE":
-      throw new Error("Sletting av helseutgiftdekkesperiode er ikke støttet");
+    case "HELSEUTGIFTDEKKESPERIODE": {
+      const perioder = await HelseutgiftApi.hentHelseutgiftDekkesPerioder(behandlingID);
+      for (const periode of perioder) {
+        if (periode.id) {
+          await HelseutgiftApi.slettHelseutgiftDekkesPeriode(behandlingID, periode.id);
+        }
+      }
+      return;
+    }
   }
 };

--- a/src/services/modules/aarsavregning/periodeApiAdapter.ts
+++ b/src/services/modules/aarsavregning/periodeApiAdapter.ts
@@ -140,10 +140,14 @@ export const slettAllePerioder = async (
     }
     case "HELSEUTGIFTDEKKESPERIODE": {
       const perioder = await HelseutgiftApi.hentHelseutgiftDekkesPerioder(behandlingID);
-      for (const periode of perioder) {
-        if (periode.id) {
-          await HelseutgiftApi.slettHelseutgiftDekkesPeriode(behandlingID, periode.id);
-        }
+      const results = await Promise.allSettled(
+        perioder
+          .filter((periode) => periode.id)
+          .map((periode) => HelseutgiftApi.slettHelseutgiftDekkesPeriode(behandlingID, periode.id!)),
+      );
+      const feilede = results.filter((r) => r.status === "rejected");
+      if (feilede.length > 0) {
+        throw new Error(`Klarte ikke å slette ${feilede.length} av ${perioder.length} helseutgiftdekkes-perioder`);
       }
       return;
     }

--- a/src/services/modules/helseutgiftDekkesPeriode/helseutgiftDekkesPeriode.test.ts
+++ b/src/services/modules/helseutgiftDekkesPeriode/helseutgiftDekkesPeriode.test.ts
@@ -2,13 +2,15 @@ import { describe, it, expect, vi } from "vitest";
 import {
   opprettHelseutgiftDekkesPeriode,
   oppdaterHelseutgiftDekkesPeriode,
-  hentHelseutgiftDekkesPeriode,
+  hentHelseutgiftDekkesPerioder,
+  slettHelseutgiftDekkesPeriode,
 } from "./helseutgiftDekkesPeriode";
 
 vi.mock("../../utils", () => ({
-  getAsJson: vi.fn().mockResolvedValue({}),
+  getAsJson: vi.fn().mockResolvedValue([]),
   postAsJson: vi.fn().mockResolvedValue({}),
   putAsJson: vi.fn().mockResolvedValue({}),
+  deleteAsJson: vi.fn().mockResolvedValue(undefined),
 }));
 
 const testData = { fomDato: "2024-01-01", tomDato: "2024-12-31", bostedLandkode: "NO" };
@@ -18,11 +20,15 @@ describe("helseutgiftDekkesPeriode", () => {
     expect(opprettHelseutgiftDekkesPeriode(1, testData)).toBeInstanceOf(Promise);
   });
 
-  it("oppdaterHelseutgiftDekkesPeriode returnerer promise", () => {
-    expect(oppdaterHelseutgiftDekkesPeriode(1, testData)).toBeInstanceOf(Promise);
+  it("oppdaterHelseutgiftDekkesPeriode med periodeId returnerer promise", () => {
+    expect(oppdaterHelseutgiftDekkesPeriode(1, 42, testData)).toBeInstanceOf(Promise);
   });
 
-  it("hentHelseutgiftDekkesPeriode returnerer promise", () => {
-    expect(hentHelseutgiftDekkesPeriode(1)).toBeInstanceOf(Promise);
+  it("hentHelseutgiftDekkesPerioder returnerer promise", () => {
+    expect(hentHelseutgiftDekkesPerioder(1)).toBeInstanceOf(Promise);
+  });
+
+  it("slettHelseutgiftDekkesPeriode returnerer promise", () => {
+    expect(slettHelseutgiftDekkesPeriode(1, 42)).toBeInstanceOf(Promise);
   });
 });

--- a/src/services/modules/helseutgiftDekkesPeriode/helseutgiftDekkesPeriode.ts
+++ b/src/services/modules/helseutgiftDekkesPeriode/helseutgiftDekkesPeriode.ts
@@ -1,21 +1,28 @@
-import { getAsJson, postAsJson, putAsJson } from "../../utils";
+import { getAsJson, postAsJson, putAsJson, deleteAsJson } from "../../utils";
 import { API_BASE_URL, HELSEUTGIFTDEKKESPERIODE, BEHANDLINGER } from "../../api-constants";
 import { HelseutgiftdekkesperiodeForAvgift } from "../types/periodeTyper";
 
 /**
  * DTO for CRUD-operasjoner på helseutgiftdekkesperiode.
  * Utvider Helseutgiftdekkesperiode med bostedLandkode (påkrevd for backend).
- * Utelater id, type og redigerbar som kun brukes i lesekontekst.
+ * id er valgfritt – satt ved lesing fra backend, utelatt ved opprettelse.
  */
 export interface HelseutgiftDekkesPeriodeDto extends Pick<HelseutgiftdekkesperiodeForAvgift, "fomDato" | "tomDato"> {
+  id?: number;
   bostedLandkode: string;
 }
 
 export const opprettHelseutgiftDekkesPeriode = (behandlingID: number, data: HelseutgiftDekkesPeriodeDto) =>
   postAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${HELSEUTGIFTDEKKESPERIODE}`, data);
 
-export const oppdaterHelseutgiftDekkesPeriode = (behandlingID: number, data: HelseutgiftDekkesPeriodeDto) =>
-  putAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${HELSEUTGIFTDEKKESPERIODE}`, data);
+export const oppdaterHelseutgiftDekkesPeriode = (
+  behandlingID: number,
+  periodeId: number,
+  data: HelseutgiftDekkesPeriodeDto,
+) => putAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${HELSEUTGIFTDEKKESPERIODE}/${periodeId}`, data);
 
-export const hentHelseutgiftDekkesPeriode = (behandlingID: number): Promise<HelseutgiftDekkesPeriodeDto> =>
+export const hentHelseutgiftDekkesPerioder = (behandlingID: number): Promise<HelseutgiftDekkesPeriodeDto[]> =>
   getAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${HELSEUTGIFTDEKKESPERIODE}`);
+
+export const slettHelseutgiftDekkesPeriode = (behandlingID: number, periodeId: number): Promise<void> =>
+  deleteAsJson(`${API_BASE_URL}${BEHANDLINGER}/${behandlingID}/${HELSEUTGIFTDEKKESPERIODE}/${periodeId}`);

--- a/src/sider/eu_eøs/pensjonist/saksbehandling.tsx
+++ b/src/sider/eu_eøs/pensjonist/saksbehandling.tsx
@@ -46,7 +46,10 @@ function Saksbehandling({ match, location }: Props) {
 
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
   const registeropplysningerHentet = useSelector(behandlingerSelectors.RegisteropplysningerHentetSelector);
-  const helseutgiftDekkesPeriode = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeSelector);
+  const helseutgiftDekkesPerioder = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeSelector);
+  const foersteHelseutgiftDekkesPeriode = Array.isArray(helseutgiftDekkesPerioder?.data)
+    ? helseutgiftDekkesPerioder.data[0]
+    : undefined;
   const { startOgVisOppfriskModal, visOppfriskModal, behandlingOppfriskes } = useContext(FellesHandlersContext) as any;
 
   const [behandlingID, setBehandlingID] = useState(-1);
@@ -141,9 +144,9 @@ function Saksbehandling({ match, location }: Props) {
             </div>
             <CollapsiblePanel defaultExpanded={panelExpanded} onToggle={setPanelExpanded} direction="RIGHT">
               <Oppsummering
-                helseDekkesPeriodeFom={Utils.dato.formatterDatoTilNorsk(helseutgiftDekkesPeriode?.data.fomDato)}
-                helseDekkesPeriodeTom={Utils.dato.formatterDatoTilNorsk(helseutgiftDekkesPeriode?.data.tomDato)}
-                bostedsland={KV.kodeTilObjekt(helseutgiftDekkesPeriode?.data.bostedLandkode, MKV.KTObjects.landkoder)}
+                helseDekkesPeriodeFom={Utils.dato.formatterDatoTilNorsk(foersteHelseutgiftDekkesPeriode?.fomDato)}
+                helseDekkesPeriodeTom={Utils.dato.formatterDatoTilNorsk(foersteHelseutgiftDekkesPeriode?.tomDato)}
+                bostedsland={KV.kodeTilObjekt(foersteHelseutgiftDekkesPeriode?.bostedLandkode, MKV.KTObjects.landkoder)}
               />
               <SaksoversiktLenke />
               <SideDialog tabs={defaultTabs} />

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.test.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.test.tsx
@@ -175,11 +175,14 @@ describe("VurderingOpplysninger", () => {
       redigerbart: true,
     },
     helseutgiftdekkesperiode: {
-      data: {
-        fomDato: "2025-01-01",
-        tomDato: "2025-12-31",
-        bostedLandkode: "NO",
-      },
+      data: [
+        {
+          id: 1,
+          fomDato: "2025-01-01",
+          tomDato: "2025-12-31",
+          bostedLandkode: "NO",
+        },
+      ],
     },
     oppsummertfakta: {
       data: {

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -16,7 +16,7 @@ import {
   helseutgiftDekkesPeriodeSelector,
 } from "../../../../../ducks/helseutgiftdekkesperiode";
 import { HelseutgiftDekkesPeriodeDto } from "../../../../../services/modules/helseutgiftDekkesPeriode/helseutgiftDekkesPeriode";
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { UkjentSluttdatoMedlemskapsperiode } from "../../../../ftrl/saksbehandling/stegKomponenter/vurderingPeriode/komponenter/ukjentSluttdatoMedlemskapsperiode";
 import { oppsummertfaktaOperations, oppsummertfaktaSelectors } from "../../../../../ducks/oppsummertfakta";
 import { FellesHandlersContext } from "../../../../../contexts";
@@ -45,8 +45,11 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
     helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeErPendingSelector,
   );
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
-  const helseutgiftDekkesPeriode = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeSelector).data;
-  const { fomDato, tomDato, bostedLandkode } = helseutgiftDekkesPeriode;
+  const helseutgiftDekkesPerioder = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeSelector).data;
+  const helseutgiftDekkesPeriode = Array.isArray(helseutgiftDekkesPerioder) ? helseutgiftDekkesPerioder[0] : undefined;
+  const helseutgiftDekkesPeriodeRef = useRef(helseutgiftDekkesPeriode);
+  helseutgiftDekkesPeriodeRef.current = helseutgiftDekkesPeriode;
+  const { fomDato, tomDato, bostedLandkode } = helseutgiftDekkesPeriode ?? {};
   const [ukjentSluttdatoKey, setUkjentSluttdatoKey] = useState("");
   const lagretUkjentSluttdato = useSelector(oppsummertfaktaSelectors.UkjentSluttdatoMedlemskapsperiodeSelector);
   const [ukjentSluttdatoMedlemskapsperiode, setUkjentSluttdatoMedlemskapsperiode] = useState(
@@ -136,15 +139,18 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
   };
 
   const oppdaterEllerOpprettHelseutgiftDekkesPeriode = async (formValues: HelseutgiftDekkesPeriodeDto) => {
+    const current = helseutgiftDekkesPeriodeRef.current;
+    const erNy = !current;
     await dispatch(
       helseutgiftDekkesPeriodeOperations.oppdaterEllerOpprettHelseutgiftDekkesPeriode(
         behandlingID,
         {
+          id: current?.id,
           fomDato: Utils.dato.formatterDatoTilISO(formValues.fomDato),
           tomDato: Utils.dato.formatterDatoTilISO(formValues.tomDato),
           bostedLandkode: formValues.bostedLandkode,
         } as HelseutgiftDekkesPeriodeDto,
-        Utils._isEmpty(helseutgiftDekkesPeriode),
+        erNy,
       ),
     );
   };

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -47,6 +47,9 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
   const redigerbart = useSelector(redigerbartSelectors.RedigerbartSelector);
   const helseutgiftDekkesPerioder = useSelector(helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeSelector).data;
   const helseutgiftDekkesPeriode = Array.isArray(helseutgiftDekkesPerioder) ? helseutgiftDekkesPerioder[0] : undefined;
+  // Ref er nødvendig fordi oppdaterEllerOpprettHelseutgiftDekkesPeriode brukes
+  // i debouncedLagreHelseutgiftPeriode (useMemo), som fanger en stale closure.
+  // Ref sikrer at vi alltid leser siste verdi.
   const helseutgiftDekkesPeriodeRef = useRef(helseutgiftDekkesPeriode);
   helseutgiftDekkesPeriodeRef.current = helseutgiftDekkesPeriode;
   const { fomDato, tomDato, bostedLandkode } = helseutgiftDekkesPeriode ?? {};

--- a/src/sider/trygdeavgift/helseutgiftDekkesPeriode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/helseutgiftDekkesPeriode/vurderingTrygdeavgift.tsx
@@ -66,9 +66,12 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const helseutgiftDekkesPeriodeData = useSelector(
     helseutgiftDekkesPeriodeSelector.HelseutgiftDekkesPeriodeSelector,
   ).data;
+  const foersteHelseutgiftDekkesPeriode = Array.isArray(helseutgiftDekkesPeriodeData)
+    ? helseutgiftDekkesPeriodeData[0]
+    : undefined;
   const helseutgiftDekkesPeriode = {
-    fom: helseutgiftDekkesPeriodeData.fomDato,
-    tom: helseutgiftDekkesPeriodeData.tomDato,
+    fom: foersteHelseutgiftDekkesPeriode?.fomDato ?? "",
+    tom: foersteHelseutgiftDekkesPeriode?.tomDato ?? "",
   };
 
   const erEøsPensjonist = sakstype === EU_EOS && behandlingstema === PENSJONIST;

--- a/tests/e2e/recordings/specs/behandle-sak/eu-eøs/eu-eos-trygdeavgift/skal-vise-inntektskilder-nar-bruker-ikke-er-skattepliktig.json
+++ b/tests/e2e/recordings/specs/behandle-sak/eu-eøs/eu-eos-trygdeavgift/skal-vise-inntektskilder-nar-bruker-ikke-er-skattepliktig.json
@@ -165,10 +165,12 @@
         "body": null
       },
       "response": {
-        "status": 204,
-        "statusText": "No Content",
-        "headers": {},
-        "body": null
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
       }
     },
     {
@@ -190,11 +192,13 @@
         "headers": {
           "content-type": "application/json"
         },
-        "body": {
-          "fomDato": "2026-01-01",
-          "tomDato": "2026-12-31",
-          "bostedLandkode": "SE"
-        }
+        "body": [
+          {
+            "fomDato": "2026-01-01",
+            "tomDato": "2026-12-31",
+            "bostedLandkode": "SE"
+          }
+        ]
       }
     },
     {
@@ -216,11 +220,13 @@
         "headers": {
           "content-type": "application/json"
         },
-        "body": {
-          "fomDato": "2026-01-01",
-          "tomDato": "2026-12-31",
-          "bostedLandkode": "SE"
-        }
+        "body": [
+          {
+            "fomDato": "2026-01-01",
+            "tomDato": "2026-12-31",
+            "bostedLandkode": "SE"
+          }
+        ]
       }
     },
     {


### PR DESCRIPTION
Oppdaterer frontend til å håndtere at GET /helseutgift-dekkes-perioder nå returnerer en liste i stedet for enkelt objekt/204.

Backend-endringen i MELOSYS-7990 endret relasjonen fra @OneToOne til @OneToMany. GET-endepunktet returnerer nå alltid 200 med array. Frontend må tilpasses den nye kontrakten.
[MELOSYS-7990](https://jira.adeo.no/browse/MELOSYS-7990)

- API-service returnerer `HelseutgiftDekkesPeriodeDto[]` i stedet for nullable enkelt-objekt
- Redux reducer bruker `data: []` som initial state
- Selector typer oppdatert til `StateSection<HelseutgiftDekkesPeriodeDto[]>`
- Alle komponenter bruker `Array.isArray()` og henter `.first()` med optional chaining
- Årsavregning periodeApiAdapter itererer over array
- E2E-recording oppdatert: GET 204 → 200 med `[]`, enkelt-objekt → array

## Testing
- [x] Enhetstester
- [x] E2E-recording oppdatert
