### PR TITLE
8027 Rett feilmelding for bostedsland og hindre for tidlig validering

### DIFF
--- a/src/kodeverk/feilmeldinger.js
+++ b/src/kodeverk/feilmeldinger.js
@@ -5,6 +5,7 @@ export const SENERE_ENN_TOM = { melding: "Senere enn t.o.m.-dato" };
 export const SKRIV_INN_GYLDIG_DATO = { melding: "Skriv inn en gyldig dato" };
 export const UTENFOR_SOKNADSPERIODEN = { melding: "Utenfor søknadsperioden" };
 export const MAA_FYLLES_UT = { melding: "Må fylles ut" };
+export const MAA_VELGE_BOSTEDSLAND = { melding: "Du må velge bostedsland" };
 export const SKRIV_INN_GYLDIG_FNR_ELLER_DNR = { melding: "Skriv inn gyldig f.nr. eller d-nr." };
 export const SKRIV_INN_GYLDIG_ORGNR_FNR_DNR = { melding: "Du må skrive et gyldig org.nr. eller f.nr./d-nr." };
 export const FANT_INGEN_NAVN_PA_FNR_ELLER_DNR = { melding: "Fant ingen navn på dette f.nr. eller d-nr." };

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysninger.tsx
@@ -75,12 +75,11 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
   const {
     control,
     watch,
-    trigger,
     reset,
     formState: { isValid: formIsValid },
   } = useForm({
     resolver: yupResolver(vurdering_opplysninger),
-    mode: "all",
+    mode: "onTouched",
     values: initialValues,
   });
   const formValues = watch();
@@ -95,7 +94,9 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
     () =>
       Utils._debounce(async (ukjentSluttdato?: boolean) => {
         const latestValues = watch() as { fomDato: string; tomDato: string; bostedLandkode: string };
-        const isValid = await trigger();
+        // Validerer stille mot schemaet i stedet for trigger(), slik at autolagringen
+        // ikke tvinger frem feilmeldinger på felt brukeren ennå ikke har rørt.
+        const isValid = await vurdering_opplysninger.isValid(latestValues);
         if (isValid) {
           const currentUkjentSluttdato = ukjentSluttdato ?? ukjentSluttdatoMedlemskapsperiode;
           await oppdaterEllerOpprettHelseutgiftDekkesPeriode(latestValues);
@@ -104,7 +105,7 @@ export function VurderingOpplysninger({ bekreft, oppdaterStatus, aktivtSteg }: P
           );
         }
       }, 500),
