### PR TITLE
NOJIRA Ekskluder melosys-kodeverk fra minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - .
 
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - "@navikt/melosys-kodeverk"
 
 onlyBuiltDependencies:
   - "@parcel/watcher"


### PR DESCRIPTION
Ekskluderer `@navikt/melosys-kodeverk` fra `minimumReleaseAge`-regelen.

`minimumReleaseAge: 10080` (7 dager) blokkerer også oppdateringer fra
det interne melosys-kodeverk-repoet, som vi stoler på og ønsker å
kunne oppdatere umiddelbart.

- Lagt til `minimumReleaseAgeExclude` for `@navikt/melosys-kodeverk`

### Testing
- [x] Verifisert konfigurasjon mot pnpm-dokumentasjon
