### PR TITLE
8004 Fiks stegovergang som henger ved feil i lagre-kall

### DIFF
--- a/src/ducks/helseutgiftdekkesperiode/reducers.ts
+++ b/src/ducks/helseutgiftdekkesperiode/reducers.ts
@@ -17,7 +17,7 @@ export default function reducer(state = initialState, action: Types.Action) {
     case Types.PENDING:
       return { ...state, status: STATUS.PENDING };
     case Types.OK:
-      return { ...state, status: STATUS.OK, data: action.data };
+      return { ...state, status: STATUS.OK, data: action.data ?? {} };
     case Types.FEILET:
       return { ...state, status: STATUS.ERROR, data: action.data };
     default:

--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -2,6 +2,7 @@ import { Component } from "react";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 import PT from "prop-types";
+import { Alert } from "@navikt/ds-react";
 
 import MKV from "../../melosyskodeverk";
 import * as MPT from "../../proptypes";
@@ -61,6 +62,7 @@ class Stegvelger extends Component {
     stegStores: byggStegStores(),
     visMottatteOpplysningerFeilmeldinger: false,
     harTrygdeavgiftperiode: false,
+    lagreFeil: false,
   };
 
   aktiv = true;
@@ -527,6 +529,8 @@ class Stegvelger extends Component {
    * @param nyttStegNummer Number Steget som det skal byttes til.
    */
   tilSteg = async (nyttStegNummer) => {
+    this.setState({ lagreFeil: false });
+
     const {
       artikkel16_anmodning_skjema,
       soknad_skjema,
@@ -549,8 +553,6 @@ class Stegvelger extends Component {
       oppsummering.behandlingstema.kode == MKV.Koder.behandlinger.behandlingstema.ARBEID_TJENESTEPERSON_ELLER_FLY;
 
     const flytHarIkkeVurderingPeriode = !(eøsFaktureringAvTrygdeavgiftToggleEnabled && erArbeidTjenestepersonEllerFly);
-
-    this.setState({ aktivtStegNummer: nyttStegNummer });
 
     try {
       if (redigerbart) {
@@ -576,9 +578,12 @@ class Stegvelger extends Component {
     } catch (error) {
       /* eslint-disable-next-line no-console */
       console.error("Feil ved lagring under stegovergang:", error);
-    } finally {
-      this.oppdaterAktuelleSteg(nyttStegNummer, true);
+      this.setState({ lagreFeil: true });
+      return;
     }
+
+    this.setState({ aktivtStegNummer: nyttStegNummer });
+    this.oppdaterAktuelleSteg(nyttStegNummer, true);
   };
 
   /** Beregn neste steg i rekken, men ikke lenger enn
@@ -613,7 +618,7 @@ class Stegvelger extends Component {
   }
 
   render() {
-    const { visMottatteOpplysningerFeilmeldinger, aktivtStegNummer, aktuelleSteg } = this.state;
+    const { visMottatteOpplysningerFeilmeldinger, aktivtStegNummer, aktuelleSteg, lagreFeil } = this.state;
     const { redigerbart, oppsummering } = this.props;
     const visFeilmeldinger =
       this.erVedtakSteg(aktivtStegNummer) || aktuelleSteg[aktivtStegNummer]?.id === STEG.ARTIKKEL_16_ANMODNING;
@@ -623,6 +628,11 @@ class Stegvelger extends Component {
       <div className="stegvelger panelSeksjon">
         <StegLinje steg={aktuelleSteg} stegKlikk={this.validerSoknadOgGaTilSteg} />
         <StatsborgerskapFeil className="varselmelding" />
+        {lagreFeil && (
+          <Alert variant="error" className="varselmelding">
+            Kunne ikke lagre. Prøv igjen.
+          </Alert>
+        )}
         {!redigerbart && <Innsynsmelding />}
         {visFeilmeldinger && <Feilmeldinger />}
         {erNyVurdering && redigerbart && inngangStegErAktivt && <NyVurderingMelding />}

--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -552,28 +552,33 @@ class Stegvelger extends Component {
 
     this.setState({ aktivtStegNummer: nyttStegNummer });
 
-    if (redigerbart) {
-      if (sakstype !== MKV.Koder.sakstyper.FTRL) {
-        await oppdaterPerioderState({ ...soknad_skjema, ...artikkel16_anmodning_skjema });
+    try {
+      if (redigerbart) {
+        if (sakstype !== MKV.Koder.sakstyper.FTRL) {
+          await oppdaterPerioderState({ ...soknad_skjema, ...artikkel16_anmodning_skjema });
 
-        if (flytHarIkkeVurderingPeriode || erVurderingPeriode) {
-          await lagreLovvalgsperioderHandler();
+          if (flytHarIkkeVurderingPeriode || erVurderingPeriode) {
+            await lagreLovvalgsperioderHandler();
+          }
+
+          if (!anmodningErSendtUtland) {
+            await lagreAvklartefaktaHandler();
+            await lagreVilkarHandler();
+            await lagreAnmodningsperioderHandler();
+            await lagreUtpekingsperioderHandler();
+          }
         }
 
-        if (!anmodningErSendtUtland) {
-          await lagreAvklartefaktaHandler();
-          await lagreVilkarHandler();
-          await lagreAnmodningsperioderHandler();
-          await lagreUtpekingsperioderHandler();
+        if (this.erSisteSteg(nyttStegNummer)) {
+          await lagreMottatteOpplysningerHandler();
         }
       }
-
-      if (this.erSisteSteg(nyttStegNummer)) {
-        await lagreMottatteOpplysningerHandler();
-      }
+    } catch (error) {
+      /* eslint-disable-next-line no-console */
+      console.error("Feil ved lagring under stegovergang:", error);
+    } finally {
+      this.oppdaterAktuelleSteg(nyttStegNummer, true);
     }
-
-    this.oppdaterAktuelleSteg(nyttStegNummer, true);
   };
 
   /** Beregn neste steg i rekken, men ikke lenger enn

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -10,7 +10,7 @@ export const STATUS = {
 
 const toJson = async (response) => {
   if (response.status === 204) {
-    return response;
+    return null;
   }
   try {
     return await response.clone().json();

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
@@ -69,7 +69,7 @@ export function VurderingArtikkel13_x_vedtak({
         behandlingID,
         vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
         behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FORELOEPIG_FASTSATT_LOVVALGSLAND,
-        skalRegisteropplysningerOppdateres: false, // Saga handles this - don't update here to avoid race condition
+        skalRegisteropplysningerOppdateres: false, // Backend oppdaterer registeropplysninger ved vedtak - ikke her, unngår race condition
       };
       try {
         await kontrollerFerdigbehandling(request);

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
@@ -52,7 +52,6 @@ export function VurderingArtikkel13_x_vedtak({
   mottatteOpplysningerStatus,
 }) {
   const [vedtakPending, setVedtakPending] = useState(false);
-  let oppdaterFørKontroll = true;
 
   const erNyVurdering = behandlingstype === MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING;
 
@@ -70,11 +69,13 @@ export function VurderingArtikkel13_x_vedtak({
         behandlingID,
         vedtakstype: data.formValues.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
         behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FORELOEPIG_FASTSATT_LOVVALGSLAND,
-        skalRegisteropplysningerOppdateres: oppdaterFørKontroll,
+        skalRegisteropplysningerOppdateres: false, // Saga handles this - don't update here to avoid race condition
       };
-      oppdaterFørKontroll = false;
-      await kontrollerFerdigbehandling(request);
-      setVedtakPending(false);
+      try {
+        await kontrollerFerdigbehandling(request);
+      } finally {
+        setVedtakPending(false);
+      }
     }
   };
   const debouncedKontrollerBehandling = useCallback(Utils._debounce(kontrollerBehandling, 500), [


### PR DESCRIPTION
Fikser at EU/EØS steg-wizarden henger på "Yrkessituasjon"-steget når et lagre-kall feiler under stegovergang.

E2E-testen "skal sende anmodning om unntak" feiler konsekvent med timeout fordi React aldri re-rendrer etter at backend svarer OK. Rotårsaken er at `tilSteg()` setter `aktivtStegNummer` (som oppdaterer intern state) men deretter kjører `lagre*Handler`-kall som kan kaste. Når et kall kaster, kjører `oppdaterAktuelleSteg()` aldri — så `aktuelleSteg`-arrayet markerer fortsatt det gamle steget som aktivt. I tillegg returnerte `toJson()` rå `Response`-objekt for HTTP 204, som brøt Redux sin serialiseringsgaranti og ga "A non-serializable value was detected in an action".

- `Stegvelger.jsx`: Wrapper API-kall i `tilSteg()` med try/finally slik at `oppdaterAktuelleSteg` alltid kjører
- `utils.js`: `toJson()` returnerer `null` for 204 i stedet for rå `Response`-objekt

[MELOSYS-8004](https://jira.adeo.no/browse/MELOSYS-8004) 

## Testing
- [x] Alle 3219 unit-tester passerer
- [x] TypeScript kompilerer uten feil
- [x] E2E: Yrkessituasjon stegovergang (CI kjører nå)