### PR TITLE
6221 Legg til videresendt som saksstatus som hindrer ny behandling

### DIFF
--- a/src/ducks/journalforing/operations.test.ts
+++ b/src/ducks/journalforing/operations.test.ts
@@ -336,7 +336,10 @@ describe("journalforing operations", () => {
       );
     });
 
-    it("håndterer sak som ikke kan viderebehandles (opphørt/henlagt/bortfalt/annullert)", async () => {
+    it.each([
+      { kode: MKV.Koder.saksstatuser.HENLAGT, term: "Henlagt" },
+      { kode: MKV.Koder.saksstatuser.VIDERESENDT, term: "Videresendt" },
+    ])("håndterer sak som ikke kan viderebehandles når saksstatus er $term", async (saksstatus) => {
       // Mock API responses
       mswServer.use(
         http.get("/api/anmodningsperioder/:behandlingId", () => HttpResponse.json({ anmodningsperioder: [] })),
@@ -351,9 +354,9 @@ describe("journalforing operations", () => {
         ),
       );
 
-      const henlagtSak: Sak = {
+      const sakSomIkkeKanViderebehandles: Sak = {
         ...baseSak,
-        saksstatus: { kode: MKV.Koder.saksstatuser.HENLAGT, term: "Henlagt" },
+        saksstatus,
       };
 
       const initialState: Partial<RootState> = {
@@ -367,7 +370,7 @@ describe("journalforing operations", () => {
       const store = createTestStore(initialState);
 
       const result = await store.dispatch(
-        operations.prepareKnyttTilSakForm(henlagtSak, false, "BRUKER", feltNavn) as any,
+        operations.prepareKnyttTilSakForm(sakSomIkkeKanViderebehandles, false, "BRUKER", feltNavn) as any,
       );
 
       expect(result.sakKanIkkeViderebehandles).toBe(true);

--- a/src/ducks/journalforing/operations.ts
+++ b/src/ducks/journalforing/operations.ts
@@ -13,11 +13,11 @@ import { change } from "redux-form";
 import { KTObject } from "@navikt/melosys-kodeverk";
 import { doThenDispatch } from "../../services/utils";
 import * as Api from "../../services/api";
+import type { FeltNavn, Sak } from "./types";
 import * as Types from "./types";
 import * as Actions from "./actions";
 import { MKVUtils } from "../../melosyskodeverk";
 import MKV from "../../melosyskodeverk/index.js";
-import type { Sak, FeltNavn } from "./types";
 import type { RootState } from "AppTypes";
 import type { Anmodningsperiode } from "../../services/modules/anmodningsperioder";
 
@@ -83,7 +83,9 @@ export function prepareKnyttTilSakForm(
     const sisteBehandlingErInaktiv = MKVUtils.erAvsluttetEllerMidlertidigBeslutning(
       sisteBehandling.behandlingsstatus.kode,
     );
-    const sakKanIkkeViderebehandles = MKVUtils.erOpphørtEllerHenlagtEllerBortfaltEllerAnnullert(saksstatus.kode);
+    const sakKanIkkeViderebehandles = MKVUtils.erOpphørtEllerHenlagtEllerBortfaltEllerAnnullertEllerVideresendt(
+      saksstatus.kode,
+    );
 
     // Hent alle async data parallelt
     const [anmodningsperioderResponse, trygdeavgiftResponse, muligeBehandlingstemaer] = await Promise.all([

--- a/src/felleskomponenter/fagsakVelger/knyttTilSak.tsx
+++ b/src/felleskomponenter/fagsakVelger/knyttTilSak.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from "../../hooks";
 
 import * as Skjema from "../skjema";
 import * as Nav from "../../navFrontend";
-import { journalforingOperations, PrepareKnyttTilSakFormResult, journalforingTypes } from "../../ducks/journalforing";
+import { journalforingOperations, journalforingTypes, PrepareKnyttTilSakFormResult } from "../../ducks/journalforing";
 import * as Utils from "../../utils";
 
 import "./knyttTilSak.less";
@@ -156,13 +156,14 @@ export function KnyttTilSak(props: KnyttTilSakProps) {
       <div className="knyttTilSak__behandlingspanel">
         {erJournalføring ? (
           <Nav.Alert variant="info" className="feilmelding_innrykk">
-            Du kan ikke opprette en ny behandling på eksisterende sak som er opphørt/henlagt/bortfalt/annullert i
-            Melosys, men du kan knytte dokumentet til den avsluttede behandlingen
+            Du kan ikke opprette en ny behandling på eksisterende sak som er
+            opphørt/henlagt/bortfalt/annullert/videresendt i Melosys, men du kan knytte dokumentet til den avsluttede
+            behandlingen
           </Nav.Alert>
         ) : (
           <Nav.Alert variant="warning" className="feilmelding_innrykk">
-            Du kan ikke opprette en ny behandling på eksisterende sak som er opphørt/henlagt/bortfalt/annullert i
-            Melosys
+            Du kan ikke opprette en ny behandling på eksisterende sak som er
+            opphørt/henlagt/bortfalt/annullert/videresendt i Melosys
           </Nav.Alert>
         )}
       </div>

--- a/src/melosyskodeverk/utils.js
+++ b/src/melosyskodeverk/utils.js
@@ -55,10 +55,11 @@ export const harFlerePågåendeBehandlinger = (behandlingsstatuser) => {
   return pågåendeBehandlingsstatuser.length > 1;
 };
 
-export const erOpphørtEllerHenlagtEllerBortfaltEllerAnnullert = (saksstatus) =>
+export const erOpphørtEllerHenlagtEllerBortfaltEllerAnnullertEllerVideresendt = (saksstatus) =>
   [
     MKV.Koder.saksstatuser.OPPHØRT,
     MKV.Koder.saksstatuser.HENLAGT,
     MKV.Koder.saksstatuser.HENLAGT_BORTFALT,
     MKV.Koder.saksstatuser.ANNULLERT,
+    MKV.Koder.saksstatuser.VIDERESENDT,
   ].includes(saksstatus);

--- a/src/sider/journalforing/komponenter/journalforingform/journalforingform.jsx
+++ b/src/sider/journalforing/komponenter/journalforingform/journalforingform.jsx
@@ -91,7 +91,7 @@ function JournalforingForm({
   const visSkalTilordnes = !fagsakListe.find(
     (sak) =>
       sak.saksnummer === formValues?.saksnummer &&
-      MKVUtils.erOpphørtEllerHenlagtEllerBortfaltEllerAnnullert(sak.saksstatus.kode),
+      MKVUtils.erOpphørtEllerHenlagtEllerBortfaltEllerAnnullertEllerVideresendt(sak.saksstatus.kode),
   );
 
   const [adresseOpplysninger, setAdresseOpplysninger] = useState({


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6221

Utvider sjekken for saksstatuser som hindrer opprettelse av ny behandling til å inkludere "videresendt". Funksjonen er omdøpt fra erOpphørtEllerHenlagtEllerBortfaltEllerAnnullert til erOpphørtEllerHenlagtEllerBortfaltEllerAnnullertEllerVideresendt, og brukervendte meldinger i journalføringsdialogen er oppdatert tilsvarende.

Saker med status "videresendt" skal ikke kunne få opprettet nye behandlinger, på lik linje med opphørte, henlagte, bortfalte og annullerte saker.