### PR TITLE
8088 G4P Uthev placeholders i tekstblokk-forhåndsvisning

### DIFF
--- a/src/felleskomponenter/htmlEditor/tekstblokkForhandsvisning.tsx
+++ b/src/felleskomponenter/htmlEditor/tekstblokkForhandsvisning.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import { useMemo } from "react";
 
 import "./tekstblokkForhandsvisning.less";
 
@@ -7,9 +8,19 @@ interface Props {
   className?: string;
 }
 
+// Wrapper [PLACEHOLDER]-tokens i en span med samme uthevingsstil som Quill-editoren,
+// slik at forhåndsvisningen markerer placeholders rødt på samme måte som ved redigering.
+// Mønsteret krysser ikke tag-grenser (ingen <, > eller nøstede klammer).
+const uthevPlaceholders = (html: string): string =>
+  html.replace(/\[[^[\]<>]*\]/g, (token) => `<span class="bracketed-text">${token}</span>`);
+
 function TekstblokkForhandsvisning({ html, className }: Props) {
+  const uthevet = useMemo(() => uthevPlaceholders(html), [html]);
   return (
-    <div className={classNames("tekstblokk-forhandsvisning", className)} dangerouslySetInnerHTML={{ __html: html }} />
+    <div
+      className={classNames("tekstblokk-forhandsvisning", className)}
+      dangerouslySetInnerHTML={{ __html: uthevet }}
+    />
   );
 }
 

--- a/src/felleskomponenter/htmlEditor/tekstblokkForhandsvisning.tsx
+++ b/src/felleskomponenter/htmlEditor/tekstblokkForhandsvisning.tsx
@@ -8,9 +8,6 @@ interface Props {
   className?: string;
 }
 
-// Wrapper [PLACEHOLDER]-tokens i en span med samme uthevingsstil som Quill-editoren,
-// slik at forhåndsvisningen markerer placeholders rødt på samme måte som ved redigering.
-// Mønsteret krysser ikke tag-grenser (ingen <, > eller nøstede klammer).
 const uthevPlaceholders = (html: string): string =>
   html.replace(/\[[^[\]<>]*\]/g, (token) => `<span class="bracketed-text">${token}</span>`);
 


### PR DESCRIPTION
Placeholders ([NAVN], [DATO_FRA] osv.) vises nå rødt/fet i forhåndsvisningen av tekstblokker – både i Send brev-popoveren og admin-listen – på samme måte som ved redigering i editoren.

Lagret HTML har placeholders som ren tekst; forhåndsvisningen wrapper dem i span.bracketed-text før render. CSS-stilen fantes allerede.