### PR TITLE
8052 TOGGLE Fiks årsavregning med innbetalt trygdeavgift

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -29,6 +29,8 @@ import { SumArsavregningTabell } from "../vurderingAarsavregning/komponenter/sum
 import { beregnSumTilFakturaEllerRefusjon } from "../vurderingAarsavregning/utils";
 import "./vurderingVedtak.less";
 import vurdering_vedtak from "./vurderingVedtakSchema";
+import { useFeatureToggle } from "../../../../featuretoggle";
+import { ÅRSAVREGNING_EØS_PENSJONIST } from "../../../../featuretoggle/toggleNavn";
 
 const { FASTSATT_TRYGDEAVGIFT } = MKV.Koder.behandlinger.behandlingsresultattyper;
 const { FØRSTEGANGSVEDTAK } = MKV.Koder.vedtakstyper;
@@ -89,6 +91,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
   const behandlingID = useSelector(behandlingerSelectors.BehandlingIDSelector) as number;
   const erFullmektigEndret = useSelector(menypanelSelectors.MenypanelErFullmektigEndretSelector) as boolean;
   const saksnummer = useSelector(fagsakSelectors.SaksnummerSelector);
+  const erÅrsavregningEøsPensjonistToggleEnabled = useFeatureToggle(ÅRSAVREGNING_EØS_PENSJONIST);
 
   const { fattVedtak } = komponentDispatch(dispatch);
 
@@ -372,7 +375,11 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
     return rader;
   };
 
-  const tidligereTrygdeavgift = lagretAarsavregning?.avregning?.tidligereFakturertBeloep;
+  const tidligereTrygdeavgift =
+    lagretAarsavregning?.harInnbetaltTrygdeavgift && erÅrsavregningEøsPensjonistToggleEnabled
+      ? 0
+      : lagretAarsavregning?.avregning?.tidligereFakturertBeloep;
+
   const innbetaltTrygdeavgift = lagretAarsavregning?.avregning?.innbetaltTrygdeavgift;
   const nyTrygdeavgift =
     lagretAarsavregning?.endeligAvgiftValg === MANUELL_ENDELIG_AVGIFT


### PR DESCRIPTION
Fikser beregning av årsavregning slik at tidligere beregnet trygdeavgift ikke tas med når det finnes innbetalt trygdeavgift.

Endringen sikrer at årsavregning for EØS-pensjonister ikke dobbeltteller tidligere trygdeavgift ved innbetalt trygdeavgift. Endringen er lagt bak feature toggle for kontrollert utrulling.
[MELOSYS-8052](https://jira.adeo.no/browse/MELOSYS-8052)

- Bruker `ÅRSAVREGNING_EØS_PENSJONIST` toggle i vurdering av vedtak
- Setter tidligere trygdeavgift til 0 når årsavregningen har innbetalt trygdeavgift og toggle er aktiv
- Beholder eksisterende beregning når toggle ikke er aktiv

## Testing
- [ ] Enhetstester
- [ ] Manuell testing lokalt