### PR TITLE
NOJIRA G4P Oppdater prod dato til datoen toggle faktisk ble skrudd på

### DIFF
--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -14,7 +14,7 @@ const MAX_AR_FREM_I_TID = 10;
 
 /**
  * Z indikerer at datoen er i UTC tidssone, i vinteren er det 1 time forskjell mellom UTC og norsk tid.
- * 08:00 er derfor kl 09:00 i norsk tid.
+ * 14:19 er derfor kl 15:19 i norsk tid.
  */
 const FLYT_PRODUKSJON_DATO_EØS_11_3_B = moment("2026-03-10T14:19:00Z");
 

--- a/src/utils/dato.js
+++ b/src/utils/dato.js
@@ -16,7 +16,7 @@ const MAX_AR_FREM_I_TID = 10;
  * Z indikerer at datoen er i UTC tidssone, i vinteren er det 1 time forskjell mellom UTC og norsk tid.
  * 08:00 er derfor kl 09:00 i norsk tid.
  */
-const FLYT_PRODUKSJON_DATO_EØS_11_3_B = moment("2026-02-26T08:00:00Z");
+const FLYT_PRODUKSJON_DATO_EØS_11_3_B = moment("2026-03-10T14:19:00Z");
 
 /** Gjør et beste forsøk på å vaske inputdato. Dersom vask ikke er mulig (feks ved helt feil datoformat eller
  * ugyldig dato, returner false.


### PR DESCRIPTION
Hvorvidt de nye endringene for 11.3.b skal vises, er basert på en dato ettersom saksbehandler ønsket ulike visnings tilpasninger.

Denne datoen burde samsvare med tidspunktet vi aktiverer toggelen. Opprinnelig skulle dette vært 2026-02-26 kl. 09:00:00, men feil toggle ble aktivert, og den faktiske toggelen for 11.3.b ble først skrudd på 2026-03-10 kl. 15:19:32. Dette kan medføre visningsfeil i innsynsmodus for 11.3.b-saker som ble ferdigbehandlet i denne mellomperioden. Oppdaterer derfor dato i produksjon til korrekt tidspunkt.

<img width="1712" height="744" alt="image" src="https://github.com/user-attachments/assets/649f2cbb-b005-45f2-ab25-30a18cd7d17c" />
