### PR TITLE
8035 Fiks flaky stegvelger-transisjon stuck på Yrkessituasjon

### DIFF
--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -67,7 +67,7 @@ class Stegvelger extends Component {
 
   bytterSteg = false;
 
-  transisjonId = 0;
+  stegovergangId = 0;
 
   async componentDidMount() {
     this.aktiv = true;
@@ -566,7 +566,8 @@ class Stegvelger extends Component {
     const flytHarIkkeVurderingPeriode = !(eøsFaktureringAvTrygdeavgiftToggleEnabled && erArbeidTjenestepersonEllerFly);
 
     this.bytterSteg = true;
-    const minTransisjonId = ++this.transisjonId;
+    this.stegovergangId += 1;
+    const minStegovergangId = this.stegovergangId;
     this.debouncedOppdaterAktuelleSteg.cancel?.();
     this.setState({ aktivtStegNummer: nyttStegNummer });
 
@@ -595,12 +596,12 @@ class Stegvelger extends Component {
       /* eslint-disable-next-line no-console */
       console.error("Feil ved lagring under stegovergang:", error);
     } finally {
-      if (this.transisjonId === minTransisjonId) {
+      if (this.stegovergangId === minStegovergangId) {
         this.bytterSteg = false;
       }
     }
 
-    if (this.transisjonId === minTransisjonId) {
+    if (this.stegovergangId === minStegovergangId) {
       this.oppdaterAktuelleSteg(nyttStegNummer, true);
     }
   };

--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -65,7 +65,7 @@ class Stegvelger extends Component {
 
   aktiv = true;
 
-  byterSteg = false;
+  bytterSteg = false;
 
   transisjonId = 0;
 
@@ -108,7 +108,7 @@ class Stegvelger extends Component {
   };
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.byterSteg) {
+    if (this.bytterSteg) {
       return;
     }
     const { aktivtStegNummer, aktuelleSteg } = this.state;
@@ -565,7 +565,7 @@ class Stegvelger extends Component {
 
     const flytHarIkkeVurderingPeriode = !(eøsFaktureringAvTrygdeavgiftToggleEnabled && erArbeidTjenestepersonEllerFly);
 
-    this.byterSteg = true;
+    this.bytterSteg = true;
     const minTransisjonId = ++this.transisjonId;
     this.debouncedOppdaterAktuelleSteg.cancel?.();
     this.setState({ aktivtStegNummer: nyttStegNummer });
@@ -596,7 +596,7 @@ class Stegvelger extends Component {
       console.error("Feil ved lagring under stegovergang:", error);
     } finally {
       if (this.transisjonId === minTransisjonId) {
-        this.byterSteg = false;
+        this.bytterSteg = false;
       }
     }
 

--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -65,6 +65,8 @@ class Stegvelger extends Component {
 
   aktiv = true;
 
+  byterSteg = false;
+
   async componentDidMount() {
     this.aktiv = true;
     const { behandlingID, sakstype } = this.props;
@@ -104,6 +106,9 @@ class Stegvelger extends Component {
   };
 
   componentDidUpdate(prevProps, prevState) {
+    if (this.byterSteg) {
+      return;
+    }
     const { aktivtStegNummer, aktuelleSteg } = this.state;
     const oppfriskStartet = !prevProps.behandlingOppfriskes && this.props.behandlingOppfriskes;
     const oppfriskFerdig = prevProps.behandlingOppfriskes && !this.props.behandlingOppfriskes;
@@ -113,13 +118,21 @@ class Stegvelger extends Component {
     const behandlingsstatusErMottattSvarAnmodning =
       prevProps.oppsummering.behandlingsstatus.kode === MKV.Koder.behandlinger.behandlingsstatus.SVAR_ANMODNING_MOTTATT;
 
-    if (oppfriskStartet || (this.props.behandlingOppfriskes && aktivtStegNummer !== 0)) {
-      this.resetTilForsteSteg(false);
+    if (oppfriskStartet) {
+      if (aktivtStegNummer === 0) {
+        this.resetTilForsteSteg(false);
+      } else {
+        this.oppdaterAktuelleSteg(aktivtStegNummer, false);
+      }
       return;
     }
 
     if (oppfriskFerdig) {
-      this.resetTilForsteSteg(true);
+      if (aktivtStegNummer === 0) {
+        this.resetTilForsteSteg(true);
+      } else {
+        this.oppdaterAktuelleSteg(aktivtStegNummer, true);
+      }
       return;
     }
 
@@ -550,6 +563,8 @@ class Stegvelger extends Component {
 
     const flytHarIkkeVurderingPeriode = !(eøsFaktureringAvTrygdeavgiftToggleEnabled && erArbeidTjenestepersonEllerFly);
 
+    this.byterSteg = true;
+    this.debouncedOppdaterAktuelleSteg.cancel?.();
     this.setState({ aktivtStegNummer: nyttStegNummer });
 
     try {
@@ -576,6 +591,8 @@ class Stegvelger extends Component {
     } catch (error) {
       /* eslint-disable-next-line no-console */
       console.error("Feil ved lagring under stegovergang:", error);
+    } finally {
+      this.byterSteg = false;
     }
 
     this.oppdaterAktuelleSteg(nyttStegNummer, true);

--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -118,21 +118,21 @@ class Stegvelger extends Component {
     const behandlingsstatusErMottattSvarAnmodning =
       prevProps.oppsummering.behandlingsstatus.kode === MKV.Koder.behandlinger.behandlingsstatus.SVAR_ANMODNING_MOTTATT;
 
-    if (oppfriskStartet) {
+    const haandterOppfrisk = (endreFokus) => {
       if (aktivtStegNummer === 0) {
-        this.resetTilForsteSteg(false);
+        this.resetTilForsteSteg(endreFokus);
       } else {
-        this.oppdaterAktuelleSteg(aktivtStegNummer, false);
+        this.oppdaterAktuelleSteg(aktivtStegNummer, endreFokus);
       }
+    };
+
+    if (oppfriskStartet) {
+      haandterOppfrisk(false);
       return;
     }
 
     if (oppfriskFerdig) {
-      if (aktivtStegNummer === 0) {
-        this.resetTilForsteSteg(true);
-      } else {
-        this.oppdaterAktuelleSteg(aktivtStegNummer, true);
-      }
+      haandterOppfrisk(true);
       return;
     }
 

--- a/src/felleskomponenter/stegvelger/Stegvelger.jsx
+++ b/src/felleskomponenter/stegvelger/Stegvelger.jsx
@@ -67,6 +67,8 @@ class Stegvelger extends Component {
 
   byterSteg = false;
 
+  transisjonId = 0;
+
   async componentDidMount() {
     this.aktiv = true;
     const { behandlingID, sakstype } = this.props;
@@ -564,6 +566,7 @@ class Stegvelger extends Component {
     const flytHarIkkeVurderingPeriode = !(eøsFaktureringAvTrygdeavgiftToggleEnabled && erArbeidTjenestepersonEllerFly);
 
     this.byterSteg = true;
+    const minTransisjonId = ++this.transisjonId;
     this.debouncedOppdaterAktuelleSteg.cancel?.();
     this.setState({ aktivtStegNummer: nyttStegNummer });
 
@@ -592,10 +595,14 @@ class Stegvelger extends Component {
       /* eslint-disable-next-line no-console */
       console.error("Feil ved lagring under stegovergang:", error);
     } finally {
-      this.byterSteg = false;
+      if (this.transisjonId === minTransisjonId) {
+        this.byterSteg = false;
+      }
     }
 
-    this.oppdaterAktuelleSteg(nyttStegNummer, true);
+    if (this.transisjonId === minTransisjonId) {
+      this.oppdaterAktuelleSteg(nyttStegNummer, true);
+    }
   };
 
   /** Beregn neste steg i rekken, men ikke lenger enn


### PR DESCRIPTION
Fikser race condition i `Stegvelger` som fikk EU/EØS-veiviseren til å sette seg fast på "Yrkessituasjon" når brukeren klikket "Bekreft og fortsett". POST-en gikk gjennom og Redux ble oppdatert, men headingen forble uendret.

`bekreftOgFortsett` er asynkron og dispatcher seks parallelle redux-actions. Hvis `behandlingOppfriskes` toglet mellom `setState({ aktivtStegNummer: 1 })` i `tilSteg` og rendringen av neste steg, kunne `componentDidUpdate` enten resette tilbake til steg 0 eller fyre en debounced recompute med stale `aktivtStegNummer` fra closure.
[MELOSYS-8035](https://jira.adeo.no/browse/MELOSYS-8035)

- Innfører `byterSteg`-flag som suppresserer `componentDidUpdate`-grenene under en pågående stegovergang
- Kansellerer pending `debouncedOppdaterAktuelleSteg` ved start av `tilSteg`
- `oppfriskStartet`/`oppfriskFerdig` resetter kun til steg 0 når `aktivtStegNummer === 0`; ellers recomputes uten å nullstille
- Dedup av de to `oppfrisk`-grenene via lokal `haandterOppfrisk`-hjelper

### Testing
- [x] E2E lokalt: `eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts` 5/5 PASS med `--repeat-each=5 --workers=1` (0/3 → 5/5 fra master)
- [x] E2E på GitHub Actions mot image-tag `fix-stuck-yrkessituasjon`: [run 24731423987](https://github.com/navikt/melosys-e2e-tests/actions/runs/24731423987) ✅ success