### PR TITLE
7828 TOGGLE Oppretter ingen flyt visning for EØS-tjenesteperson

### DIFF
--- a/src/felleskomponenter/alertmeldinger/alertmeldinger.tsx
+++ b/src/felleskomponenter/alertmeldinger/alertmeldinger.tsx
@@ -21,6 +21,14 @@ export function VirksomhetMelding() {
   );
 }
 
+export function IngenFlytÅrsavregningMelding() {
+  return (
+    <Nav.Alert variant="warning" className="ingenFlytMelding">
+      <b>Du kan ikke årsavregne disse type saker i Melosys enda, vi jobber med å få det på plass</b>
+    </Nav.Alert>
+  );
+}
+
 export function IngenFlytMelding() {
   return (
     <Nav.Alert variant="warning" className="ingenFlytMelding">

--- a/src/felleskomponenter/alertmeldinger/index.ts
+++ b/src/felleskomponenter/alertmeldinger/index.ts
@@ -2,6 +2,7 @@ import {
   StandardMeldingOverst,
   IngenFlytMelding,
   VirksomhetMelding,
+  IngenFlytÅrsavregningMelding,
   Innsynsmelding,
   NyVurderingMelding,
 } from "./alertmeldinger";
@@ -11,6 +12,7 @@ import StatsborgerskapFeil from "./statsborgerskapFeil";
 export {
   VirksomhetMelding,
   IngenFlytMelding,
+  IngenFlytÅrsavregningMelding,
   StandardMeldingOverst,
   UnntakHjelpetekst,
   Innsynsmelding,

--- a/src/sider/ingenFlyt/behandling.tsx
+++ b/src/sider/ingenFlyt/behandling.tsx
@@ -20,7 +20,12 @@ import Informasjonlinje from "../../felleskomponenter/informasjonlinje";
 import { SoknadMenypanelForm } from "../../felleskomponenter/menypanelForm";
 import Oppsummering from "../../felleskomponenter/oppsummering";
 import SaksoversiktLenke from "../../felleskomponenter/saksoversiktLenke";
-import { Innsynsmelding, IngenFlytMelding, VirksomhetMelding } from "../../felleskomponenter/alertmeldinger";
+import {
+  Innsynsmelding,
+  IngenFlytMelding,
+  VirksomhetMelding,
+  IngenFlytÅrsavregningMelding,
+} from "../../felleskomponenter/alertmeldinger";
 import SideDialog, { defaultTabs, tabsUtenBucOgSed } from "../../felleskomponenter/sideDialog";
 
 import "./behandling.less";
@@ -30,6 +35,7 @@ import { behandlingsresultatSelectors } from "../../ducks/behandlingsresultat";
 const mapStateToProps = (state: RootState) => ({
   arbeidsland: mottatteOpplysningerSelectors.SoknadslandKTSelector(state),
   behandlingstema: behandlingerSelectors.BehandlingstemaKodeSelector(state),
+  behandlingstype: behandlingerSelectors.BehandlingstypeKodeSelector(state),
   behandlingsresultatType: behandlingsresultatSelectors.BehandlingsresultatTypeSelector(state),
   fagsakStatus: fagsakSelectors.FagsakStatusSelector(state),
   hovedpartRolle: fagsakSelectors.HovedpartRolleSelector(state),
@@ -57,6 +63,7 @@ interface Props extends RouteComponentProps<MatchParams> {}
 function Behandling({
   arbeidsland,
   behandlingstema,
+  behandlingstype,
   behandlingsresultatType,
   fagsakStatus,
   hovedpartRolle,
@@ -92,7 +99,12 @@ function Behandling({
   const erAvslåttPgaManglendeOpplysninger =
     behandlingsresultatType === MKV.Koder.behandlinger.behandlingsresultattyper.AVSLAG_MANGLENDE_OPPL;
   const visAvslåttPgaManglendeOpplysninger = erAvslåttPgaManglendeOpplysninger && !erHenlagtSak;
-  const visTomFlytMelding = !erAvslåttPgaManglendeOpplysninger && !erHenlagtSak;
+
+  const visTomFlytMeldingForÅrsavregning =
+    [MKV.Koder.behandlinger.behandlingstema.ARBEID_TJENESTEPERSON_ELLER_FLY].includes(behandlingstema) &&
+    [MKV.Koder.behandlinger.behandlingstyper.ÅRSAVREGNING].includes(behandlingstype);
+
+  const visTomFlytMelding = !erAvslåttPgaManglendeOpplysninger && !erHenlagtSak && !visTomFlytMeldingForÅrsavregning;
 
   return (
     <>
@@ -111,6 +123,7 @@ function Behandling({
                   <main id="main-container">
                     {erHenlagtSak && <HenlagtSak />}
                     {visAvslåttPgaManglendeOpplysninger && <AvslaattPgaManglendeOpplysninger />}
+                    {visTomFlytMeldingForÅrsavregning && <IngenFlytÅrsavregningMelding />}
                     {visTomFlytMelding && <IngenFlytMelding />}
                   </main>
                   <SoknadMenypanelForm startOgVisOppfriskModal={() => null} visOppdaterRegisteropplysninger={false} />

--- a/src/url/url.ts
+++ b/src/url/url.ts
@@ -95,10 +95,6 @@ export const lagUrl = (
   erPensjonistToggleEnabled?: boolean,
   erPensjonistEØSToggleEnabled?: boolean,
 ) => {
-  if (behandlingstypeKode === MKV.Koder.behandlinger.behandlingstyper.ÅRSAVREGNING) {
-    return lagÅrsavregningFlytUrl(sakstypeKode, saksnummer, behandlingID);
-  }
-
   if (
     skalViseIngenFlyt(
       sakstypeKode,
@@ -110,6 +106,10 @@ export const lagUrl = (
     )
   ) {
     return lagIngenFlytUrl(sakstypeKode, saksnummer, behandlingID);
+  }
+
+  if (behandlingstypeKode === MKV.Koder.behandlinger.behandlingstyper.ÅRSAVREGNING) {
+    return lagÅrsavregningFlytUrl(sakstypeKode, saksnummer, behandlingID);
   }
 
   return lagUrlFraSakstypeOgBehandlingstema(saksnummer, behandlingID, sakstypeKode, behandlingstemaKode);
@@ -160,6 +160,14 @@ export const skalViseIngenFlyt = (
   erPensjonsistToggleEnabled?: boolean,
   erPensjonistToggleEnabled_EØS?: boolean,
 ) => {
+  // Årsavregning EØS offentlig tjenesteperson
+  if (
+    behandlingstema === MKV.Koder.behandlinger.behandlingstema.ARBEID_TJENESTEPERSON_ELLER_FLY &&
+    behandlingstype === MKV.Koder.behandlinger.behandlingstyper.ÅRSAVREGNING
+  ) {
+    return true;
+  }
+
   if (
     sakstype === EU_EOS &&
     sakstema === TRYGDEAVGIFT &&


### PR DESCRIPTION
Tidligere ble årsavregning kun automatisk opprettet for FTRL yrkesaktive. Nå støttes også EØS offentlig tjenesteperson (ARBEID_TJENESTEPERSON_ELLER_FLY).

Tom visning for årsavregning eøs offentlig tjenesteperson

[MELOSYS-7828](https://jira.adeo.no/browse/MELOSYS-7828)