-    [watch, trigger, ukjentSluttdatoMedlemskapsperiode, behandlingID, dispatch],
+    [watch, ukjentSluttdatoMedlemskapsperiode, behandlingID, dispatch],
   );
 
   const oppdaterSluttdato = async (ukjentSluttdato: boolean) => {

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysningerMode.test.ts
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysningerMode.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import schema from "./vurderingOpplysningerSchema";
+
+// Verifiserer Thangs spørsmål på PR #3072: med mode "onTouched", blir steget
+// regnet som gyldig etter at lagrede data lastes inn (f.eks. ved refresh av
+// nettleseren), UTEN at brukeren har rørt noe felt?
+//
+// Vi etterligner komponentens subscription ved å lese formState.isValid under render.
+const brukSkjema = (values: { fomDato: string; tomDato: string; bostedLandkode: string }) =>
+  renderHook(() => {
+    const {
+      formState: { isValid },
+      formState: { errors },
+    } = useForm({
+      resolver: yupResolver(schema),
+      mode: "onTouched",
+      values,
+    });
+    return { isValid, errors };
+  });
+
+describe("vurderingOpplysninger – mode onTouched og isValid", () => {
+  it("isValid blir true på mount med gyldige values uten interaksjon (simulerer refresh)", async () => {
+    const { result } = brukSkjema({ fomDato: "01.01.2025", tomDato: "31.12.2025", bostedLandkode: "NO" });
+
+    await waitFor(() => expect(result.current.isValid).toBe(true));
+    // og ingen feilmeldinger er surfacet uten at noe er rørt
+    expect(result.current.errors).toEqual({});
+  });
+
+  it("isValid blir false med ugyldige values, men ingen feil vises før touch", async () => {
+    const { result } = brukSkjema({ fomDato: "", tomDato: "", bostedLandkode: "" });
+
+    await waitFor(() => expect(result.current.isValid).toBe(false));
+    expect(result.current.errors).toEqual({});
+  });
+});

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysningerSchema.jsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysningerSchema.jsx
@@ -1,12 +1,12 @@
 import { object, string } from "yup";
 import * as KV from "../../../../../kodeverk";
 
-const { MAA_FYLLES_UT } = KV.Feilmeldinger;
+const { MAA_FYLLES_UT, MAA_VELGE_BOSTEDSLAND } = KV.Feilmeldinger;
 
 const vurdering_opplysninger = object().shape({
   fomDato: string().erGyldigDato().required(MAA_FYLLES_UT),
   tomDato: string().erGyldigDato().erEtterDatofelt("fomDato").required(MAA_FYLLES_UT),
-  bostedLandkode: string().required(),
+  bostedLandkode: string().required(MAA_VELGE_BOSTEDSLAND),
 });
 
 export default vurdering_opplysninger;

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysningerSchema.test.ts
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingOpplysninger/vurderingOpplysningerSchema.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import type { ValidationError } from "yup";
+
+const getErrors = async (schema: any, values: any): Promise<string[]> => {
+  try {
+    await schema.validate(values, { abortEarly: false });
+    return [];
+  } catch (error) {
+    const ve = error as ValidationError;
+    return (
+      ve.inner?.map((e) => {
+        const msg = (e as any).message;
+        return typeof msg === "object" ? msg.melding : msg;
+      }) || []
+    );
+  }
+};
+
+const baseValid = {
+  fomDato: "01.01.2025",
+  tomDato: "31.12.2025",
+  bostedLandkode: "NO",
+};
+
+describe("vurderingOpplysningerSchema", () => {
+  let schema: any;
+
+  beforeAll(async () => {
+    const mod = await import("./vurderingOpplysningerSchema");
+    schema = mod.default;
+  });
+
+  it("skal godta gyldige verdier", async () => {
+    const errors = await getErrors(schema, baseValid);
+    expect(errors).toEqual([]);
+  });
+
+  it("skal gi 'Du må velge bostedsland' når bostedLandkode mangler", async () => {
+    const errors = await getErrors(schema, { ...baseValid, bostedLandkode: "" });
+    expect(errors).toContain("Du må velge bostedsland");
+  });
+
+  it("skal gi 'Må fylles ut' når fomDato mangler", async () => {
+    const errors = await getErrors(schema, { ...baseValid, fomDato: "" });
+    expect(errors).toContain("Må fylles ut");
+  });
+
+  it("skal gi 'Må fylles ut' når tomDato mangler", async () => {
+    const errors = await getErrors(schema, { ...baseValid, tomDato: "" });
+    expect(errors).toContain("Må fylles ut");
+  });
+});


### PR DESCRIPTION
Retter feilmeldingen for bostedsland på EØS pensjonist-inngangen og hindrer at feilmeldinger vises på felt brukeren ennå ikke har rørt.

Feltet bostedsland viste den rå Yup-meldingen i stedet for en forståelig tekst. I tillegg tvang autolagringen (via `trigger()`) frem validering på hele skjemaet, slik at feilmeldinger dukket opp for tidlig — før brukeren fikk fylt inn feltene.
[MELOSYS-8027](https://jira.adeo.no/browse/MELOSYS-8027)

- Ny feilmelding `MAA_VELGE_BOSTEDSLAND` ("Du må velge bostedsland")
- Byttet valideringsmodus fra `all` til `onTouched`
- Autolagring validerer stille mot schemaet i stedet for `trigger()`
- La til enhetstest for valideringsschemaet

## Testing
- [x] Enhetstester (schema-test for feilmeldinger)
- [x] Manuell testing lokalt
- [ ] E2E-tester (hvis relevant)