### PR TITLE
7530 Bruk norske tegn i Beregningsregel enum-verdier

### DIFF
--- a/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/beregningsforklaring.tsx
@@ -13,7 +13,7 @@ const BEREGNINGSREGEL_FORKLARINGER: Partial<Record<Beregningsregel, { symbol: st
     symbol: "*",
     tekst: "Beregnet etter 25 %-regelen: Trygdeavgift skal ikke utgjøre mer enn 25 % av inntekt over minstebeløpet.",
   },
-  MINSTEBELOEP: { symbol: "**", tekst: "Inntekten er under minstebeløpet." },
+  MINSTEBELØP: { symbol: "**", tekst: "Inntekten er under minstebeløpet." },
 };
 
 export function formaterSats(periode: MedBeregningsregel): string {
@@ -23,7 +23,7 @@ export function formaterSats(periode: MedBeregningsregel): string {
 }
 
 export function erOrdinaerBeregning(beregningsregel?: Beregningsregel | null): boolean {
-  return !beregningsregel || beregningsregel === "ORDINAER";
+  return !beregningsregel || beregningsregel === "ORDINÆR";
 }
 
 const AVGIFTSDEL_TEKST: Record<string, string> = {

--- a/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
+++ b/src/felleskomponenter/trygdeavgift/komponenter/trygdeavgiftsperioderTabell.test.tsx
@@ -93,7 +93,7 @@ describe("TrygdeavgiftsperioderTabell", () => {
       lagPeriode("2024-01-01", "2024-12-31", {
         avgiftssats: null,
         avgiftPerMd: 0,
-        beregningsregel: "MINSTEBELOEP",
+        beregningsregel: "MINSTEBELØP",
       }),
     ];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
@@ -104,7 +104,7 @@ describe("TrygdeavgiftsperioderTabell", () => {
     const perioder = [
       lagPeriode("2024-01-01", "2024-12-31", {
         avgiftssats: 6.8,
-        beregningsregel: "ORDINAER",
+        beregningsregel: "ORDINÆR",
       }),
     ];
     render(<TrygdeavgiftsperioderTabell perioder={perioder} lagrePending={false} />);
@@ -115,7 +115,7 @@ describe("TrygdeavgiftsperioderTabell", () => {
     const perioder = [
       lagPeriode("2024-01-01", "2024-06-30", {
         avgiftssats: null,
-        beregningsregel: "MINSTEBELOEP",
+        beregningsregel: "MINSTEBELØP",
       }),
       lagPeriode("2024-07-01", "2024-12-31", {
         avgiftssats: null,

--- a/src/services/modules/trygdeavgift.ts
+++ b/src/services/modules/trygdeavgift.ts
@@ -23,7 +23,7 @@ export interface TrygdeavgiftMottakerDto {
   trygdeavgiftMottaker: KTObject;
 }
 
-export type Beregningsregel = "ORDINAER" | "TJUEFEM_PROSENT_REGEL" | "MINSTEBELOEP";
+export type Beregningsregel = "ORDINÆR" | "TJUEFEM_PROSENT_REGEL" | "MINSTEBELØP";
 
 export interface Trygdeavgiftsperiode {
   fom: string;


### PR DESCRIPTION
Oppdaterer Beregningsregel-typen til å bruke norske tegn: ORDINAER → ORDINÆR, MINSTEBELOEP → MINSTEBELØP.

Backend (melosys-trygdeavgift-beregning PR #379 og melosys-api PR #3273) har oppdatert
enum-verdiene til norske tegn etter review-tilbakemelding. Frontend må matche for at
beregningsforklaring og tabellvisning skal fungere korrekt.
[MELOSYS-7530](https://jira.adeo.no/browse/MELOSYS-7530)

- Oppdatert `Beregningsregel` type-definisjon i trygdeavgift.ts
- Oppdatert enum-keys i beregningsforklaring.tsx (MINSTEBELØP, ORDINÆR)
- Oppdatert testdata i trygdeavgiftsperioderTabell.test.tsx

### Testing
- [x] Enhetstester (16/16 grønne)
- [ ] E2E-tester (kjøres fra melosys-e2e-tests)