### PR TITLE
7921 Fiks feilmelding for skatteforhold i årsavregning uten grunnlag

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.jsx
@@ -161,16 +161,11 @@ const medlemskapsperiodeSchema = object().shape({
 });
 
 const skatteforholdsperiodeSchema = object().shape({
-  fomDato: string()
-    .required(MAA_FYLLES_UT)
-    .erGyldigDato()
-    .test(erInnenforValgtAarTest)
-    .test(erInnenforAvgiftspliktigperiodeTest),
+  fomDato: string().required(MAA_FYLLES_UT).erGyldigDato().test(erInnenforAvgiftspliktigperiodeTest),
   tomDato: string()
     .required(MAA_FYLLES_UT)
     .erGyldigDato()
     .test(åpenTomTest)
-    .test(erInnenforValgtAarTest)
     .test(erInnenforAvgiftspliktigperiodeTest)
     .erEtterDatofelt("fomDato"),
   skatteplikttype: string().required(MAA_FYLLES_UT),

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.test.ts
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagSchema.test.ts
@@ -216,7 +216,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
       expect(hasError(err, "skatteforholdsperioder[0].fomDato", "Utenfor valgt år")).toBe(false);
     });
 
-    it("skal vise 'Utenfor valgt år' for gyldig dato utenfor året", async () => {
+    it("skal vise 'Utenfor medlemskapsperiode' for gyldig dato utenfor medlemskapsperioden", async () => {
       const values = {
         endeligAvgiftValg: OPPLYSNINGER_ENDRET,
         bestemmelse: "FTRL_2_7",
@@ -242,7 +242,7 @@ describe("aarsavregningUtenEllerDeltGrunnlagSchema - Datovalidering (MELOSYS-761
 
       const err = await validate(values, { aar: 2024 });
       expect(err).toBeTruthy();
-      expect(hasError(err, "skatteforholdsperioder[0].fomDato", "Utenfor valgt år")).toBe(true);
+      expect(hasError(err, "skatteforholdsperioder[0].fomDato", "Utenfor medlemskapsperiode")).toBe(true);
     });
   });
 


### PR DESCRIPTION
Fikser feilmeldinger for skatteforholdsperioder i årsavregning uten grunnlag slik at de matcher med-grunnlag-varianten.

Skatteforholdsperioder utenfor avgiftspliktigperioden fikk feilmeldingen "Utenfor valgt år" istedenfor den kontekst-avhengige meldingen som brukes i årsavregning med grunnlag.
[MELOSYS-7921](https://jira.adeo.no/browse/MELOSYS-7921)

- Fjernet erInnenforValgtAarTest fra skatteforholdsperiodeSchema - bruker kun erInnenforAvgiftspliktigperiodeTest
- FTRL: viser nå "Utenfor medlemskapsperiode", EØS-pensjonist: viser "Utenfor periode Norge dekker helseutgifter"

## Testing
- [x] Enhetstester
- [x] Manuell testing lokalt