### PR TITLE
7954 TOGGLE Håndter innbetalt trygdeavgift uten tidligere grunnlag

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -917,6 +917,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
           control={control}
           redigerbart={skjemaErRedigerbart}
           erNyAarsavregning={Boolean(tidligereAarsavregningInnbetaltTrygdeavgift)}
+          harTidligereTrygdeavgiftsgrunnlag={harTidligereTrygdeavgiftsgrunnlag}
         />
       )}
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/aarsavregningUtenEllerDeltGrunnlag/aarsavregningUtenEllerDeltGrunnlagForm.tsx
@@ -928,6 +928,7 @@ export function AarsavregningUtenEllerDeltGrunnlagForm({
         endeligAvgiftValg={endeligAvgiftValg}
         endretPeriodeFraAvgiftssystemetValg={erDeltGrunnlag}
         harInnbetaltTrygdeavgift={harInnbetaltTrygdeavgift}
+        harTidligereTrygdeavgiftsgrunnlag={harTidligereTrygdeavgiftsgrunnlag}
       />
 
       {(endeligAvgiftValg === OPPLYSNINGER_ENDRET ||

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.test.tsx
@@ -25,12 +25,20 @@ describe("EndeligAvgiftValgRadioGroup", () => {
     endeligAvgiftValg: undefined as string | undefined,
     endretPeriodeFraAvgiftssystemetValg: true,
     harInnbetaltTrygdeavgift: true,
+    harTidligereTrygdeavgiftsgrunnlag: true,
   };
 
   it("rendrer alle radioknapper", () => {
     render(<EndeligAvgiftValgRadioGroup {...defaultProps} />);
     expect(screen.getByText("Beregn endelig trygdeavgift")).toBeDefined();
     expect(screen.getByText("Beregn trygdeavgift med periode fra avgiftssystemet")).toBeDefined();
+    expect(screen.getByText("Oppgi endelig beregnet trygdeavgift")).toBeDefined();
+  });
+
+  it("rendrer ikke radioknappen for periode fra avgiftssystemet når det ikke finnes tidligere trygdeavgiftsgrunnlag", () => {
+    render(<EndeligAvgiftValgRadioGroup {...defaultProps} harTidligereTrygdeavgiftsgrunnlag={false} />);
+    expect(screen.getByText("Beregn endelig trygdeavgift")).toBeDefined();
+    expect(screen.queryByText("Beregn trygdeavgift med periode fra avgiftssystemet")).toBeNull();
     expect(screen.getByText("Oppgi endelig beregnet trygdeavgift")).toBeDefined();
   });
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.tsx
@@ -15,6 +15,7 @@ interface EndeligAvgiftValgRadioGroupProps {
   endeligAvgiftValg?: string;
   endretPeriodeFraAvgiftssystemetValg?: boolean;
   harInnbetaltTrygdeavgift?: boolean;
+  harTidligereTrygdeavgiftsgrunnlag?: boolean;
 }
 
 export function EndeligAvgiftValgRadioGroup({
@@ -24,6 +25,7 @@ export function EndeligAvgiftValgRadioGroup({
   endeligAvgiftValg,
   endretPeriodeFraAvgiftssystemetValg,
   harInnbetaltTrygdeavgift,
+  harTidligereTrygdeavgiftsgrunnlag,
 }: EndeligAvgiftValgRadioGroupProps) {
   const erPensjonistEØSToggleEnabled = useFeatureToggle(ÅRSAVREGNING_EØS_PENSJONIST);
   return (
@@ -42,14 +44,17 @@ export function EndeligAvgiftValgRadioGroup({
           <Nav.Radio value={OPPLYSNINGER_ENDRET} className={endeligAvgiftValg === OPPLYSNINGER_ENDRET ? "checked" : ""}>
             Beregn endelig trygdeavgift
           </Nav.Radio>
-          {erPensjonistEØSToggleEnabled && endretPeriodeFraAvgiftssystemetValg && harInnbetaltTrygdeavgift && (
-            <Nav.Radio
-              value={OPPLYSNINGER_ENDRET_MED_PERIODE_FRA_AVGIFTSSYSTEMET}
-              className={endeligAvgiftValg === OPPLYSNINGER_ENDRET_MED_PERIODE_FRA_AVGIFTSSYSTEMET ? "checked" : ""}
-            >
-              Beregn trygdeavgift med periode fra avgiftssystemet
-            </Nav.Radio>
-          )}
+          {erPensjonistEØSToggleEnabled &&
+            endretPeriodeFraAvgiftssystemetValg &&
+            harInnbetaltTrygdeavgift &&
+            harTidligereTrygdeavgiftsgrunnlag && (
+              <Nav.Radio
+                value={OPPLYSNINGER_ENDRET_MED_PERIODE_FRA_AVGIFTSSYSTEMET}
+                className={endeligAvgiftValg === OPPLYSNINGER_ENDRET_MED_PERIODE_FRA_AVGIFTSSYSTEMET ? "checked" : ""}
+              >
+                Beregn trygdeavgift med periode fra avgiftssystemet
+              </Nav.Radio>
+            )}
           <Nav.Radio
             value={MANUELL_ENDELIG_AVGIFT}
             className={endeligAvgiftValg === MANUELL_ENDELIG_AVGIFT ? "checked" : ""}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/endeligAvgiftValgRadioGroup.tsx
@@ -47,7 +47,7 @@ export function EndeligAvgiftValgRadioGroup({
           {erPensjonistEØSToggleEnabled &&
             endretPeriodeFraAvgiftssystemetValg &&
             harInnbetaltTrygdeavgift &&
-            harTidligereTrygdeavgiftsgrunnlag && (
+            harTidligereTrygdeavgiftsgrunnlag !== false && (
               <Nav.Radio
                 value={OPPLYSNINGER_ENDRET_MED_PERIODE_FRA_AVGIFTSSYSTEMET}
                 className={endeligAvgiftValg === OPPLYSNINGER_ENDRET_MED_PERIODE_FRA_AVGIFTSSYSTEMET ? "checked" : ""}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.test.tsx
@@ -22,7 +22,6 @@ describe("InnbetaltTrygdeavgiftInput", () => {
     control: {} as any,
     redigerbart: true,
     erNyAarsavregning: false,
-    harInnbetaltTrygdeavgift: true,
     harTidligereTrygdeavgiftsgrunnlag: true,
   };
 
@@ -30,6 +29,18 @@ describe("InnbetaltTrygdeavgiftInput", () => {
     vi.mocked(useFeatureToggle).mockReturnValue(true);
     render(<InnbetaltTrygdeavgiftInput {...defaultProps} />);
     expect(screen.getByText("Innbetalt trygdeavgift")).toBeDefined();
+  });
+
+  it("viser hjelpetekst når toggle er aktiv og tidligere grunnlag mangler", () => {
+    vi.mocked(useFeatureToggle).mockReturnValue(true);
+    render(<InnbetaltTrygdeavgiftInput {...defaultProps} harTidligereTrygdeavgiftsgrunnlag={false} />);
+
+    expect(screen.getByText("Innbetalt trygdeavgift")).toBeDefined();
+    expect(
+      screen.getByText(
+        "Oppgi innbetalt avgift. Dette kan f.eks. være avgift fakturert fra Avgiftssystemet eller avgift som har blitt manuelt fakturert. Hvis personen ikke har innbetalt noe, skriv 0,-",
+      ),
+    ).toBeDefined();
   });
 
   it("rendrer label", () => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.test.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.test.tsx
@@ -18,30 +18,39 @@ vi.mock("../../../../../featuretoggle/useFeatureToggle", () => ({
 }));
 
 describe("InnbetaltTrygdeavgiftInput", () => {
+  const defaultProps = {
+    control: {} as any,
+    redigerbart: true,
+    erNyAarsavregning: false,
+    harInnbetaltTrygdeavgift: true,
+    harTidligereTrygdeavgiftsgrunnlag: true,
+  };
+
   it("rendrer label", () => {
     vi.mocked(useFeatureToggle).mockReturnValue(true);
-    render(<InnbetaltTrygdeavgiftInput control={{} as any} redigerbart={true} erNyAarsavregning={false} />);
+    render(<InnbetaltTrygdeavgiftInput {...defaultProps} />);
     expect(screen.getByText("Innbetalt trygdeavgift")).toBeDefined();
   });
 
   it("rendrer label", () => {
     vi.mocked(useFeatureToggle).mockReturnValue(false);
-    render(<InnbetaltTrygdeavgiftInput control={{} as any} redigerbart={true} erNyAarsavregning={false} />);
+    render(<InnbetaltTrygdeavgiftInput {...defaultProps} />);
     expect(screen.getByText("Trygdeavgift fra Avgiftssystemet")).toBeDefined();
   });
 
   it("viser beskrivelse for ny årsavregning", () => {
-    render(<InnbetaltTrygdeavgiftInput control={{} as any} redigerbart={true} erNyAarsavregning={true} />);
+    render(<InnbetaltTrygdeavgiftInput {...defaultProps} erNyAarsavregning={true} />);
     expect(screen.getByText("Du skal kun endre hvis tidligere oppgitte beløp er feil")).toBeDefined();
   });
 
   it("viser ingen beskrivelse for eksisterende årsavregning", () => {
-    render(<InnbetaltTrygdeavgiftInput control={{} as any} redigerbart={true} erNyAarsavregning={false} />);
+    render(<InnbetaltTrygdeavgiftInput {...defaultProps} erNyAarsavregning={false} />);
     expect(screen.queryByText("Du skal kun endre hvis tidligere oppgitte beløp er feil")).toBeNull();
   });
 
   it("er readOnly når ikke redigerbart", () => {
-    render(<InnbetaltTrygdeavgiftInput control={{} as any} redigerbart={false} erNyAarsavregning={false} />);
+    render(<InnbetaltTrygdeavgiftInput {...defaultProps} redigerbart={false} />);
+
     expect(screen.getByRole("textbox").getAttribute("readonly")).not.toBeNull();
   });
 });

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.tsx
@@ -3,25 +3,42 @@ import { Control } from "react-hook-form";
 import * as Forms from "../../../../../felleskomponenter/forms";
 import { useFeatureToggle } from "../../../../../featuretoggle";
 import { ÅRSAVREGNING_EØS_PENSJONIST } from "../../../../../featuretoggle/toggleNavn";
+import LabelMedHjelpetekst from "../../../../../felleskomponenter/labelMedHjelpetekst";
+
 interface InnbetaltTrygdeavgiftInputProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   control: Control<any>;
   redigerbart: boolean;
   erNyAarsavregning: boolean;
+  harTidligereTrygdeavgiftsgrunnlag: boolean;
 }
 
 export function InnbetaltTrygdeavgiftInput({
   control,
   redigerbart,
   erNyAarsavregning,
+  harTidligereTrygdeavgiftsgrunnlag,
 }: InnbetaltTrygdeavgiftInputProps) {
-  const label = useFeatureToggle(ÅRSAVREGNING_EØS_PENSJONIST)
-    ? "Innbetalt trygdeavgift"
+  const UTEN_GRUNNLAG_HJELPETEKST = (
+    <p>
+      Oppgi innbetalt avgift. Dette kan f.eks. være avgift fakturert fra Avgiftssystemet eller avgift som har blitt
+      manuelt fakturert. Hvis personen ikke har innbetalt noe, skrive 0,-
+    </p>
+  );
+
+  const innbetaltTrygdeavgiftTekst = harTidligereTrygdeavgiftsgrunnlag ? (
+    "Innbetalt trygdeavgift"
+  ) : (
+    <LabelMedHjelpetekst label="Innbetalt trygdeavgift" hjelpetekst={UTEN_GRUNNLAG_HJELPETEKST} />
+  );
+
+  const innbetaltTrygdeavgiftLabel = useFeatureToggle(ÅRSAVREGNING_EØS_PENSJONIST)
+    ? innbetaltTrygdeavgiftTekst
     : "Trygdeavgift fra Avgiftssystemet";
 
   return (
     <Forms.Input
-      label={label}
+      label={innbetaltTrygdeavgiftLabel}
       description={erNyAarsavregning ? "Du skal kun endre hvis tidligere oppgitte beløp er feil" : ""}
       name="innbetaltTrygdeavgift"
       control={control}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/innbetaltTrygdeavgiftInput.tsx
@@ -22,7 +22,7 @@ export function InnbetaltTrygdeavgiftInput({
   const UTEN_GRUNNLAG_HJELPETEKST = (
     <p>
       Oppgi innbetalt avgift. Dette kan f.eks. være avgift fakturert fra Avgiftssystemet eller avgift som har blitt
-      manuelt fakturert. Hvis personen ikke har innbetalt noe, skrive 0,-
+      manuelt fakturert. Hvis personen ikke har innbetalt noe, skriv 0,-
     </p>
   );
 

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useContext, useEffect, useState } from "react";
+import { ChangeEvent, use, useContext, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { useDispatch } from "../../../../hooks";
 import { OK } from "../../../../ducks/aarsavregning/types";
@@ -40,13 +40,11 @@ const DELT_GRUNNLAG_HJELPETEKST = (
 );
 
 const DELT_GRUNNLAG_INNBETALT_TRYGDEAVGIFT_HJELPETEKST = (
-  <>
-    <p>
-      Oppgi innbetalt avgift hvis innbetalt beløp ikke samsvarer med tidligere beregnet trygdeavgift. Dette kan for
-      eksempel skyldes at det ikke har vært mulig å trekke fullt beløp fra pensjon, eller at det også er innbetalt
-      avgift i samme sak i Avgiftssystemet.
-    </p>
-  </>
+  <p>
+    Oppgi innbetalt avgift hvis innbetalt beløp ikke samsvarer med tidligere beregnet trygdeavgift. Dette kan for
+    eksempel skyldes at det ikke har vært mulig å trekke fullt beløp fra pensjon, eller at det også er innbetalt avgift
+    i samme sak i Avgiftssystemet.
+  </p>
 );
 
 const behandlingHarÅrsavregning = (behandlingID: number, årsavregningList: AarsavregningListResponse[]) => {
@@ -101,6 +99,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   const saksnummer = useSelector(fagsakSelectors.SaksnummerSelector) as any;
   const { oppfriskOgLastInnSaksopplysningerForAarsavregning } = useContext(FellesHandlersContext) as any;
   const dispatch = useDispatch();
+  const erÅrsavregningEøsPensjonistToggleEnabled = useFeatureToggle(ÅRSAVREGNING_EØS_PENSJONIST);
 
   /**
    * Utleder harInnbetaltTrygdeavgift når verdien er null (bakoverkompatibilitet).
@@ -139,6 +138,22 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
       // Bakoverkompatibilitet: utled verdi fra eksisterende data
       const utledetVerdi = utledHarInnbetaltTrygdeavgiftNårNull(res);
       setHarInnbetaltTrygdeavgift(utledetVerdi ?? false);
+    }
+
+    if (erÅrsavregningEøsPensjonistToggleEnabled) {
+      const harGrunnlag = !(
+        res.tidligereTrygdeavgiftsGrunnlagsopplysninger === null ||
+        Utils._isEmpty(res.tidligereTrygdeavgiftsGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.avgiftspliktigperioder)
+      );
+
+      setHarTidligereTrygdeavgiftsgrunnlag(harGrunnlag);
+
+      if (!harGrunnlag) {
+        // Når det ikke finnes grunnlag skal harInnbetaltTrygdeavgift alltid være true
+        setHarInnbetaltTrygdeavgift(true);
+        håndterHarInnbetaltTrygdeavgift(true);
+        return;
+      }
     }
 
     setHarTidligereTrygdeavgiftsgrunnlag(
@@ -207,7 +222,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
 
   const håndterHarInnbetaltTrygdeavgift = async (value: boolean) => {
     setHarInnbetaltTrygdeavgiftIsPending(true);
-    Api.Aarsavregning.oppdaterHarInnbetaltTrygdeavgift(behandlingID, {
+    await Api.Aarsavregning.oppdaterHarInnbetaltTrygdeavgift(behandlingID, {
       harInnbetaltTrygdeavgift: value,
     })
       .then((res) => {
@@ -236,7 +251,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
   const antallÅrTilbakeITid = 6;
   const muligeAar = Array.from({ length: antallÅrTilbakeITid }, (_, i) => sisteMuligeÅr - i);
 
-  const trygdeavgiftAvvikLabelHjelpetekst = useFeatureToggle(ÅRSAVREGNING_EØS_PENSJONIST) ? (
+  const trygdeavgiftAvvikLabelHjelpetekst = erÅrsavregningEøsPensjonistToggleEnabled ? (
     <LabelMedHjelpetekst
       label="Avviker innbetalt trygdeavgift fra tidligere beregnet avgift?"
       hjelpetekst={harTidligereTrygdeavgiftsgrunnlag ? DELT_GRUNNLAG_INNBETALT_TRYGDEAVGIFT_HJELPETEKST : ""}
@@ -324,24 +339,25 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
             </Nav.Alert>
           )}
 
-          {(valgtÅr || initieltÅr) && (
-            <Nav.HStack>
-              <Nav.VStack>
-                <Nav.RadioGroup
-                  key={`innbetaltTrygdeavgiftRadioGroup ${valgtÅr || initieltÅr || ""}`}
-                  onChange={håndterHarInnbetaltTrygdeavgift}
-                  legend={trygdeavgiftAvvikLabelHjelpetekst}
-                  value={harInnbetaltTrygdeavgift}
-                  readOnly={!redigerbart || harAktivÅrsavregning || forrigeÅrsavregningHarInnbetaltTrygdeavgift}
-                >
-                  <Nav.HStack gap="6">
-                    <Nav.Radio value>Ja</Nav.Radio>
-                    <Nav.Radio value={false}>Nei</Nav.Radio>
-                  </Nav.HStack>
-                </Nav.RadioGroup>
-              </Nav.VStack>
-            </Nav.HStack>
-          )}
+          {(valgtÅr || initieltÅr) &&
+            (!erÅrsavregningEøsPensjonistToggleEnabled || harTidligereTrygdeavgiftsgrunnlag) && (
+              <Nav.HStack>
+                <Nav.VStack>
+                  <Nav.RadioGroup
+                    key={`innbetaltTrygdeavgiftRadioGroup ${valgtÅr || initieltÅr || ""}`}
+                    onChange={håndterHarInnbetaltTrygdeavgift}
+                    legend={trygdeavgiftAvvikLabelHjelpetekst}
+                    value={harInnbetaltTrygdeavgift}
+                    readOnly={!redigerbart || harAktivÅrsavregning || forrigeÅrsavregningHarInnbetaltTrygdeavgift}
+                  >
+                    <Nav.HStack gap="6">
+                      <Nav.Radio value>Ja</Nav.Radio>
+                      <Nav.Radio value={false}>Nei</Nav.Radio>
+                    </Nav.HStack>
+                  </Nav.RadioGroup>
+                </Nav.VStack>
+              </Nav.HStack>
+            )}
 
           {!harInnbetaltTrygdeavgiftIsPending &&
             harTidligereTrygdeavgiftsgrunnlag === true &&
@@ -350,7 +366,7 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
             )}
           {!harInnbetaltTrygdeavgiftIsPending &&
             (harTidligereTrygdeavgiftsgrunnlag === false || harInnbetaltTrygdeavgift) &&
-            (harInnbetaltTrygdeavgift === true || harInnbetaltTrygdeavgift === false) && (
+            harInnbetaltTrygdeavgift != null && (
               <AarsavregningUtenEllerDeltGrunnlag
                 bekreft={bekreft}
                 aktivtSteg={aktivtSteg}

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -151,17 +151,19 @@ export function VurderingAarsavregningInngang({ bekreft, oppdaterStatus, aktivtS
       if (!harGrunnlag) {
         // Når det ikke finnes grunnlag skal harInnbetaltTrygdeavgift alltid være true
         setHarInnbetaltTrygdeavgift(true);
-        håndterHarInnbetaltTrygdeavgift(true);
+        if (res.harInnbetaltTrygdeavgift !== true) {
+          håndterHarInnbetaltTrygdeavgift(true);
+        }
         return;
       }
+    } else {
+      setHarTidligereTrygdeavgiftsgrunnlag(
+        !(
+          res.tidligereTrygdeavgiftsGrunnlagsopplysninger === null ||
+          Utils._isEmpty(res.tidligereTrygdeavgiftsGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.avgiftspliktigperioder)
+        ),
+      );
     }
-
-    setHarTidligereTrygdeavgiftsgrunnlag(
-      !(
-        res.tidligereTrygdeavgiftsGrunnlagsopplysninger === null ||
-        Utils._isEmpty(res.tidligereTrygdeavgiftsGrunnlagsopplysninger?.trygdeavgiftsgrunnlag.avgiftspliktigperioder)
-      ),
-    );
   };
 
   useEffect(() => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/vurderingAarsavregningInngang.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, use, useContext, useEffect, useState } from "react";
+import { ChangeEvent, useContext, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { useDispatch } from "../../../../hooks";
 import { OK } from "../../../../ducks/aarsavregning/types";


### PR DESCRIPTION
Forenkler årsavregning når det ikke finnes tidligere trygdeavgiftsgrunnlag. Saksbehandler kan da registrere innbetalt trygdeavgift direkte uten å velge avvik mot en tidligere beregning.

Endringen er nødvendig fordi det ikke gir mening å spørre om avvik når det ikke finnes et tidligere grunnlag å sammenligne med. Dette gjør flyten tydeligere og reduserer risikoen for feilregistrering i saker uten tidligere beregnet avgift.
[MELOSYS-7954](https://jira.adeo.no/browse/MELOSYS-7954)

- Skjuler radioknapp for avvik når tidligere trygdeavgiftsgrunnlag mangler
- Setter `harInnbetaltTrygdeavgift` automatisk til `true` i disse tilfellene
- Viser hjelpetekst direkte på feltet for innbetalt trygdeavgift

## Testing
- [ ] Enhetstester
- [x] Manuell testing lokalt
- [x] E2E-tester (hvis relevant)