### PR TITLE
7525 Vis brevmal først når organisasjon er funnet

### DIFF
--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.test.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.test.tsx
@@ -47,7 +47,7 @@ describe("brevMottaker utility functions", () => {
   });
 });
 
-describe("skalViseBrevmalvalg (MELOSYS-7525)", () => {
+describe("skalViseBrevmalvalg", () => {
   const medMottaker = (rolle: string, ekstra: Partial<SendBrevFormValues> = {}): SendBrevFormValues =>
     ({ valgtMottaker: { rolle }, ...ekstra }) as SendBrevFormValues;
 

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.test.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.test.tsx
@@ -7,7 +7,9 @@ import {
   erAnnenOrganisasjon,
   erNorskMyndighet,
   erUtenlandskTrygdemyndighet,
+  skalViseBrevmalvalg,
 } from "./brevMottaker";
+import { SendBrevFormValues } from "../types";
 
 const { BRUKER, ARBEIDSGIVER, VIRKSOMHET, ANNEN_ORGANISASJON, NORSK_MYNDIGHET, UTENLANDSK_TRYGDEMYNDIGHET } =
   MKV.Koder.mottakerroller;
@@ -42,5 +44,34 @@ describe("brevMottaker utility functions", () => {
   it("erUtenlandskTrygdemyndighet returnerer true for UTENLANDSK_TRYGDEMYNDIGHET", () => {
     expect(erUtenlandskTrygdemyndighet(UTENLANDSK_TRYGDEMYNDIGHET)).toBe(true);
     expect(erUtenlandskTrygdemyndighet(BRUKER)).toBe(false);
+  });
+});
+
+describe("skalViseBrevmalvalg (MELOSYS-7525)", () => {
+  const medMottaker = (rolle: string, ekstra: Partial<SendBrevFormValues> = {}): SendBrevFormValues =>
+    ({ valgtMottaker: { rolle }, ...ekstra }) as SendBrevFormValues;
+
+  it("returnerer false når ingen mottaker er valgt", () => {
+    expect(skalViseBrevmalvalg(undefined)).toBe(false);
+    expect(skalViseBrevmalvalg({} as SendBrevFormValues)).toBe(false);
+  });
+
+  it("returnerer false når valgt mottaker har en feilmelding", () => {
+    const formValues = { valgtMottaker: { rolle: BRUKER, feilmelding: { tittel: "Feil" } } } as SendBrevFormValues;
+    expect(skalViseBrevmalvalg(formValues)).toBe(false);
+  });
+
+  it("returnerer true for vanlig mottaker uten feilmelding", () => {
+    expect(skalViseBrevmalvalg(medMottaker(BRUKER))).toBe(true);
+    expect(skalViseBrevmalvalg(medMottaker(VIRKSOMHET))).toBe(true);
+  });
+
+  it("returnerer false for Annen organisasjon når organisasjon ikke er funnet", () => {
+    expect(skalViseBrevmalvalg(medMottaker(ANNEN_ORGANISASJON))).toBe(false);
+    expect(skalViseBrevmalvalg(medMottaker(ANNEN_ORGANISASJON, { organisasjonFunnet: false }))).toBe(false);
+  });
+
+  it("returnerer true for Annen organisasjon først når organisasjon er funnet", () => {
+    expect(skalViseBrevmalvalg(medMottaker(ANNEN_ORGANISASJON, { organisasjonFunnet: true }))).toBe(true);
   });
 });

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.test.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.test.tsx
@@ -68,10 +68,28 @@ describe("skalViseBrevmalvalg (MELOSYS-7525)", () => {
 
   it("returnerer false for Annen organisasjon når organisasjon ikke er funnet", () => {
     expect(skalViseBrevmalvalg(medMottaker(ANNEN_ORGANISASJON))).toBe(false);
-    expect(skalViseBrevmalvalg(medMottaker(ANNEN_ORGANISASJON, { organisasjonFunnet: false }))).toBe(false);
+    expect(skalViseBrevmalvalg(medMottaker(ANNEN_ORGANISASJON, { organisasjonsnummer: "123456789" }))).toBe(false);
   });
 
-  it("returnerer true for Annen organisasjon først når organisasjon er funnet", () => {
-    expect(skalViseBrevmalvalg(medMottaker(ANNEN_ORGANISASJON, { organisasjonFunnet: true }))).toBe(true);
+  it("returnerer true for Annen organisasjon først når funnet org.nr matcher feltet", () => {
+    expect(
+      skalViseBrevmalvalg(
+        medMottaker(ANNEN_ORGANISASJON, {
+          organisasjonsnummer: "123456789",
+          organisasjonFunnetForOrgnr: "123456789",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returnerer false når funnet org.nr ikke matcher gjeldende felt (org.nr nettopp endret)", () => {
+    expect(
+      skalViseBrevmalvalg(
+        medMottaker(ANNEN_ORGANISASJON, {
+          organisasjonsnummer: "987654321",
+          organisasjonFunnetForOrgnr: "123456789",
+        }),
+      ),
+    ).toBe(false);
   });
 });

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
@@ -1,4 +1,4 @@
-import { FocusEvent, Fragment, useCallback, useEffect, useState } from "react";
+import { FocusEvent, Fragment, useCallback, useEffect, useRef, useState } from "react";
 import { RootState } from "AppTypes";
 import { connect, ConnectedProps } from "react-redux";
 import { ThunkDispatch } from "redux-thunk";
@@ -34,12 +34,6 @@ export const erAnnenOrganisasjon = (rolle: string | undefined) => rolle === ANNE
 export const erNorskMyndighet = (rolle: string | undefined) => rolle === NORSK_MYNDIGHET;
 export const erUtenlandskTrygdemyndighet = (rolle: string | undefined) => rolle === UTENLANDSK_TRYGDEMYNDIGHET;
 
-/**
- * Avgjør om «Velg brevmal» skal vises. For «Annen organisasjon» skal brevmal
- * først vises når organisasjonen er funnet (navn hentet), slik at man ikke kan
- * velge brevmal mens org.nr har en feilmelding. Den funne org.nr-en sammenliknes
- * med gjeldende felt, slik at brevmal skjules straks org.nr endres. (MELOSYS-7525)
- */
 export const skalViseBrevmalvalg = (formValues?: SendBrevFormValues): boolean => {
   const valgtMottaker = formValues?.valgtMottaker;
   if (!valgtMottaker || valgtMottaker.feilmelding) return false;
@@ -99,9 +93,13 @@ function BrevMottaker({
     "Hvis arbeidsgiveren du ønsker å sende brev til ikke vises her, må du legge til denne i sidemenyen under «Arbeidsgiver/virksomhet». Det samme gjelder hvis du skal legge til kontaktopplysninger.\n" +
     "Hvis arbeidsgiveren ikke er en nåværende arbeidsgiver, kan du velge «Annen organisasjon» som mottaker og legge den til manuelt.";
 
+  const sisteForespurteOrgnrRef = useRef<string | undefined>(undefined);
+
   const hentOrganisasjonIfValid = async (data: { orgnr?: string; valid: boolean }) => {
     if (!data.valid || !data.orgnr) return;
     const response = await hentOrganisasjon(data.orgnr);
+    // Forkast svar som kom ut av rekkefølge: org.nr er ikke lenger det aktuelle.
+    if (data.orgnr !== sisteForespurteOrgnrRef.current) return;
     if (response.data.response) {
       setFeil({
         tittel:
@@ -153,8 +151,8 @@ function BrevMottaker({
     }
 
     if (erAnnenOrganisasjon(valgtMottaker.rolle)) {
-      // Skjul brevmal til organisasjonen er bekreftet funnet (settes til org.nr i debouncedHentOrganisasjon)
       changeField("organisasjonFunnetForOrgnr", undefined);
+      sisteForespurteOrgnrRef.current = formValues.organisasjonsnummer;
       debouncedHentOrganisasjon({ orgnr: formValues.organisasjonsnummer, valid: orgnrValid });
     }
   }, [formValues?.mottaker, formValues?.organisasjonsnummer, orgnrValid, formValues?.arbeidsgiver]);

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
@@ -34,6 +34,20 @@ export const erAnnenOrganisasjon = (rolle: string | undefined) => rolle === ANNE
 export const erNorskMyndighet = (rolle: string | undefined) => rolle === NORSK_MYNDIGHET;
 export const erUtenlandskTrygdemyndighet = (rolle: string | undefined) => rolle === UTENLANDSK_TRYGDEMYNDIGHET;
 
+/**
+ * Avgjør om «Velg brevmal» skal vises. For «Annen organisasjon» skal brevmal
+ * først vises når organisasjonen er funnet (navn hentet), slik at man ikke kan
+ * velge brevmal mens org.nr har en feilmelding. (MELOSYS-7525)
+ */
+export const skalViseBrevmalvalg = (formValues?: SendBrevFormValues): boolean => {
+  const valgtMottaker = formValues?.valgtMottaker;
+  if (!valgtMottaker || valgtMottaker.feilmelding) return false;
+  if (erAnnenOrganisasjon(valgtMottaker.rolle)) {
+    return Boolean(formValues?.organisasjonFunnet);
+  }
+  return true;
+};
+
 const mapStateToProps = (state: RootState) => ({
   formValues: getFormValues(KV.Form.SEND_BREV)(state) as SendBrevFormValues,
   orgnrValid: formSelectors.SendBrevOrgnummerValidSelector(state),
@@ -89,8 +103,10 @@ function BrevMottaker({
         tittel:
           response.data.response.status === 404 ? "Kunne ikke finne organisasjon" : "Feil ved henting av organisasjon",
       });
+      changeField("organisasjonFunnet", false);
     } else {
       setAdresse({ organisasjonsAdresse: response.data });
+      changeField("organisasjonFunnet", true);
     }
   };
 
@@ -133,6 +149,8 @@ function BrevMottaker({
     }
 
     if (erAnnenOrganisasjon(valgtMottaker.rolle)) {
+      // Skjul brevmal til organisasjonen er bekreftet funnet (settes true i debouncedHentOrganisasjon)
+      changeField("organisasjonFunnet", false);
       debouncedHentOrganisasjon({ orgnr: formValues.organisasjonsnummer, valid: orgnrValid });
     }
   }, [formValues?.mottaker, formValues?.organisasjonsnummer, orgnrValid, formValues?.arbeidsgiver]);
@@ -236,7 +254,7 @@ function BrevMottaker({
             <Skjema.Input
               className="kontaktperson"
               feltNavn="kontaktperson"
-              label="Kontaktperson"
+              label="Kontaktperson (valgfritt)"
               disabled={!redigerbart}
             />
           </Nav.Column>

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
@@ -37,13 +37,17 @@ export const erUtenlandskTrygdemyndighet = (rolle: string | undefined) => rolle 
 /**
  * Avgjør om «Velg brevmal» skal vises. For «Annen organisasjon» skal brevmal
  * først vises når organisasjonen er funnet (navn hentet), slik at man ikke kan
- * velge brevmal mens org.nr har en feilmelding. (MELOSYS-7525)
+ * velge brevmal mens org.nr har en feilmelding. Den funne org.nr-en sammenliknes
+ * med gjeldende felt, slik at brevmal skjules straks org.nr endres. (MELOSYS-7525)
  */
 export const skalViseBrevmalvalg = (formValues?: SendBrevFormValues): boolean => {
   const valgtMottaker = formValues?.valgtMottaker;
   if (!valgtMottaker || valgtMottaker.feilmelding) return false;
   if (erAnnenOrganisasjon(valgtMottaker.rolle)) {
-    return Boolean(formValues?.organisasjonFunnet);
+    return (
+      Boolean(formValues?.organisasjonsnummer) &&
+      formValues?.organisasjonFunnetForOrgnr === formValues?.organisasjonsnummer
+    );
   }
   return true;
 };
@@ -103,10 +107,10 @@ function BrevMottaker({
         tittel:
           response.data.response.status === 404 ? "Kunne ikke finne organisasjon" : "Feil ved henting av organisasjon",
       });
-      changeField("organisasjonFunnet", false);
+      changeField("organisasjonFunnetForOrgnr", undefined);
     } else {
       setAdresse({ organisasjonsAdresse: response.data });
-      changeField("organisasjonFunnet", true);
+      changeField("organisasjonFunnetForOrgnr", data.orgnr);
     }
   };
 
@@ -149,8 +153,8 @@ function BrevMottaker({
     }
 
     if (erAnnenOrganisasjon(valgtMottaker.rolle)) {
-      // Skjul brevmal til organisasjonen er bekreftet funnet (settes true i debouncedHentOrganisasjon)
-      changeField("organisasjonFunnet", false);
+      // Skjul brevmal til organisasjonen er bekreftet funnet (settes til org.nr i debouncedHentOrganisasjon)
+      changeField("organisasjonFunnetForOrgnr", undefined);
       debouncedHentOrganisasjon({ orgnr: formValues.organisasjonsnummer, valid: orgnrValid });
     }
   }, [formValues?.mottaker, formValues?.organisasjonsnummer, orgnrValid, formValues?.arbeidsgiver]);

--- a/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/brevMottaker/brevMottaker.tsx
@@ -98,7 +98,6 @@ function BrevMottaker({
   const hentOrganisasjonIfValid = async (data: { orgnr?: string; valid: boolean }) => {
     if (!data.valid || !data.orgnr) return;
     const response = await hentOrganisasjon(data.orgnr);
-    // Forkast svar som kom ut av rekkefølge: org.nr er ikke lenger det aktuelle.
     if (data.orgnr !== sisteForespurteOrgnrRef.current) return;
     if (response.data.response) {
       setFeil({

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -28,7 +28,7 @@ import { behandlingerOperations } from "../../../ducks/behandlinger";
 import { fagsakSelectors } from "../../../ducks/fagsaker";
 import { formSelectors } from "../../../ducks/form";
 
-import BrevMottaker, { erAnnenOrganisasjon, erNorskMyndighet } from "./brevMottaker/brevMottaker";
+import BrevMottaker, { erAnnenOrganisasjon, erNorskMyndighet, skalViseBrevmalvalg } from "./brevMottaker/brevMottaker";
 import BrevMottakereTabell from "./brevMottaker/brevMottakereTabell";
 import Brevutkast from "./brevutkast/brevutkast";
 import BrevValg from "./brevValg";
@@ -259,6 +259,7 @@ function SendBrev({
     changeField("fritekstTittel", undefined);
     changeField("erFeltGyldig", undefined);
     changeField("organisasjonsnummer", undefined);
+    changeField("organisasjonFunnet", undefined);
     changeField("kontaktperson", undefined);
     changeField("norskeMyndigheter", undefined);
     changeField("kopiTilBruker", undefined);
@@ -627,7 +628,7 @@ function SendBrev({
         </Nav.Column>
       </Nav.Row>
 
-      {mottakerErValgt && !valgtMottakerHarFeilmelding && (
+      {skalViseBrevmalvalg(formValues) && (
         <Nav.Row>
           <Nav.Column xs={brevTypeSelectWidth}>
             <Skjema.Select

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -194,10 +194,6 @@ function SendBrev({
       case ARBEIDSGIVER:
         return Boolean(values.arbeidsgiver);
       case ANNEN_ORGANISASJON:
-        // Krev at organisasjonen er funnet (navn hentet) for nettopp det org.nr-et som står i
-        // feltet nå, ikke bare at feltet er utfylt. Sammenlikningen hindrer at vi henter mulige
-        // mottakere / auto-velger brevmal for et nytt, ennå ubekreftet org.nr i renderet før
-        // BrevMottaker rekker å nullstille flagget. (MELOSYS-7525)
         return Boolean(values.organisasjonsnummer) && values.organisasjonFunnetForOrgnr === values.organisasjonsnummer;
       case NORSK_MYNDIGHET:
         return !Utils._isEmpty(values.norskeMyndigheter);

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -194,10 +194,11 @@ function SendBrev({
       case ARBEIDSGIVER:
         return Boolean(values.arbeidsgiver);
       case ANNEN_ORGANISASJON:
-        // Krev at organisasjonen er funnet (navn hentet), ikke bare at feltet er utfylt,
-        // slik at vi ikke henter mulige mottakere / auto-velger brevmal for et ugyldig
-        // eller ikke-eksisterende org.nr. (MELOSYS-7525)
-        return Boolean(values.organisasjonFunnet);
+        // Krev at organisasjonen er funnet (navn hentet) for nettopp det org.nr-et som står i
+        // feltet nå, ikke bare at feltet er utfylt. Sammenlikningen hindrer at vi henter mulige
+        // mottakere / auto-velger brevmal for et nytt, ennå ubekreftet org.nr i renderet før
+        // BrevMottaker rekker å nullstille flagget. (MELOSYS-7525)
+        return Boolean(values.organisasjonsnummer) && values.organisasjonFunnetForOrgnr === values.organisasjonsnummer;
       case NORSK_MYNDIGHET:
         return !Utils._isEmpty(values.norskeMyndigheter);
       case UTENLANDSK_TRYGDEMYNDIGHET:
@@ -262,7 +263,7 @@ function SendBrev({
     changeField("fritekstTittel", undefined);
     changeField("erFeltGyldig", undefined);
     changeField("organisasjonsnummer", undefined);
-    changeField("organisasjonFunnet", undefined);
+    changeField("organisasjonFunnetForOrgnr", undefined);
     changeField("kontaktperson", undefined);
     changeField("norskeMyndigheter", undefined);
     changeField("kopiTilBruker", undefined);
@@ -311,7 +312,7 @@ function SendBrev({
     tilgjengeligeBrevtyper,
     formValues?.valgtMottaker,
     formValues?.organisasjonsnummer,
-    formValues?.organisasjonFunnet,
+    formValues?.organisasjonFunnetForOrgnr,
     formValues?.arbeidsgiver,
     formValues?.norskeMyndigheter,
   ]);
@@ -353,7 +354,7 @@ function SendBrev({
   }, [
     formValues?.valgtBrev,
     formValues?.organisasjonsnummer,
-    formValues?.organisasjonFunnet,
+    formValues?.organisasjonFunnetForOrgnr,
     formValues?.arbeidsgiver,
     formValues?.norskeMyndigheter,
     formValues?.felt?.UTENLANDSK_TRYGDEMYNDIGHET_MOTTAKER,

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -194,7 +194,10 @@ function SendBrev({
       case ARBEIDSGIVER:
         return Boolean(values.arbeidsgiver);
       case ANNEN_ORGANISASJON:
-        return Boolean(values.organisasjonsnummer);
+        // Krev at organisasjonen er funnet (navn hentet), ikke bare at feltet er utfylt,
+        // slik at vi ikke henter mulige mottakere / auto-velger brevmal for et ugyldig
+        // eller ikke-eksisterende org.nr. (MELOSYS-7525)
+        return Boolean(values.organisasjonFunnet);
       case NORSK_MYNDIGHET:
         return !Utils._isEmpty(values.norskeMyndigheter);
       case UTENLANDSK_TRYGDEMYNDIGHET:
@@ -308,6 +311,7 @@ function SendBrev({
     tilgjengeligeBrevtyper,
     formValues?.valgtMottaker,
     formValues?.organisasjonsnummer,
+    formValues?.organisasjonFunnet,
     formValues?.arbeidsgiver,
     formValues?.norskeMyndigheter,
   ]);
@@ -349,6 +353,7 @@ function SendBrev({
   }, [
     formValues?.valgtBrev,
     formValues?.organisasjonsnummer,
+    formValues?.organisasjonFunnet,
     formValues?.arbeidsgiver,
     formValues?.norskeMyndigheter,
     formValues?.felt?.UTENLANDSK_TRYGDEMYNDIGHET_MOTTAKER,

--- a/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
+++ b/src/felleskomponenter/sideDialog/sendBrev/sendBrev.tsx
@@ -194,7 +194,7 @@ function SendBrev({
       case ARBEIDSGIVER:
         return Boolean(values.arbeidsgiver);
       case ANNEN_ORGANISASJON:
-        return Boolean(values.organisasjonsnummer) && values.organisasjonFunnetForOrgnr === values.organisasjonsnummer;
+        return skalViseBrevmalvalg(values);
       case NORSK_MYNDIGHET:
         return !Utils._isEmpty(values.norskeMyndigheter);
       case UTENLANDSK_TRYGDEMYNDIGHET:

--- a/src/felleskomponenter/sideDialog/sendBrev/types.ts
+++ b/src/felleskomponenter/sideDialog/sendBrev/types.ts
@@ -28,7 +28,7 @@ export interface SendBrevFormValues {
   valgtMottaker?: Api.DokumenterV2.TilgjengeligMottaker;
   valgtBrev?: Api.DokumenterV2.TilgjengeligBrev;
   organisasjonsnummer?: string;
-  organisasjonFunnet?: boolean;
+  organisasjonFunnetForOrgnr?: string;
   norskeMyndigheter?: string[];
   kontaktperson?: string;
   arbeidsgiver?: string;

--- a/src/felleskomponenter/sideDialog/sendBrev/types.ts
+++ b/src/felleskomponenter/sideDialog/sendBrev/types.ts
@@ -28,6 +28,7 @@ export interface SendBrevFormValues {
   valgtMottaker?: Api.DokumenterV2.TilgjengeligMottaker;
   valgtBrev?: Api.DokumenterV2.TilgjengeligBrev;
   organisasjonsnummer?: string;
+  organisasjonFunnet?: boolean;
   norskeMyndigheter?: string[];
   kontaktperson?: string;
   arbeidsgiver?: string;

--- a/tests/e2e/pages/behandling/send-brev.page.ts
+++ b/tests/e2e/pages/behandling/send-brev.page.ts
@@ -1,7 +1,7 @@
 import { Page, Locator, expect } from "@playwright/test";
 import { BehandlingPage } from "./behandling.page";
 import { PrepopulertSaksnummer } from "../../utils/testdataUtils";
-import { finnCombobox } from "../../utils/testUtils";
+import { assertFieldError, finnCombobox } from "../../utils/testUtils";
 
 export class SendBrevPage extends BehandlingPage {
   constructor(page: Page, saksnummer: PrepopulertSaksnummer) {
@@ -121,7 +121,8 @@ export class SendBrevPage extends BehandlingPage {
     await expect(this.sendButton, `${this.ctx}: Send-knappen er uventet deaktivert`).toBeEnabled();
   }
 
-  async selectMottakerByLabel(label: string | RegExp) {
+  // Velg mottaker via synlig tekst, uten å vente på at brevmal dukker opp
+  private async velgMottakerOption(label: string | RegExp): Promise<void> {
     const sel = this.mottakerNativeSelect;
     await expect(sel, `${this.ctx}: Fant ikke mottaker-feltet`).toBeVisible();
 
@@ -137,8 +138,74 @@ export class SendBrevPage extends BehandlingPage {
 
     expect(value, `${this.ctx}: Fant ikke mottakeren "${label}"`).toBeTruthy();
     await sel.selectOption(value);
+  }
 
+  async selectMottakerByLabel(label: string | RegExp) {
+    await this.velgMottakerOption(label);
     await this.waitForBrevmalSelect();
+  }
+
+  /**
+   * Velg mottaker uten å vente på at «Velg brevmal» dukker opp.
+   * Brukes for «Annen organisasjon», der brevmal først vises når org.nr er korrekt utfylt. (MELOSYS-7525)
+   */
+  async velgMottaker(label: string | RegExp): Promise<void> {
+    await this.velgMottakerOption(label);
+  }
+
+  // Tekstfelt for «Annen organisasjon»
+  private get organisasjonsnummerInput(): Locator {
+    const scope = this.sendBrevPanel ?? this.page;
+    return scope.getByRole("textbox", { name: "Org.nr." });
+  }
+
+  private get kontaktpersonInput(): Locator {
+    const scope = this.sendBrevPanel ?? this.page;
+    return scope.getByRole("textbox", { name: "Kontaktperson (valgfritt)" });
+  }
+
+  private get brevmalCombobox(): Locator {
+    const scope = this.sendBrevPanel ?? this.page;
+    return scope.getByRole("combobox", { name: this.labels.brevmal });
+  }
+
+  /** Fyll ut org.nr og blur slik at validering trigges (validering skjer når man går ut av feltet). */
+  async inputOrganisasjonsnummer(orgnr: string, saksnummer?: string): Promise<void> {
+    const sakId = saksnummer ?? this.ctx;
+    const input = this.organisasjonsnummerInput;
+    await expect(input, `${sakId}: Fant ikke Org.nr-feltet`).toBeVisible();
+    await input.fill(orgnr);
+    await input.blur();
+  }
+
+  async verifiserBrevmalSkjult(saksnummer?: string): Promise<void> {
+    const sakId = saksnummer ?? this.ctx;
+    await expect(
+      this.brevmalCombobox,
+      `${sakId}: «Velg brevmal» skal være skjult før org.nr er korrekt utfylt`,
+    ).toBeHidden();
+  }
+
+  async verifiserBrevmalSynlig(saksnummer?: string): Promise<void> {
+    const sakId = saksnummer ?? this.ctx;
+    await expect(
+      this.brevmalCombobox,
+      `${sakId}: «Velg brevmal» skal være synlig når organisasjonen er funnet`,
+    ).toBeVisible();
+  }
+
+  async verifiserOrgnrFeilmelding(tekst: string | RegExp): Promise<void> {
+    const scope = this.sendBrevPanel ?? this.page;
+    await assertFieldError(scope, tekst);
+  }
+
+  /** Verifiser at Kontaktperson-feltet vises med «(valgfritt)» i label. (MELOSYS-7525, oppgave 2) */
+  async verifiserKontaktpersonValgfri(saksnummer?: string): Promise<void> {
+    const sakId = saksnummer ?? this.ctx;
+    await expect(
+      this.kontaktpersonInput,
+      `${sakId}: Kontaktperson-feltet skal vises med «(valgfritt)» i label`,
+    ).toBeVisible();
   }
 
   async clickSendBrev() {

--- a/tests/e2e/pages/behandling/send-brev.page.ts
+++ b/tests/e2e/pages/behandling/send-brev.page.ts
@@ -121,7 +121,6 @@ export class SendBrevPage extends BehandlingPage {
     await expect(this.sendButton, `${this.ctx}: Send-knappen er uventet deaktivert`).toBeEnabled();
   }
 
-  // Velg mottaker via synlig tekst, uten å vente på at brevmal dukker opp
   private async velgMottakerOption(label: string | RegExp): Promise<void> {
     const sel = this.mottakerNativeSelect;
     await expect(sel, `${this.ctx}: Fant ikke mottaker-feltet`).toBeVisible();
@@ -145,15 +144,10 @@ export class SendBrevPage extends BehandlingPage {
     await this.waitForBrevmalSelect();
   }
 
-  /**
-   * Velg mottaker uten å vente på at «Velg brevmal» dukker opp.
-   * Brukes for «Annen organisasjon», der brevmal først vises når org.nr er korrekt utfylt.
-   */
   async velgMottaker(label: string | RegExp): Promise<void> {
     await this.velgMottakerOption(label);
   }
 
-  // Tekstfelt for «Annen organisasjon»
   private get organisasjonsnummerInput(): Locator {
     const scope = this.sendBrevPanel ?? this.page;
     return scope.getByRole("textbox", { name: "Org.nr." });
@@ -169,7 +163,6 @@ export class SendBrevPage extends BehandlingPage {
     return scope.getByRole("combobox", { name: this.labels.brevmal });
   }
 
-  /** Fyll ut org.nr og blur slik at validering trigges (validering skjer når man går ut av feltet). */
   async inputOrganisasjonsnummer(orgnr: string, saksnummer?: string): Promise<void> {
     const sakId = saksnummer ?? this.ctx;
     const input = this.organisasjonsnummerInput;
@@ -199,7 +192,6 @@ export class SendBrevPage extends BehandlingPage {
     await assertFieldError(scope, tekst);
   }
 
-  /** Verifiser at Kontaktperson-feltet vises med «(valgfritt)» i label. */
   async verifiserKontaktpersonValgfri(saksnummer?: string): Promise<void> {
     const sakId = saksnummer ?? this.ctx;
     await expect(

--- a/tests/e2e/pages/behandling/send-brev.page.ts
+++ b/tests/e2e/pages/behandling/send-brev.page.ts
@@ -147,7 +147,7 @@ export class SendBrevPage extends BehandlingPage {
 
   /**
    * Velg mottaker uten å vente på at «Velg brevmal» dukker opp.
-   * Brukes for «Annen organisasjon», der brevmal først vises når org.nr er korrekt utfylt. (MELOSYS-7525)
+   * Brukes for «Annen organisasjon», der brevmal først vises når org.nr er korrekt utfylt.
    */
   async velgMottaker(label: string | RegExp): Promise<void> {
     await this.velgMottakerOption(label);
@@ -199,7 +199,7 @@ export class SendBrevPage extends BehandlingPage {
     await assertFieldError(scope, tekst);
   }
 
-  /** Verifiser at Kontaktperson-feltet vises med «(valgfritt)» i label. (MELOSYS-7525, oppgave 2) */
+  /** Verifiser at Kontaktperson-feltet vises med «(valgfritt)» i label. */
   async verifiserKontaktpersonValgfri(saksnummer?: string): Promise<void> {
     const sakId = saksnummer ?? this.ctx;
     await expect(

--- a/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/for-fa-siffer-i-org-nr-gir-feilmelding-og-holder-brevmal-skjult.json
+++ b/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/for-fa-siffer-i-org-nr-gir-feilmelding-og-holder-brevmal-skjult.json
@@ -1,0 +1,2509 @@
+{
+  "version": "1.0",
+  "recordedAt": "2025-01-01T00:00:00.000Z",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts",
+  "testName": "For få siffer i org.nr gir feilmelding og holder brevmal skjult",
+  "exchanges": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/9/aarsak/mottaksdato",
+        "pathname": "/api/behandlinger/9/aarsak/mottaksdato",
+        "normalizedPath": "/api/behandlinger/:behandlingId/aarsak/mottaksdato",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "mottaksdato": "2025-01-01"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/9/resultat",
+        "pathname": "/api/behandlinger/9/resultat",
+        "normalizedPath": "/api/behandlinger/:behandlingId/resultat",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "aarsavregningID": null,
+          "begrunnelseFritekst": null,
+          "begrunnelseKoder": [],
+          "behandlingsresultatTypeKode": "IKKE_FASTSATT",
+          "fakturaserieReferanse": null,
+          "innledningFritekst": null,
+          "kontrollresultatBegrunnelseKoder": [],
+          "nyVurderingBakgrunn": null,
+          "trygdeavgiftFritekst": null,
+          "utfallRegistreringUnntak": null,
+          "utfallUtpeking": null,
+          "vedtakstype": null
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/9",
+        "pathname": "/api/behandlinger/9",
+        "normalizedPath": "/api/behandlinger/:behandlingId",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "behandlingID": 9,
+          "oppsummering": {
+            "behandlingsfrist": "2025-01-01",
+            "behandlingsresultattype": {
+              "kode": "IKKE_FASTSATT",
+              "term": "Ikke fastsatt"
+            },
+            "behandlingsstatus": {
+              "kode": "UNDER_BEHANDLING",
+              "term": "Behandlingen pågår"
+            },
+            "behandlingstema": {
+              "kode": "YRKESAKTIV",
+              "term": "Yrkesaktiv"
+            },
+            "behandlingstype": {
+              "kode": "FØRSTEGANG",
+              "term": "Førstegangsbehandling"
+            },
+            "endretAvNavn": "Lokal Testbruker",
+            "endretDato": "2025-01-01T00:00:00.000Z",
+            "registrertDato": "2025-01-01T00:00:00.000Z",
+            "sisteOpplysningerHentetDato": null,
+            "svarFrist": null
+          },
+          "saksopplysninger": {
+            "arbeidsforhold": [],
+            "organisasjoner": [],
+            "medlemskap": {
+              "medlemsperiode": []
+            },
+            "inntekt": {
+              "arbeidsInntektMaanedListe": [],
+              "frilansInntektMaanedListe": []
+            },
+            "sed": {
+              "bucType": null,
+              "erEndring": false,
+              "fnr": null,
+              "lovvalgsbestemmelse": null,
+              "lovvalgslandKode": null,
+              "lovvalgsperiode": null,
+              "rinaDokumentID": null,
+              "rinaSaksnummer": null,
+              "sedType": null
+            }
+          },
+          "redigerbart": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/brev/utkast/9",
+        "pathname": "/api/brev/utkast/9",
+        "normalizedPath": "/api/brev/utkast/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/brev/utkast/9",
+        "pathname": "/api/brev/utkast/9",
+        "normalizedPath": "/api/brev/utkast/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/dokumenter/v2/standardvedlegg",
+        "pathname": "/api/dokumenter/v2/standardvedlegg",
+        "normalizedPath": "/api/dokumenter/v2/standardvedlegg",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "type": "VIKTIG_INFORMASJON_RETTIGHETER_PLIKTER_AVSLAG",
+            "frontendTittel": "Avslag: Viktig informasjon om rettigheter",
+            "dokumentTittel": "Viktig informasjon om rettigheter"
+          },
+          {
+            "type": "VIKTIG_INFORMASJON_RETTIGHETER_PLIKTER_INNVILGELSE",
+            "frontendTittel": "Innvilgelse: Viktig informasjon om rettigheter og plikter",
+            "dokumentTittel": "Viktig informasjon om rettigheter og plikter"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/dokumenter/v2/tilgjengelige-maler/9",
+        "pathname": "/api/dokumenter/v2/tilgjengelige-maler/9",
+        "normalizedPath": "/api/dokumenter/v2/tilgjengelige-maler/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "mottaker": {
+              "adresser": [
+                {
+                  "mottakerNavn": "TRIVIELL KARAFFEL",
+                  "orgnr": null,
+                  "adresselinjer": ["CO 2", "kontakt gata 1 42"],
+                  "postnr": "0001",
+                  "poststed": null,
+                  "region": null,
+                  "land": "SE",
+                  "ugyldig": false
+                }
+              ],
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "BRUKER",
+              "type": "Bruker eller brukers fullmektig"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_BRUKER",
+                  "term": "Melding om manglende opplysninger til bruker"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_BRUKER",
+                  "term": "Fritekstbrev til bruker"
+                }
+              },
+              {
+                "felter": null,
+                "type": {
+                  "kode": "MELDING_FORVENTET_SAKSBEHANDLINGSTID_SOKNAD",
+                  "term": "Melding om forventet saksbehandlingstid"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": {
+                "tittel": "Du må velge land på inngangssteget for å kunne sende brev til utenlandsk trygdemyndighet.",
+                "underpunkter": []
+              },
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "UTENLANDSK_TRYGDEMYNDIGHET",
+              "type": "Utenlandsk trygdemyndighet"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "UTENLANDSK_TRYGDEMYNDIGHET_FRITEKSTBREV",
+                  "term": "Fritekstbrev"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": {
+                "tittel": "Finner ikke gyldig adresse til arbeidsgiver(e). Kontroller at arbeidsgiver(e) er lagt inn korrekt i sidemenyen",
+                "underpunkter": []
+              },
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "ARBEIDSGIVER",
+              "type": "Arbeidsgiver eller arbeidsgivers fullmektig"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_ARBEIDSGIVER",
+                  "term": "Melding om manglende opplysninger til virksomhet"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_ARBEIDSGIVER",
+                  "term": "Fritekstbrev til virksomhet"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "ANNEN_ORGANISASJON",
+              "type": "Annen organisasjon"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_ARBEIDSGIVER",
+                  "term": "Melding om manglende opplysninger til virksomhet"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_ARBEIDSGIVER",
+                  "term": "Fritekstbrev til virksomhet"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "NORSK_MYNDIGHET",
+              "type": "Norske myndigheter"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Orientering om vår beslutning",
+                          "kode": "ORIENTERING_BESLUTNING",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "FRITEKSTBREV",
+                  "term": "Fritekstbrev"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1009/aktoerer/?rolleKode=FULLMEKTIG",
+        "pathname": "/api/fagsaker/MEL-1009/aktoerer/",
+        "normalizedPath": "/api/fagsaker/:saksnummer/aktoerer/",
+        "query": {
+          "rolleKode": "FULLMEKTIG"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1009/dokumenter",
+        "pathname": "/api/fagsaker/MEL-1009/dokumenter",
+        "normalizedPath": "/api/fagsaker/:saksnummer/dokumenter",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1009/trygdeavgift/oppsummering",
+        "pathname": "/api/fagsaker/MEL-1009/trygdeavgift/oppsummering",
+        "normalizedPath": "/api/fagsaker/:saksnummer/trygdeavgift/oppsummering",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "harBehandlingMedTrygdeavgift": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1009/trygdeavgift/oppsummering",
+        "pathname": "/api/fagsaker/MEL-1009/trygdeavgift/oppsummering",
+        "normalizedPath": "/api/fagsaker/:saksnummer/trygdeavgift/oppsummering",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "harBehandlingMedTrygdeavgift": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1009",
+        "pathname": "/api/fagsaker/MEL-1009",
+        "normalizedPath": "/api/fagsaker/:saksnummer",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "betalingsvalg": null,
+          "endretDato": "2025-01-01T00:00:00.000Z",
+          "gsakSaksnummer": null,
+          "hovedpartRolle": "BRUKER",
+          "registrertDato": "2025-01-01T00:00:00.000Z",
+          "saksnummer": "MEL-1009",
+          "saksstatus": {
+            "kode": "OPPRETTET",
+            "term": "Saken er opprettet"
+          },
+          "sakstema": {
+            "kode": "MEDLEMSKAP_LOVVALG",
+            "term": "Medlemskap og lovvalg"
+          },
+          "sakstype": {
+            "kode": "TRYGDEAVTALE",
+            "term": "Avtaleland"
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.arsavregning.eos_pensjonist&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
+        "pathname": "/api/featuretoggle",
+        "normalizedPath": "/api/featuretoggle",
+        "query": {
+          "features": "melosys.cdm-4-4"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "melosys.faktureringskomponent.vis_referanse": true,
+          "melosys.pensjonist": true,
+          "melosys.pensjonist_eos": true,
+          "standardvedlegg_eget_vedlegg_avtaleland": true,
+          "melosys.ftrl.begrense_periode_vedtak": true,
+          "melosys.arsavregning": true,
+          "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
+          "melosys.11_3_a_Norge_er_utpekt": true,
+          "melosys.eos_fakturering_av_trygdeavgift": true,
+          "melosys.arsavregning.eos_pensjonist": true,
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "pathname": "/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "normalizedPath": "/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "???",
+            "term": "UOPPGITT/UKJENT"
+          },
+          {
+            "kode": "AD",
+            "term": "ANDORRA"
+          },
+          {
+            "kode": "AE",
+            "term": "DE FORENTE ARABISKE EMIRATER"
+          },
+          {
+            "kode": "AF",
+            "term": "AFGHANISTAN"
+          },
+          {
+            "kode": "AG",
+            "term": "ANTIGUA OG BARBUDA"
+          },
+          {
+            "kode": "AI",
+            "term": "ANGUILLA"
+          },
+          {
+            "kode": "AL",
+            "term": "ALBANIA"
+          },
+          {
+            "kode": "AM",
+            "term": "ARMENIA"
+          },
+          {
+            "kode": "AO",
+            "term": "ANGOLA"
+          },
+          {
+            "kode": "AQ",
+            "term": "Antarktis"
+          },
+          {
+            "kode": "AR",
+            "term": "ARGENTINA"
+          },
+          {
+            "kode": "AS",
+            "term": "AM. SAMOA"
+          },
+          {
+            "kode": "AT",
+            "term": "ØSTERRIKE"
+          },
+          {
+            "kode": "AU",
+            "term": "AUSTRALIA"
+          },
+          {
+            "kode": "AW",
+            "term": "ARUBA"
+          },
+          {
+            "kode": "AX",
+            "term": "ÅLAND"
+          },
+          {
+            "kode": "AZ",
+            "term": "ASERBAJDSJAN"
+          },
+          {
+            "kode": "BA",
+            "term": "BOSNIA-HERCEGOVINA"
+          },
+          {
+            "kode": "BB",
+            "term": "BARBADOS"
+          },
+          {
+            "kode": "BD",
+            "term": "BANGLADESH"
+          },
+          {
+            "kode": "BE",
+            "term": "BELGIA"
+          },
+          {
+            "kode": "BF",
+            "term": "BURKINA FASO"
+          },
+          {
+            "kode": "BG",
+            "term": "BULGARIA"
+          },
+          {
+            "kode": "BH",
+            "term": "BAHRAIN"
+          },
+          {
+            "kode": "BI",
+            "term": "BURUNDI"
+          },
+          {
+            "kode": "BJ",
+            "term": "BENIN"
+          },
+          {
+            "kode": "BL",
+            "term": "SAINT BARTHELEMY"
+          },
+          {
+            "kode": "BM",
+            "term": "BERMUDA"
+          },
+          {
+            "kode": "BN",
+            "term": "BRUNEI"
+          },
+          {
+            "kode": "BO",
+            "term": "BOLIVIA"
+          },
+          {
+            "kode": "BQ",
+            "term": "BONAIRE, SINT EUSTATIUS OG SABA"
+          },
+          {
+            "kode": "BR",
+            "term": "BRASIL"
+          },
+          {
+            "kode": "BS",
+            "term": "BAHAMAS"
+          },
+          {
+            "kode": "BT",
+            "term": "BHUTAN"
+          },
+          {
+            "kode": "BV",
+            "term": "BOUVETØYA"
+          },
+          {
+            "kode": "BW",
+            "term": "BOTSWANA"
+          },
+          {
+            "kode": "BY",
+            "term": "BELARUS"
+          },
+          {
+            "kode": "BZ",
+            "term": "BELIZE"
+          },
+          {
+            "kode": "CA",
+            "term": "CANADA"
+          },
+          {
+            "kode": "CC",
+            "term": "KOKOSØYENE (KEELINGØYENE)"
+          },
+          {
+            "kode": "CD",
+            "term": "KONGO"
+          },
+          {
+            "kode": "CF",
+            "term": "DEN SENTRALAFRIKANSKE REPUBLIKK"
+          },
+          {
+            "kode": "CG",
+            "term": "KONGO-BRAZZAVILLE"
+          },
+          {
+            "kode": "CH",
+            "term": "SVEITS"
+          },
+          {
+            "kode": "CI",
+            "term": "ELFENBENSKYSTEN"
+          },
+          {
+            "kode": "CK",
+            "term": "COOKØYENE"
+          },
+          {
+            "kode": "CL",
+            "term": "CHILE"
+          },
+          {
+            "kode": "CM",
+            "term": "KAMERUN"
+          },
+          {
+            "kode": "CN",
+            "term": "KINA"
+          },
+          {
+            "kode": "CO",
+            "term": "COLOMBIA"
+          },
+          {
+            "kode": "CR",
+            "term": "COSTA RICA"
+          },
+          {
+            "kode": "CS",
+            "term": "SERBIA OG MONTENEGRO"
+          },
+          {
+            "kode": "CU",
+            "term": "CUBA"
+          },
+          {
+            "kode": "CV",
+            "term": "KAPP VERDE"
+          },
+          {
+            "kode": "CW",
+            "term": "CURACAO"
+          },
+          {
+            "kode": "CX",
+            "term": "CHRISTMASØYA"
+          },
+          {
+            "kode": "CY",
+            "term": "KYPROS"
+          },
+          {
+            "kode": "CZ",
+            "term": "TSJEKKIA"
+          },
+          {
+            "kode": "DE",
+            "term": "TYSKLAND"
+          },
+          {
+            "kode": "DJ",
+            "term": "DJIBOUTI"
+          },
+          {
+            "kode": "DK",
+            "term": "DANMARK"
+          },
+          {
+            "kode": "DM",
+            "term": "DOMINICA"
+          },
+          {
+            "kode": "DO",
+            "term": "DEN DOMINIKANSKE REPUBLIKK"
+          },
+          {
+            "kode": "DZ",
+            "term": "ALGERIE"
+          },
+          {
+            "kode": "EC",
+            "term": "ECUADOR"
+          },
+          {
+            "kode": "EE",
+            "term": "ESTLAND"
+          },
+          {
+            "kode": "EG",
+            "term": "EGYPT"
+          },
+          {
+            "kode": "EH",
+            "term": "VEST-SAHARA"
+          },
+          {
+            "kode": "ER",
+            "term": "ERITREA"
+          },
+          {
+            "kode": "ES",
+            "term": "SPANIA"
+          },
+          {
+            "kode": "ET",
+            "term": "ETIOPIA"
+          },
+          {
+            "kode": "FI",
+            "term": "FINLAND"
+          },
+          {
+            "kode": "FJ",
+            "term": "FIJI"
+          },
+          {
+            "kode": "FK",
+            "term": "FALKLANDSØYENE"
+          },
+          {
+            "kode": "FM",
+            "term": "MIKRONESIAFØDERASJONEN"
+          },
+          {
+            "kode": "FO",
+            "term": "FÆRØYENE"
+          },
+          {
+            "kode": "FR",
+            "term": "FRANKRIKE"
+          },
+          {
+            "kode": "GA",
+            "term": "GABON"
+          },
+          {
+            "kode": "GB",
+            "term": "STORBRITANNIA"
+          },
+          {
+            "kode": "GD",
+            "term": "GRENADA"
+          },
+          {
+            "kode": "GE",
+            "term": "GEORGIA"
+          },
+          {
+            "kode": "GF",
+            "term": "FRANSK GUYANA"
+          },
+          {
+            "kode": "GG",
+            "term": "GUERNSEY"
+          },
+          {
+            "kode": "GH",
+            "term": "GHANA"
+          },
+          {
+            "kode": "GI",
+            "term": "GIBRALTAR"
+          },
+          {
+            "kode": "GL",
+            "term": "GRØNLAND"
+          },
+          {
+            "kode": "GM",
+            "term": "GAMBIA"
+          },
+          {
+            "kode": "GN",
+            "term": "GUINEA"
+          },
+          {
+            "kode": "GP",
+            "term": "GUADELOUPE"
+          },
+          {
+            "kode": "GQ",
+            "term": "EKVATORIAL-GUINEA"
+          },
+          {
+            "kode": "GR",
+            "term": "HELLAS"
+          },
+          {
+            "kode": "GS",
+            "term": "SØR-GEORGIA OG SØR-SANDWICHØYENE"
+          },
+          {
+            "kode": "GT",
+            "term": "GUATEMALA"
+          },
+          {
+            "kode": "GU",
+            "term": "GUAM"
+          },
+          {
+            "kode": "GW",
+            "term": "GUINEA-BISSAU"
+          },
+          {
+            "kode": "GY",
+            "term": "GUYANA"
+          },
+          {
+            "kode": "HK",
+            "term": "HONGKONG"
+          },
+          {
+            "kode": "HM",
+            "term": "HEARD- OG MCDONALD-ØYENE"
+          },
+          {
+            "kode": "HN",
+            "term": "HONDURAS"
+          },
+          {
+            "kode": "HR",
+            "term": "KROATIA"
+          },
+          {
+            "kode": "HT",
+            "term": "HAITI"
+          },
+          {
+            "kode": "HU",
+            "term": "UNGARN"
+          },
+          {
+            "kode": "ID",
+            "term": "INDONESIA"
+          },
+          {
+            "kode": "IE",
+            "term": "IRLAND"
+          },
+          {
+            "kode": "IL",
+            "term": "ISRAEL"
+          },
+          {
+            "kode": "IM",
+            "term": "ISLE OF MAN"
+          },
+          {
+            "kode": "IN",
+            "term": "INDIA"
+          },
+          {
+            "kode": "IO",
+            "term": "DET BRITISKE TERRITORIET I INDIAHAVET"
+          },
+          {
+            "kode": "IQ",
+            "term": "IRAK"
+          },
+          {
+            "kode": "IR",
+            "term": "IRAN"
+          },
+          {
+            "kode": "IS",
+            "term": "ISLAND"
+          },
+          {
+            "kode": "IT",
+            "term": "ITALIA"
+          },
+          {
+            "kode": "JE",
+            "term": "JERSEY"
+          },
+          {
+            "kode": "JM",
+            "term": "JAMAICA"
+          },
+          {
+            "kode": "JO",
+            "term": "JORDAN"
+          },
+          {
+            "kode": "JP",
+            "term": "JAPAN"
+          },
+          {
+            "kode": "KE",
+            "term": "KENYA"
+          },
+          {
+            "kode": "KG",
+            "term": "KIRGISISTAN"
+          },
+          {
+            "kode": "KH",
+            "term": "KAMBODSJA"
+          },
+          {
+            "kode": "KI",
+            "term": "KIRIBATI"
+          },
+          {
+            "kode": "KM",
+            "term": "KOMORENE"
+          },
+          {
+            "kode": "KN",
+            "term": "SAINT KITTS OG NEVIS"
+          },
+          {
+            "kode": "KP",
+            "term": "NORD-KOREA"
+          },
+          {
+            "kode": "KR",
+            "term": "SØR-KOREA"
+          },
+          {
+            "kode": "KW",
+            "term": "KUWAIT"
+          },
+          {
+            "kode": "KY",
+            "term": "CAYMANØYENE"
+          },
+          {
+            "kode": "KZ",
+            "term": "KASAKHSTAN"
+          },
+          {
+            "kode": "LA",
+            "term": "LAOS"
+          },
+          {
+            "kode": "LB",
+            "term": "LIBANON"
+          },
+          {
+            "kode": "LC",
+            "term": "SAINT LUCIA"
+          },
+          {
+            "kode": "LI",
+            "term": "LIECHTENSTEIN"
+          },
+          {
+            "kode": "LK",
+            "term": "SRI LANKA"
+          },
+          {
+            "kode": "LR",
+            "term": "LIBERIA"
+          },
+          {
+            "kode": "LS",
+            "term": "LESOTHO"
+          },
+          {
+            "kode": "LT",
+            "term": "LITAUEN"
+          },
+          {
+            "kode": "LU",
+            "term": "LUXEMBOURG"
+          },
+          {
+            "kode": "LV",
+            "term": "LATVIA"
+          },
+          {
+            "kode": "LY",
+            "term": "LIBYA"
+          },
+          {
+            "kode": "MA",
+            "term": "MAROKKO"
+          },
+          {
+            "kode": "MC",
+            "term": "MONACO"
+          },
+          {
+            "kode": "MD",
+            "term": "MOLDOVA"
+          },
+          {
+            "kode": "ME",
+            "term": "MONTENEGRO"
+          },
+          {
+            "kode": "MF",
+            "term": "SAINT MARTIN"
+          },
+          {
+            "kode": "MG",
+            "term": "MADAGASKAR"
+          },
+          {
+            "kode": "MH",
+            "term": "MARSHALLØYENE"
+          },
+          {
+            "kode": "MK",
+            "term": "NORD-MAKEDONIA"
+          },
+          {
+            "kode": "ML",
+            "term": "MALI"
+          },
+          {
+            "kode": "MM",
+            "term": "MYANMAR (BURMA)"
+          },
+          {
+            "kode": "MN",
+            "term": "MONGOLIA"
+          },
+          {
+            "kode": "MO",
+            "term": "MACAO"
+          },
+          {
+            "kode": "MP",
+            "term": "NORD-MARIANENE"
+          },
+          {
+            "kode": "MQ",
+            "term": "MARTINIQUE"
+          },
+          {
+            "kode": "MR",
+            "term": "MAURITANIA"
+          },
+          {
+            "kode": "MS",
+            "term": "MONTSERRAT"
+          },
+          {
+            "kode": "MT",
+            "term": "MALTA"
+          },
+          {
+            "kode": "MU",
+            "term": "MAURITIUS"
+          },
+          {
+            "kode": "MV",
+            "term": "MALDIVENE"
+          },
+          {
+            "kode": "MW",
+            "term": "MALAWI"
+          },
+          {
+            "kode": "MX",
+            "term": "MEXICO"
+          },
+          {
+            "kode": "MY",
+            "term": "MALAYSIA"
+          },
+          {
+            "kode": "MZ",
+            "term": "MOSAMBIK"
+          },
+          {
+            "kode": "NA",
+            "term": "NAMIBIA"
+          },
+          {
+            "kode": "NC",
+            "term": "NY-CALEDONIA"
+          },
+          {
+            "kode": "NE",
+            "term": "NIGER"
+          },
+          {
+            "kode": "NF",
+            "term": "NORFOLKØYA"
+          },
+          {
+            "kode": "NG",
+            "term": "NIGERIA"
+          },
+          {
+            "kode": "NI",
+            "term": "NICARAGUA"
+          },
+          {
+            "kode": "NL",
+            "term": "NEDERLAND"
+          },
+          {
+            "kode": "NO",
+            "term": "NORGE"
+          },
+          {
+            "kode": "NP",
+            "term": "NEPAL"
+          },
+          {
+            "kode": "NR",
+            "term": "NAURU"
+          },
+          {
+            "kode": "NU",
+            "term": "NIUE"
+          },
+          {
+            "kode": "NZ",
+            "term": "NEW ZEALAND"
+          },
+          {
+            "kode": "OM",
+            "term": "OMAN"
+          },
+          {
+            "kode": "PA",
+            "term": "PANAMA"
+          },
+          {
+            "kode": "PE",
+            "term": "PERU"
+          },
+          {
+            "kode": "PF",
+            "term": "FRANSK POLYNESIA"
+          },
+          {
+            "kode": "PG",
+            "term": "PAPUA NY-GUINEA"
+          },
+          {
+            "kode": "PH",
+            "term": "FILIPPINENE"
+          },
+          {
+            "kode": "PK",
+            "term": "PAKISTAN"
+          },
+          {
+            "kode": "PL",
+            "term": "POLEN"
+          },
+          {
+            "kode": "PM",
+            "term": "SAINT-PIERRE OG MIQUELON"
+          },
+          {
+            "kode": "PN",
+            "term": "PITCAIRN"
+          },
+          {
+            "kode": "PR",
+            "term": "PUERTO RICO"
+          },
+          {
+            "kode": "PS",
+            "term": "PALESTINA"
+          },
+          {
+            "kode": "PT",
+            "term": "PORTUGAL"
+          },
+          {
+            "kode": "PW",
+            "term": "PALAU"
+          },
+          {
+            "kode": "PY",
+            "term": "PARAGUAY"
+          },
+          {
+            "kode": "QA",
+            "term": "QATAR"
+          },
+          {
+            "kode": "RE",
+            "term": "REUNION"
+          },
+          {
+            "kode": "RO",
+            "term": "ROMANIA"
+          },
+          {
+            "kode": "RS",
+            "term": "SERBIA"
+          },
+          {
+            "kode": "RU",
+            "term": "RUSSLAND"
+          },
+          {
+            "kode": "RW",
+            "term": "RWANDA"
+          },
+          {
+            "kode": "SA",
+            "term": "SAUDI-ARABIA"
+          },
+          {
+            "kode": "SB",
+            "term": "SALOMONØYENE"
+          },
+          {
+            "kode": "SC",
+            "term": "SEYCHELLENE"
+          },
+          {
+            "kode": "SD",
+            "term": "SUDAN"
+          },
+          {
+            "kode": "SE",
+            "term": "SVERIGE"
+          },
+          {
+            "kode": "SG",
+            "term": "SINGAPORE"
+          },
+          {
+            "kode": "SH",
+            "term": "SANKT HELENA, ASCENSION OG TRISTAN DA CUNHA"
+          },
+          {
+            "kode": "SI",
+            "term": "SLOVENIA"
+          },
+          {
+            "kode": "SJ",
+            "term": "SVALBARD OG JAN MAYEN"
+          },
+          {
+            "kode": "SK",
+            "term": "SLOVAKIA"
+          },
+          {
+            "kode": "SL",
+            "term": "SIERRA LEONE"
+          },
+          {
+            "kode": "SM",
+            "term": "SAN MARINO"
+          },
+          {
+            "kode": "SN",
+            "term": "SENEGAL"
+          },
+          {
+            "kode": "SO",
+            "term": "SOMALIA"
+          },
+          {
+            "kode": "SR",
+            "term": "SURINAM"
+          },
+          {
+            "kode": "SS",
+            "term": "SØR-SUDAN"
+          },
+          {
+            "kode": "ST",
+            "term": "SAO TOME OG PRINCIPE"
+          },
+          {
+            "kode": "SV",
+            "term": "EL SALVADOR"
+          },
+          {
+            "kode": "SX",
+            "term": "SINT MAARTEN"
+          },
+          {
+            "kode": "SY",
+            "term": "SYRIA"
+          },
+          {
+            "kode": "SZ",
+            "term": "ESWATINI"
+          },
+          {
+            "kode": "TC",
+            "term": "TURKS- OG CAICOSØYENE"
+          },
+          {
+            "kode": "TD",
+            "term": "TSJAD"
+          },
+          {
+            "kode": "TG",
+            "term": "TOGO"
+          },
+          {
+            "kode": "TH",
+            "term": "THAILAND"
+          },
+          {
+            "kode": "TJ",
+            "term": "TADSJIKISTAN"
+          },
+          {
+            "kode": "TK",
+            "term": "TOKELAU"
+          },
+          {
+            "kode": "TL",
+            "term": "ØST-TIMOR"
+          },
+          {
+            "kode": "TM",
+            "term": "TURKMENISTAN"
+          },
+          {
+            "kode": "TN",
+            "term": "TUNISIA"
+          },
+          {
+            "kode": "TO",
+            "term": "TONGA"
+          },
+          {
+            "kode": "TR",
+            "term": "TYRKIA"
+          },
+          {
+            "kode": "TT",
+            "term": "TRINIDAD OG TOBAGO"
+          },
+          {
+            "kode": "TV",
+            "term": "TUVALU"
+          },
+          {
+            "kode": "TW",
+            "term": "TAIWAN"
+          },
+          {
+            "kode": "TZ",
+            "term": "TANZANIA"
+          },
+          {
+            "kode": "UA",
+            "term": "UKRAINA"
+          },
+          {
+            "kode": "UG",
+            "term": "UGANDA"
+          },
+          {
+            "kode": "UM",
+            "term": "USAS YTRE SMÅØYER"
+          },
+          {
+            "kode": "US",
+            "term": "USA"
+          },
+          {
+            "kode": "UY",
+            "term": "URUGUAY"
+          },
+          {
+            "kode": "UZ",
+            "term": "USBEKISTAN"
+          },
+          {
+            "kode": "VA",
+            "term": "VATIKANSTATEN"
+          },
+          {
+            "kode": "VC",
+            "term": "SAINT VINCENT OG GRENADINENE"
+          },
+          {
+            "kode": "VE",
+            "term": "VENEZUELA"
+          },
+          {
+            "kode": "VG",
+            "term": "DE BRITISKE JOMFRUØYER"
+          },
+          {
+            "kode": "VI",
+            "term": "DE AMERIKANSKE JOMFRUØYER"
+          },
+          {
+            "kode": "VN",
+            "term": "VIETNAM"
+          },
+          {
+            "kode": "VU",
+            "term": "VANUATU"
+          },
+          {
+            "kode": "WF",
+            "term": "WALLIS OG FUTUNA"
+          },
+          {
+            "kode": "WS",
+            "term": "SAMOA"
+          },
+          {
+            "kode": "XB",
+            "term": "Kanariøyene"
+          },
+          {
+            "kode": "XK",
+            "term": "KOSOVO"
+          },
+          {
+            "kode": "YE",
+            "term": "JEMEN"
+          },
+          {
+            "kode": "YT",
+            "term": "MAYOTTE"
+          },
+          {
+            "kode": "ZA",
+            "term": "SØR-AFRIKA"
+          },
+          {
+            "kode": "ZM",
+            "term": "ZAMBIA"
+          },
+          {
+            "kode": "ZW",
+            "term": "ZIMBABWE"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/lovvalgsperioder/9",
+        "pathname": "/api/lovvalgsperioder/9",
+        "normalizedPath": "/api/lovvalgsperioder/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/mottatteopplysninger/9",
+        "pathname": "/api/mottatteopplysninger/9",
+        "normalizedPath": "/api/mottatteopplysninger/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "arbeidPaaLand": {
+              "erFastArbeidssted": null,
+              "erHjemmekontor": null,
+              "fysiskeArbeidssteder": []
+            },
+            "bosted": {
+              "antallMaanederINorge": 0,
+              "intensjonOmRetur": null,
+              "oppgittAdresse": {
+                "tilleggsnavn": null,
+                "gatenavn": null,
+                "husnummerEtasjeLeilighet": null,
+                "postboks": null,
+                "postnummer": null,
+                "poststed": null,
+                "region": null,
+                "landkode": null
+              }
+            },
+            "foretakUtland": [],
+            "juridiskArbeidsgiverNorge": {
+              "andelKontrakterINorge": null,
+              "andelOmsetningINorge": null,
+              "andelOppdragINorge": null,
+              "andelRekruttertINorge": null,
+              "antallAdmAnsatte": null,
+              "antallAnsatte": null,
+              "antallUtsendte": null,
+              "ekstraArbeidsgivere": [],
+              "erOffentligVirksomhet": null
+            },
+            "luftfartBaser": [],
+            "maritimtArbeid": [],
+            "oppholdUtland": {
+              "ektefelleEllerBarnINorge": null,
+              "oppholdsPeriode": {
+                "fom": null,
+                "tom": null
+              },
+              "oppholdslandkoder": [],
+              "studentFinansieringKode": null,
+              "studentSemester": null
+            },
+            "periode": {
+              "fom": null,
+              "tom": null
+            },
+            "personOpplysninger": {
+              "foedestedOgLand": null,
+              "medfolgendeFamilie": [],
+              "utenlandskIdent": []
+            },
+            "representantIUtlandet": null,
+            "selvstendigArbeid": {
+              "erSelvstendig": null,
+              "selvstendigForetak": []
+            },
+            "soeknadsland": {
+              "landkoder": [],
+              "flereLandUkjentHvilke": false
+            },
+            "trygdedekning": null
+          },
+          "mottaksdato": "2025-01-01",
+          "type": "SØKNAD_YRKESAKTIVE_NORGE_ELLER_UTENFOR_EØS"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/MEL-1009/behandlingstyper/kombinasjoner-for-endring/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&sakstema=MEDLEMSKAP_LOVVALG&behandlingstema=YRKESAKTIV",
+        "pathname": "/api/saksbehandling/MEL-1009/behandlingstyper/kombinasjoner-for-endring/",
+        "normalizedPath": "/api/saksbehandling/:saksnummer/behandlingstyper/kombinasjoner-for-endring/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "sakstema": "MEDLEMSKAP_LOVVALG",
+          "behandlingstema": "YRKESAKTIV"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "FØRSTEGANG",
+            "term": "Førstegangsbehandling"
+          },
+          {
+            "kode": "HENVENDELSE",
+            "term": "Henvendelse"
+          },
+          {
+            "kode": "KLAGE",
+            "term": "Klage"
+          },
+          {
+            "kode": "NY_VURDERING",
+            "term": "Ny vurdering"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&sakstema=MEDLEMSKAP_LOVVALG&aktivBehandlingID=9",
+        "pathname": "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "sakstema": "MEDLEMSKAP_LOVVALG",
+          "aktivBehandlingID": "9"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "FORESPØRSEL_TRYGDEMYNDIGHET",
+            "term": "Forespørsel fra trygdemyndighet"
+          },
+          {
+            "kode": "IKKE_YRKESAKTIV",
+            "term": "Ikke yrkesaktiv"
+          },
+          {
+            "kode": "PENSJONIST",
+            "term": "Pensjonist/uføretrygdet"
+          },
+          {
+            "kode": "YRKESAKTIV",
+            "term": "Yrkesaktiv"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&saksnummer=MEL-1009",
+        "pathname": "/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "saksnummer": "MEL-1009"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "MEDLEMSKAP_LOVVALG",
+            "term": "Medlemskap og lovvalg"
+          },
+          {
+            "kode": "TRYGDEAVGIFT",
+            "term": "Trygdeavgift"
+          },
+          {
+            "kode": "UNNTAK",
+            "term": "Unntak"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/?saksnummer=MEL-1009",
+        "pathname": "/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/",
+        "query": {
+          "saksnummer": "MEL-1009"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "EU_EOS",
+            "term": "EU/EØS-land"
+          },
+          {
+            "kode": "FTRL",
+            "term": "Utenfor avtaleland"
+          },
+          {
+            "kode": "TRYGDEAVTALE",
+            "term": "Avtaleland"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 9
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/gyldig-org-nr-som-ikke-finnes-gir-kunne-ikke-finne-organisasjon-og-holder-brevmal-skjult.json
+++ b/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/gyldig-org-nr-som-ikke-finnes-gir-kunne-ikke-finne-organisasjon-og-holder-brevmal-skjult.json
@@ -1,0 +1,2536 @@
+{
+  "version": "1.0",
+  "recordedAt": "2025-01-01T00:00:00.000Z",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts",
+  "testName": "Gyldig org.nr som ikke finnes gir «Kunne ikke finne organisasjon» og holder brevmal skjult",
+  "exchanges": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/10/aarsak/mottaksdato",
+        "pathname": "/api/behandlinger/10/aarsak/mottaksdato",
+        "normalizedPath": "/api/behandlinger/:behandlingId/aarsak/mottaksdato",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "mottaksdato": "2025-01-01"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/10/resultat",
+        "pathname": "/api/behandlinger/10/resultat",
+        "normalizedPath": "/api/behandlinger/:behandlingId/resultat",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "aarsavregningID": null,
+          "begrunnelseFritekst": null,
+          "begrunnelseKoder": [],
+          "behandlingsresultatTypeKode": "IKKE_FASTSATT",
+          "fakturaserieReferanse": null,
+          "innledningFritekst": null,
+          "kontrollresultatBegrunnelseKoder": [],
+          "nyVurderingBakgrunn": null,
+          "trygdeavgiftFritekst": null,
+          "utfallRegistreringUnntak": null,
+          "utfallUtpeking": null,
+          "vedtakstype": null
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/10",
+        "pathname": "/api/behandlinger/10",
+        "normalizedPath": "/api/behandlinger/:behandlingId",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "behandlingID": 10,
+          "oppsummering": {
+            "behandlingsfrist": "2025-01-01",
+            "behandlingsresultattype": {
+              "kode": "IKKE_FASTSATT",
+              "term": "Ikke fastsatt"
+            },
+            "behandlingsstatus": {
+              "kode": "UNDER_BEHANDLING",
+              "term": "Behandlingen pågår"
+            },
+            "behandlingstema": {
+              "kode": "YRKESAKTIV",
+              "term": "Yrkesaktiv"
+            },
+            "behandlingstype": {
+              "kode": "FØRSTEGANG",
+              "term": "Førstegangsbehandling"
+            },
+            "endretAvNavn": "Lokal Testbruker",
+            "endretDato": "2025-01-01T00:00:00.000Z",
+            "registrertDato": "2025-01-01T00:00:00.000Z",
+            "sisteOpplysningerHentetDato": null,
+            "svarFrist": null
+          },
+          "saksopplysninger": {
+            "arbeidsforhold": [],
+            "organisasjoner": [],
+            "medlemskap": {
+              "medlemsperiode": []
+            },
+            "inntekt": {
+              "arbeidsInntektMaanedListe": [],
+              "frilansInntektMaanedListe": []
+            },
+            "sed": {
+              "bucType": null,
+              "erEndring": false,
+              "fnr": null,
+              "lovvalgsbestemmelse": null,
+              "lovvalgslandKode": null,
+              "lovvalgsperiode": null,
+              "rinaDokumentID": null,
+              "rinaSaksnummer": null,
+              "sedType": null
+            }
+          },
+          "redigerbart": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/brev/utkast/10",
+        "pathname": "/api/brev/utkast/10",
+        "normalizedPath": "/api/brev/utkast/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/brev/utkast/10",
+        "pathname": "/api/brev/utkast/10",
+        "normalizedPath": "/api/brev/utkast/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/dokumenter/v2/standardvedlegg",
+        "pathname": "/api/dokumenter/v2/standardvedlegg",
+        "normalizedPath": "/api/dokumenter/v2/standardvedlegg",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "type": "VIKTIG_INFORMASJON_RETTIGHETER_PLIKTER_AVSLAG",
+            "frontendTittel": "Avslag: Viktig informasjon om rettigheter",
+            "dokumentTittel": "Viktig informasjon om rettigheter"
+          },
+          {
+            "type": "VIKTIG_INFORMASJON_RETTIGHETER_PLIKTER_INNVILGELSE",
+            "frontendTittel": "Innvilgelse: Viktig informasjon om rettigheter og plikter",
+            "dokumentTittel": "Viktig informasjon om rettigheter og plikter"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/dokumenter/v2/tilgjengelige-maler/10",
+        "pathname": "/api/dokumenter/v2/tilgjengelige-maler/10",
+        "normalizedPath": "/api/dokumenter/v2/tilgjengelige-maler/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "mottaker": {
+              "adresser": [
+                {
+                  "mottakerNavn": "TRIVIELL KARAFFEL",
+                  "orgnr": null,
+                  "adresselinjer": ["CO 2", "kontakt gata 1 42"],
+                  "postnr": "0001",
+                  "poststed": null,
+                  "region": null,
+                  "land": "SE",
+                  "ugyldig": false
+                }
+              ],
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "BRUKER",
+              "type": "Bruker eller brukers fullmektig"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_BRUKER",
+                  "term": "Melding om manglende opplysninger til bruker"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_BRUKER",
+                  "term": "Fritekstbrev til bruker"
+                }
+              },
+              {
+                "felter": null,
+                "type": {
+                  "kode": "MELDING_FORVENTET_SAKSBEHANDLINGSTID_SOKNAD",
+                  "term": "Melding om forventet saksbehandlingstid"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": {
+                "tittel": "Du må velge land på inngangssteget for å kunne sende brev til utenlandsk trygdemyndighet.",
+                "underpunkter": []
+              },
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "UTENLANDSK_TRYGDEMYNDIGHET",
+              "type": "Utenlandsk trygdemyndighet"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "UTENLANDSK_TRYGDEMYNDIGHET_FRITEKSTBREV",
+                  "term": "Fritekstbrev"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": {
+                "tittel": "Finner ikke gyldig adresse til arbeidsgiver(e). Kontroller at arbeidsgiver(e) er lagt inn korrekt i sidemenyen",
+                "underpunkter": []
+              },
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "ARBEIDSGIVER",
+              "type": "Arbeidsgiver eller arbeidsgivers fullmektig"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_ARBEIDSGIVER",
+                  "term": "Melding om manglende opplysninger til virksomhet"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_ARBEIDSGIVER",
+                  "term": "Fritekstbrev til virksomhet"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "ANNEN_ORGANISASJON",
+              "type": "Annen organisasjon"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_ARBEIDSGIVER",
+                  "term": "Melding om manglende opplysninger til virksomhet"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_ARBEIDSGIVER",
+                  "term": "Fritekstbrev til virksomhet"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "NORSK_MYNDIGHET",
+              "type": "Norske myndigheter"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Orientering om vår beslutning",
+                          "kode": "ORIENTERING_BESLUTNING",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "FRITEKSTBREV",
+                  "term": "Fritekstbrev"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1010/aktoerer/?rolleKode=FULLMEKTIG",
+        "pathname": "/api/fagsaker/MEL-1010/aktoerer/",
+        "normalizedPath": "/api/fagsaker/:saksnummer/aktoerer/",
+        "query": {
+          "rolleKode": "FULLMEKTIG"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1010/dokumenter",
+        "pathname": "/api/fagsaker/MEL-1010/dokumenter",
+        "normalizedPath": "/api/fagsaker/:saksnummer/dokumenter",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1010/trygdeavgift/oppsummering",
+        "pathname": "/api/fagsaker/MEL-1010/trygdeavgift/oppsummering",
+        "normalizedPath": "/api/fagsaker/:saksnummer/trygdeavgift/oppsummering",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "harBehandlingMedTrygdeavgift": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1010/trygdeavgift/oppsummering",
+        "pathname": "/api/fagsaker/MEL-1010/trygdeavgift/oppsummering",
+        "normalizedPath": "/api/fagsaker/:saksnummer/trygdeavgift/oppsummering",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "harBehandlingMedTrygdeavgift": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1010",
+        "pathname": "/api/fagsaker/MEL-1010",
+        "normalizedPath": "/api/fagsaker/:saksnummer",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "betalingsvalg": null,
+          "endretDato": "2025-01-01T00:00:00.000Z",
+          "gsakSaksnummer": null,
+          "hovedpartRolle": "BRUKER",
+          "registrertDato": "2025-01-01T00:00:00.000Z",
+          "saksnummer": "MEL-1010",
+          "saksstatus": {
+            "kode": "OPPRETTET",
+            "term": "Saken er opprettet"
+          },
+          "sakstema": {
+            "kode": "MEDLEMSKAP_LOVVALG",
+            "term": "Medlemskap og lovvalg"
+          },
+          "sakstype": {
+            "kode": "TRYGDEAVTALE",
+            "term": "Avtaleland"
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.arsavregning.eos_pensjonist&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
+        "pathname": "/api/featuretoggle",
+        "normalizedPath": "/api/featuretoggle",
+        "query": {
+          "features": "melosys.cdm-4-4"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "melosys.faktureringskomponent.vis_referanse": true,
+          "melosys.pensjonist": true,
+          "melosys.pensjonist_eos": true,
+          "standardvedlegg_eget_vedlegg_avtaleland": true,
+          "melosys.ftrl.begrense_periode_vedtak": true,
+          "melosys.arsavregning": true,
+          "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
+          "melosys.11_3_a_Norge_er_utpekt": true,
+          "melosys.eos_fakturering_av_trygdeavgift": true,
+          "melosys.arsavregning.eos_pensjonist": true,
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "pathname": "/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "normalizedPath": "/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "???",
+            "term": "UOPPGITT/UKJENT"
+          },
+          {
+            "kode": "AD",
+            "term": "ANDORRA"
+          },
+          {
+            "kode": "AE",
+            "term": "DE FORENTE ARABISKE EMIRATER"
+          },
+          {
+            "kode": "AF",
+            "term": "AFGHANISTAN"
+          },
+          {
+            "kode": "AG",
+            "term": "ANTIGUA OG BARBUDA"
+          },
+          {
+            "kode": "AI",
+            "term": "ANGUILLA"
+          },
+          {
+            "kode": "AL",
+            "term": "ALBANIA"
+          },
+          {
+            "kode": "AM",
+            "term": "ARMENIA"
+          },
+          {
+            "kode": "AO",
+            "term": "ANGOLA"
+          },
+          {
+            "kode": "AQ",
+            "term": "Antarktis"
+          },
+          {
+            "kode": "AR",
+            "term": "ARGENTINA"
+          },
+          {
+            "kode": "AS",
+            "term": "AM. SAMOA"
+          },
+          {
+            "kode": "AT",
+            "term": "ØSTERRIKE"
+          },
+          {
+            "kode": "AU",
+            "term": "AUSTRALIA"
+          },
+          {
+            "kode": "AW",
+            "term": "ARUBA"
+          },
+          {
+            "kode": "AX",
+            "term": "ÅLAND"
+          },
+          {
+            "kode": "AZ",
+            "term": "ASERBAJDSJAN"
+          },
+          {
+            "kode": "BA",
+            "term": "BOSNIA-HERCEGOVINA"
+          },
+          {
+            "kode": "BB",
+            "term": "BARBADOS"
+          },
+          {
+            "kode": "BD",
+            "term": "BANGLADESH"
+          },
+          {
+            "kode": "BE",
+            "term": "BELGIA"
+          },
+          {
+            "kode": "BF",
+            "term": "BURKINA FASO"
+          },
+          {
+            "kode": "BG",
+            "term": "BULGARIA"
+          },
+          {
+            "kode": "BH",
+            "term": "BAHRAIN"
+          },
+          {
+            "kode": "BI",
+            "term": "BURUNDI"
+          },
+          {
+            "kode": "BJ",
+            "term": "BENIN"
+          },
+          {
+            "kode": "BL",
+            "term": "SAINT BARTHELEMY"
+          },
+          {
+            "kode": "BM",
+            "term": "BERMUDA"
+          },
+          {
+            "kode": "BN",
+            "term": "BRUNEI"
+          },
+          {
+            "kode": "BO",
+            "term": "BOLIVIA"
+          },
+          {
+            "kode": "BQ",
+            "term": "BONAIRE, SINT EUSTATIUS OG SABA"
+          },
+          {
+            "kode": "BR",
+            "term": "BRASIL"
+          },
+          {
+            "kode": "BS",
+            "term": "BAHAMAS"
+          },
+          {
+            "kode": "BT",
+            "term": "BHUTAN"
+          },
+          {
+            "kode": "BV",
+            "term": "BOUVETØYA"
+          },
+          {
+            "kode": "BW",
+            "term": "BOTSWANA"
+          },
+          {
+            "kode": "BY",
+            "term": "BELARUS"
+          },
+          {
+            "kode": "BZ",
+            "term": "BELIZE"
+          },
+          {
+            "kode": "CA",
+            "term": "CANADA"
+          },
+          {
+            "kode": "CC",
+            "term": "KOKOSØYENE (KEELINGØYENE)"
+          },
+          {
+            "kode": "CD",
+            "term": "KONGO"
+          },
+          {
+            "kode": "CF",
+            "term": "DEN SENTRALAFRIKANSKE REPUBLIKK"
+          },
+          {
+            "kode": "CG",
+            "term": "KONGO-BRAZZAVILLE"
+          },
+          {
+            "kode": "CH",
+            "term": "SVEITS"
+          },
+          {
+            "kode": "CI",
+            "term": "ELFENBENSKYSTEN"
+          },
+          {
+            "kode": "CK",
+            "term": "COOKØYENE"
+          },
+          {
+            "kode": "CL",
+            "term": "CHILE"
+          },
+          {
+            "kode": "CM",
+            "term": "KAMERUN"
+          },
+          {
+            "kode": "CN",
+            "term": "KINA"
+          },
+          {
+            "kode": "CO",
+            "term": "COLOMBIA"
+          },
+          {
+            "kode": "CR",
+            "term": "COSTA RICA"
+          },
+          {
+            "kode": "CS",
+            "term": "SERBIA OG MONTENEGRO"
+          },
+          {
+            "kode": "CU",
+            "term": "CUBA"
+          },
+          {
+            "kode": "CV",
+            "term": "KAPP VERDE"
+          },
+          {
+            "kode": "CW",
+            "term": "CURACAO"
+          },
+          {
+            "kode": "CX",
+            "term": "CHRISTMASØYA"
+          },
+          {
+            "kode": "CY",
+            "term": "KYPROS"
+          },
+          {
+            "kode": "CZ",
+            "term": "TSJEKKIA"
+          },
+          {
+            "kode": "DE",
+            "term": "TYSKLAND"
+          },
+          {
+            "kode": "DJ",
+            "term": "DJIBOUTI"
+          },
+          {
+            "kode": "DK",
+            "term": "DANMARK"
+          },
+          {
+            "kode": "DM",
+            "term": "DOMINICA"
+          },
+          {
+            "kode": "DO",
+            "term": "DEN DOMINIKANSKE REPUBLIKK"
+          },
+          {
+            "kode": "DZ",
+            "term": "ALGERIE"
+          },
+          {
+            "kode": "EC",
+            "term": "ECUADOR"
+          },
+          {
+            "kode": "EE",
+            "term": "ESTLAND"
+          },
+          {
+            "kode": "EG",
+            "term": "EGYPT"
+          },
+          {
+            "kode": "EH",
+            "term": "VEST-SAHARA"
+          },
+          {
+            "kode": "ER",
+            "term": "ERITREA"
+          },
+          {
+            "kode": "ES",
+            "term": "SPANIA"
+          },
+          {
+            "kode": "ET",
+            "term": "ETIOPIA"
+          },
+          {
+            "kode": "FI",
+            "term": "FINLAND"
+          },
+          {
+            "kode": "FJ",
+            "term": "FIJI"
+          },
+          {
+            "kode": "FK",
+            "term": "FALKLANDSØYENE"
+          },
+          {
+            "kode": "FM",
+            "term": "MIKRONESIAFØDERASJONEN"
+          },
+          {
+            "kode": "FO",
+            "term": "FÆRØYENE"
+          },
+          {
+            "kode": "FR",
+            "term": "FRANKRIKE"
+          },
+          {
+            "kode": "GA",
+            "term": "GABON"
+          },
+          {
+            "kode": "GB",
+            "term": "STORBRITANNIA"
+          },
+          {
+            "kode": "GD",
+            "term": "GRENADA"
+          },
+          {
+            "kode": "GE",
+            "term": "GEORGIA"
+          },
+          {
+            "kode": "GF",
+            "term": "FRANSK GUYANA"
+          },
+          {
+            "kode": "GG",
+            "term": "GUERNSEY"
+          },
+          {
+            "kode": "GH",
+            "term": "GHANA"
+          },
+          {
+            "kode": "GI",
+            "term": "GIBRALTAR"
+          },
+          {
+            "kode": "GL",
+            "term": "GRØNLAND"
+          },
+          {
+            "kode": "GM",
+            "term": "GAMBIA"
+          },
+          {
+            "kode": "GN",
+            "term": "GUINEA"
+          },
+          {
+            "kode": "GP",
+            "term": "GUADELOUPE"
+          },
+          {
+            "kode": "GQ",
+            "term": "EKVATORIAL-GUINEA"
+          },
+          {
+            "kode": "GR",
+            "term": "HELLAS"
+          },
+          {
+            "kode": "GS",
+            "term": "SØR-GEORGIA OG SØR-SANDWICHØYENE"
+          },
+          {
+            "kode": "GT",
+            "term": "GUATEMALA"
+          },
+          {
+            "kode": "GU",
+            "term": "GUAM"
+          },
+          {
+            "kode": "GW",
+            "term": "GUINEA-BISSAU"
+          },
+          {
+            "kode": "GY",
+            "term": "GUYANA"
+          },
+          {
+            "kode": "HK",
+            "term": "HONGKONG"
+          },
+          {
+            "kode": "HM",
+            "term": "HEARD- OG MCDONALD-ØYENE"
+          },
+          {
+            "kode": "HN",
+            "term": "HONDURAS"
+          },
+          {
+            "kode": "HR",
+            "term": "KROATIA"
+          },
+          {
+            "kode": "HT",
+            "term": "HAITI"
+          },
+          {
+            "kode": "HU",
+            "term": "UNGARN"
+          },
+          {
+            "kode": "ID",
+            "term": "INDONESIA"
+          },
+          {
+            "kode": "IE",
+            "term": "IRLAND"
+          },
+          {
+            "kode": "IL",
+            "term": "ISRAEL"
+          },
+          {
+            "kode": "IM",
+            "term": "ISLE OF MAN"
+          },
+          {
+            "kode": "IN",
+            "term": "INDIA"
+          },
+          {
+            "kode": "IO",
+            "term": "DET BRITISKE TERRITORIET I INDIAHAVET"
+          },
+          {
+            "kode": "IQ",
+            "term": "IRAK"
+          },
+          {
+            "kode": "IR",
+            "term": "IRAN"
+          },
+          {
+            "kode": "IS",
+            "term": "ISLAND"
+          },
+          {
+            "kode": "IT",
+            "term": "ITALIA"
+          },
+          {
+            "kode": "JE",
+            "term": "JERSEY"
+          },
+          {
+            "kode": "JM",
+            "term": "JAMAICA"
+          },
+          {
+            "kode": "JO",
+            "term": "JORDAN"
+          },
+          {
+            "kode": "JP",
+            "term": "JAPAN"
+          },
+          {
+            "kode": "KE",
+            "term": "KENYA"
+          },
+          {
+            "kode": "KG",
+            "term": "KIRGISISTAN"
+          },
+          {
+            "kode": "KH",
+            "term": "KAMBODSJA"
+          },
+          {
+            "kode": "KI",
+            "term": "KIRIBATI"
+          },
+          {
+            "kode": "KM",
+            "term": "KOMORENE"
+          },
+          {
+            "kode": "KN",
+            "term": "SAINT KITTS OG NEVIS"
+          },
+          {
+            "kode": "KP",
+            "term": "NORD-KOREA"
+          },
+          {
+            "kode": "KR",
+            "term": "SØR-KOREA"
+          },
+          {
+            "kode": "KW",
+            "term": "KUWAIT"
+          },
+          {
+            "kode": "KY",
+            "term": "CAYMANØYENE"
+          },
+          {
+            "kode": "KZ",
+            "term": "KASAKHSTAN"
+          },
+          {
+            "kode": "LA",
+            "term": "LAOS"
+          },
+          {
+            "kode": "LB",
+            "term": "LIBANON"
+          },
+          {
+            "kode": "LC",
+            "term": "SAINT LUCIA"
+          },
+          {
+            "kode": "LI",
+            "term": "LIECHTENSTEIN"
+          },
+          {
+            "kode": "LK",
+            "term": "SRI LANKA"
+          },
+          {
+            "kode": "LR",
+            "term": "LIBERIA"
+          },
+          {
+            "kode": "LS",
+            "term": "LESOTHO"
+          },
+          {
+            "kode": "LT",
+            "term": "LITAUEN"
+          },
+          {
+            "kode": "LU",
+            "term": "LUXEMBOURG"
+          },
+          {
+            "kode": "LV",
+            "term": "LATVIA"
+          },
+          {
+            "kode": "LY",
+            "term": "LIBYA"
+          },
+          {
+            "kode": "MA",
+            "term": "MAROKKO"
+          },
+          {
+            "kode": "MC",
+            "term": "MONACO"
+          },
+          {
+            "kode": "MD",
+            "term": "MOLDOVA"
+          },
+          {
+            "kode": "ME",
+            "term": "MONTENEGRO"
+          },
+          {
+            "kode": "MF",
+            "term": "SAINT MARTIN"
+          },
+          {
+            "kode": "MG",
+            "term": "MADAGASKAR"
+          },
+          {
+            "kode": "MH",
+            "term": "MARSHALLØYENE"
+          },
+          {
+            "kode": "MK",
+            "term": "NORD-MAKEDONIA"
+          },
+          {
+            "kode": "ML",
+            "term": "MALI"
+          },
+          {
+            "kode": "MM",
+            "term": "MYANMAR (BURMA)"
+          },
+          {
+            "kode": "MN",
+            "term": "MONGOLIA"
+          },
+          {
+            "kode": "MO",
+            "term": "MACAO"
+          },
+          {
+            "kode": "MP",
+            "term": "NORD-MARIANENE"
+          },
+          {
+            "kode": "MQ",
+            "term": "MARTINIQUE"
+          },
+          {
+            "kode": "MR",
+            "term": "MAURITANIA"
+          },
+          {
+            "kode": "MS",
+            "term": "MONTSERRAT"
+          },
+          {
+            "kode": "MT",
+            "term": "MALTA"
+          },
+          {
+            "kode": "MU",
+            "term": "MAURITIUS"
+          },
+          {
+            "kode": "MV",
+            "term": "MALDIVENE"
+          },
+          {
+            "kode": "MW",
+            "term": "MALAWI"
+          },
+          {
+            "kode": "MX",
+            "term": "MEXICO"
+          },
+          {
+            "kode": "MY",
+            "term": "MALAYSIA"
+          },
+          {
+            "kode": "MZ",
+            "term": "MOSAMBIK"
+          },
+          {
+            "kode": "NA",
+            "term": "NAMIBIA"
+          },
+          {
+            "kode": "NC",
+            "term": "NY-CALEDONIA"
+          },
+          {
+            "kode": "NE",
+            "term": "NIGER"
+          },
+          {
+            "kode": "NF",
+            "term": "NORFOLKØYA"
+          },
+          {
+            "kode": "NG",
+            "term": "NIGERIA"
+          },
+          {
+            "kode": "NI",
+            "term": "NICARAGUA"
+          },
+          {
+            "kode": "NL",
+            "term": "NEDERLAND"
+          },
+          {
+            "kode": "NO",
+            "term": "NORGE"
+          },
+          {
+            "kode": "NP",
+            "term": "NEPAL"
+          },
+          {
+            "kode": "NR",
+            "term": "NAURU"
+          },
+          {
+            "kode": "NU",
+            "term": "NIUE"
+          },
+          {
+            "kode": "NZ",
+            "term": "NEW ZEALAND"
+          },
+          {
+            "kode": "OM",
+            "term": "OMAN"
+          },
+          {
+            "kode": "PA",
+            "term": "PANAMA"
+          },
+          {
+            "kode": "PE",
+            "term": "PERU"
+          },
+          {
+            "kode": "PF",
+            "term": "FRANSK POLYNESIA"
+          },
+          {
+            "kode": "PG",
+            "term": "PAPUA NY-GUINEA"
+          },
+          {
+            "kode": "PH",
+            "term": "FILIPPINENE"
+          },
+          {
+            "kode": "PK",
+            "term": "PAKISTAN"
+          },
+          {
+            "kode": "PL",
+            "term": "POLEN"
+          },
+          {
+            "kode": "PM",
+            "term": "SAINT-PIERRE OG MIQUELON"
+          },
+          {
+            "kode": "PN",
+            "term": "PITCAIRN"
+          },
+          {
+            "kode": "PR",
+            "term": "PUERTO RICO"
+          },
+          {
+            "kode": "PS",
+            "term": "PALESTINA"
+          },
+          {
+            "kode": "PT",
+            "term": "PORTUGAL"
+          },
+          {
+            "kode": "PW",
+            "term": "PALAU"
+          },
+          {
+            "kode": "PY",
+            "term": "PARAGUAY"
+          },
+          {
+            "kode": "QA",
+            "term": "QATAR"
+          },
+          {
+            "kode": "RE",
+            "term": "REUNION"
+          },
+          {
+            "kode": "RO",
+            "term": "ROMANIA"
+          },
+          {
+            "kode": "RS",
+            "term": "SERBIA"
+          },
+          {
+            "kode": "RU",
+            "term": "RUSSLAND"
+          },
+          {
+            "kode": "RW",
+            "term": "RWANDA"
+          },
+          {
+            "kode": "SA",
+            "term": "SAUDI-ARABIA"
+          },
+          {
+            "kode": "SB",
+            "term": "SALOMONØYENE"
+          },
+          {
+            "kode": "SC",
+            "term": "SEYCHELLENE"
+          },
+          {
+            "kode": "SD",
+            "term": "SUDAN"
+          },
+          {
+            "kode": "SE",
+            "term": "SVERIGE"
+          },
+          {
+            "kode": "SG",
+            "term": "SINGAPORE"
+          },
+          {
+            "kode": "SH",
+            "term": "SANKT HELENA, ASCENSION OG TRISTAN DA CUNHA"
+          },
+          {
+            "kode": "SI",
+            "term": "SLOVENIA"
+          },
+          {
+            "kode": "SJ",
+            "term": "SVALBARD OG JAN MAYEN"
+          },
+          {
+            "kode": "SK",
+            "term": "SLOVAKIA"
+          },
+          {
+            "kode": "SL",
+            "term": "SIERRA LEONE"
+          },
+          {
+            "kode": "SM",
+            "term": "SAN MARINO"
+          },
+          {
+            "kode": "SN",
+            "term": "SENEGAL"
+          },
+          {
+            "kode": "SO",
+            "term": "SOMALIA"
+          },
+          {
+            "kode": "SR",
+            "term": "SURINAM"
+          },
+          {
+            "kode": "SS",
+            "term": "SØR-SUDAN"
+          },
+          {
+            "kode": "ST",
+            "term": "SAO TOME OG PRINCIPE"
+          },
+          {
+            "kode": "SV",
+            "term": "EL SALVADOR"
+          },
+          {
+            "kode": "SX",
+            "term": "SINT MAARTEN"
+          },
+          {
+            "kode": "SY",
+            "term": "SYRIA"
+          },
+          {
+            "kode": "SZ",
+            "term": "ESWATINI"
+          },
+          {
+            "kode": "TC",
+            "term": "TURKS- OG CAICOSØYENE"
+          },
+          {
+            "kode": "TD",
+            "term": "TSJAD"
+          },
+          {
+            "kode": "TG",
+            "term": "TOGO"
+          },
+          {
+            "kode": "TH",
+            "term": "THAILAND"
+          },
+          {
+            "kode": "TJ",
+            "term": "TADSJIKISTAN"
+          },
+          {
+            "kode": "TK",
+            "term": "TOKELAU"
+          },
+          {
+            "kode": "TL",
+            "term": "ØST-TIMOR"
+          },
+          {
+            "kode": "TM",
+            "term": "TURKMENISTAN"
+          },
+          {
+            "kode": "TN",
+            "term": "TUNISIA"
+          },
+          {
+            "kode": "TO",
+            "term": "TONGA"
+          },
+          {
+            "kode": "TR",
+            "term": "TYRKIA"
+          },
+          {
+            "kode": "TT",
+            "term": "TRINIDAD OG TOBAGO"
+          },
+          {
+            "kode": "TV",
+            "term": "TUVALU"
+          },
+          {
+            "kode": "TW",
+            "term": "TAIWAN"
+          },
+          {
+            "kode": "TZ",
+            "term": "TANZANIA"
+          },
+          {
+            "kode": "UA",
+            "term": "UKRAINA"
+          },
+          {
+            "kode": "UG",
+            "term": "UGANDA"
+          },
+          {
+            "kode": "UM",
+            "term": "USAS YTRE SMÅØYER"
+          },
+          {
+            "kode": "US",
+            "term": "USA"
+          },
+          {
+            "kode": "UY",
+            "term": "URUGUAY"
+          },
+          {
+            "kode": "UZ",
+            "term": "USBEKISTAN"
+          },
+          {
+            "kode": "VA",
+            "term": "VATIKANSTATEN"
+          },
+          {
+            "kode": "VC",
+            "term": "SAINT VINCENT OG GRENADINENE"
+          },
+          {
+            "kode": "VE",
+            "term": "VENEZUELA"
+          },
+          {
+            "kode": "VG",
+            "term": "DE BRITISKE JOMFRUØYER"
+          },
+          {
+            "kode": "VI",
+            "term": "DE AMERIKANSKE JOMFRUØYER"
+          },
+          {
+            "kode": "VN",
+            "term": "VIETNAM"
+          },
+          {
+            "kode": "VU",
+            "term": "VANUATU"
+          },
+          {
+            "kode": "WF",
+            "term": "WALLIS OG FUTUNA"
+          },
+          {
+            "kode": "WS",
+            "term": "SAMOA"
+          },
+          {
+            "kode": "XB",
+            "term": "Kanariøyene"
+          },
+          {
+            "kode": "XK",
+            "term": "KOSOVO"
+          },
+          {
+            "kode": "YE",
+            "term": "JEMEN"
+          },
+          {
+            "kode": "YT",
+            "term": "MAYOTTE"
+          },
+          {
+            "kode": "ZA",
+            "term": "SØR-AFRIKA"
+          },
+          {
+            "kode": "ZM",
+            "term": "ZAMBIA"
+          },
+          {
+            "kode": "ZW",
+            "term": "ZIMBABWE"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/lovvalgsperioder/10",
+        "pathname": "/api/lovvalgsperioder/10",
+        "normalizedPath": "/api/lovvalgsperioder/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/mottatteopplysninger/10",
+        "pathname": "/api/mottatteopplysninger/10",
+        "normalizedPath": "/api/mottatteopplysninger/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "arbeidPaaLand": {
+              "erFastArbeidssted": null,
+              "erHjemmekontor": null,
+              "fysiskeArbeidssteder": []
+            },
+            "bosted": {
+              "antallMaanederINorge": 0,
+              "intensjonOmRetur": null,
+              "oppgittAdresse": {
+                "tilleggsnavn": null,
+                "gatenavn": null,
+                "husnummerEtasjeLeilighet": null,
+                "postboks": null,
+                "postnummer": null,
+                "poststed": null,
+                "region": null,
+                "landkode": null
+              }
+            },
+            "foretakUtland": [],
+            "juridiskArbeidsgiverNorge": {
+              "andelKontrakterINorge": null,
+              "andelOmsetningINorge": null,
+              "andelOppdragINorge": null,
+              "andelRekruttertINorge": null,
+              "antallAdmAnsatte": null,
+              "antallAnsatte": null,
+              "antallUtsendte": null,
+              "ekstraArbeidsgivere": [],
+              "erOffentligVirksomhet": null
+            },
+            "luftfartBaser": [],
+            "maritimtArbeid": [],
+            "oppholdUtland": {
+              "ektefelleEllerBarnINorge": null,
+              "oppholdsPeriode": {
+                "fom": null,
+                "tom": null
+              },
+              "oppholdslandkoder": [],
+              "studentFinansieringKode": null,
+              "studentSemester": null
+            },
+            "periode": {
+              "fom": null,
+              "tom": null
+            },
+            "personOpplysninger": {
+              "foedestedOgLand": null,
+              "medfolgendeFamilie": [],
+              "utenlandskIdent": []
+            },
+            "representantIUtlandet": null,
+            "selvstendigArbeid": {
+              "erSelvstendig": null,
+              "selvstendigForetak": []
+            },
+            "soeknadsland": {
+              "landkoder": [],
+              "flereLandUkjentHvilke": false
+            },
+            "trygdedekning": null
+          },
+          "mottaksdato": "2025-01-01",
+          "type": "SØKNAD_YRKESAKTIVE_NORGE_ELLER_UTENFOR_EØS"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/organisasjoner/123456785",
+        "pathname": "/api/organisasjoner/123456785",
+        "normalizedPath": "/api/organisasjoner/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 404,
+        "statusText": "Not Found",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "status": 404,
+          "error": "Not Found",
+          "message": "Henting av organisasjon fra ereg feilet 404 NOT_FOUND - {\"melding\": \"Ingen organisasjon med organisasjonsnummer 123456785 ble funnet\"}",
+          "correlationId": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/MEL-1010/behandlingstyper/kombinasjoner-for-endring/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&sakstema=MEDLEMSKAP_LOVVALG&behandlingstema=YRKESAKTIV",
+        "pathname": "/api/saksbehandling/MEL-1010/behandlingstyper/kombinasjoner-for-endring/",
+        "normalizedPath": "/api/saksbehandling/:saksnummer/behandlingstyper/kombinasjoner-for-endring/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "sakstema": "MEDLEMSKAP_LOVVALG",
+          "behandlingstema": "YRKESAKTIV"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "FØRSTEGANG",
+            "term": "Førstegangsbehandling"
+          },
+          {
+            "kode": "HENVENDELSE",
+            "term": "Henvendelse"
+          },
+          {
+            "kode": "KLAGE",
+            "term": "Klage"
+          },
+          {
+            "kode": "NY_VURDERING",
+            "term": "Ny vurdering"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&sakstema=MEDLEMSKAP_LOVVALG&aktivBehandlingID=10",
+        "pathname": "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "sakstema": "MEDLEMSKAP_LOVVALG",
+          "aktivBehandlingID": "10"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "FORESPØRSEL_TRYGDEMYNDIGHET",
+            "term": "Forespørsel fra trygdemyndighet"
+          },
+          {
+            "kode": "IKKE_YRKESAKTIV",
+            "term": "Ikke yrkesaktiv"
+          },
+          {
+            "kode": "PENSJONIST",
+            "term": "Pensjonist/uføretrygdet"
+          },
+          {
+            "kode": "YRKESAKTIV",
+            "term": "Yrkesaktiv"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&saksnummer=MEL-1010",
+        "pathname": "/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "saksnummer": "MEL-1010"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "MEDLEMSKAP_LOVVALG",
+            "term": "Medlemskap og lovvalg"
+          },
+          {
+            "kode": "TRYGDEAVGIFT",
+            "term": "Trygdeavgift"
+          },
+          {
+            "kode": "UNNTAK",
+            "term": "Unntak"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/?saksnummer=MEL-1010",
+        "pathname": "/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/",
+        "query": {
+          "saksnummer": "MEL-1010"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "EU_EOS",
+            "term": "EU/EØS-land"
+          },
+          {
+            "kode": "FTRL",
+            "term": "Utenfor avtaleland"
+          },
+          {
+            "kode": "TRYGDEAVTALE",
+            "term": "Avtaleland"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 10
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/nar-org-nr-er-korrekt-og-organisasjon-funnet-blir-velg-brevmal-synlig.json
+++ b/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/nar-org-nr-er-korrekt-og-organisasjon-funnet-blir-velg-brevmal-synlig.json
@@ -1,0 +1,2558 @@
+{
+  "version": "1.0",
+  "recordedAt": "2025-01-01T00:00:00.000Z",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts",
+  "testName": "Når org.nr er korrekt og organisasjon funnet, blir «Velg brevmal» synlig",
+  "exchanges": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/11/aarsak/mottaksdato",
+        "pathname": "/api/behandlinger/11/aarsak/mottaksdato",
+        "normalizedPath": "/api/behandlinger/:behandlingId/aarsak/mottaksdato",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "mottaksdato": "2025-01-01"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/11/resultat",
+        "pathname": "/api/behandlinger/11/resultat",
+        "normalizedPath": "/api/behandlinger/:behandlingId/resultat",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "aarsavregningID": null,
+          "begrunnelseFritekst": null,
+          "begrunnelseKoder": [],
+          "behandlingsresultatTypeKode": "IKKE_FASTSATT",
+          "fakturaserieReferanse": null,
+          "innledningFritekst": null,
+          "kontrollresultatBegrunnelseKoder": [],
+          "nyVurderingBakgrunn": null,
+          "trygdeavgiftFritekst": null,
+          "utfallRegistreringUnntak": null,
+          "utfallUtpeking": null,
+          "vedtakstype": null
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/11",
+        "pathname": "/api/behandlinger/11",
+        "normalizedPath": "/api/behandlinger/:behandlingId",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "behandlingID": 11,
+          "oppsummering": {
+            "behandlingsfrist": "2025-01-01",
+            "behandlingsresultattype": {
+              "kode": "IKKE_FASTSATT",
+              "term": "Ikke fastsatt"
+            },
+            "behandlingsstatus": {
+              "kode": "UNDER_BEHANDLING",
+              "term": "Behandlingen pågår"
+            },
+            "behandlingstema": {
+              "kode": "YRKESAKTIV",
+              "term": "Yrkesaktiv"
+            },
+            "behandlingstype": {
+              "kode": "FØRSTEGANG",
+              "term": "Førstegangsbehandling"
+            },
+            "endretAvNavn": "Lokal Testbruker",
+            "endretDato": "2025-01-01T00:00:00.000Z",
+            "registrertDato": "2025-01-01T00:00:00.000Z",
+            "sisteOpplysningerHentetDato": null,
+            "svarFrist": null
+          },
+          "saksopplysninger": {
+            "arbeidsforhold": [],
+            "organisasjoner": [],
+            "medlemskap": {
+              "medlemsperiode": []
+            },
+            "inntekt": {
+              "arbeidsInntektMaanedListe": [],
+              "frilansInntektMaanedListe": []
+            },
+            "sed": {
+              "bucType": null,
+              "erEndring": false,
+              "fnr": null,
+              "lovvalgsbestemmelse": null,
+              "lovvalgslandKode": null,
+              "lovvalgsperiode": null,
+              "rinaDokumentID": null,
+              "rinaSaksnummer": null,
+              "sedType": null
+            }
+          },
+          "redigerbart": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/brev/utkast/11",
+        "pathname": "/api/brev/utkast/11",
+        "normalizedPath": "/api/brev/utkast/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/brev/utkast/11",
+        "pathname": "/api/brev/utkast/11",
+        "normalizedPath": "/api/brev/utkast/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/dokumenter/v2/standardvedlegg",
+        "pathname": "/api/dokumenter/v2/standardvedlegg",
+        "normalizedPath": "/api/dokumenter/v2/standardvedlegg",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "type": "VIKTIG_INFORMASJON_RETTIGHETER_PLIKTER_AVSLAG",
+            "frontendTittel": "Avslag: Viktig informasjon om rettigheter",
+            "dokumentTittel": "Viktig informasjon om rettigheter"
+          },
+          {
+            "type": "VIKTIG_INFORMASJON_RETTIGHETER_PLIKTER_INNVILGELSE",
+            "frontendTittel": "Innvilgelse: Viktig informasjon om rettigheter og plikter",
+            "dokumentTittel": "Viktig informasjon om rettigheter og plikter"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/dokumenter/v2/tilgjengelige-maler/11",
+        "pathname": "/api/dokumenter/v2/tilgjengelige-maler/11",
+        "normalizedPath": "/api/dokumenter/v2/tilgjengelige-maler/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "mottaker": {
+              "adresser": [
+                {
+                  "mottakerNavn": "TRIVIELL KARAFFEL",
+                  "orgnr": null,
+                  "adresselinjer": ["CO 2", "kontakt gata 1 42"],
+                  "postnr": "0001",
+                  "poststed": null,
+                  "region": null,
+                  "land": "SE",
+                  "ugyldig": false
+                }
+              ],
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "BRUKER",
+              "type": "Bruker eller brukers fullmektig"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_BRUKER",
+                  "term": "Melding om manglende opplysninger til bruker"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_BRUKER",
+                  "term": "Fritekstbrev til bruker"
+                }
+              },
+              {
+                "felter": null,
+                "type": {
+                  "kode": "MELDING_FORVENTET_SAKSBEHANDLINGSTID_SOKNAD",
+                  "term": "Melding om forventet saksbehandlingstid"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": {
+                "tittel": "Du må velge land på inngangssteget for å kunne sende brev til utenlandsk trygdemyndighet.",
+                "underpunkter": []
+              },
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "UTENLANDSK_TRYGDEMYNDIGHET",
+              "type": "Utenlandsk trygdemyndighet"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "UTENLANDSK_TRYGDEMYNDIGHET_FRITEKSTBREV",
+                  "term": "Fritekstbrev"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": {
+                "tittel": "Finner ikke gyldig adresse til arbeidsgiver(e). Kontroller at arbeidsgiver(e) er lagt inn korrekt i sidemenyen",
+                "underpunkter": []
+              },
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "ARBEIDSGIVER",
+              "type": "Arbeidsgiver eller arbeidsgivers fullmektig"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_ARBEIDSGIVER",
+                  "term": "Melding om manglende opplysninger til virksomhet"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_ARBEIDSGIVER",
+                  "term": "Fritekstbrev til virksomhet"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "ANNEN_ORGANISASJON",
+              "type": "Annen organisasjon"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_ARBEIDSGIVER",
+                  "term": "Melding om manglende opplysninger til virksomhet"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_ARBEIDSGIVER",
+                  "term": "Fritekstbrev til virksomhet"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "NORSK_MYNDIGHET",
+              "type": "Norske myndigheter"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Orientering om vår beslutning",
+                          "kode": "ORIENTERING_BESLUTNING",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "FRITEKSTBREV",
+                  "term": "Fritekstbrev"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1011/aktoerer/?rolleKode=FULLMEKTIG",
+        "pathname": "/api/fagsaker/MEL-1011/aktoerer/",
+        "normalizedPath": "/api/fagsaker/:saksnummer/aktoerer/",
+        "query": {
+          "rolleKode": "FULLMEKTIG"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1011/dokumenter",
+        "pathname": "/api/fagsaker/MEL-1011/dokumenter",
+        "normalizedPath": "/api/fagsaker/:saksnummer/dokumenter",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1011/trygdeavgift/oppsummering",
+        "pathname": "/api/fagsaker/MEL-1011/trygdeavgift/oppsummering",
+        "normalizedPath": "/api/fagsaker/:saksnummer/trygdeavgift/oppsummering",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "harBehandlingMedTrygdeavgift": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1011/trygdeavgift/oppsummering",
+        "pathname": "/api/fagsaker/MEL-1011/trygdeavgift/oppsummering",
+        "normalizedPath": "/api/fagsaker/:saksnummer/trygdeavgift/oppsummering",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "harBehandlingMedTrygdeavgift": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1011",
+        "pathname": "/api/fagsaker/MEL-1011",
+        "normalizedPath": "/api/fagsaker/:saksnummer",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "betalingsvalg": null,
+          "endretDato": "2025-01-01T00:00:00.000Z",
+          "gsakSaksnummer": null,
+          "hovedpartRolle": "BRUKER",
+          "registrertDato": "2025-01-01T00:00:00.000Z",
+          "saksnummer": "MEL-1011",
+          "saksstatus": {
+            "kode": "OPPRETTET",
+            "term": "Saken er opprettet"
+          },
+          "sakstema": {
+            "kode": "MEDLEMSKAP_LOVVALG",
+            "term": "Medlemskap og lovvalg"
+          },
+          "sakstype": {
+            "kode": "TRYGDEAVTALE",
+            "term": "Avtaleland"
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.arsavregning.eos_pensjonist&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
+        "pathname": "/api/featuretoggle",
+        "normalizedPath": "/api/featuretoggle",
+        "query": {
+          "features": "melosys.cdm-4-4"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "melosys.faktureringskomponent.vis_referanse": true,
+          "melosys.pensjonist": true,
+          "melosys.pensjonist_eos": true,
+          "standardvedlegg_eget_vedlegg_avtaleland": true,
+          "melosys.ftrl.begrense_periode_vedtak": true,
+          "melosys.arsavregning": true,
+          "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
+          "melosys.11_3_a_Norge_er_utpekt": true,
+          "melosys.eos_fakturering_av_trygdeavgift": true,
+          "melosys.arsavregning.eos_pensjonist": true,
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "pathname": "/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "normalizedPath": "/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "???",
+            "term": "UOPPGITT/UKJENT"
+          },
+          {
+            "kode": "AD",
+            "term": "ANDORRA"
+          },
+          {
+            "kode": "AE",
+            "term": "DE FORENTE ARABISKE EMIRATER"
+          },
+          {
+            "kode": "AF",
+            "term": "AFGHANISTAN"
+          },
+          {
+            "kode": "AG",
+            "term": "ANTIGUA OG BARBUDA"
+          },
+          {
+            "kode": "AI",
+            "term": "ANGUILLA"
+          },
+          {
+            "kode": "AL",
+            "term": "ALBANIA"
+          },
+          {
+            "kode": "AM",
+            "term": "ARMENIA"
+          },
+          {
+            "kode": "AO",
+            "term": "ANGOLA"
+          },
+          {
+            "kode": "AQ",
+            "term": "Antarktis"
+          },
+          {
+            "kode": "AR",
+            "term": "ARGENTINA"
+          },
+          {
+            "kode": "AS",
+            "term": "AM. SAMOA"
+          },
+          {
+            "kode": "AT",
+            "term": "ØSTERRIKE"
+          },
+          {
+            "kode": "AU",
+            "term": "AUSTRALIA"
+          },
+          {
+            "kode": "AW",
+            "term": "ARUBA"
+          },
+          {
+            "kode": "AX",
+            "term": "ÅLAND"
+          },
+          {
+            "kode": "AZ",
+            "term": "ASERBAJDSJAN"
+          },
+          {
+            "kode": "BA",
+            "term": "BOSNIA-HERCEGOVINA"
+          },
+          {
+            "kode": "BB",
+            "term": "BARBADOS"
+          },
+          {
+            "kode": "BD",
+            "term": "BANGLADESH"
+          },
+          {
+            "kode": "BE",
+            "term": "BELGIA"
+          },
+          {
+            "kode": "BF",
+            "term": "BURKINA FASO"
+          },
+          {
+            "kode": "BG",
+            "term": "BULGARIA"
+          },
+          {
+            "kode": "BH",
+            "term": "BAHRAIN"
+          },
+          {
+            "kode": "BI",
+            "term": "BURUNDI"
+          },
+          {
+            "kode": "BJ",
+            "term": "BENIN"
+          },
+          {
+            "kode": "BL",
+            "term": "SAINT BARTHELEMY"
+          },
+          {
+            "kode": "BM",
+            "term": "BERMUDA"
+          },
+          {
+            "kode": "BN",
+            "term": "BRUNEI"
+          },
+          {
+            "kode": "BO",
+            "term": "BOLIVIA"
+          },
+          {
+            "kode": "BQ",
+            "term": "BONAIRE, SINT EUSTATIUS OG SABA"
+          },
+          {
+            "kode": "BR",
+            "term": "BRASIL"
+          },
+          {
+            "kode": "BS",
+            "term": "BAHAMAS"
+          },
+          {
+            "kode": "BT",
+            "term": "BHUTAN"
+          },
+          {
+            "kode": "BV",
+            "term": "BOUVETØYA"
+          },
+          {
+            "kode": "BW",
+            "term": "BOTSWANA"
+          },
+          {
+            "kode": "BY",
+            "term": "BELARUS"
+          },
+          {
+            "kode": "BZ",
+            "term": "BELIZE"
+          },
+          {
+            "kode": "CA",
+            "term": "CANADA"
+          },
+          {
+            "kode": "CC",
+            "term": "KOKOSØYENE (KEELINGØYENE)"
+          },
+          {
+            "kode": "CD",
+            "term": "KONGO"
+          },
+          {
+            "kode": "CF",
+            "term": "DEN SENTRALAFRIKANSKE REPUBLIKK"
+          },
+          {
+            "kode": "CG",
+            "term": "KONGO-BRAZZAVILLE"
+          },
+          {
+            "kode": "CH",
+            "term": "SVEITS"
+          },
+          {
+            "kode": "CI",
+            "term": "ELFENBENSKYSTEN"
+          },
+          {
+            "kode": "CK",
+            "term": "COOKØYENE"
+          },
+          {
+            "kode": "CL",
+            "term": "CHILE"
+          },
+          {
+            "kode": "CM",
+            "term": "KAMERUN"
+          },
+          {
+            "kode": "CN",
+            "term": "KINA"
+          },
+          {
+            "kode": "CO",
+            "term": "COLOMBIA"
+          },
+          {
+            "kode": "CR",
+            "term": "COSTA RICA"
+          },
+          {
+            "kode": "CS",
+            "term": "SERBIA OG MONTENEGRO"
+          },
+          {
+            "kode": "CU",
+            "term": "CUBA"
+          },
+          {
+            "kode": "CV",
+            "term": "KAPP VERDE"
+          },
+          {
+            "kode": "CW",
+            "term": "CURACAO"
+          },
+          {
+            "kode": "CX",
+            "term": "CHRISTMASØYA"
+          },
+          {
+            "kode": "CY",
+            "term": "KYPROS"
+          },
+          {
+            "kode": "CZ",
+            "term": "TSJEKKIA"
+          },
+          {
+            "kode": "DE",
+            "term": "TYSKLAND"
+          },
+          {
+            "kode": "DJ",
+            "term": "DJIBOUTI"
+          },
+          {
+            "kode": "DK",
+            "term": "DANMARK"
+          },
+          {
+            "kode": "DM",
+            "term": "DOMINICA"
+          },
+          {
+            "kode": "DO",
+            "term": "DEN DOMINIKANSKE REPUBLIKK"
+          },
+          {
+            "kode": "DZ",
+            "term": "ALGERIE"
+          },
+          {
+            "kode": "EC",
+            "term": "ECUADOR"
+          },
+          {
+            "kode": "EE",
+            "term": "ESTLAND"
+          },
+          {
+            "kode": "EG",
+            "term": "EGYPT"
+          },
+          {
+            "kode": "EH",
+            "term": "VEST-SAHARA"
+          },
+          {
+            "kode": "ER",
+            "term": "ERITREA"
+          },
+          {
+            "kode": "ES",
+            "term": "SPANIA"
+          },
+          {
+            "kode": "ET",
+            "term": "ETIOPIA"
+          },
+          {
+            "kode": "FI",
+            "term": "FINLAND"
+          },
+          {
+            "kode": "FJ",
+            "term": "FIJI"
+          },
+          {
+            "kode": "FK",
+            "term": "FALKLANDSØYENE"
+          },
+          {
+            "kode": "FM",
+            "term": "MIKRONESIAFØDERASJONEN"
+          },
+          {
+            "kode": "FO",
+            "term": "FÆRØYENE"
+          },
+          {
+            "kode": "FR",
+            "term": "FRANKRIKE"
+          },
+          {
+            "kode": "GA",
+            "term": "GABON"
+          },
+          {
+            "kode": "GB",
+            "term": "STORBRITANNIA"
+          },
+          {
+            "kode": "GD",
+            "term": "GRENADA"
+          },
+          {
+            "kode": "GE",
+            "term": "GEORGIA"
+          },
+          {
+            "kode": "GF",
+            "term": "FRANSK GUYANA"
+          },
+          {
+            "kode": "GG",
+            "term": "GUERNSEY"
+          },
+          {
+            "kode": "GH",
+            "term": "GHANA"
+          },
+          {
+            "kode": "GI",
+            "term": "GIBRALTAR"
+          },
+          {
+            "kode": "GL",
+            "term": "GRØNLAND"
+          },
+          {
+            "kode": "GM",
+            "term": "GAMBIA"
+          },
+          {
+            "kode": "GN",
+            "term": "GUINEA"
+          },
+          {
+            "kode": "GP",
+            "term": "GUADELOUPE"
+          },
+          {
+            "kode": "GQ",
+            "term": "EKVATORIAL-GUINEA"
+          },
+          {
+            "kode": "GR",
+            "term": "HELLAS"
+          },
+          {
+            "kode": "GS",
+            "term": "SØR-GEORGIA OG SØR-SANDWICHØYENE"
+          },
+          {
+            "kode": "GT",
+            "term": "GUATEMALA"
+          },
+          {
+            "kode": "GU",
+            "term": "GUAM"
+          },
+          {
+            "kode": "GW",
+            "term": "GUINEA-BISSAU"
+          },
+          {
+            "kode": "GY",
+            "term": "GUYANA"
+          },
+          {
+            "kode": "HK",
+            "term": "HONGKONG"
+          },
+          {
+            "kode": "HM",
+            "term": "HEARD- OG MCDONALD-ØYENE"
+          },
+          {
+            "kode": "HN",
+            "term": "HONDURAS"
+          },
+          {
+            "kode": "HR",
+            "term": "KROATIA"
+          },
+          {
+            "kode": "HT",
+            "term": "HAITI"
+          },
+          {
+            "kode": "HU",
+            "term": "UNGARN"
+          },
+          {
+            "kode": "ID",
+            "term": "INDONESIA"
+          },
+          {
+            "kode": "IE",
+            "term": "IRLAND"
+          },
+          {
+            "kode": "IL",
+            "term": "ISRAEL"
+          },
+          {
+            "kode": "IM",
+            "term": "ISLE OF MAN"
+          },
+          {
+            "kode": "IN",
+            "term": "INDIA"
+          },
+          {
+            "kode": "IO",
+            "term": "DET BRITISKE TERRITORIET I INDIAHAVET"
+          },
+          {
+            "kode": "IQ",
+            "term": "IRAK"
+          },
+          {
+            "kode": "IR",
+            "term": "IRAN"
+          },
+          {
+            "kode": "IS",
+            "term": "ISLAND"
+          },
+          {
+            "kode": "IT",
+            "term": "ITALIA"
+          },
+          {
+            "kode": "JE",
+            "term": "JERSEY"
+          },
+          {
+            "kode": "JM",
+            "term": "JAMAICA"
+          },
+          {
+            "kode": "JO",
+            "term": "JORDAN"
+          },
+          {
+            "kode": "JP",
+            "term": "JAPAN"
+          },
+          {
+            "kode": "KE",
+            "term": "KENYA"
+          },
+          {
+            "kode": "KG",
+            "term": "KIRGISISTAN"
+          },
+          {
+            "kode": "KH",
+            "term": "KAMBODSJA"
+          },
+          {
+            "kode": "KI",
+            "term": "KIRIBATI"
+          },
+          {
+            "kode": "KM",
+            "term": "KOMORENE"
+          },
+          {
+            "kode": "KN",
+            "term": "SAINT KITTS OG NEVIS"
+          },
+          {
+            "kode": "KP",
+            "term": "NORD-KOREA"
+          },
+          {
+            "kode": "KR",
+            "term": "SØR-KOREA"
+          },
+          {
+            "kode": "KW",
+            "term": "KUWAIT"
+          },
+          {
+            "kode": "KY",
+            "term": "CAYMANØYENE"
+          },
+          {
+            "kode": "KZ",
+            "term": "KASAKHSTAN"
+          },
+          {
+            "kode": "LA",
+            "term": "LAOS"
+          },
+          {
+            "kode": "LB",
+            "term": "LIBANON"
+          },
+          {
+            "kode": "LC",
+            "term": "SAINT LUCIA"
+          },
+          {
+            "kode": "LI",
+            "term": "LIECHTENSTEIN"
+          },
+          {
+            "kode": "LK",
+            "term": "SRI LANKA"
+          },
+          {
+            "kode": "LR",
+            "term": "LIBERIA"
+          },
+          {
+            "kode": "LS",
+            "term": "LESOTHO"
+          },
+          {
+            "kode": "LT",
+            "term": "LITAUEN"
+          },
+          {
+            "kode": "LU",
+            "term": "LUXEMBOURG"
+          },
+          {
+            "kode": "LV",
+            "term": "LATVIA"
+          },
+          {
+            "kode": "LY",
+            "term": "LIBYA"
+          },
+          {
+            "kode": "MA",
+            "term": "MAROKKO"
+          },
+          {
+            "kode": "MC",
+            "term": "MONACO"
+          },
+          {
+            "kode": "MD",
+            "term": "MOLDOVA"
+          },
+          {
+            "kode": "ME",
+            "term": "MONTENEGRO"
+          },
+          {
+            "kode": "MF",
+            "term": "SAINT MARTIN"
+          },
+          {
+            "kode": "MG",
+            "term": "MADAGASKAR"
+          },
+          {
+            "kode": "MH",
+            "term": "MARSHALLØYENE"
+          },
+          {
+            "kode": "MK",
+            "term": "NORD-MAKEDONIA"
+          },
+          {
+            "kode": "ML",
+            "term": "MALI"
+          },
+          {
+            "kode": "MM",
+            "term": "MYANMAR (BURMA)"
+          },
+          {
+            "kode": "MN",
+            "term": "MONGOLIA"
+          },
+          {
+            "kode": "MO",
+            "term": "MACAO"
+          },
+          {
+            "kode": "MP",
+            "term": "NORD-MARIANENE"
+          },
+          {
+            "kode": "MQ",
+            "term": "MARTINIQUE"
+          },
+          {
+            "kode": "MR",
+            "term": "MAURITANIA"
+          },
+          {
+            "kode": "MS",
+            "term": "MONTSERRAT"
+          },
+          {
+            "kode": "MT",
+            "term": "MALTA"
+          },
+          {
+            "kode": "MU",
+            "term": "MAURITIUS"
+          },
+          {
+            "kode": "MV",
+            "term": "MALDIVENE"
+          },
+          {
+            "kode": "MW",
+            "term": "MALAWI"
+          },
+          {
+            "kode": "MX",
+            "term": "MEXICO"
+          },
+          {
+            "kode": "MY",
+            "term": "MALAYSIA"
+          },
+          {
+            "kode": "MZ",
+            "term": "MOSAMBIK"
+          },
+          {
+            "kode": "NA",
+            "term": "NAMIBIA"
+          },
+          {
+            "kode": "NC",
+            "term": "NY-CALEDONIA"
+          },
+          {
+            "kode": "NE",
+            "term": "NIGER"
+          },
+          {
+            "kode": "NF",
+            "term": "NORFOLKØYA"
+          },
+          {
+            "kode": "NG",
+            "term": "NIGERIA"
+          },
+          {
+            "kode": "NI",
+            "term": "NICARAGUA"
+          },
+          {
+            "kode": "NL",
+            "term": "NEDERLAND"
+          },
+          {
+            "kode": "NO",
+            "term": "NORGE"
+          },
+          {
+            "kode": "NP",
+            "term": "NEPAL"
+          },
+          {
+            "kode": "NR",
+            "term": "NAURU"
+          },
+          {
+            "kode": "NU",
+            "term": "NIUE"
+          },
+          {
+            "kode": "NZ",
+            "term": "NEW ZEALAND"
+          },
+          {
+            "kode": "OM",
+            "term": "OMAN"
+          },
+          {
+            "kode": "PA",
+            "term": "PANAMA"
+          },
+          {
+            "kode": "PE",
+            "term": "PERU"
+          },
+          {
+            "kode": "PF",
+            "term": "FRANSK POLYNESIA"
+          },
+          {
+            "kode": "PG",
+            "term": "PAPUA NY-GUINEA"
+          },
+          {
+            "kode": "PH",
+            "term": "FILIPPINENE"
+          },
+          {
+            "kode": "PK",
+            "term": "PAKISTAN"
+          },
+          {
+            "kode": "PL",
+            "term": "POLEN"
+          },
+          {
+            "kode": "PM",
+            "term": "SAINT-PIERRE OG MIQUELON"
+          },
+          {
+            "kode": "PN",
+            "term": "PITCAIRN"
+          },
+          {
+            "kode": "PR",
+            "term": "PUERTO RICO"
+          },
+          {
+            "kode": "PS",
+            "term": "PALESTINA"
+          },
+          {
+            "kode": "PT",
+            "term": "PORTUGAL"
+          },
+          {
+            "kode": "PW",
+            "term": "PALAU"
+          },
+          {
+            "kode": "PY",
+            "term": "PARAGUAY"
+          },
+          {
+            "kode": "QA",
+            "term": "QATAR"
+          },
+          {
+            "kode": "RE",
+            "term": "REUNION"
+          },
+          {
+            "kode": "RO",
+            "term": "ROMANIA"
+          },
+          {
+            "kode": "RS",
+            "term": "SERBIA"
+          },
+          {
+            "kode": "RU",
+            "term": "RUSSLAND"
+          },
+          {
+            "kode": "RW",
+            "term": "RWANDA"
+          },
+          {
+            "kode": "SA",
+            "term": "SAUDI-ARABIA"
+          },
+          {
+            "kode": "SB",
+            "term": "SALOMONØYENE"
+          },
+          {
+            "kode": "SC",
+            "term": "SEYCHELLENE"
+          },
+          {
+            "kode": "SD",
+            "term": "SUDAN"
+          },
+          {
+            "kode": "SE",
+            "term": "SVERIGE"
+          },
+          {
+            "kode": "SG",
+            "term": "SINGAPORE"
+          },
+          {
+            "kode": "SH",
+            "term": "SANKT HELENA, ASCENSION OG TRISTAN DA CUNHA"
+          },
+          {
+            "kode": "SI",
+            "term": "SLOVENIA"
+          },
+          {
+            "kode": "SJ",
+            "term": "SVALBARD OG JAN MAYEN"
+          },
+          {
+            "kode": "SK",
+            "term": "SLOVAKIA"
+          },
+          {
+            "kode": "SL",
+            "term": "SIERRA LEONE"
+          },
+          {
+            "kode": "SM",
+            "term": "SAN MARINO"
+          },
+          {
+            "kode": "SN",
+            "term": "SENEGAL"
+          },
+          {
+            "kode": "SO",
+            "term": "SOMALIA"
+          },
+          {
+            "kode": "SR",
+            "term": "SURINAM"
+          },
+          {
+            "kode": "SS",
+            "term": "SØR-SUDAN"
+          },
+          {
+            "kode": "ST",
+            "term": "SAO TOME OG PRINCIPE"
+          },
+          {
+            "kode": "SV",
+            "term": "EL SALVADOR"
+          },
+          {
+            "kode": "SX",
+            "term": "SINT MAARTEN"
+          },
+          {
+            "kode": "SY",
+            "term": "SYRIA"
+          },
+          {
+            "kode": "SZ",
+            "term": "ESWATINI"
+          },
+          {
+            "kode": "TC",
+            "term": "TURKS- OG CAICOSØYENE"
+          },
+          {
+            "kode": "TD",
+            "term": "TSJAD"
+          },
+          {
+            "kode": "TG",
+            "term": "TOGO"
+          },
+          {
+            "kode": "TH",
+            "term": "THAILAND"
+          },
+          {
+            "kode": "TJ",
+            "term": "TADSJIKISTAN"
+          },
+          {
+            "kode": "TK",
+            "term": "TOKELAU"
+          },
+          {
+            "kode": "TL",
+            "term": "ØST-TIMOR"
+          },
+          {
+            "kode": "TM",
+            "term": "TURKMENISTAN"
+          },
+          {
+            "kode": "TN",
+            "term": "TUNISIA"
+          },
+          {
+            "kode": "TO",
+            "term": "TONGA"
+          },
+          {
+            "kode": "TR",
+            "term": "TYRKIA"
+          },
+          {
+            "kode": "TT",
+            "term": "TRINIDAD OG TOBAGO"
+          },
+          {
+            "kode": "TV",
+            "term": "TUVALU"
+          },
+          {
+            "kode": "TW",
+            "term": "TAIWAN"
+          },
+          {
+            "kode": "TZ",
+            "term": "TANZANIA"
+          },
+          {
+            "kode": "UA",
+            "term": "UKRAINA"
+          },
+          {
+            "kode": "UG",
+            "term": "UGANDA"
+          },
+          {
+            "kode": "UM",
+            "term": "USAS YTRE SMÅØYER"
+          },
+          {
+            "kode": "US",
+            "term": "USA"
+          },
+          {
+            "kode": "UY",
+            "term": "URUGUAY"
+          },
+          {
+            "kode": "UZ",
+            "term": "USBEKISTAN"
+          },
+          {
+            "kode": "VA",
+            "term": "VATIKANSTATEN"
+          },
+          {
+            "kode": "VC",
+            "term": "SAINT VINCENT OG GRENADINENE"
+          },
+          {
+            "kode": "VE",
+            "term": "VENEZUELA"
+          },
+          {
+            "kode": "VG",
+            "term": "DE BRITISKE JOMFRUØYER"
+          },
+          {
+            "kode": "VI",
+            "term": "DE AMERIKANSKE JOMFRUØYER"
+          },
+          {
+            "kode": "VN",
+            "term": "VIETNAM"
+          },
+          {
+            "kode": "VU",
+            "term": "VANUATU"
+          },
+          {
+            "kode": "WF",
+            "term": "WALLIS OG FUTUNA"
+          },
+          {
+            "kode": "WS",
+            "term": "SAMOA"
+          },
+          {
+            "kode": "XB",
+            "term": "Kanariøyene"
+          },
+          {
+            "kode": "XK",
+            "term": "KOSOVO"
+          },
+          {
+            "kode": "YE",
+            "term": "JEMEN"
+          },
+          {
+            "kode": "YT",
+            "term": "MAYOTTE"
+          },
+          {
+            "kode": "ZA",
+            "term": "SØR-AFRIKA"
+          },
+          {
+            "kode": "ZM",
+            "term": "ZAMBIA"
+          },
+          {
+            "kode": "ZW",
+            "term": "ZIMBABWE"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/lovvalgsperioder/11",
+        "pathname": "/api/lovvalgsperioder/11",
+        "normalizedPath": "/api/lovvalgsperioder/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/mottatteopplysninger/11",
+        "pathname": "/api/mottatteopplysninger/11",
+        "normalizedPath": "/api/mottatteopplysninger/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "arbeidPaaLand": {
+              "erFastArbeidssted": null,
+              "erHjemmekontor": null,
+              "fysiskeArbeidssteder": []
+            },
+            "bosted": {
+              "antallMaanederINorge": 0,
+              "intensjonOmRetur": null,
+              "oppgittAdresse": {
+                "tilleggsnavn": null,
+                "gatenavn": null,
+                "husnummerEtasjeLeilighet": null,
+                "postboks": null,
+                "postnummer": null,
+                "poststed": null,
+                "region": null,
+                "landkode": null
+              }
+            },
+            "foretakUtland": [],
+            "juridiskArbeidsgiverNorge": {
+              "andelKontrakterINorge": null,
+              "andelOmsetningINorge": null,
+              "andelOppdragINorge": null,
+              "andelRekruttertINorge": null,
+              "antallAdmAnsatte": null,
+              "antallAnsatte": null,
+              "antallUtsendte": null,
+              "ekstraArbeidsgivere": [],
+              "erOffentligVirksomhet": null
+            },
+            "luftfartBaser": [],
+            "maritimtArbeid": [],
+            "oppholdUtland": {
+              "ektefelleEllerBarnINorge": null,
+              "oppholdsPeriode": {
+                "fom": null,
+                "tom": null
+              },
+              "oppholdslandkoder": [],
+              "studentFinansieringKode": null,
+              "studentSemester": null
+            },
+            "periode": {
+              "fom": null,
+              "tom": null
+            },
+            "personOpplysninger": {
+              "foedestedOgLand": null,
+              "medfolgendeFamilie": [],
+              "utenlandskIdent": []
+            },
+            "representantIUtlandet": null,
+            "selvstendigArbeid": {
+              "erSelvstendig": null,
+              "selvstendigForetak": []
+            },
+            "soeknadsland": {
+              "landkoder": [],
+              "flereLandUkjentHvilke": false
+            },
+            "trygdedekning": null
+          },
+          "mottaksdato": "2025-01-01",
+          "type": "SØKNAD_YRKESAKTIVE_NORGE_ELLER_UTENFOR_EØS"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/organisasjoner/999999999",
+        "pathname": "/api/organisasjoner/999999999",
+        "normalizedPath": "/api/organisasjoner/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "forretningsadresse": {
+            "gateadresse": {
+              "gatenavn": "Adresselinje1",
+              "gatenummer": null,
+              "husbokstav": null,
+              "husnummer": null
+            },
+            "land": "NORGE",
+            "postnr": "0010",
+            "poststed": "Oslo"
+          },
+          "navn": "Ståles Stål AS",
+          "oppstartdato": null,
+          "organisasjonsform": "Aksjeselskap",
+          "orgnr": "999999999",
+          "postadresse": {
+            "gateadresse": {
+              "gatenavn": "Adresselinje1",
+              "gatenummer": null,
+              "husbokstav": null,
+              "husnummer": null
+            },
+            "land": "NORGE",
+            "postnr": "0010",
+            "poststed": "Oslo"
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/MEL-1011/behandlingstyper/kombinasjoner-for-endring/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&sakstema=MEDLEMSKAP_LOVVALG&behandlingstema=YRKESAKTIV",
+        "pathname": "/api/saksbehandling/MEL-1011/behandlingstyper/kombinasjoner-for-endring/",
+        "normalizedPath": "/api/saksbehandling/:saksnummer/behandlingstyper/kombinasjoner-for-endring/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "sakstema": "MEDLEMSKAP_LOVVALG",
+          "behandlingstema": "YRKESAKTIV"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "FØRSTEGANG",
+            "term": "Førstegangsbehandling"
+          },
+          {
+            "kode": "HENVENDELSE",
+            "term": "Henvendelse"
+          },
+          {
+            "kode": "KLAGE",
+            "term": "Klage"
+          },
+          {
+            "kode": "NY_VURDERING",
+            "term": "Ny vurdering"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&sakstema=MEDLEMSKAP_LOVVALG&aktivBehandlingID=11",
+        "pathname": "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "sakstema": "MEDLEMSKAP_LOVVALG",
+          "aktivBehandlingID": "11"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "FORESPØRSEL_TRYGDEMYNDIGHET",
+            "term": "Forespørsel fra trygdemyndighet"
+          },
+          {
+            "kode": "IKKE_YRKESAKTIV",
+            "term": "Ikke yrkesaktiv"
+          },
+          {
+            "kode": "PENSJONIST",
+            "term": "Pensjonist/uføretrygdet"
+          },
+          {
+            "kode": "YRKESAKTIV",
+            "term": "Yrkesaktiv"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&saksnummer=MEL-1011",
+        "pathname": "/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "saksnummer": "MEL-1011"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "MEDLEMSKAP_LOVVALG",
+            "term": "Medlemskap og lovvalg"
+          },
+          {
+            "kode": "TRYGDEAVGIFT",
+            "term": "Trygdeavgift"
+          },
+          {
+            "kode": "UNNTAK",
+            "term": "Unntak"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/?saksnummer=MEL-1011",
+        "pathname": "/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/",
+        "query": {
+          "saksnummer": "MEL-1011"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "EU_EOS",
+            "term": "EU/EØS-land"
+          },
+          {
+            "kode": "FTRL",
+            "term": "Utenfor avtaleland"
+          },
+          {
+            "kode": "TRYGDEAVTALE",
+            "term": "Avtaleland"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 11
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/ved-valg-av-annen-organisasjon-vises-kontaktperson-valgfritt-og-brevmal-er-skjult.json
+++ b/tests/e2e/recordings/specs/behandle-sak/send-brev-validering/ved-valg-av-annen-organisasjon-vises-kontaktperson-valgfritt-og-brevmal-er-skjult.json
@@ -1,0 +1,2509 @@
+{
+  "version": "1.0",
+  "recordedAt": "2025-01-01T00:00:00.000Z",
+  "testFile": "/Users/ragnarwestad/develop/nav/melosys-web/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts",
+  "testName": "Ved valg av «Annen organisasjon» vises Kontaktperson (valgfritt) og brevmal er skjult",
+  "exchanges": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/8/aarsak/mottaksdato",
+        "pathname": "/api/behandlinger/8/aarsak/mottaksdato",
+        "normalizedPath": "/api/behandlinger/:behandlingId/aarsak/mottaksdato",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "mottaksdato": "2025-01-01"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/8/resultat",
+        "pathname": "/api/behandlinger/8/resultat",
+        "normalizedPath": "/api/behandlinger/:behandlingId/resultat",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "aarsavregningID": null,
+          "begrunnelseFritekst": null,
+          "begrunnelseKoder": [],
+          "behandlingsresultatTypeKode": "IKKE_FASTSATT",
+          "fakturaserieReferanse": null,
+          "innledningFritekst": null,
+          "kontrollresultatBegrunnelseKoder": [],
+          "nyVurderingBakgrunn": null,
+          "trygdeavgiftFritekst": null,
+          "utfallRegistreringUnntak": null,
+          "utfallUtpeking": null,
+          "vedtakstype": null
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/behandlinger/8",
+        "pathname": "/api/behandlinger/8",
+        "normalizedPath": "/api/behandlinger/:behandlingId",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "behandlingID": 8,
+          "oppsummering": {
+            "behandlingsfrist": "2025-01-01",
+            "behandlingsresultattype": {
+              "kode": "IKKE_FASTSATT",
+              "term": "Ikke fastsatt"
+            },
+            "behandlingsstatus": {
+              "kode": "UNDER_BEHANDLING",
+              "term": "Behandlingen pågår"
+            },
+            "behandlingstema": {
+              "kode": "YRKESAKTIV",
+              "term": "Yrkesaktiv"
+            },
+            "behandlingstype": {
+              "kode": "FØRSTEGANG",
+              "term": "Førstegangsbehandling"
+            },
+            "endretAvNavn": "Lokal Testbruker",
+            "endretDato": "2025-01-01T00:00:00.000Z",
+            "registrertDato": "2025-01-01T00:00:00.000Z",
+            "sisteOpplysningerHentetDato": null,
+            "svarFrist": null
+          },
+          "saksopplysninger": {
+            "arbeidsforhold": [],
+            "organisasjoner": [],
+            "medlemskap": {
+              "medlemsperiode": []
+            },
+            "inntekt": {
+              "arbeidsInntektMaanedListe": [],
+              "frilansInntektMaanedListe": []
+            },
+            "sed": {
+              "bucType": null,
+              "erEndring": false,
+              "fnr": null,
+              "lovvalgsbestemmelse": null,
+              "lovvalgslandKode": null,
+              "lovvalgsperiode": null,
+              "rinaDokumentID": null,
+              "rinaSaksnummer": null,
+              "sedType": null
+            }
+          },
+          "redigerbart": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/brev/utkast/8",
+        "pathname": "/api/brev/utkast/8",
+        "normalizedPath": "/api/brev/utkast/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/brev/utkast/8",
+        "pathname": "/api/brev/utkast/8",
+        "normalizedPath": "/api/brev/utkast/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/dokumenter/v2/standardvedlegg",
+        "pathname": "/api/dokumenter/v2/standardvedlegg",
+        "normalizedPath": "/api/dokumenter/v2/standardvedlegg",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "type": "VIKTIG_INFORMASJON_RETTIGHETER_PLIKTER_AVSLAG",
+            "frontendTittel": "Avslag: Viktig informasjon om rettigheter",
+            "dokumentTittel": "Viktig informasjon om rettigheter"
+          },
+          {
+            "type": "VIKTIG_INFORMASJON_RETTIGHETER_PLIKTER_INNVILGELSE",
+            "frontendTittel": "Innvilgelse: Viktig informasjon om rettigheter og plikter",
+            "dokumentTittel": "Viktig informasjon om rettigheter og plikter"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/dokumenter/v2/tilgjengelige-maler/8",
+        "pathname": "/api/dokumenter/v2/tilgjengelige-maler/8",
+        "normalizedPath": "/api/dokumenter/v2/tilgjengelige-maler/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "mottaker": {
+              "adresser": [
+                {
+                  "mottakerNavn": "TRIVIELL KARAFFEL",
+                  "orgnr": null,
+                  "adresselinjer": ["CO 2", "kontakt gata 1 42"],
+                  "postnr": "0001",
+                  "poststed": null,
+                  "region": null,
+                  "land": "SE",
+                  "ugyldig": false
+                }
+              ],
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "BRUKER",
+              "type": "Bruker eller brukers fullmektig"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_BRUKER",
+                  "term": "Melding om manglende opplysninger til bruker"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_BRUKER",
+                  "term": "Fritekstbrev til bruker"
+                }
+              },
+              {
+                "felter": null,
+                "type": {
+                  "kode": "MELDING_FORVENTET_SAKSBEHANDLINGSTID_SOKNAD",
+                  "term": "Melding om forventet saksbehandlingstid"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": {
+                "tittel": "Du må velge land på inngangssteget for å kunne sende brev til utenlandsk trygdemyndighet.",
+                "underpunkter": []
+              },
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "UTENLANDSK_TRYGDEMYNDIGHET",
+              "type": "Utenlandsk trygdemyndighet"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "UTENLANDSK_TRYGDEMYNDIGHET_FRITEKSTBREV",
+                  "term": "Fritekstbrev"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": {
+                "tittel": "Finner ikke gyldig adresse til arbeidsgiver(e). Kontroller at arbeidsgiver(e) er lagt inn korrekt i sidemenyen",
+                "underpunkter": []
+              },
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "ARBEIDSGIVER",
+              "type": "Arbeidsgiver eller arbeidsgivers fullmektig"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_ARBEIDSGIVER",
+                  "term": "Melding om manglende opplysninger til virksomhet"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_ARBEIDSGIVER",
+                  "term": "Fritekstbrev til virksomhet"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "ANNEN_ORGANISASJON",
+              "type": "Annen organisasjon"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Innledningstekst",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "INNLEDNING_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst (erstatter standardtekst)",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Standardtekst søknad/klage",
+                          "kode": "STANDARD",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Hva skal mottakeren sende inn?",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "MANGLER_FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "MANGELBREV_ARBEIDSGIVER",
+                  "term": "Melding om manglende opplysninger til virksomhet"
+                }
+              },
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Request to remain subject to Norwegian legislation",
+                          "kode": "ENGELSK_FRITEKSTBREV",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Fritekst (maks 60 tegn)",
+                          "kode": "FRITEKST_BRUKER_OG_VIRKSOMHET",
+                          "visFelt": true
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til standardtekst med kontaktinformasjon nederst i brevet",
+                    "feltType": "SJEKKBOKS",
+                    "hjelpetekst": null,
+                    "kode": "STANDARDTEKST_KONTAKTINFORMASJON",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "GENERELT_FRITEKSTBREV_ARBEIDSGIVER",
+                  "term": "Fritekstbrev til virksomhet"
+                }
+              }
+            ]
+          },
+          {
+            "mottaker": {
+              "adresser": null,
+              "feilmelding": null,
+              "orgnrSettesAvSaksbehandler": false,
+              "rolle": "NORSK_MYNDIGHET",
+              "type": "Norske myndigheter"
+            },
+            "brevTyper": [
+              {
+                "felter": [
+                  {
+                    "beskrivelse": "Overskrift i brev",
+                    "feltType": "TEKST",
+                    "hjelpetekst": null,
+                    "kode": "BREV_TITTEL",
+                    "paakrevd": true,
+                    "tegnBegrensning": 60,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Fritekst",
+                          "kode": "FRITEKST",
+                          "visFelt": true
+                        },
+                        {
+                          "beskrivelse": "Orientering om vår beslutning",
+                          "kode": "ORIENTERING_BESLUTNING",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "SELECT"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Type brev",
+                    "feltType": null,
+                    "hjelpetekst": "Type brev må angis slik at bruker får riktig varseltekst om brevet som sendes. Gjelder det et vedtak eller en forespørsel, vil bruker få en påminnelse hvis brevet ikke har blitt lest innen 7 dager.",
+                    "kode": "DISTRIBUSJONSTYPE",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": {
+                      "valgAlternativer": [
+                        {
+                          "beskrivelse": "Annet",
+                          "kode": "ANNET",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Vedtak",
+                          "kode": "VEDTAK",
+                          "visFelt": false
+                        },
+                        {
+                          "beskrivelse": "Viktig",
+                          "kode": "VIKTIG",
+                          "visFelt": false
+                        }
+                      ],
+                      "valgType": "RADIO"
+                    }
+                  },
+                  {
+                    "beskrivelse": "Dokumenttittel (valgfri, maks 60 tegn)",
+                    "feltType": "TEKST",
+                    "hjelpetekst": "Dette blir teksten som vises i dokumentoversikten.\nHvis feltet står tomt brukes navnet på brevmalen som dokumenttittel.",
+                    "kode": "DOKUMENT_TITTEL",
+                    "paakrevd": false,
+                    "tegnBegrensning": 60,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Hovedtekst til brev",
+                    "feltType": "FRITEKST",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKST",
+                    "paakrevd": true,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Legg til fritekstvedlegg",
+                    "feltType": "FRITEKSTVEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "FRITEKSTVEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  },
+                  {
+                    "beskrivelse": "Vedlegg",
+                    "feltType": "VEDLEGG",
+                    "hjelpetekst": null,
+                    "kode": "VEDLEGG",
+                    "paakrevd": false,
+                    "tegnBegrensning": null,
+                    "valg": null
+                  }
+                ],
+                "type": {
+                  "kode": "FRITEKSTBREV",
+                  "term": "Fritekstbrev"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1008/aktoerer/?rolleKode=FULLMEKTIG",
+        "pathname": "/api/fagsaker/MEL-1008/aktoerer/",
+        "normalizedPath": "/api/fagsaker/:saksnummer/aktoerer/",
+        "query": {
+          "rolleKode": "FULLMEKTIG"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1008/dokumenter",
+        "pathname": "/api/fagsaker/MEL-1008/dokumenter",
+        "normalizedPath": "/api/fagsaker/:saksnummer/dokumenter",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1008/trygdeavgift/oppsummering",
+        "pathname": "/api/fagsaker/MEL-1008/trygdeavgift/oppsummering",
+        "normalizedPath": "/api/fagsaker/:saksnummer/trygdeavgift/oppsummering",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "harBehandlingMedTrygdeavgift": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1008/trygdeavgift/oppsummering",
+        "pathname": "/api/fagsaker/MEL-1008/trygdeavgift/oppsummering",
+        "normalizedPath": "/api/fagsaker/:saksnummer/trygdeavgift/oppsummering",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "harBehandlingMedTrygdeavgift": false
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/fagsaker/MEL-1008",
+        "pathname": "/api/fagsaker/MEL-1008",
+        "normalizedPath": "/api/fagsaker/:saksnummer",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "betalingsvalg": null,
+          "endretDato": "2025-01-01T00:00:00.000Z",
+          "gsakSaksnummer": null,
+          "hovedpartRolle": "BRUKER",
+          "registrertDato": "2025-01-01T00:00:00.000Z",
+          "saksnummer": "MEL-1008",
+          "saksstatus": {
+            "kode": "OPPRETTET",
+            "term": "Saken er opprettet"
+          },
+          "sakstema": {
+            "kode": "MEDLEMSKAP_LOVVALG",
+            "term": "Medlemskap og lovvalg"
+          },
+          "sakstype": {
+            "kode": "TRYGDEAVTALE",
+            "term": "Avtaleland"
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.arsavregning.eos_pensjonist&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
+        "pathname": "/api/featuretoggle",
+        "normalizedPath": "/api/featuretoggle",
+        "query": {
+          "features": "melosys.cdm-4-4"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "melosys.faktureringskomponent.vis_referanse": true,
+          "melosys.pensjonist": true,
+          "melosys.pensjonist_eos": true,
+          "standardvedlegg_eget_vedlegg_avtaleland": true,
+          "melosys.ftrl.begrense_periode_vedtak": true,
+          "melosys.arsavregning": true,
+          "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
+          "melosys.11_3_a_Norge_er_utpekt": true,
+          "melosys.eos_fakturering_av_trygdeavgift": true,
+          "melosys.arsavregning.eos_pensjonist": true,
+          "melosys.arsavregning.uten.flyt": false,
+          "melosys.cdm-4-4": true
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "pathname": "/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "normalizedPath": "/api/kodeverk/nav-felles/LANDKODER_ISO2",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "???",
+            "term": "UOPPGITT/UKJENT"
+          },
+          {
+            "kode": "AD",
+            "term": "ANDORRA"
+          },
+          {
+            "kode": "AE",
+            "term": "DE FORENTE ARABISKE EMIRATER"
+          },
+          {
+            "kode": "AF",
+            "term": "AFGHANISTAN"
+          },
+          {
+            "kode": "AG",
+            "term": "ANTIGUA OG BARBUDA"
+          },
+          {
+            "kode": "AI",
+            "term": "ANGUILLA"
+          },
+          {
+            "kode": "AL",
+            "term": "ALBANIA"
+          },
+          {
+            "kode": "AM",
+            "term": "ARMENIA"
+          },
+          {
+            "kode": "AO",
+            "term": "ANGOLA"
+          },
+          {
+            "kode": "AQ",
+            "term": "Antarktis"
+          },
+          {
+            "kode": "AR",
+            "term": "ARGENTINA"
+          },
+          {
+            "kode": "AS",
+            "term": "AM. SAMOA"
+          },
+          {
+            "kode": "AT",
+            "term": "ØSTERRIKE"
+          },
+          {
+            "kode": "AU",
+            "term": "AUSTRALIA"
+          },
+          {
+            "kode": "AW",
+            "term": "ARUBA"
+          },
+          {
+            "kode": "AX",
+            "term": "ÅLAND"
+          },
+          {
+            "kode": "AZ",
+            "term": "ASERBAJDSJAN"
+          },
+          {
+            "kode": "BA",
+            "term": "BOSNIA-HERCEGOVINA"
+          },
+          {
+            "kode": "BB",
+            "term": "BARBADOS"
+          },
+          {
+            "kode": "BD",
+            "term": "BANGLADESH"
+          },
+          {
+            "kode": "BE",
+            "term": "BELGIA"
+          },
+          {
+            "kode": "BF",
+            "term": "BURKINA FASO"
+          },
+          {
+            "kode": "BG",
+            "term": "BULGARIA"
+          },
+          {
+            "kode": "BH",
+            "term": "BAHRAIN"
+          },
+          {
+            "kode": "BI",
+            "term": "BURUNDI"
+          },
+          {
+            "kode": "BJ",
+            "term": "BENIN"
+          },
+          {
+            "kode": "BL",
+            "term": "SAINT BARTHELEMY"
+          },
+          {
+            "kode": "BM",
+            "term": "BERMUDA"
+          },
+          {
+            "kode": "BN",
+            "term": "BRUNEI"
+          },
+          {
+            "kode": "BO",
+            "term": "BOLIVIA"
+          },
+          {
+            "kode": "BQ",
+            "term": "BONAIRE, SINT EUSTATIUS OG SABA"
+          },
+          {
+            "kode": "BR",
+            "term": "BRASIL"
+          },
+          {
+            "kode": "BS",
+            "term": "BAHAMAS"
+          },
+          {
+            "kode": "BT",
+            "term": "BHUTAN"
+          },
+          {
+            "kode": "BV",
+            "term": "BOUVETØYA"
+          },
+          {
+            "kode": "BW",
+            "term": "BOTSWANA"
+          },
+          {
+            "kode": "BY",
+            "term": "BELARUS"
+          },
+          {
+            "kode": "BZ",
+            "term": "BELIZE"
+          },
+          {
+            "kode": "CA",
+            "term": "CANADA"
+          },
+          {
+            "kode": "CC",
+            "term": "KOKOSØYENE (KEELINGØYENE)"
+          },
+          {
+            "kode": "CD",
+            "term": "KONGO"
+          },
+          {
+            "kode": "CF",
+            "term": "DEN SENTRALAFRIKANSKE REPUBLIKK"
+          },
+          {
+            "kode": "CG",
+            "term": "KONGO-BRAZZAVILLE"
+          },
+          {
+            "kode": "CH",
+            "term": "SVEITS"
+          },
+          {
+            "kode": "CI",
+            "term": "ELFENBENSKYSTEN"
+          },
+          {
+            "kode": "CK",
+            "term": "COOKØYENE"
+          },
+          {
+            "kode": "CL",
+            "term": "CHILE"
+          },
+          {
+            "kode": "CM",
+            "term": "KAMERUN"
+          },
+          {
+            "kode": "CN",
+            "term": "KINA"
+          },
+          {
+            "kode": "CO",
+            "term": "COLOMBIA"
+          },
+          {
+            "kode": "CR",
+            "term": "COSTA RICA"
+          },
+          {
+            "kode": "CS",
+            "term": "SERBIA OG MONTENEGRO"
+          },
+          {
+            "kode": "CU",
+            "term": "CUBA"
+          },
+          {
+            "kode": "CV",
+            "term": "KAPP VERDE"
+          },
+          {
+            "kode": "CW",
+            "term": "CURACAO"
+          },
+          {
+            "kode": "CX",
+            "term": "CHRISTMASØYA"
+          },
+          {
+            "kode": "CY",
+            "term": "KYPROS"
+          },
+          {
+            "kode": "CZ",
+            "term": "TSJEKKIA"
+          },
+          {
+            "kode": "DE",
+            "term": "TYSKLAND"
+          },
+          {
+            "kode": "DJ",
+            "term": "DJIBOUTI"
+          },
+          {
+            "kode": "DK",
+            "term": "DANMARK"
+          },
+          {
+            "kode": "DM",
+            "term": "DOMINICA"
+          },
+          {
+            "kode": "DO",
+            "term": "DEN DOMINIKANSKE REPUBLIKK"
+          },
+          {
+            "kode": "DZ",
+            "term": "ALGERIE"
+          },
+          {
+            "kode": "EC",
+            "term": "ECUADOR"
+          },
+          {
+            "kode": "EE",
+            "term": "ESTLAND"
+          },
+          {
+            "kode": "EG",
+            "term": "EGYPT"
+          },
+          {
+            "kode": "EH",
+            "term": "VEST-SAHARA"
+          },
+          {
+            "kode": "ER",
+            "term": "ERITREA"
+          },
+          {
+            "kode": "ES",
+            "term": "SPANIA"
+          },
+          {
+            "kode": "ET",
+            "term": "ETIOPIA"
+          },
+          {
+            "kode": "FI",
+            "term": "FINLAND"
+          },
+          {
+            "kode": "FJ",
+            "term": "FIJI"
+          },
+          {
+            "kode": "FK",
+            "term": "FALKLANDSØYENE"
+          },
+          {
+            "kode": "FM",
+            "term": "MIKRONESIAFØDERASJONEN"
+          },
+          {
+            "kode": "FO",
+            "term": "FÆRØYENE"
+          },
+          {
+            "kode": "FR",
+            "term": "FRANKRIKE"
+          },
+          {
+            "kode": "GA",
+            "term": "GABON"
+          },
+          {
+            "kode": "GB",
+            "term": "STORBRITANNIA"
+          },
+          {
+            "kode": "GD",
+            "term": "GRENADA"
+          },
+          {
+            "kode": "GE",
+            "term": "GEORGIA"
+          },
+          {
+            "kode": "GF",
+            "term": "FRANSK GUYANA"
+          },
+          {
+            "kode": "GG",
+            "term": "GUERNSEY"
+          },
+          {
+            "kode": "GH",
+            "term": "GHANA"
+          },
+          {
+            "kode": "GI",
+            "term": "GIBRALTAR"
+          },
+          {
+            "kode": "GL",
+            "term": "GRØNLAND"
+          },
+          {
+            "kode": "GM",
+            "term": "GAMBIA"
+          },
+          {
+            "kode": "GN",
+            "term": "GUINEA"
+          },
+          {
+            "kode": "GP",
+            "term": "GUADELOUPE"
+          },
+          {
+            "kode": "GQ",
+            "term": "EKVATORIAL-GUINEA"
+          },
+          {
+            "kode": "GR",
+            "term": "HELLAS"
+          },
+          {
+            "kode": "GS",
+            "term": "SØR-GEORGIA OG SØR-SANDWICHØYENE"
+          },
+          {
+            "kode": "GT",
+            "term": "GUATEMALA"
+          },
+          {
+            "kode": "GU",
+            "term": "GUAM"
+          },
+          {
+            "kode": "GW",
+            "term": "GUINEA-BISSAU"
+          },
+          {
+            "kode": "GY",
+            "term": "GUYANA"
+          },
+          {
+            "kode": "HK",
+            "term": "HONGKONG"
+          },
+          {
+            "kode": "HM",
+            "term": "HEARD- OG MCDONALD-ØYENE"
+          },
+          {
+            "kode": "HN",
+            "term": "HONDURAS"
+          },
+          {
+            "kode": "HR",
+            "term": "KROATIA"
+          },
+          {
+            "kode": "HT",
+            "term": "HAITI"
+          },
+          {
+            "kode": "HU",
+            "term": "UNGARN"
+          },
+          {
+            "kode": "ID",
+            "term": "INDONESIA"
+          },
+          {
+            "kode": "IE",
+            "term": "IRLAND"
+          },
+          {
+            "kode": "IL",
+            "term": "ISRAEL"
+          },
+          {
+            "kode": "IM",
+            "term": "ISLE OF MAN"
+          },
+          {
+            "kode": "IN",
+            "term": "INDIA"
+          },
+          {
+            "kode": "IO",
+            "term": "DET BRITISKE TERRITORIET I INDIAHAVET"
+          },
+          {
+            "kode": "IQ",
+            "term": "IRAK"
+          },
+          {
+            "kode": "IR",
+            "term": "IRAN"
+          },
+          {
+            "kode": "IS",
+            "term": "ISLAND"
+          },
+          {
+            "kode": "IT",
+            "term": "ITALIA"
+          },
+          {
+            "kode": "JE",
+            "term": "JERSEY"
+          },
+          {
+            "kode": "JM",
+            "term": "JAMAICA"
+          },
+          {
+            "kode": "JO",
+            "term": "JORDAN"
+          },
+          {
+            "kode": "JP",
+            "term": "JAPAN"
+          },
+          {
+            "kode": "KE",
+            "term": "KENYA"
+          },
+          {
+            "kode": "KG",
+            "term": "KIRGISISTAN"
+          },
+          {
+            "kode": "KH",
+            "term": "KAMBODSJA"
+          },
+          {
+            "kode": "KI",
+            "term": "KIRIBATI"
+          },
+          {
+            "kode": "KM",
+            "term": "KOMORENE"
+          },
+          {
+            "kode": "KN",
+            "term": "SAINT KITTS OG NEVIS"
+          },
+          {
+            "kode": "KP",
+            "term": "NORD-KOREA"
+          },
+          {
+            "kode": "KR",
+            "term": "SØR-KOREA"
+          },
+          {
+            "kode": "KW",
+            "term": "KUWAIT"
+          },
+          {
+            "kode": "KY",
+            "term": "CAYMANØYENE"
+          },
+          {
+            "kode": "KZ",
+            "term": "KASAKHSTAN"
+          },
+          {
+            "kode": "LA",
+            "term": "LAOS"
+          },
+          {
+            "kode": "LB",
+            "term": "LIBANON"
+          },
+          {
+            "kode": "LC",
+            "term": "SAINT LUCIA"
+          },
+          {
+            "kode": "LI",
+            "term": "LIECHTENSTEIN"
+          },
+          {
+            "kode": "LK",
+            "term": "SRI LANKA"
+          },
+          {
+            "kode": "LR",
+            "term": "LIBERIA"
+          },
+          {
+            "kode": "LS",
+            "term": "LESOTHO"
+          },
+          {
+            "kode": "LT",
+            "term": "LITAUEN"
+          },
+          {
+            "kode": "LU",
+            "term": "LUXEMBOURG"
+          },
+          {
+            "kode": "LV",
+            "term": "LATVIA"
+          },
+          {
+            "kode": "LY",
+            "term": "LIBYA"
+          },
+          {
+            "kode": "MA",
+            "term": "MAROKKO"
+          },
+          {
+            "kode": "MC",
+            "term": "MONACO"
+          },
+          {
+            "kode": "MD",
+            "term": "MOLDOVA"
+          },
+          {
+            "kode": "ME",
+            "term": "MONTENEGRO"
+          },
+          {
+            "kode": "MF",
+            "term": "SAINT MARTIN"
+          },
+          {
+            "kode": "MG",
+            "term": "MADAGASKAR"
+          },
+          {
+            "kode": "MH",
+            "term": "MARSHALLØYENE"
+          },
+          {
+            "kode": "MK",
+            "term": "NORD-MAKEDONIA"
+          },
+          {
+            "kode": "ML",
+            "term": "MALI"
+          },
+          {
+            "kode": "MM",
+            "term": "MYANMAR (BURMA)"
+          },
+          {
+            "kode": "MN",
+            "term": "MONGOLIA"
+          },
+          {
+            "kode": "MO",
+            "term": "MACAO"
+          },
+          {
+            "kode": "MP",
+            "term": "NORD-MARIANENE"
+          },
+          {
+            "kode": "MQ",
+            "term": "MARTINIQUE"
+          },
+          {
+            "kode": "MR",
+            "term": "MAURITANIA"
+          },
+          {
+            "kode": "MS",
+            "term": "MONTSERRAT"
+          },
+          {
+            "kode": "MT",
+            "term": "MALTA"
+          },
+          {
+            "kode": "MU",
+            "term": "MAURITIUS"
+          },
+          {
+            "kode": "MV",
+            "term": "MALDIVENE"
+          },
+          {
+            "kode": "MW",
+            "term": "MALAWI"
+          },
+          {
+            "kode": "MX",
+            "term": "MEXICO"
+          },
+          {
+            "kode": "MY",
+            "term": "MALAYSIA"
+          },
+          {
+            "kode": "MZ",
+            "term": "MOSAMBIK"
+          },
+          {
+            "kode": "NA",
+            "term": "NAMIBIA"
+          },
+          {
+            "kode": "NC",
+            "term": "NY-CALEDONIA"
+          },
+          {
+            "kode": "NE",
+            "term": "NIGER"
+          },
+          {
+            "kode": "NF",
+            "term": "NORFOLKØYA"
+          },
+          {
+            "kode": "NG",
+            "term": "NIGERIA"
+          },
+          {
+            "kode": "NI",
+            "term": "NICARAGUA"
+          },
+          {
+            "kode": "NL",
+            "term": "NEDERLAND"
+          },
+          {
+            "kode": "NO",
+            "term": "NORGE"
+          },
+          {
+            "kode": "NP",
+            "term": "NEPAL"
+          },
+          {
+            "kode": "NR",
+            "term": "NAURU"
+          },
+          {
+            "kode": "NU",
+            "term": "NIUE"
+          },
+          {
+            "kode": "NZ",
+            "term": "NEW ZEALAND"
+          },
+          {
+            "kode": "OM",
+            "term": "OMAN"
+          },
+          {
+            "kode": "PA",
+            "term": "PANAMA"
+          },
+          {
+            "kode": "PE",
+            "term": "PERU"
+          },
+          {
+            "kode": "PF",
+            "term": "FRANSK POLYNESIA"
+          },
+          {
+            "kode": "PG",
+            "term": "PAPUA NY-GUINEA"
+          },
+          {
+            "kode": "PH",
+            "term": "FILIPPINENE"
+          },
+          {
+            "kode": "PK",
+            "term": "PAKISTAN"
+          },
+          {
+            "kode": "PL",
+            "term": "POLEN"
+          },
+          {
+            "kode": "PM",
+            "term": "SAINT-PIERRE OG MIQUELON"
+          },
+          {
+            "kode": "PN",
+            "term": "PITCAIRN"
+          },
+          {
+            "kode": "PR",
+            "term": "PUERTO RICO"
+          },
+          {
+            "kode": "PS",
+            "term": "PALESTINA"
+          },
+          {
+            "kode": "PT",
+            "term": "PORTUGAL"
+          },
+          {
+            "kode": "PW",
+            "term": "PALAU"
+          },
+          {
+            "kode": "PY",
+            "term": "PARAGUAY"
+          },
+          {
+            "kode": "QA",
+            "term": "QATAR"
+          },
+          {
+            "kode": "RE",
+            "term": "REUNION"
+          },
+          {
+            "kode": "RO",
+            "term": "ROMANIA"
+          },
+          {
+            "kode": "RS",
+            "term": "SERBIA"
+          },
+          {
+            "kode": "RU",
+            "term": "RUSSLAND"
+          },
+          {
+            "kode": "RW",
+            "term": "RWANDA"
+          },
+          {
+            "kode": "SA",
+            "term": "SAUDI-ARABIA"
+          },
+          {
+            "kode": "SB",
+            "term": "SALOMONØYENE"
+          },
+          {
+            "kode": "SC",
+            "term": "SEYCHELLENE"
+          },
+          {
+            "kode": "SD",
+            "term": "SUDAN"
+          },
+          {
+            "kode": "SE",
+            "term": "SVERIGE"
+          },
+          {
+            "kode": "SG",
+            "term": "SINGAPORE"
+          },
+          {
+            "kode": "SH",
+            "term": "SANKT HELENA, ASCENSION OG TRISTAN DA CUNHA"
+          },
+          {
+            "kode": "SI",
+            "term": "SLOVENIA"
+          },
+          {
+            "kode": "SJ",
+            "term": "SVALBARD OG JAN MAYEN"
+          },
+          {
+            "kode": "SK",
+            "term": "SLOVAKIA"
+          },
+          {
+            "kode": "SL",
+            "term": "SIERRA LEONE"
+          },
+          {
+            "kode": "SM",
+            "term": "SAN MARINO"
+          },
+          {
+            "kode": "SN",
+            "term": "SENEGAL"
+          },
+          {
+            "kode": "SO",
+            "term": "SOMALIA"
+          },
+          {
+            "kode": "SR",
+            "term": "SURINAM"
+          },
+          {
+            "kode": "SS",
+            "term": "SØR-SUDAN"
+          },
+          {
+            "kode": "ST",
+            "term": "SAO TOME OG PRINCIPE"
+          },
+          {
+            "kode": "SV",
+            "term": "EL SALVADOR"
+          },
+          {
+            "kode": "SX",
+            "term": "SINT MAARTEN"
+          },
+          {
+            "kode": "SY",
+            "term": "SYRIA"
+          },
+          {
+            "kode": "SZ",
+            "term": "ESWATINI"
+          },
+          {
+            "kode": "TC",
+            "term": "TURKS- OG CAICOSØYENE"
+          },
+          {
+            "kode": "TD",
+            "term": "TSJAD"
+          },
+          {
+            "kode": "TG",
+            "term": "TOGO"
+          },
+          {
+            "kode": "TH",
+            "term": "THAILAND"
+          },
+          {
+            "kode": "TJ",
+            "term": "TADSJIKISTAN"
+          },
+          {
+            "kode": "TK",
+            "term": "TOKELAU"
+          },
+          {
+            "kode": "TL",
+            "term": "ØST-TIMOR"
+          },
+          {
+            "kode": "TM",
+            "term": "TURKMENISTAN"
+          },
+          {
+            "kode": "TN",
+            "term": "TUNISIA"
+          },
+          {
+            "kode": "TO",
+            "term": "TONGA"
+          },
+          {
+            "kode": "TR",
+            "term": "TYRKIA"
+          },
+          {
+            "kode": "TT",
+            "term": "TRINIDAD OG TOBAGO"
+          },
+          {
+            "kode": "TV",
+            "term": "TUVALU"
+          },
+          {
+            "kode": "TW",
+            "term": "TAIWAN"
+          },
+          {
+            "kode": "TZ",
+            "term": "TANZANIA"
+          },
+          {
+            "kode": "UA",
+            "term": "UKRAINA"
+          },
+          {
+            "kode": "UG",
+            "term": "UGANDA"
+          },
+          {
+            "kode": "UM",
+            "term": "USAS YTRE SMÅØYER"
+          },
+          {
+            "kode": "US",
+            "term": "USA"
+          },
+          {
+            "kode": "UY",
+            "term": "URUGUAY"
+          },
+          {
+            "kode": "UZ",
+            "term": "USBEKISTAN"
+          },
+          {
+            "kode": "VA",
+            "term": "VATIKANSTATEN"
+          },
+          {
+            "kode": "VC",
+            "term": "SAINT VINCENT OG GRENADINENE"
+          },
+          {
+            "kode": "VE",
+            "term": "VENEZUELA"
+          },
+          {
+            "kode": "VG",
+            "term": "DE BRITISKE JOMFRUØYER"
+          },
+          {
+            "kode": "VI",
+            "term": "DE AMERIKANSKE JOMFRUØYER"
+          },
+          {
+            "kode": "VN",
+            "term": "VIETNAM"
+          },
+          {
+            "kode": "VU",
+            "term": "VANUATU"
+          },
+          {
+            "kode": "WF",
+            "term": "WALLIS OG FUTUNA"
+          },
+          {
+            "kode": "WS",
+            "term": "SAMOA"
+          },
+          {
+            "kode": "XB",
+            "term": "Kanariøyene"
+          },
+          {
+            "kode": "XK",
+            "term": "KOSOVO"
+          },
+          {
+            "kode": "YE",
+            "term": "JEMEN"
+          },
+          {
+            "kode": "YT",
+            "term": "MAYOTTE"
+          },
+          {
+            "kode": "ZA",
+            "term": "SØR-AFRIKA"
+          },
+          {
+            "kode": "ZM",
+            "term": "ZAMBIA"
+          },
+          {
+            "kode": "ZW",
+            "term": "ZIMBABWE"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/lovvalgsperioder/8",
+        "pathname": "/api/lovvalgsperioder/8",
+        "normalizedPath": "/api/lovvalgsperioder/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": []
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/mottatteopplysninger/8",
+        "pathname": "/api/mottatteopplysninger/8",
+        "normalizedPath": "/api/mottatteopplysninger/:id",
+        "query": {},
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "arbeidPaaLand": {
+              "erFastArbeidssted": null,
+              "erHjemmekontor": null,
+              "fysiskeArbeidssteder": []
+            },
+            "bosted": {
+              "antallMaanederINorge": 0,
+              "intensjonOmRetur": null,
+              "oppgittAdresse": {
+                "tilleggsnavn": null,
+                "gatenavn": null,
+                "husnummerEtasjeLeilighet": null,
+                "postboks": null,
+                "postnummer": null,
+                "poststed": null,
+                "region": null,
+                "landkode": null
+              }
+            },
+            "foretakUtland": [],
+            "juridiskArbeidsgiverNorge": {
+              "andelKontrakterINorge": null,
+              "andelOmsetningINorge": null,
+              "andelOppdragINorge": null,
+              "andelRekruttertINorge": null,
+              "antallAdmAnsatte": null,
+              "antallAnsatte": null,
+              "antallUtsendte": null,
+              "ekstraArbeidsgivere": [],
+              "erOffentligVirksomhet": null
+            },
+            "luftfartBaser": [],
+            "maritimtArbeid": [],
+            "oppholdUtland": {
+              "ektefelleEllerBarnINorge": null,
+              "oppholdsPeriode": {
+                "fom": null,
+                "tom": null
+              },
+              "oppholdslandkoder": [],
+              "studentFinansieringKode": null,
+              "studentSemester": null
+            },
+            "periode": {
+              "fom": null,
+              "tom": null
+            },
+            "personOpplysninger": {
+              "foedestedOgLand": null,
+              "medfolgendeFamilie": [],
+              "utenlandskIdent": []
+            },
+            "representantIUtlandet": null,
+            "selvstendigArbeid": {
+              "erSelvstendig": null,
+              "selvstendigForetak": []
+            },
+            "soeknadsland": {
+              "landkoder": [],
+              "flereLandUkjentHvilke": false
+            },
+            "trygdedekning": null
+          },
+          "mottaksdato": "2025-01-01",
+          "type": "SØKNAD_YRKESAKTIVE_NORGE_ELLER_UTENFOR_EØS"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/MEL-1008/behandlingstyper/kombinasjoner-for-endring/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&sakstema=MEDLEMSKAP_LOVVALG&behandlingstema=YRKESAKTIV",
+        "pathname": "/api/saksbehandling/MEL-1008/behandlingstyper/kombinasjoner-for-endring/",
+        "normalizedPath": "/api/saksbehandling/:saksnummer/behandlingstyper/kombinasjoner-for-endring/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "sakstema": "MEDLEMSKAP_LOVVALG",
+          "behandlingstema": "YRKESAKTIV"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "FØRSTEGANG",
+            "term": "Førstegangsbehandling"
+          },
+          {
+            "kode": "HENVENDELSE",
+            "term": "Henvendelse"
+          },
+          {
+            "kode": "KLAGE",
+            "term": "Klage"
+          },
+          {
+            "kode": "NY_VURDERING",
+            "term": "Ny vurdering"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&sakstema=MEDLEMSKAP_LOVVALG&aktivBehandlingID=8",
+        "pathname": "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/behandlingstemaer/hent-lovlige-kombinasjoner/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "sakstema": "MEDLEMSKAP_LOVVALG",
+          "aktivBehandlingID": "8"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "FORESPØRSEL_TRYGDEMYNDIGHET",
+            "term": "Forespørsel fra trygdemyndighet"
+          },
+          {
+            "kode": "IKKE_YRKESAKTIV",
+            "term": "Ikke yrkesaktiv"
+          },
+          {
+            "kode": "PENSJONIST",
+            "term": "Pensjonist/uføretrygdet"
+          },
+          {
+            "kode": "YRKESAKTIV",
+            "term": "Yrkesaktiv"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/?hovedpart=BRUKER&sakstype=TRYGDEAVTALE&saksnummer=MEL-1008",
+        "pathname": "/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/sakstemaer/hent-lovlige-kombinasjoner/",
+        "query": {
+          "hovedpart": "BRUKER",
+          "sakstype": "TRYGDEAVTALE",
+          "saksnummer": "MEL-1008"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "MEDLEMSKAP_LOVVALG",
+            "term": "Medlemskap og lovvalg"
+          },
+          {
+            "kode": "TRYGDEAVGIFT",
+            "term": "Trygdeavgift"
+          },
+          {
+            "kode": "UNNTAK",
+            "term": "Unntak"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:3333/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/?saksnummer=MEL-1008",
+        "pathname": "/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/",
+        "normalizedPath": "/api/saksbehandling/sakstyper/hent-lovlige-kombinasjoner/",
+        "query": {
+          "saksnummer": "MEL-1008"
+        },
+        "headers": {
+          "accept": "application/json",
+          "authorization": "[REDACTED]"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": [
+          {
+            "kode": "EU_EOS",
+            "term": "EU/EØS-land"
+          },
+          {
+            "kode": "FTRL",
+            "term": "Utenfor avtaleland"
+          },
+          {
+            "kode": "TRYGDEAVTALE",
+            "term": "Avtaleland"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3333/graphql/",
+        "pathname": "/graphql/",
+        "normalizedPath": "/graphql/",
+        "query": {},
+        "headers": {
+          "content-type": "application/json",
+          "accept": "*/*",
+          "authorization": "[REDACTED]"
+        },
+        "body": {
+          "operationName": "hentPersonopplysninger",
+          "variables": {
+            "behandlingID": 8
+          },
+          "query": "query hentPersonopplysninger($behandlingID: Long!) {\n  hentSaksopplysninger(behandlingID: $behandlingID) {\n    persondata {\n      navn {\n        fornavn\n        mellomnavn\n        etternavn\n        __typename\n      }\n      kjoenn\n      folkeregisterpersonstatuser {\n        kode\n        erHistorisk\n        __typename\n      }\n      folkeregisteridentifikator\n      statsborgerskap {\n        land\n        erHistorisk\n        __typename\n      }\n      sivilstand {\n        type\n        erHistorisk\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}"
+        }
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "hentSaksopplysninger": {
+              "persondata": {
+                "navn": {
+                  "fornavn": "KARAFFEL",
+                  "mellomnavn": null,
+                  "etternavn": "TRIVIELL",
+                  "__typename": "Navn"
+                },
+                "kjoenn": "MANN",
+                "folkeregisterpersonstatuser": [
+                  {
+                    "kode": "BOSATT",
+                    "erHistorisk": false,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "MIDLERTIDIG",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  },
+                  {
+                    "kode": "UTFLYTTET",
+                    "erHistorisk": true,
+                    "__typename": "Folkeregisterpersonstatus"
+                  }
+                ],
+                "folkeregisteridentifikator": "30056928150",
+                "statsborgerskap": [
+                  {
+                    "land": "NORGE",
+                    "erHistorisk": false,
+                    "__typename": "Statsborgerskap"
+                  }
+                ],
+                "sivilstand": [
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Gift",
+                    "erHistorisk": false,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Separert",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  },
+                  {
+                    "type": "Skilt",
+                    "erHistorisk": true,
+                    "__typename": "Sivilstand"
+                  }
+                ],
+                "__typename": "Personopplysninger"
+              },
+              "__typename": "Saksopplysninger"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts
+++ b/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts
@@ -4,8 +4,8 @@ import { assertErrors, TIMEOUT_FOR_COMPLEX_TESTS } from "../../utils/testUtils";
 import { hentPrepopulertSakUrl, PrepopulertSaksnummer } from "../../utils/testdataUtils";
 import { Page } from "@playwright/test";
 
-const ORGNR_GYLDIG_FUNNET = "999999999"; // syntetisk test-org «Ståles Stål AS» i test-/dev-backend
-const ORGNR_GYLDIG_IKKE_FUNNET = "123456785"; // gyldig kontrollsiffer, men finnes ikke
+const ORGNR_GYLDIG_FUNNET = "999999999";
+const ORGNR_GYLDIG_IKKE_FUNNET = "123456785";
 const ORGNR_FOR_FA_SIFFER = "123";
 const MOTTAKER_ANNEN_ORGANISASJON = "Annen organisasjon";
 

--- a/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts
+++ b/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts
@@ -5,7 +5,7 @@ import { hentPrepopulertSakUrl, PrepopulertSaksnummer } from "../../utils/testda
 import { Page } from "@playwright/test";
 
 /**
- * MELOSYS-7525: org.nr som brukes i «Annen organisasjon»-testene må gi forventet
+ * Org.nr som brukes i «Annen organisasjon»-testene må gi forventet
  * resultat i test-/dev-backend ved opptak:
  *   - ORGNR_GYLDIG_FUNNET: gyldig org.nr (mod11) som resolver til en organisasjon (navn hentes)
  *   - ORGNR_GYLDIG_IKKE_FUNNET: gyldig org.nr (mod11) som IKKE finnes (gir HTTP 404)
@@ -119,7 +119,7 @@ test.describe("Validering av årsavregning brevmaler", () => {
   });
 });
 
-test.describe("Annen organisasjon: brevmal vises først når org.nr er korrekt (MELOSYS-7525)", () => {
+test.describe("Annen organisasjon: brevmal vises først når org.nr er korrekt", () => {
   test("Ved valg av «Annen organisasjon» vises Kontaktperson (valgfritt) og brevmal er skjult", async ({
     page,
     apiRecorder,

--- a/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts
+++ b/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts
@@ -5,6 +5,18 @@ import { hentPrepopulertSakUrl, PrepopulertSaksnummer } from "../../utils/testda
 import { Page } from "@playwright/test";
 
 /**
+ * MELOSYS-7525: org.nr som brukes i «Annen organisasjon»-testene må gi forventet
+ * resultat i test-/dev-backend ved opptak:
+ *   - ORGNR_GYLDIG_FUNNET: gyldig org.nr (mod11) som resolver til en organisasjon (navn hentes)
+ *   - ORGNR_GYLDIG_IKKE_FUNNET: gyldig org.nr (mod11) som IKKE finnes (gir HTTP 404)
+ * Juster verdiene ved behov før `pnpm test:e2e:record`.
+ */
+const ORGNR_GYLDIG_FUNNET = "999999999"; // syntetisk test-org «Ståles Stål AS» i test-/dev-backend
+const ORGNR_GYLDIG_IKKE_FUNNET = "123456785"; // gyldig kontrollsiffer, men finnes ikke
+const ORGNR_FOR_FA_SIFFER = "123";
+const MOTTAKER_ANNEN_ORGANISASJON = "Annen organisasjon";
+
+/**
  * Gjenbrukbar setup-funksjon som oppretter egen testdata
  * Returnerer sendBrevPage for å unngå race conditions ved parallell kjøring
  */
@@ -104,5 +116,47 @@ test.describe("Validering av årsavregning brevmaler", () => {
     await sendBrevPage.clickSendBrev();
 
     await assertErrors(page, ["Du må velge minst én av standardtekst eller fritekst"]);
+  });
+});
+
+test.describe("Annen organisasjon: brevmal vises først når org.nr er korrekt (MELOSYS-7525)", () => {
+  test("Ved valg av «Annen organisasjon» vises Kontaktperson (valgfritt) og brevmal er skjult", async ({
+    page,
+    apiRecorder,
+  }) => {
+    const sendBrevPage = await setupSendBrevTest(page, "MEL-1008");
+    await sendBrevPage.velgMottaker(MOTTAKER_ANNEN_ORGANISASJON);
+
+    await sendBrevPage.verifiserKontaktpersonValgfri();
+    await sendBrevPage.verifiserBrevmalSkjult();
+  });
+
+  test("For få siffer i org.nr gir feilmelding og holder brevmal skjult", async ({ page, apiRecorder }) => {
+    const sendBrevPage = await setupSendBrevTest(page, "MEL-1009");
+    await sendBrevPage.velgMottaker(MOTTAKER_ANNEN_ORGANISASJON);
+    await sendBrevPage.inputOrganisasjonsnummer(ORGNR_FOR_FA_SIFFER);
+
+    await sendBrevPage.verifiserOrgnrFeilmelding("Ugyldig organisasjonsnummer");
+    await sendBrevPage.verifiserBrevmalSkjult();
+  });
+
+  test("Gyldig org.nr som ikke finnes gir «Kunne ikke finne organisasjon» og holder brevmal skjult", async ({
+    page,
+    apiRecorder,
+  }) => {
+    const sendBrevPage = await setupSendBrevTest(page, "MEL-1010");
+    await sendBrevPage.velgMottaker(MOTTAKER_ANNEN_ORGANISASJON);
+    await sendBrevPage.inputOrganisasjonsnummer(ORGNR_GYLDIG_IKKE_FUNNET);
+
+    await sendBrevPage.verifiserOrgnrFeilmelding("Kunne ikke finne organisasjon");
+    await sendBrevPage.verifiserBrevmalSkjult();
+  });
+
+  test("Når org.nr er korrekt og organisasjon funnet, blir «Velg brevmal» synlig", async ({ page, apiRecorder }) => {
+    const sendBrevPage = await setupSendBrevTest(page, "MEL-1011");
+    await sendBrevPage.velgMottaker(MOTTAKER_ANNEN_ORGANISASJON);
+    await sendBrevPage.inputOrganisasjonsnummer(ORGNR_GYLDIG_FUNNET);
+
+    await sendBrevPage.verifiserBrevmalSynlig();
   });
 });

--- a/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts
+++ b/tests/e2e/specs/behandle-sak/send-brev-validering.spec.ts
@@ -4,13 +4,6 @@ import { assertErrors, TIMEOUT_FOR_COMPLEX_TESTS } from "../../utils/testUtils";
 import { hentPrepopulertSakUrl, PrepopulertSaksnummer } from "../../utils/testdataUtils";
 import { Page } from "@playwright/test";
 
-/**
- * Org.nr som brukes i «Annen organisasjon»-testene må gi forventet
- * resultat i test-/dev-backend ved opptak:
- *   - ORGNR_GYLDIG_FUNNET: gyldig org.nr (mod11) som resolver til en organisasjon (navn hentes)
- *   - ORGNR_GYLDIG_IKKE_FUNNET: gyldig org.nr (mod11) som IKKE finnes (gir HTTP 404)
- * Juster verdiene ved behov før `pnpm test:e2e:record`.
- */
 const ORGNR_GYLDIG_FUNNET = "999999999"; // syntetisk test-org «Ståles Stål AS» i test-/dev-backend
 const ORGNR_GYLDIG_IKKE_FUNNET = "123456785"; // gyldig kontrollsiffer, men finnes ikke
 const ORGNR_FOR_FA_SIFFER = "123";


### PR DESCRIPTION
For mottaker «Annen organisasjon» i Send brev vises «Velg brevmal» nå først når
organisasjonen faktisk er funnet (navn hentet), ikke så snart en mottaker er valgt.

Tidligere kunne man velge brevmal mens org.nr fortsatt hadde en feilmelding, noe
som trigget de gule «hentMuligeMottakere»-varslene. Nå gates både visningen av
brevmal og gyldighetssjekken på at organisasjonen er bekreftet funnet.
[MELOSYS-7525](https://jira.adeo.no/browse/MELOSYS-7525)

- Ny `skalViseBrevmalvalg` gater «Velg brevmal» på `organisasjonFunnet`
- `erMottakerGyldig` krever `organisasjonFunnet` for «Annen organisasjon»
- La til «(valgfritt)» i label over Kontaktperson-feltet
- Playwright-tester + opptak for de fire scenariene (skjult/ugyldig/ikke funnet/funnet)

## Testing
- [x] Enhetstester (`brevMottaker.test.tsx`)
- [x] Manuell testing lokalt
- [x] Playwright-tester (live + playback grønne)