### PR TITLE
NOJIRA G4P La til minimumReleaseAge i pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages:
   - .
 
+minimumReleaseAge: 10080
+
 onlyBuiltDependencies:
   - "@parcel/watcher"
   - esbuild


### PR DESCRIPTION
## Summary
- Legger til `minimumReleaseAge: 10080` (7 dager) i `pnpm-workspace.yaml`
- Utfyller eksisterende `cooldown: default-days: 7` i `.github/dependabot.yml`

## Bakgrunn
Dependabot `cooldown` forsinker kun Dependabots PR-er, ikke manuelle `pnpm install`/`pnpm add` eller CI-installasjoner. pnpm introduserte `minimumReleaseAge` i 10.16 som respons på supply-chain-angrep (shai-hulud m.fl.) for å forhindre at nylig kompromitterte pakkeversjoner installeres.

Sammen gir de defense-in-depth: dependabot cooldown beskytter automatiske oppdateringer, `minimumReleaseAge` beskytter alle andre installasjoner (utviklere, CI, transitive deps).

Verdien er i minutter: `10080 = 7 dager`, samme som dependabot cooldown.

## Test plan
- [ ] `pnpm install` fungerer som før (eksisterende låste versjoner er eldre enn 7 dager)
- [ ] CI-bygg passerer