### PR TITLE
7925 Vis advarsel om tidligere år også i lesemodus

### DIFF
--- a/src/sider/trygdeavgift/helseutgiftDekkesPeriode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/helseutgiftDekkesPeriode/vurderingTrygdeavgift.tsx
@@ -351,7 +351,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
         </Nav.BodyLong>
       )}
 
-      {skalIkkeViseTidligerePerioderToggle && harHelseutgiftDekkesPeriodeFraTidligereÅr && redigerbart && (
+      {skalIkkeViseTidligerePerioderToggle && harHelseutgiftDekkesPeriodeFraTidligereÅr && (
         <Nav.Alert variant="warning" size="small" className="alert--spacing-bottom">
           Trygdeavgift for tidligere år skal fastsettes på årsavregning. Du skal derfor ikke oppgi skatte- og
           inntektsperioder for tidligere år i denne behandlingen.

--- a/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/lovvalgsperiode/vurderingTrygdeavgift.tsx
@@ -349,7 +349,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
         </Nav.BodyLong>
       )}
 
-      {skalIkkeViseTidligerePerioderToggle && harLovvalgsperiodeFraTidligereÅr && redigerbart && (
+      {skalIkkeViseTidligerePerioderToggle && harLovvalgsperiodeFraTidligereÅr && (
         <Nav.Alert variant="warning" size="small" className="alert--spacing-bottom">
           Trygdeavgift for tidligere år skal fastsettes på årsavregning. Du skal derfor ikke oppgi skatte- og
           inntektsperioder for tidligere år i denne behandlingen.

--- a/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
+++ b/src/sider/trygdeavgift/medlemskapsperiode/vurderingTrygdeavgift.tsx
@@ -340,7 +340,7 @@ export function VurderingTrygdeavgift({ bekreft, tilbake, aktivtSteg, oppdaterSt
         </Nav.BodyLong>
       )}
 
-      {skalIkkeViseTidligerePerioderToggle && harMedlemskapsperiodeFraTidligereÅr && redigerbart && (
+      {skalIkkeViseTidligerePerioderToggle && harMedlemskapsperiodeFraTidligereÅr && (
         <Nav.Alert variant="warning" size="small" className="alert--spacing-bottom">
           Trygdeavgift for tidligere år skal fastsettes på årsavregning. Du skal derfor ikke oppgi skatte- og
           inntektsperioder for tidligere år i denne behandlingen.


### PR DESCRIPTION
Viser advarselen om at trygdeavgift for tidligere år skal fastsettes på årsavregning også når skjemaet ikke er redigerbart.

Saksbehandler trenger å se denne advarselen uavhengig av om de er i redigeringsmodus eller lesemodus.
[MELOSYS-7925](https://jira.adeo.no/browse/MELOSYS-7925)

- Fjernet `redigerbart`-betingelsen fra warning-alert i helseutgiftDekkesPeriode, lovvalgsperiode og medlemskapsperiode

## Testing
- [x] Manuell testing lokalt