### PR TITLE
7887 DAPI Endre tekst på innbetalt trygdeavgift

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { InnbetaltTrygdeavgiftInput } from "./innbetaltTrygdeavgiftInput";
+import { useFeatureToggle } from "../../../../../featuretoggle";
 
 vi.mock("../../../../../felleskomponenter/forms", () => ({
   Input: ({ label, description, readOnly, numeric }: any) => (
@@ -11,12 +13,21 @@ vi.mock("../../../../../felleskomponenter/forms", () => ({
   ),
 }));
 
-import { InnbetaltTrygdeavgiftInput } from "./innbetaltTrygdeavgiftInput";
+vi.mock("../../../../../featuretoggle/useFeatureToggle", () => ({
+  default: vi.fn(),
+}));
 
 describe("InnbetaltTrygdeavgiftInput", () => {
   it("rendrer label", () => {
+    vi.mocked(useFeatureToggle).mockReturnValue(true);
     render(<InnbetaltTrygdeavgiftInput control={{} as any} redigerbart={true} erNyAarsavregning={false} />);
     expect(screen.getByText("Innbetalt trygdeavgift")).toBeDefined();
+  });
+
+  it("rendrer label", () => {
+    vi.mocked(useFeatureToggle).mockReturnValue(false);
+    render(<InnbetaltTrygdeavgiftInput control={{} as any} redigerbart={true} erNyAarsavregning={false} />);
+    expect(screen.getByText("Trygdeavgift fra Avgiftssystemet")).toBeDefined();
   });
 
   it("viser beskrivelse for ny årsavregning", () => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.tsx
@@ -1,7 +1,8 @@
 import "../vurderingAarsavregningInngang.less";
 import { Control } from "react-hook-form";
 import * as Forms from "../../../../../felleskomponenter/forms";
-
+import { useFeatureToggle } from "../../../../../featuretoggle";
+import { ÅRSAVREGNING_EØS_PENSJONIST } from "../../../../../featuretoggle/toggleNavn";
 interface InnbetaltTrygdeavgiftInputProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   control: Control<any>;
@@ -14,9 +15,13 @@ export function InnbetaltTrygdeavgiftInput({
   redigerbart,
   erNyAarsavregning,
 }: InnbetaltTrygdeavgiftInputProps) {
+  const label = useFeatureToggle(ÅRSAVREGNING_EØS_PENSJONIST)
+    ? "Innbetalt trygdeavgift"
+    : "Trygdeavgift fra Avgiftssystemet";
+
   return (
     <Forms.Input
-      label="Innbetalt trygdeavgift"
+      label={label}
       description={erNyAarsavregning ? "Du skal kun endre hvis tidligere oppgitte beløp er feil" : ""}
       name="innbetaltTrygdeavgift"
       control={control}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -39,6 +39,20 @@ const DELT_GRUNNLAG_HJELPETEKST = (
   </>
 );
 
+const DELT_GRUNNLAG_INNBETALT_TRYGDEAVGIFT_HJELPETEKST = (
+  <>
+    <p>
+      Oppgi innbetalt avgift hvis innbetalt beløp ikke samsvarer med tidligere beregnet trygdeavgift. Dette kan for
+      eksempel skyldes at det ikke har vært mulig å trekke fullt beløp fra pensjon, eller at det også er innbetalt
+      avgift i samme sak i Avgiftssystemet.
+    </p>
+    <ul>
+      <li>Hvis ja må saksbehandler oppgi innbetalt trygdeavgift i et eget felt.</li>
+      <li>Hvis nei må kan saksbehandler gå videre.</li>
+    </ul>
+  </>
+);
+
 const behandlingHarÅrsavregning = (behandlingID: number, årsavregningList: AarsavregningListResponse[]) => {
   return årsavregningList.find((aarsavregning) => aarsavregning.behandlingID === behandlingID);
 };
@@ -229,7 +243,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   const trygdeavgiftAvvikLabelHjelpetekst = useFeatureToggle(ÅRSAVREGNING_EØS_PENSJONIST) ? (
     <LabelMedHjelpetekst
       label="Avviker innbetalt trygdeavgift fra tidligere beregnet avgift?"
-      hjelpetekst={harTidligereTrygdeavgiftsgrunnlag ? DELT_GRUNNLAG_HJELPETEKST : ""}
+      hjelpetekst={harTidligereTrygdeavgiftsgrunnlag ? DELT_GRUNNLAG_INNBETALT_TRYGDEAVGIFT_HJELPETEKST : ""}
     />
   ) : (
     <LabelMedHjelpetekst


### PR DESCRIPTION
Endrer label og hjelpetekst for innbetalt trygdeavgift i årsavregning, styrt av feature toggle.

Saksbehandlere trenger tydeligere tekst som skiller mellom "Innbetalt trygdeavgift" og "Trygdeavgift fra Avgiftssystemet" avhengig av om EØS-pensjonist-funksjonaliteten er aktivert. Hjelpeteksten er også oppdatert for å forklare når innbetalt avgift avviker fra beregnet.
[MELOSYS-7887](https://jira.adeo.no/browse/MELOSYS-7887)

- Dynamisk label på innbetalt trygdeavgift basert på ÅRSAVREGNING_EØS_PENSJONIST toggle
- Ny hjelpetekst som forklarer avvik mellom innbetalt og beregnet trygdeavgift

## Testing
- [ ] Manuell testing lokalt