### PR TITLE
7896 Fiks stale closure i debounced trygdeavgiftsberegning

### DIFF
--- a/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FieldValue, useFieldArray, useForm } from "react-hook-form";
 import { useSelector } from "react-redux";
 import * as Mui from "../../../felleskomponenter/ui";
@@ -126,6 +126,10 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     replace: resetInntektskilder,
   } = useFieldArray({ control: control as any, name: "inntektskilder" }) as any;
   const formValues = watch();
+  const formVerdierNøkkel = JSON.stringify({
+    skatteforholdsperioder: formValues?.skatteforholdsperioder,
+    inntektskilder: formValues?.inntektskilder,
+  });
 
   const aktivFeilmeldingType = finnAktivFeilmeldingEuEøs(
     formValues?.inntektskilder,
@@ -148,6 +152,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
   const harLovvalgsperiodeFraTidligereÅr = harPerioderFraTidligereÅr(
     tidligereLovvalgsperioder as Avgiftspliktigperiode[],
   );
+  const beregningErGyldig = formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType);
 
   const stegErGyldig =
     (formIsValid || skalIkkeBeregneForelopigTrygdeavgift) && !feilMeldingBlokkerer(aktivFeilmeldingType) && !feil;
@@ -244,39 +249,42 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     oppdaterStatus(stegErGyldig && harBeregnetForeløpigTrygdeavgift);
   }, [stegErGyldig, harBeregnetForeløpigTrygdeavgift]);
 
-  const beregnTrygdeavgiftsperioder = (formVerdier: FieldValue<FormValuesProps>) => {
-    setFeil(undefined);
-    setLagrePending(true);
+  const beregnTrygdeavgiftsperioder = useCallback(
+    (formVerdier: FieldValue<FormValuesProps>) => {
+      setFeil(undefined);
+      setLagrePending(true);
 
-    if (skalIkkeBeregneForelopigTrygdeavgift && skalIkkeViseTidligerePerioderToggle) {
-      setTrygdeavgift(undefined);
-      setLagrePending(false);
-    } else {
-      Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
-        skatteforholdsperioder: formVerdier.skatteforholdsperioder.map((skatteforhold: Skatteforhold) => ({
-          fomDato: Utils.dato.formatterDatoTilISO(skatteforhold.fomDato),
-          tomDato: Utils.dato.formatterDatoTilISO(skatteforhold.tomDato, null),
-          skatteplikttype: skatteforhold.skatteplikttype,
-        })),
-        inntektskilder: erBrukerSkattepliktigIHelePerioden(formVerdier.skatteforholdsperioder)
-          ? []
-          : formVerdier.inntektskilder.map((inntektskilde: Inntektskilde) => ({
-              type: inntektskilde.kildetype,
-              arbeidsgiversavgiftBetales: Utils.streng.uppercaseStrengTilBool(inntektskilde.arbAvgBetales) || false,
-              avgiftspliktigInntekt: inntektskilde.bruttoInntekt,
-              fomDato: Utils.dato.formatterDatoTilISO(inntektskilde.fomDato),
-              tomDato: Utils.dato.formatterDatoTilISO(inntektskilde.tomDato, null),
-              erMaanedsbelop: true,
-            })),
-      })
-        .then((beregnetTrygdeavgift) => {
-          setFeil(undefined);
-          setTrygdeavgift(beregnetTrygdeavgift);
+      if (skalIkkeBeregneForelopigTrygdeavgift && skalIkkeViseTidligerePerioderToggle) {
+        setTrygdeavgift(undefined);
+        setLagrePending(false);
+      } else {
+        Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
+          skatteforholdsperioder: formVerdier.skatteforholdsperioder.map((skatteforhold: Skatteforhold) => ({
+            fomDato: Utils.dato.formatterDatoTilISO(skatteforhold.fomDato),
+            tomDato: Utils.dato.formatterDatoTilISO(skatteforhold.tomDato, null),
+            skatteplikttype: skatteforhold.skatteplikttype,
+          })),
+          inntektskilder: erBrukerSkattepliktigIHelePerioden(formVerdier.skatteforholdsperioder)
+            ? []
+            : formVerdier.inntektskilder.map((inntektskilde: Inntektskilde) => ({
+                type: inntektskilde.kildetype,
+                arbeidsgiversavgiftBetales: Utils.streng.uppercaseStrengTilBool(inntektskilde.arbAvgBetales) || false,
+                avgiftspliktigInntekt: inntektskilde.bruttoInntekt,
+                fomDato: Utils.dato.formatterDatoTilISO(inntektskilde.fomDato),
+                tomDato: Utils.dato.formatterDatoTilISO(inntektskilde.tomDato, null),
+                erMaanedsbelop: true,
+              })),
         })
-        .catch((error) => setFeil(mapFeilmelding(error)))
-        .finally(() => setLagrePending(false));
-    }
-  };
+          .then((beregnetTrygdeavgift) => {
+            setFeil(undefined);
+            setTrygdeavgift(beregnetTrygdeavgift);
+          })
+          .catch((error) => setFeil(mapFeilmelding(error)))
+          .finally(() => setLagrePending(false));
+      }
+    },
+    [behandlingID, skalIkkeBeregneForelopigTrygdeavgift, skalIkkeViseTidligerePerioderToggle],
+  );
 
   const mapFeilmelding = (error: any) => {
     const feilmelding = "Finner ikke trygdeavgiftssats. Melosys har ikke satser for årene før 2014.";
@@ -290,24 +298,32 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     return error.body?.feilkoder || error.body?.message || error;
   };
 
