### PR TITLE
8030 DAPI: Bevar Content-Type fra serveren ved dokumentvisning

### DIFF
--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -261,12 +261,11 @@ export const postAsJsonReceiveAsPDF = (url, data = {}, extendResponse = false) =
 export const fetchAsPDFBlob = (url) =>
   fetch(url, { credentials: "include" })
     .then(sjekkStatuskode)
-    .then((response) => response.blob())
-    .then((blob) => new Blob([blob], { type: "application/pdf" }));
+    .then((response) => response.blob());
 
 export const apnePdfINyFane = async (url) => {
-  fetchAsPDFBlob(url).then((pdfBlob) => {
-    const _url = window.URL.createObjectURL(pdfBlob);
+  fetchAsPDFBlob(url).then((blob) => {
+    const _url = window.URL.createObjectURL(blob);
     window.open(_url, "_blank")?.focus();
   });
 };


### PR DESCRIPTION
Slutter å hardkode application/pdf på blob-en. PNG/JPEG-vedlegg åpnes nå i ny fane med riktig viewer.

https://github.com/navikt/melosys-api/pull/3323