### PR TITLE
MELOSYS-8023 Sidemeny-felter for pre-utfylling av digital søknad

### DIFF
--- a/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/enkeltArbeidsforholdUtlandRedigerer/__snapshots__/enkeltArbeidsforholdUtland.test.tsx.snap
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/enkeltArbeidsforholdUtlandRedigerer/__snapshots__/enkeltArbeidsforholdUtland.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`EnkeltArbeidsforholdUtland > snapshot test 1`] = `
             for="333"
             class="navds-form-field__label navds-label navds-label--small"
           >
-            Adressetilleggsnavn
+            Bygning
           </label>
           <input
             meta="[object Object]"
@@ -90,7 +90,7 @@ exports[`EnkeltArbeidsforholdUtland > snapshot test 1`] = `
             for="333"
             class="navds-form-field__label navds-label navds-label--small"
           >
-            Adresse til arbeidsgiver
+            Gate/veg
           </label>
           <input
             meta="[object Object]"
@@ -189,7 +189,7 @@ exports[`EnkeltArbeidsforholdUtland > snapshot test 1`] = `
     </div>
     <div class="row">
       <div class="col col-xs-12">
-        <div class="melosys-textfield  navds-form-field navds-form-field--small">
+        <div class="melosys-textfield  navds-form-field navds-form-field--small navds-text-field--disabled navds-form-field--disabled">
           <label
             for="333"
             class="navds-form-field__label navds-label navds-label--small"
@@ -198,6 +198,7 @@ exports[`EnkeltArbeidsforholdUtland > snapshot test 1`] = `
           </label>
           <input
             meta="[object Object]"
+            disabled
             id="333"
             class="navds-text-field__input navds-body-short navds-body-short--small"
             type="text"
@@ -216,7 +217,7 @@ exports[`EnkeltArbeidsforholdUtland > snapshot test 1`] = `
     </div>
     <div class="row">
       <div class="col col-xs-6">
-        <div class="melosys-textfield  navds-form-field navds-form-field--small">
+        <div class="melosys-textfield  navds-form-field navds-form-field--small navds-text-field--disabled navds-form-field--disabled">
           <label
             for="333"
             class="navds-form-field__label navds-label navds-label--small"
@@ -225,6 +226,7 @@ exports[`EnkeltArbeidsforholdUtland > snapshot test 1`] = `
           </label>
           <input
             meta="[object Object]"
+            disabled
             id="333"
             class="navds-text-field__input navds-body-short navds-body-short--small"
             type="text"