-  const debounceBeregnTrygdeavgiftsperioder = useCallback(
-    Utils._debounce(
-      (formVerdier: FormValuesProps, isValid: boolean) => isValid && beregnTrygdeavgiftsperioder(formVerdier),
-      500,
-    ),
-    [],
+  const debounceBeregnTrygdeavgiftsperioder = useMemo(
+    () =>
+      Utils._debounce((formVerdier: FormValuesProps, isValid: boolean) => {
+        if (isValid) {
+          beregnTrygdeavgiftsperioder(formVerdier);
+        }
+      }, 500),
+    [beregnTrygdeavgiftsperioder],
   );
 
   useEffect(() => {
+    return () => debounceBeregnTrygdeavgiftsperioder.cancel();
+  }, [debounceBeregnTrygdeavgiftsperioder]);
+
+  useEffect(() => {
     if (redigerbart && aktivtSteg && !isValidating && !erÅpenSluttDato) {
-      debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
+      debounceBeregnTrygdeavgiftsperioder(formValues, beregningErGyldig);
     }
   }, [
-    formIsValid,
-    aktivFeilmeldingType,
+    aktivtSteg,
+    beregningErGyldig,
+    debounceBeregnTrygdeavgiftsperioder,
+    erÅpenSluttDato,
     isValidating,
-    formValues?.inntektskilder?.length,
-    formValues?.skatteforholdsperioder?.length,
+    formVerdierNøkkel,
+    redigerbart,
   ]);
 
   useEffect(() => {
@@ -321,7 +337,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
         trigger(`inntektskilder[${index}].tomDato`);
       });
       if (!erÅpenSluttDato && (feil || harEndretLovvalgsperiode)) {
-        debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
+        debounceBeregnTrygdeavgiftsperioder(formValues, beregningErGyldig);
         setHarEndretLovvalgsperiode(false);
       }
     }

--- a/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
@@ -126,10 +126,6 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     replace: resetInntektskilder,
   } = useFieldArray({ control: control as any, name: "inntektskilder" }) as any;
   const formValues = watch();
