### PR TITLE
7938 Cancel debounced kontroll i vurderingAvslag12_x_og_16

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingAvslag12_x_og_16.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingAvslag12_x_og_16.jsx
@@ -118,6 +118,7 @@ function VurderingAvslag12_x_og_16({
 
   useEffect(() => {
     debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus, kopiTilArbeidsgiver, vedtakstype });
+    return () => debouncedKontrollerBehandling.cancel?.();
   }, [kopiTilArbeidsgiver, mottatteOpplysningerStatus, aktivtSteg]);
 
   const validerForm = () => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingAvslag12_x_og_16.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingAvslag12_x_og_16.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { connect, useDispatch, useSelector } from "react-redux";
 import { getFormValues, isValid, reduxForm } from "redux-form";
 import PT from "prop-types";
@@ -8,6 +8,7 @@ import * as KV from "../../../kodeverk";
 import * as Nav from "../../../navFrontend";
 import * as Skjema from "../../../felleskomponenter/skjema";
 import * as Mui from "../../../felleskomponenter/ui";
+import * as Utils from "../../../utils";
 
 import { vilkarSelectors } from "../../../ducks/vilkar";
 import { behandlingerSelectors } from "../../../ducks/behandlinger";
@@ -98,20 +99,25 @@ function VurderingAvslag12_x_og_16({
     ...MKV.KTObjects.begrunnelser.bosted,
   ];
 
-  useEffect(() => {
-    if (redigerbart && aktivtSteg && mottatteOpplysningerStatus === "OK") {
+  const kontrollerBehandling = (data) => {
+    if (redigerbart && data.aktivtSteg && data.mottatteOpplysningerStatus === "OK") {
       dispatch(
         kontrollerFerdigbehandling({
           behandlingID,
-          vedtakstype: vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
+          vedtakstype: data.vedtakstype || MKV.Koder.vedtakstyper.FØRSTEGANGSVEDTAK,
           behandlingsresultattype: MKV.Koder.behandlinger.behandlingsresultattyper.FASTSATT_LOVVALGSLAND,
-          kontrollerSomSkalIgnoreres: kopiTilArbeidsgiver
+          kontrollerSomSkalIgnoreres: data.kopiTilArbeidsgiver
             ? []
             : [MKV.Koder.begrunnelser.kontroll_begrunnelser.OPPHØRT_ARBEIDSGIVER],
           skalRegisteropplysningerOppdateres: false,
         }),
       );
     }
+  };
+  const debouncedKontrollerBehandling = useCallback(Utils._debounce(kontrollerBehandling, 500), []);
+
+  useEffect(() => {
+    debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus, kopiTilArbeidsgiver, vedtakstype });
   }, [kopiTilArbeidsgiver, mottatteOpplysningerStatus, aktivtSteg]);
 
   const validerForm = () => {
@@ -121,6 +127,8 @@ function VurderingAvslag12_x_og_16({
   };
 
   const avslaa = async () => {
+    debouncedKontrollerBehandling.cancel?.();
+
     const { UTSENDT_ARBEIDSTAKER, UTSENDT_SELVSTENDIG } = MKV.Koder.behandlinger.behandlingstema;
 
     const { FASTSATT_LOVVALGSLAND, AVSLAG_SØKNAD } = MKV.Koder.behandlinger.behandlingsresultattyper;


### PR DESCRIPTION
Mirrors patternet fra [PR #3022](https://github.com/navikt/melosys-web/pull/3022) (cancel debounced `kontrollerFerdigbehandling` ved submit) for å lukke siste hullet i frontend-coverage på SaksopplysningKilde-racet ([MELOSYS-7938](https://jira.adeo.no/browse/MELOSYS-7938)).

Da PR #3022 fikset 4 EU/EØS vedtak-komponenter (`vurderingVedtak.tsx`, `vurderingArtikkel13_x_vedtak.jsx`, `vurderingArtikkel16Vedtak.tsx`, begge varianter av `vurderingArbeidTjenestepersonEllerFlyVedtak.jsx`), ble denne komponenten oversett. Den manglet både `_debounce`-wrappingen og `cancel?.()`-kallet, og var derfor sårbar for samme race mellom `kontroll/ferdigbehandling` (fra useEffect) og `vedtak/fatt` (fra `avslaa`) — begge ender opp i `RegisteropplysningerService.hentOgLagreOpplysninger()` for samme behandling og kan kaste `OptimisticLockingFailureException` på SaksopplysningKilde.

`vedtak/fatt` kjører `kontrollerVedtakMedRegisteropplysninger` internt, så den useEffect-trigget kontrollen er redundant ved submit.

## Endringer
- Wrap `kontrollerFerdigbehandling` i `Utils._debounce(kontrollerBehandling, 500)` via `useCallback`
- Flytter useEffect-state inn i debounced-kallet via `data`-arg (matcher patternet fra `vurderingArtikkel13_x_vedtak.jsx`)
- `debouncedKontrollerBehandling.cancel?.()` ved start av `avslaa()`

## Testing
- [x] Eksisterende `vurderingAvslag12_x_og_16Schema.test.ts` passerer
- [x] `pnpm tsc --noEmit` rent
- [x] `pnpm eslint src/...` ingen nye warnings
- [ ] E2E-verifisering på Q2 (avslag-flyt på art. 12 / art. 16)

## Notater
Sister-komponenten `vurderingVedtak11_3_og_13_3a.tsx` har samme racing-shape, men er allerede dekket av en annen mekanisme: submit-knappen er deaktivert mens `kontrollerPending` er sann (`stegErGyldig` inkluderer `!kontrollerPending`). Ingen endring nødvendig der.