@@ -378,6 +380,54 @@ exports[`EnkeltArbeidsforholdUtland > snapshot test 1`] = `
               </option>
             </datalist>
           </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col col-xs-12">
+        <div class="navds-checkbox navds-checkbox--small">
+          <input
+            class="navds-checkbox__input"
+            id="333"
+            aria-labelledby="333"
+            type="checkbox"
+            value
+            name="333"
+          >
+          <label
+            for="333"
+            class="navds-checkbox__label"
+          >
+            <span class="navds-checkbox__icon">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="0.8125rem"
+                height="0.625rem"
+                viewbox="0 0 13 10"
+                fill="none"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  d="M4.03524 6.41478L10.4752 0.404669C11.0792 -0.160351 12.029 -0.130672 12.5955 0.47478C13.162 1.08027 13.1296 2.03007 12.5245 2.59621L5.02111 9.59934C4.74099 9.85904 4.37559 10 4.00025 10C3.60651 10 3.22717 9.84621 2.93914 9.56111L0.439143 7.06111C-0.146381 6.47558 -0.146381 5.52542 0.439143 4.93989C1.02467 4.35437 1.97483 4.35437 2.56036 4.93989L4.03524 6.41478Z"
+                  fill="currentColor"
+                >
+                </path>
+              </svg>
+            </span>
+            <span class="navds-checkbox__icon-indeterminate">
+            </span>
+            <span class="navds-checkbox__content">
+              <span
+                id="333"
+                aria-hidden="true"
+                class="navds-checkbox__label-text navds-body-short navds-body-short--small"
+              >
+                Tilhører virksomheten samme konsern som den norske arbeidsgiveren?
+              </span>
+            </span>
+          </label>
         </div>
       </div>
     </div>

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/enkeltArbeidsforholdUtlandRedigerer/enkeltArbeidsforholdUtland.jsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/enkeltArbeidsforholdUtlandRedigerer/enkeltArbeidsforholdUtland.jsx
@@ -17,7 +17,7 @@ export function EnkeltArbeidsforholdUtland({ redigerbart, overordnetFeltNavn, cl
       <Nav.Row>
         <Nav.Column xs="12">
           <Skjema.Input
-            label="Adressetilleggsnavn"
+            label="Bygning"
             feltNavn={`${overordnetFeltNavn}.adresse.tilleggsnavn`}
             disabled={!redigerbart}
           />
@@ -25,11 +25,7 @@ export function EnkeltArbeidsforholdUtland({ redigerbart, overordnetFeltNavn, cl
       </Nav.Row>
       <Nav.Row>
         <Nav.Column xs="6">
-          <Skjema.Input
-            label="Adresse til arbeidsgiver"
-            feltNavn={`${overordnetFeltNavn}.adresse.gatenavn`}
-            disabled={!redigerbart}
-          />
+          <Skjema.Input label="Gate/veg" feltNavn={`${overordnetFeltNavn}.adresse.gatenavn`} disabled={!redigerbart} />
         </Nav.Column>
         <Nav.Column xs="6">
           <Skjema.Input
@@ -53,12 +49,12 @@ export function EnkeltArbeidsforholdUtland({ redigerbart, overordnetFeltNavn, cl
       </Nav.Row>
       <Nav.Row>
         <Nav.Column xs="12">
-          <Skjema.Input label="Postboks" feltNavn={`${overordnetFeltNavn}.adresse.postboks`} disabled={!redigerbart} />
+          <Skjema.Input label="Postboks" feltNavn={`${overordnetFeltNavn}.adresse.postboks`} disabled />
         </Nav.Column>
       </Nav.Row>
       <Nav.Row>
         <Nav.Column xs="6">
-          <Skjema.Input label="Region" feltNavn={`${overordnetFeltNavn}.adresse.region`} disabled={!redigerbart} />
+          <Skjema.Input label="Region" feltNavn={`${overordnetFeltNavn}.adresse.region`} disabled />
         </Nav.Column>
         <Nav.Column xs="6">
           <Skjema.LandVelger
@@ -66,6 +62,15 @@ export function EnkeltArbeidsforholdUtland({ redigerbart, overordnetFeltNavn, cl
             feltNavn={`${overordnetFeltNavn}.adresse.landkode`}
             disabled={!redigerbart}
             bredde="fullbredde"
+          />
+        </Nav.Column>
+      </Nav.Row>
+      <Nav.Row>
+        <Nav.Column xs="12">
+          <Skjema.Checkbox
+            label="Tilhører virksomheten samme konsern som den norske arbeidsgiveren?"
+            feltNavn={`${overordnetFeltNavn}.tilhorerSammeKonsern`}
+            disabled={!redigerbart}
           />
         </Nav.Column>
       </Nav.Row>

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/enkeltArbeidsforholdUtlandRedigeringUtfort/enkeltArbeidsforholdUtlandRedigeringUtfort.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidsgiver_og_virksomhet/enkeltArbeidsforholdUtlandRedigeringUtfort/enkeltArbeidsforholdUtlandRedigeringUtfort.tsx
@@ -21,6 +21,14 @@ function EnkeltArbeidsforholdUtlandRedigeringUtfort({ verdier }: EnkeltArbeidsfo
           </>
         )}
       </Nav.Column>
+      {verdier.tilhorerSammeKonsern != null && (
+        <Nav.Column xs="12">
+          <Nav.BodyLong size="small">Tilhører samme konsern som norsk arbeidsgiver</Nav.BodyLong>
+          <Nav.BodyLong weight="semibold" size="small">
+            {verdier.tilhorerSammeKonsern ? "Ja" : "Nei"}
+          </Nav.BodyLong>
+        </Nav.Column>
+      )}
     </Nav.Row>
   );
 }

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/fly/redigerer.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/fly/redigerer.test.tsx
@@ -1,17 +1,17 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import MKV from "../../../../../melosyskodeverk";
 
 vi.mock("../../../../../navFrontend", () => ({
   Row: ({ children }: any) => <div>{children}</div>,
   Column: ({ children }: any) => <div>{children}</div>,
+  Radio: ({ children, value }: any) => <option value={String(value)}>{children}</option>,
 }));
 
 vi.mock("../../../../skjema", () => ({
   Input: ({ label }: any) => <div>{label}</div>,
-  Select: ({ children, label }: any) => (
+  RadioGroup: ({ legend, children }: any) => (
     <div>
-      <label>{label}</label>
+      <label>{legend}</label>
       <select>{children}</select>
     </div>
   ),
@@ -25,17 +25,30 @@ vi.mock("../sletterad", () => ({
 import Redigerer from "./redigerer";
 
 describe("Redigerer (fly)", () => {
-  it("rendrer hjemmebase-input, flyvningstype-select og land-velger", () => {
+  it("rendrer hjemmebase-input og land-velger", () => {
     render(<Redigerer {...({ redigerbart: true, overordnetFeltNavn: "fly[0]", slett: vi.fn() } as any)} />);
     expect(screen.getByText("Navn på hjemmebase")).toBeDefined();
-    expect(screen.getByText("Type flyvninger")).toBeDefined();
     expect(screen.getByText("Hjemmebasens land")).toBeDefined();
   });
 
-  it("rendrer flyvningstyper fra ekte MKV-kodeverk", () => {
+  it("rendrer spørsmål om vanlig hjemmebase", () => {
     render(<Redigerer {...({ redigerbart: true, overordnetFeltNavn: "fly[0]", slett: vi.fn() } as any)} />);
-    const options = screen.getAllByRole("option");
-    expect(options.length).toBe(MKV.KTObjects.flyvningstyper.length);
+    expect(screen.getByText("Er dette hjemmebasen arbeidstakeren jobber fra til vanlig?")).toBeDefined();
+  });
+
+  it("viser vanlig-hjemmebase-felter når svar er nei", () => {
+    render(
+      <Redigerer
+        {...({
+          redigerbart: true,
+          overordnetFeltNavn: "fly[0]",
+          slett: vi.fn(),
+          verdier: { erVanligHjemmebase: false },
+        } as any)}
+      />,
+    );
+    expect(screen.getByText("Vanlig hjemmebase — navn")).toBeDefined();
+    expect(screen.getByText("Vanlig hjemmebase — land")).toBeDefined();
   });
 
   it("rendrer sletteknapp", () => {

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/fly/redigerer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/fly/redigerer.tsx
@@ -1,12 +1,8 @@
-import { KTObject } from "@navikt/melosys-kodeverk";
-
 import * as KV from "../../../../../kodeverk";
 import * as Nav from "../../../../../navFrontend";
 import * as Skjema from "../../../../skjema";
 
 import Sletterad from "../sletterad";
-
-import MKV from "../../../../../melosyskodeverk";
 
 import { EnRedigeringsknappListeRedigerer } from "../../editerbartElementListe";
 
@@ -14,6 +10,7 @@ function Redigerer({
   redigerbart,
   overordnetFeltNavn,
   slett,
+  verdier,
 }: EnRedigeringsknappListeRedigerer<KV.Form.ArbeidsstedFly>) {
   return (
     <div>
@@ -25,21 +22,6 @@ function Redigerer({
             disabled={!redigerbart}
           />
         </Nav.Column>
-      </Nav.Row>
-      <Nav.Row>
-        <Nav.Column xs="6">
-          <Skjema.Select
-            label="Type flyvninger"
-            feltNavn={`${overordnetFeltNavn}.typeFlyvninger`}
-            disabled={!redigerbart}
-          >
-            {MKV.KTObjects.flyvningstyper.map((type: KTObject) => (
-              <option key={type.kode} value={type.kode}>
-                {type.term}
-              </option>
-            ))}
-          </Skjema.Select>
-        </Nav.Column>
         <Nav.Column xs="6">
           <Skjema.LandVelger
             label="Hjemmebasens land"
@@ -49,6 +31,37 @@ function Redigerer({
           />
         </Nav.Column>
       </Nav.Row>
+      <Nav.Row>
+        <Nav.Column xs="12">
+          <Skjema.RadioGroup
+            legend="Er dette hjemmebasen arbeidstakeren jobber fra til vanlig?"
+            name={`${overordnetFeltNavn}.erVanligHjemmebase`}
+            readOnly={!redigerbart}
+          >
+            <Nav.Radio value>Ja</Nav.Radio>
+            <Nav.Radio value={false}>Nei</Nav.Radio>
+          </Skjema.RadioGroup>
+        </Nav.Column>
+      </Nav.Row>
+      {verdier?.erVanligHjemmebase === false && (
+        <Nav.Row>
+          <Nav.Column xs="6">
+            <Skjema.Input
+              label="Vanlig hjemmebase — navn"
+              feltNavn={`${overordnetFeltNavn}.vanligHjemmebaseNavn`}
+              disabled={!redigerbart}
+            />
+          </Nav.Column>
+          <Nav.Column xs="6">
+            <Skjema.LandVelger
+              label="Vanlig hjemmebase — land"
+              feltNavn={`${overordnetFeltNavn}.vanligHjemmebaseLand`}
+              disabled={!redigerbart}
+              bredde="fullbredde"
+            />
+          </Nav.Column>
+        </Nav.Row>
+      )}
       <Sletterad onClick={slett} />
     </div>
   );

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/fly/redigeringUtfort.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/fly/redigeringUtfort.test.tsx
@@ -26,12 +26,12 @@ describe("fly RedigeringUtfort", () => {
   it("rendrer tabellheadere", () => {
     render(<RedigeringUtfort verdier={[]} />);
     expect(screen.getByText("Navn på hjemmebase")).toBeDefined();
-    expect(screen.getByText("Type flyvninger")).toBeDefined();
     expect(screen.getByText("Hjemmebasens land")).toBeDefined();
+    expect(screen.getByText("Vanlig hjemmebase")).toBeDefined();
   });
 
   it("rendrer rad med data", () => {
-    const verdier = [{ hjemmebaseNavn: "Flesland", typeFlyvninger: "INNENRIKS", hjemmebaseLand: "NO" }] as any;
+    const verdier = [{ hjemmebaseNavn: "Flesland", hjemmebaseLand: "NO", erVanligHjemmebase: true }] as any;
     render(<RedigeringUtfort verdier={verdier} />);
     expect(screen.getByText("Flesland")).toBeDefined();
   });

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/fly/redigeringUtfort.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/fly/redigeringUtfort.tsx
@@ -12,8 +12,8 @@ function RedigeringUtfort({ verdier }: EnRedigeringsknappListeRedigeringUtfort<K
         <Nav.Table.Header>
           <Nav.Table.Row>
             <Nav.Table.HeaderCell>Navn på hjemmebase</Nav.Table.HeaderCell>
-            <Nav.Table.HeaderCell>Type flyvninger</Nav.Table.HeaderCell>
             <Nav.Table.HeaderCell>Hjemmebasens land</Nav.Table.HeaderCell>
+            <Nav.Table.HeaderCell>Vanlig hjemmebase</Nav.Table.HeaderCell>
           </Nav.Table.Row>
         </Nav.Table.Header>
         <Nav.Table.Body>
@@ -21,17 +21,23 @@ function RedigeringUtfort({ verdier }: EnRedigeringsknappListeRedigeringUtfort<K
             <Nav.Table.Row key={arbeidsstedFly.hjemmebaseNavn}>
               <Nav.Table.DataCell>{arbeidsstedFly.hjemmebaseNavn}</Nav.Table.DataCell>
               <Nav.Table.DataCell>
-                {KV.kodeTilTerm(arbeidsstedFly.typeFlyvninger, MKV.KTObjects.flyvningstyper)}
-              </Nav.Table.DataCell>
-              <Nav.Table.DataCell>
                 {KV.kodeTilTerm(arbeidsstedFly.hjemmebaseLand, MKV.KTObjects.landkoder)}
               </Nav.Table.DataCell>
+              <Nav.Table.DataCell>{formaterVanligHjemmebase(arbeidsstedFly)}</Nav.Table.DataCell>
             </Nav.Table.Row>
           ))}
         </Nav.Table.Body>
       </Nav.Table>
     </div>
   );
+}
+
+function formaterVanligHjemmebase(fly: KV.Form.ArbeidsstedFly): string {
+  if (fly.erVanligHjemmebase == null) return "";
+  if (fly.erVanligHjemmebase) return "Ja";
+  const land = fly.vanligHjemmebaseLand ? KV.kodeTilTerm(fly.vanligHjemmebaseLand, MKV.KTObjects.landkoder) : "";
+  const navn = fly.vanligHjemmebaseNavn ?? "";
+  return ["Nei", navn, land].filter(Boolean).join(" — ");
 }
 
 export default RedigeringUtfort;

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/land/redigerer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/land/redigerer.tsx
@@ -10,7 +10,13 @@ function Redigerer({
   redigerbart,
   overordnetFeltNavn,
   slett,
+  verdier,
 }: EnRedigeringsknappListeRedigerer<KV.Form.FysiskArbeidssted>) {
+  const adresse = verdier?.adresse;
+  const harTilleggsnavn = !!adresse?.tilleggsnavn;
+  const harRegion = !!adresse?.region;
+  const harPostboks = !!adresse?.postboks;
+
   return (
     <div>
       <Nav.Row>
@@ -22,18 +28,20 @@ function Redigerer({
           />
         </Nav.Column>
       </Nav.Row>
-      <Nav.Row>
-        <Nav.Column xs="9">
-          <Skjema.Input label="Adressetilleggsnavn" feltNavn={`${overordnetFeltNavn}.adresse.tilleggsnavn`} />
-        </Nav.Column>
-      </Nav.Row>
+      {harTilleggsnavn && (
+        <Nav.Row>
+          <Nav.Column xs="9">
+            <Skjema.Input
+              label="Adressetilleggsnavn"
+              feltNavn={`${overordnetFeltNavn}.adresse.tilleggsnavn`}
+              disabled
+            />
+          </Nav.Column>
+        </Nav.Row>
+      )}
       <Nav.Row>
         <Nav.Column xs="5">
-          <Skjema.Input
-            label="Gateadresse"
-            feltNavn={`${overordnetFeltNavn}.adresse.gatenavn`}
-            disabled={!redigerbart}
-          />
+          <Skjema.Input label="Gate/veg" feltNavn={`${overordnetFeltNavn}.adresse.gatenavn`} disabled={!redigerbart} />
         </Nav.Column>
         <Nav.Column xs="4">
           <Skjema.Input
@@ -55,15 +63,19 @@ function Redigerer({
           />
         </Nav.Column>
       </Nav.Row>
+      {harPostboks && (
+        <Nav.Row>
+          <Nav.Column xs="9">
+            <Skjema.Input label="Postboks" feltNavn={`${overordnetFeltNavn}.adresse.postboks`} disabled />
+          </Nav.Column>
+        </Nav.Row>
+      )}
       <Nav.Row>
-        <Nav.Column xs="9">
-          <Skjema.Input label="Postboks" feltNavn={`${overordnetFeltNavn}.adresse.postboks`} disabled={!redigerbart} />
-        </Nav.Column>
-      </Nav.Row>
-      <Nav.Row>
-        <Nav.Column xs="5">
-          <Skjema.Input label="Region" feltNavn={`${overordnetFeltNavn}.adresse.region`} disabled={!redigerbart} />
-        </Nav.Column>
+        {harRegion && (
+          <Nav.Column xs="5">
+            <Skjema.Input label="Region" feltNavn={`${overordnetFeltNavn}.adresse.region`} disabled />
+          </Nav.Column>
+        )}
         <Nav.Column xs="4">
           <Skjema.LandVelger label="Land" feltNavn={`${overordnetFeltNavn}.adresse.landkode`} disabled={!redigerbart} />
         </Nav.Column>

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/offshore/redigerer.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/offshore/redigerer.test.tsx
@@ -5,13 +5,14 @@ import MKV from "../../../../../melosyskodeverk";
 vi.mock("../../../../../navFrontend", () => ({
   Row: ({ children }: any) => <div>{children}</div>,
   Column: ({ children }: any) => <div>{children}</div>,
+  Radio: ({ children, value }: any) => <option value={value}>{children}</option>,
 }));
 
 vi.mock("../../../../skjema", () => ({
   Input: ({ label }: any) => <div>{label}</div>,
-  Select: ({ children, label }: any) => (
+  RadioGroup: ({ legend, children }: any) => (
     <div>
-      <label>{label}</label>
+      <label>{legend}</label>
       <select>{children}</select>
     </div>
   ),

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/offshore/redigerer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/offshore/redigerer.tsx
@@ -28,17 +28,17 @@ function Redigerer({
       </Nav.Row>
       <Nav.Row>
         <Nav.Column xs="7">
-          <Skjema.Select
-            label="Type innretning"
-            feltNavn={`${overordnetFeltNavn}.innretningstype`}
-            disabled={!redigerbart}
+          <Skjema.RadioGroup
+            legend="Type innretning"
+            name={`${overordnetFeltNavn}.innretningstype`}
+            readOnly={!redigerbart}
           >
             {MKV.KTObjects.innretningstyper.map((type: KTObject) => (
-              <option key={type.kode} value={type.kode}>
+              <Nav.Radio key={type.kode} value={type.kode}>
                 {type.term}
-              </option>
+              </Nav.Radio>
             ))}
-          </Skjema.Select>
+          </Skjema.RadioGroup>
         </Nav.Column>
         <Nav.Column xs="5">
           <Skjema.LandVelger

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/skip/redigerer.test.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/skip/redigerer.test.tsx
@@ -5,14 +5,15 @@ import MKV from "../../../../../melosyskodeverk";
 vi.mock("../../../../../navFrontend", () => ({
   Row: ({ children }: any) => <div>{children}</div>,
   Column: ({ children }: any) => <div>{children}</div>,
+  Radio: ({ children, value }: any) => <option value={value}>{children}</option>,
 }));
 
 vi.mock("../../../../skjema", () => ({
   Input: ({ label }: any) => <div>{label}</div>,
-  Select: ({ children, label, onChange }: any) => (
+  RadioGroup: ({ legend, children, onChange }: any) => (
     <div>
-      <label>{label}</label>
-      <select onChange={onChange}>{children}</select>
+      <label>{legend}</label>
+      <select onChange={(e: any) => onChange?.(e.target.value)}>{children}</select>
     </div>
   ),
   LandVelger: ({ label }: any) => <div>{label}</div>,
@@ -27,13 +28,14 @@ import Redigerer from "./redigerer";
 const { INNENRIKS, UTENRIKS } = MKV.Koder.begrunnelser.fartsomrader;
 
 describe("Redigerer (skip)", () => {
-  it("rendrer skip-input og fartsområde-select", () => {
+  it("rendrer skip-input, yrke-input og fartsområde-radio", () => {
     render(
       <Redigerer
         {...({ redigerbart: true, overordnetFeltNavn: "skip[0]", slett: vi.fn(), settVerdi: vi.fn() } as any)}
       />,
     );
     expect(screen.getByText("Navn på skip")).toBeDefined();
+    expect(screen.getByText("Yrke")).toBeDefined();
     expect(screen.getByText("Fartsområde")).toBeDefined();
   });
 

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/skip/redigerer.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/skip/redigerer.tsx
@@ -1,4 +1,3 @@
-import { ChangeEventHandler } from "react";
 import { KTObject } from "@navikt/melosys-kodeverk";
 
 import * as KV from "../../../../../kodeverk";
@@ -18,9 +17,7 @@ function Redigerer({
   settVerdi,
   verdier,
 }: EnRedigeringsknappListeRedigerer<KV.Form.ArbeidsstedSkip>) {
-  const fartsomradeChangeHandler: ChangeEventHandler<HTMLSelectElement> = (event) => {
-    const fartsomrade = event.target.value;
-
+  const fartsomradeChangeHandler = (fartsomrade: unknown) => {
     if (fartsomrade === MKV.Koder.begrunnelser.fartsomrader.INNENRIKS) {
       settVerdi("flaggLandkode", null);
     } else if (fartsomrade === MKV.Koder.begrunnelser.fartsomrader.UTENRIKS) {
@@ -34,21 +31,24 @@ function Redigerer({
         <Nav.Column xs="6">
           <Skjema.Input label="Navn på skip" feltNavn={`${overordnetFeltNavn}.enhetNavn`} disabled={!redigerbart} />
         </Nav.Column>
+        <Nav.Column xs="6">
+          <Skjema.Input label="Yrke" feltNavn={`${overordnetFeltNavn}.yrke`} disabled={!redigerbart} />
+        </Nav.Column>
       </Nav.Row>
       <Nav.Row>
         <Nav.Column xs="6">
-          <Skjema.Select
-            feltNavn={`${overordnetFeltNavn}.fartsomradeKode`}
-            label="Fartsområde"
-            disabled={!redigerbart}
+          <Skjema.RadioGroup
+            legend="Fartsområde"
+            name={`${overordnetFeltNavn}.fartsomradeKode`}
+            readOnly={!redigerbart}
             onChange={fartsomradeChangeHandler}
           >
             {MKV.KTObjects.begrunnelser.fartsomrader.map((omrade: KTObject) => (
-              <option key={omrade.kode} value={omrade.kode}>
+              <Nav.Radio key={omrade.kode} value={omrade.kode}>
                 {omrade.term}
-              </option>
+              </Nav.Radio>
             ))}
-          </Skjema.Select>
+          </Skjema.RadioGroup>
         </Nav.Column>
         <Nav.Column xs="6">
           {verdier && verdier.fartsomradeKode === MKV.Koder.begrunnelser.fartsomrader.INNENRIKS && (

--- a/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/skip/redigeringUtfort.tsx
+++ b/src/felleskomponenter/menypanel/menypunkter/arbeidssteder/skip/redigeringUtfort.tsx
@@ -12,6 +12,7 @@ function RedigeringUtfort({ verdier }: EnRedigeringsknappListeRedigeringUtfort<K
         <Nav.Table.Header>
           <Nav.Table.Row>
             <Nav.Table.HeaderCell>Navn på skip</Nav.Table.HeaderCell>
+            <Nav.Table.HeaderCell>Yrke</Nav.Table.HeaderCell>
             <Nav.Table.HeaderCell>Fartsområde</Nav.Table.HeaderCell>
             <Nav.Table.HeaderCell>Flaggstat/lands territorialfarvann</Nav.Table.HeaderCell>
           </Nav.Table.Row>
@@ -20,6 +21,7 @@ function RedigeringUtfort({ verdier }: EnRedigeringsknappListeRedigeringUtfort<K
           {verdier.map((arbeidsstedSkip) => (
             <Nav.Table.Row key={arbeidsstedSkip.enhetNavn}>
               <Nav.Table.DataCell>{arbeidsstedSkip.enhetNavn}</Nav.Table.DataCell>
+              <Nav.Table.DataCell>{arbeidsstedSkip.yrke}</Nav.Table.DataCell>
               <Nav.Table.DataCell>
                 {KV.kodeTilTerm(arbeidsstedSkip.fartsomradeKode, MKV.KTObjects.begrunnelser.fartsomrader)}
               </Nav.Table.DataCell>

--- a/src/kodeverk/form.ts
+++ b/src/kodeverk/form.ts
@@ -30,6 +30,7 @@ export interface ArbeidsforholdUtland {
   navn?: string;
   orgnr?: string;
   selvstendigNaeringsvirksomhet: boolean;
+  tilhorerSammeKonsern?: boolean | null;
   adresse?: Partial<StrukturertAdresse>;
 }
 
@@ -46,6 +47,9 @@ export interface ArbeidsstedFly {
   hjemmebaseNavn?: string;
   hjemmebaseLand?: string;
   typeFlyvninger?: string;
+  erVanligHjemmebase?: boolean | null;
+  vanligHjemmebaseLand?: string;
+  vanligHjemmebaseNavn?: string;
 }
 interface MaritimtArbeid {
   enhetNavn?: string;
@@ -58,6 +62,7 @@ export interface ArbeidsstedSkip extends MaritimtArbeid {
   fartsomradeKode?: string;
   flaggLandkode?: string;
   territorialfarvann?: string;
+  yrke?: string;
 }
 export interface RepresentantIUtlandet {
   representantNavn?: string;

--- a/src/services/modules/mottatteOpplysninger/types.ts
+++ b/src/services/modules/mottatteOpplysninger/types.ts
@@ -45,6 +45,7 @@ interface Foretakutland {
   navn: Navn;
   orgnr: string | null;
   selvstendigNaeringsvirksomhet: boolean;
+  tilhorerSammeKonsern: boolean | null;
   adresse: {
     tilleggsnavn: string | null;
     gatenavn: string | null;
@@ -289,6 +290,7 @@ interface Maritimtarbeid {
   innretningLandkode: string | null;
   territorialfarvann: Territorialfarvann;
   innretningstype: Innretningstype;
+  yrke: string | null;
 }
 interface RepresentantIUtlandet {
   representantNavn: string;
@@ -299,6 +301,9 @@ interface LuftfartBase {
   hjemmebaseNavn: HjemmebaseNavn;
   hjemmebaseLand: HjemmebaseLand;
   typeFlyvninger: TypeFlyvninger;
+  erVanligHjemmebase: boolean | null;
+  vanligHjemmebaseLand: string | null;
+  vanligHjemmebaseNavn: string | null;
 }
 export interface Soeknadsland {
   landkoder: string[];


### PR DESCRIPTION
## Endringer
Frontend-felter som matcher backend-mappingen i [melosys-api#3318](https://github.com/navikt/melosys-api/pull/3318).

- **Utenlandsk arbeidsgiver**: "Bygning" (var Tilleggsnavn), "Gate/veg" (var Adresse), ny `tilhorerSammeKonsern`-checkbox. Postboks/Region readonly for bakoverkompatibilitet.
- **Arbeidssted land**: "Gate/veg". Tilleggsnavn/Region/Postboks vises kun ved verdi (disabled — for eldre Altinn-data).
- **Skip**: yrke-felt lagt til. Fartsområde dropdown→radio.
- **Offshore**: Innretningstype dropdown→radio.
- **Fly**: typeFlyvninger fjernet fra UI. `erVanligHjemmebase`-radio + betingede vanligHjemmebase-felter lagt til.

## Test
- [x] `pnpm vitest run` for berørte mapper: alle grønne, snapshots oppdatert
- [ ] Manuell q2-test etter merge — sidemeny vises riktig for digital søknad