-  const formVerdierNøkkel = JSON.stringify({
-    skatteforholdsperioder: formValues?.skatteforholdsperioder,
-    inntektskilder: formValues?.inntektskilder,
-  });
 
   const aktivFeilmeldingType = finnAktivFeilmeldingEuEøs(
     formValues?.inntektskilder,
@@ -316,21 +312,14 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     if (redigerbart && aktivtSteg && !isValidating && !erÅpenSluttDato) {
       debounceBeregnTrygdeavgiftsperioder(formValues, beregningErGyldig);
     }
-  }, [
-    aktivtSteg,
-    beregningErGyldig,
-    debounceBeregnTrygdeavgiftsperioder,
-    erÅpenSluttDato,
-    isValidating,
-    formVerdierNøkkel,
-    redigerbart,
-  ]);
+  }, [aktivtSteg, beregningErGyldig, debounceBeregnTrygdeavgiftsperioder, erÅpenSluttDato, isValidating, redigerbart]);
 
   useEffect(() => {
     if (redigerbart && aktivtSteg) {
       formValues?.skatteforholdsperioder?.forEach((_periode: any, index: number) => {
         trigger(`skatteforholdsperioder[${index}].fomDato`);
         trigger(`skatteforholdsperioder[${index}].tomDato`);
+        trigger(`skatteforholdsperioder[${index}].skatteplikttype`);
       });
       formValues?.inntektskilder?.forEach((_periode: any, index: number) => {
         trigger(`inntektskilder[${index}].fomDato`);

--- a/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
@@ -125,10 +125,6 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     replace: resetInntektskilder,
   } = useFieldArray({ control: control as any, name: "inntektskilder" }) as any;
   const formValues = watch();
-  const formVerdierNøkkel = JSON.stringify({
-    skatteforholdsperioder: formValues?.skatteforholdsperioder,
-    inntektskilder: formValues?.inntektskilder,
-  });
 
   const aktivFeilmeldingType = finnAktivFeilmelding(
     formValues?.inntektskilder,
@@ -307,21 +303,14 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     if (redigerbart && aktivtSteg && !isValidating && !erÅpenSluttDato) {
       debounceBeregnTrygdeavgiftsperioder(formValues, beregningErGyldig);
     }
-  }, [
-    aktivtSteg,
-    beregningErGyldig,
-    debounceBeregnTrygdeavgiftsperioder,
-    erÅpenSluttDato,
-    isValidating,
-    formVerdierNøkkel,
-    redigerbart,
-  ]);
+  }, [aktivtSteg, beregningErGyldig, debounceBeregnTrygdeavgiftsperioder, erÅpenSluttDato, isValidating, redigerbart]);
 
   useEffect(() => {
     if (redigerbart && aktivtSteg) {
       formValues?.skatteforholdsperioder?.forEach((_periode: any, index: number) => {
         trigger(`skatteforholdsperioder[${index}].fomDato`);
         trigger(`skatteforholdsperioder[${index}].tomDato`);
+        trigger(`skatteforholdsperioder[${index}].skatteplikttype`);
       });
       formValues?.inntektskilder?.forEach((_periode: any, index: number) => {
         trigger(`inntektskilder[${index}].fomDato`);

--- a/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FieldValue, useFieldArray, useForm } from "react-hook-form";
 import { useSelector } from "react-redux";
 import * as Mui from "../../../felleskomponenter/ui";
@@ -125,6 +125,10 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     replace: resetInntektskilder,
   } = useFieldArray({ control: control as any, name: "inntektskilder" }) as any;
   const formValues = watch();
+  const formVerdierNøkkel = JSON.stringify({
+    skatteforholdsperioder: formValues?.skatteforholdsperioder,
+    inntektskilder: formValues?.inntektskilder,
+  });
 
   const aktivFeilmeldingType = finnAktivFeilmelding(
     formValues?.inntektskilder,
@@ -146,6 +150,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     !skalIkkeBeregneForelopigTrygdeavgift;
 
   const harMedlemskapsperiodeFraTidligereÅr = harPerioderFraTidligereÅr(medlemskapsperioder);
+  const beregningErGyldig = formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType);
 
   const stegErGyldig =
     (formIsValid || skalIkkeBeregneForelopigTrygdeavgift) && !feilMeldingBlokkerer(aktivFeilmeldingType) && !feil;
@@ -233,41 +238,44 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     oppdaterStatus(stegErGyldig && harBeregnetForeløpigTrygdeavgift);
   }, [stegErGyldig, harBeregnetForeløpigTrygdeavgift]);
 
-  const beregnTrygdeavgiftsperioder = (formVerdier: FieldValue<FormValuesProps>) => {
-    setFeil(undefined);
-    setLagrePending(true);
+  const beregnTrygdeavgiftsperioder = useCallback(
+    (formVerdier: FieldValue<FormValuesProps>) => {
+      setFeil(undefined);
+      setLagrePending(true);
 
-    if (skalIkkeBeregneForelopigTrygdeavgift && skalIkkeViseTidligerePerioderToggle) {
-      setTrygdeavgift(undefined);
-      setLagrePending(false);
-    } else {
-      const erBrukerPliktigMedlemOgSkattepliktig =
-        medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(formVerdier.skatteforholdsperioder);
-      Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
-        skatteforholdsperioder: formVerdier.skatteforholdsperioder.map((skatteforhold: Skatteforhold) => ({
-          fomDato: Utils.dato.formatterDatoTilISO(skatteforhold.fomDato),
-          tomDato: Utils.dato.formatterDatoTilISO(skatteforhold.tomDato, null),
-          skatteplikttype: skatteforhold.skatteplikttype,
-        })),
-        inntektskilder: !erBrukerPliktigMedlemOgSkattepliktig
-          ? formVerdier.inntektskilder.map((inntektskilde: Inntektskilde) => ({
-              type: inntektskilde.kildetype,
-              arbeidsgiversavgiftBetales: Utils.streng.uppercaseStrengTilBool(inntektskilde.arbAvgBetales) || false,
-              avgiftspliktigInntekt: inntektskilde.bruttoInntekt,
-              fomDato: Utils.dato.formatterDatoTilISO(inntektskilde.fomDato),
-              tomDato: Utils.dato.formatterDatoTilISO(inntektskilde.tomDato, null),
-              erMaanedsbelop: true,
-            }))
-          : [],
-      })
-        .then((beregnetTrygdeavgift) => {
-          setFeil(undefined);
-          setTrygdeavgift(beregnetTrygdeavgift);
+      if (skalIkkeBeregneForelopigTrygdeavgift && skalIkkeViseTidligerePerioderToggle) {
+        setTrygdeavgift(undefined);
+        setLagrePending(false);
+      } else {
+        const erBrukerPliktigMedlemOgSkattepliktig =
+          medlemskapsTypeErPliktig && erBrukerSkattepliktigIHelePerioden(formVerdier.skatteforholdsperioder);
+        Api.Trygdeavgift.beregnTrygdeavgiftsperioder(behandlingID, {
+          skatteforholdsperioder: formVerdier.skatteforholdsperioder.map((skatteforhold: Skatteforhold) => ({
+            fomDato: Utils.dato.formatterDatoTilISO(skatteforhold.fomDato),
+            tomDato: Utils.dato.formatterDatoTilISO(skatteforhold.tomDato, null),
+            skatteplikttype: skatteforhold.skatteplikttype,
+          })),
+          inntektskilder: !erBrukerPliktigMedlemOgSkattepliktig
+            ? formVerdier.inntektskilder.map((inntektskilde: Inntektskilde) => ({
+                type: inntektskilde.kildetype,
+                arbeidsgiversavgiftBetales: Utils.streng.uppercaseStrengTilBool(inntektskilde.arbAvgBetales) || false,
+                avgiftspliktigInntekt: inntektskilde.bruttoInntekt,
+                fomDato: Utils.dato.formatterDatoTilISO(inntektskilde.fomDato),
+                tomDato: Utils.dato.formatterDatoTilISO(inntektskilde.tomDato, null),
+                erMaanedsbelop: true,
+              }))
+            : [],
         })
-        .catch((error) => setFeil(mapFeilmelding(error)))
-        .finally(() => setLagrePending(false));
-    }
-  };
+          .then((beregnetTrygdeavgift) => {
+            setFeil(undefined);
+            setTrygdeavgift(beregnetTrygdeavgift);
+          })
+          .catch((error) => setFeil(mapFeilmelding(error)))
+          .finally(() => setLagrePending(false));
+      }
+    },
+    [behandlingID, medlemskapsTypeErPliktig, skalIkkeBeregneForelopigTrygdeavgift, skalIkkeViseTidligerePerioderToggle],
+  );
 
   const mapFeilmelding = (error: any) => {
     const feilmelding = "Finner ikke trygdeavgiftssats. Melosys har ikke satser for årene før 2014.";
@@ -281,24 +289,32 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
     return error.body?.feilkoder || error.body?.message || error;
   };
 
-  const debounceBeregnTrygdeavgiftsperioder = useCallback(
-    Utils._debounce(
-      (formVerdier: FormValuesProps, isValid: boolean) => isValid && beregnTrygdeavgiftsperioder(formVerdier),
-      500,
-    ),
-    [],
+  const debounceBeregnTrygdeavgiftsperioder = useMemo(
+    () =>
+      Utils._debounce((formVerdier: FormValuesProps, isValid: boolean) => {
+        if (isValid) {
+          beregnTrygdeavgiftsperioder(formVerdier);
+        }
+      }, 500),
+    [beregnTrygdeavgiftsperioder],
   );
 
   useEffect(() => {
+    return () => debounceBeregnTrygdeavgiftsperioder.cancel();
+  }, [debounceBeregnTrygdeavgiftsperioder]);
+
+  useEffect(() => {
     if (redigerbart && aktivtSteg && !isValidating && !erÅpenSluttDato) {
-      debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
+      debounceBeregnTrygdeavgiftsperioder(formValues, beregningErGyldig);
     }
   }, [
-    formIsValid,
-    aktivFeilmeldingType,
+    aktivtSteg,
+    beregningErGyldig,
+    debounceBeregnTrygdeavgiftsperioder,
+    erÅpenSluttDato,
     isValidating,
-    formValues?.inntektskilder?.length,
-    formValues?.skatteforholdsperioder?.length,
+    formVerdierNøkkel,
+    redigerbart,
   ]);
 
   useEffect(() => {
@@ -312,7 +328,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
         trigger(`inntektskilder[${index}].tomDato`);
       });
       if (!erÅpenSluttDato && (feil || harEndretInnvilgetMedlemskapsperiode)) {
-        debounceBeregnTrygdeavgiftsperioder(formValues, formIsValid && !feilMeldingBlokkerer(aktivFeilmeldingType));
+        debounceBeregnTrygdeavgiftsperioder(formValues, beregningErGyldig);
         setHarEndretInnvilgetMedlemskapsperiode(false);
       }
     }


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7896

Endrer beregnTrygdeavgiftsperioder til useCallback med korrekte dependencies, og debounce-wrapperen til useMemo som oppdateres når funksjonen endres. Legger til cleanup-effect for å kansellere utdatert debounce. Erstatter .length-sjekk med JSON.stringify av formverdier slik at endringer i eksisterende perioder (f.eks. valg av skattepliktig) også trigger beregning.

Debounce-funksjonen brukte useCallback med tom dependency-array, som førte til at den alltid kjørte med verdier fra første render (stale closure). Dette var spesielt synlig når skalIkkeViseTidligerePerioderToggle var aktivert, fordi den kodestien er mer sensitiv for oppdaterte verdier av skalIkkeBeregneForelopigTrygdeavgift og medlemskapsTypeErPliktig.