### PR TITLE
8004 Fiks regressjon i stegovergang og 204-håndtering

### DIFF
--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -2,7 +2,6 @@ import { Component } from "react";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 import PT from "prop-types";
-import { Alert } from "@navikt/ds-react";
 
 import MKV from "../../melosyskodeverk";
 import * as MPT from "../../proptypes";
@@ -62,7 +61,6 @@ class Stegvelger extends Component {
     stegStores: byggStegStores(),
     visMottatteOpplysningerFeilmeldinger: false,
     harTrygdeavgiftperiode: false,
-    lagreFeil: false,
   };
 
   aktiv = true;
@@ -529,8 +527,6 @@ class Stegvelger extends Component {
    * @param nyttStegNummer Number Steget som det skal byttes til.
    */
   tilSteg = async (nyttStegNummer) => {
-    this.setState({ lagreFeil: false });
-
     const {
       artikkel16_anmodning_skjema,
       soknad_skjema,
@@ -553,6 +549,8 @@ class Stegvelger extends Component {
       oppsummering.behandlingstema.kode == MKV.Koder.behandlinger.behandlingstema.ARBEID_TJENESTEPERSON_ELLER_FLY;
 
     const flytHarIkkeVurderingPeriode = !(eøsFaktureringAvTrygdeavgiftToggleEnabled && erArbeidTjenestepersonEllerFly);
+
+    this.setState({ aktivtStegNummer: nyttStegNummer });
 
     try {
       if (redigerbart) {
@@ -578,11 +576,8 @@ class Stegvelger extends Component {
     } catch (error) {
       /* eslint-disable-next-line no-console */
       console.error("Feil ved lagring under stegovergang:", error);
-      this.setState({ lagreFeil: true });
-      return;
     }
 
-    this.setState({ aktivtStegNummer: nyttStegNummer });
     this.oppdaterAktuelleSteg(nyttStegNummer, true);
   };
 
@@ -618,7 +613,7 @@ class Stegvelger extends Component {
   }
 
   render() {
-    const { visMottatteOpplysningerFeilmeldinger, aktivtStegNummer, aktuelleSteg, lagreFeil } = this.state;
+    const { visMottatteOpplysningerFeilmeldinger, aktivtStegNummer, aktuelleSteg } = this.state;
     const { redigerbart, oppsummering } = this.props;
     const visFeilmeldinger =
       this.erVedtakSteg(aktivtStegNummer) || aktuelleSteg[aktivtStegNummer]?.id === STEG.ARTIKKEL_16_ANMODNING;
@@ -628,11 +623,6 @@ class Stegvelger extends Component {
       <div className="stegvelger panelSeksjon">
         <StegLinje steg={aktuelleSteg} stegKlikk={this.validerSoknadOgGaTilSteg} />
         <StatsborgerskapFeil className="varselmelding" />
-        {lagreFeil && (
-          <Alert variant="error" className="varselmelding">
-            Kunne ikke lagre. Prøv igjen.
-          </Alert>
-        )}
         {!redigerbart && <Innsynsmelding />}
         {visFeilmeldinger && <Feilmeldinger />}
         {erNyVurdering && redigerbart && inngangStegErAktivt && <NyVurderingMelding />}

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -10,7 +10,7 @@ export const STATUS = {
 
 const toJson = async (response) => {
   if (response.status === 204) {
-    return null;
+    return {};
   }
   try {
     return await response.clone().json();


### PR DESCRIPTION
Fikser to regresjoner fra #3036 som brakk alle 6 unntak-tester i
eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts.

**Problem 1 - Stegvelger:** `tilSteg()` ble endret til try/catch med `return`
som avbrøt stegovergangen helt ved lagrefeil. I unntak-flyten kaster lagre-kall
feil som ikke er kritiske for navigasjonen, så brukeren ble sittende fast.

**Problem 2 - toJson:** Returnerte `null` for HTTP 204 som krasjet reducere
som aksesserer properties på `action.data` (bl.a. anmodningsperioder og
utpekingsperioder).

Isolert via parallelle E2E-kjøringer som viste at begge endringene brekker
uavhengig av hverandre.
[MELOSYS-8004](https://jira.adeo.no/browse/MELOSYS-8004)

- Stegvelger: wrapper lagre-kall i try/catch uten return — steget avanserer
  alltid, feil logges men blokkerer ikke navigasjon
- toJson: returnerer `{}` for 204 i stedet for rå Response-objekt — fikser
  Redux serialiseringsgaranti uten å krasje reducere

## Testing
- [x] Enhetstester (3225 passerer)
- [x] E2E unntak-tester grønne (tag `8004-fix-2`)
- [x] Isolert testet hver endring separat for å verifisere rotårsak