### PR TITLE
NOJIRA G4P Oppdater sårbarheter rapportert av Dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "graphql": "^16.8.1",
     "graphql-tag": "^2.12.6",
     "history": "^4.10.1",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.0",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.43",
     "prop-types": "^15.8.1",
-    "qs": "^6.14.1",
+    "qs": "^6.15.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.43.1",
@@ -46,7 +46,7 @@
     "redux-form": "^8.3.10",
     "redux-thunk": "^3.1.0",
     "reselect": "^4.0.0",
-    "uuid": "^11.1.0",
+    "uuid": "^11.1.1",
     "yup": "^1.6.1"
   },
   "disabled-homepage": "http://eesi2.no/melosys",
@@ -145,7 +145,7 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.44.0",
-    "vite": "^7.2.2",
+    "vite": "^7.3.2",
     "vite-plugin-svgr": "^4.5.0",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^3.2.4"
@@ -168,8 +168,10 @@
     "overrides": {
       "ws": "^8.17.1",
       "tmp": "^0.2.4",
-      "lodash": "^4.17.23",
-      "lodash-es": "^4.17.23"
+      "lodash": "^4.18.0",
+      "lodash-es": "^4.18.0",
+      "@ardatan/relay-compiler>immutable": "^3.8.3",
+      "graphql-config>minimatch": "^4.2.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,10 @@ settings:
 overrides:
   ws: ^8.17.1
   tmp: ^0.2.4
-  lodash: ^4.17.23
-  lodash-es: ^4.17.23
+  lodash: ^4.18.0
+  lodash-es: ^4.18.0
+  "@ardatan/relay-compiler>immutable": ^3.8.3
+  graphql-config>minimatch: ^4.2.5
 
 importers:
   .:
@@ -59,8 +61,8 @@ importers:
         specifier: ^4.10.1
         version: 4.10.1
       lodash:
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.18.0
+        version: 4.18.1
       moment:
         specifier: ^2.29.4
         version: 2.30.1
@@ -71,8 +73,8 @@ importers:
         specifier: ^15.8.1
         version: 15.8.1
       qs:
-        specifier: ^6.14.1
-        version: 6.14.1
+        specifier: ^6.15.2
+        version: 6.15.2
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -102,7 +104,7 @@ importers:
         version: 5.2.0(history@4.10.1)(redux@5.0.1)
       redux-form:
         specifier: ^8.3.10
-        version: 8.3.10(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1)
+        version: 8.3.10(immutable@3.8.3)(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1)
       redux-thunk:
         specifier: ^3.1.0
         version: 3.1.0(redux@5.0.1)
@@ -110,8 +112,8 @@ importers:
         specifier: ^4.0.0
         version: 4.1.8
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^11.1.1
+        version: 11.1.1
       yup:
         specifier: ^1.6.1
         version: 1.6.1
@@ -202,10 +204,10 @@ importers:
         version: 8.44.0(eslint@9.35.0(jiti@1.21.7))(typescript@5.9.2)
       "@vitejs/plugin-react":
         specifier: ^5.0.3
-        version: 5.0.3(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
+        version: 5.0.3(vite@7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0))
       "@vitest/coverage-v8":
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.8.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.9.0))
       axe-core:
         specifier: ^4.10.3
         version: 4.10.3
@@ -273,17 +275,17 @@ importers:
         specifier: ^8.44.0
         version: 8.44.0(eslint@9.35.0(jiti@1.21.7))(typescript@5.9.2)
       vite:
-        specifier: ^7.2.2
-        version: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+        specifier: ^7.3.2
+        version: 7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0)
       vite-plugin-svgr:
         specifier: ^4.5.0
-        version: 4.5.0(rollup@4.50.2)(typescript@5.9.2)(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
+        version: 4.5.0(rollup@4.60.4)(typescript@5.9.2)(vite@7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.9.2)(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
+        version: 4.3.2(typescript@5.9.2)(vite@7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.8.0)
+        version: 3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.9.0)
 
 packages:
   "@adobe/css-tools@4.4.3":
@@ -791,184 +793,184 @@ packages:
     resolution:
       { integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg== }
 
-  "@esbuild/aix-ppc64@0.25.9":
+  "@esbuild/aix-ppc64@0.27.7":
     resolution:
-      { integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA== }
+      { integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg== }
     engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.25.9":
+  "@esbuild/android-arm64@0.27.7":
     resolution:
-      { integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg== }
+      { integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ== }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm@0.25.9":
+  "@esbuild/android-arm@0.27.7":
     resolution:
-      { integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ== }
+      { integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ== }
     engines: { node: ">=18" }
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.25.9":
+  "@esbuild/android-x64@0.27.7":
     resolution:
-      { integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw== }
+      { integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg== }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.25.9":
+  "@esbuild/darwin-arm64@0.27.7":
     resolution:
-      { integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg== }
+      { integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw== }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.25.9":
+  "@esbuild/darwin-x64@0.27.7":
     resolution:
-      { integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ== }
+      { integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ== }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.25.9":
+  "@esbuild/freebsd-arm64@0.27.7":
     resolution:
-      { integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q== }
+      { integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w== }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.25.9":
+  "@esbuild/freebsd-x64@0.27.7":
     resolution:
-      { integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg== }
+      { integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ== }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.25.9":
+  "@esbuild/linux-arm64@0.27.7":
     resolution:
-      { integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw== }
+      { integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A== }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm@0.25.9":
+  "@esbuild/linux-arm@0.27.7":
     resolution:
-      { integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw== }
+      { integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA== }
     engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.25.9":
+  "@esbuild/linux-ia32@0.27.7":
     resolution:
-      { integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A== }
+      { integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg== }
     engines: { node: ">=18" }
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.25.9":
+  "@esbuild/linux-loong64@0.27.7":
     resolution:
-      { integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ== }
+      { integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q== }
     engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.25.9":
+  "@esbuild/linux-mips64el@0.27.7":
     resolution:
-      { integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA== }
+      { integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw== }
     engines: { node: ">=18" }
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.25.9":
+  "@esbuild/linux-ppc64@0.27.7":
     resolution:
-      { integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w== }
+      { integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ== }
     engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.25.9":
+  "@esbuild/linux-riscv64@0.27.7":
     resolution:
-      { integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg== }
+      { integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ== }
     engines: { node: ">=18" }
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.25.9":
+  "@esbuild/linux-s390x@0.27.7":
     resolution:
-      { integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA== }
+      { integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw== }
     engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-x64@0.25.9":
+  "@esbuild/linux-x64@0.27.7":
     resolution:
-      { integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg== }
+      { integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA== }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/netbsd-arm64@0.25.9":
+  "@esbuild/netbsd-arm64@0.27.7":
     resolution:
-      { integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q== }
+      { integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w== }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.25.9":
+  "@esbuild/netbsd-x64@0.27.7":
     resolution:
-      { integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g== }
+      { integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw== }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/openbsd-arm64@0.25.9":
+  "@esbuild/openbsd-arm64@0.27.7":
     resolution:
-      { integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ== }
+      { integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A== }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.25.9":
+  "@esbuild/openbsd-x64@0.27.7":
     resolution:
-      { integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA== }
+      { integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg== }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openharmony-arm64@0.25.9":
+  "@esbuild/openharmony-arm64@0.27.7":
     resolution:
-      { integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg== }
+      { integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw== }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
 
-  "@esbuild/sunos-x64@0.25.9":
+  "@esbuild/sunos-x64@0.27.7":
     resolution:
-      { integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw== }
+      { integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA== }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/win32-arm64@0.25.9":
+  "@esbuild/win32-arm64@0.27.7":
     resolution:
-      { integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ== }
+      { integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA== }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.25.9":
+  "@esbuild/win32-ia32@0.27.7":
     resolution:
-      { integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww== }
+      { integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw== }
     engines: { node: ">=18" }
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-x64@0.25.9":
+  "@esbuild/win32-x64@0.27.7":
     resolution:
-      { integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ== }
+      { integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg== }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [win32]
@@ -1657,140 +1659,166 @@ packages:
       rollup:
         optional: true
 
-  "@rollup/rollup-android-arm-eabi@4.50.2":
+  "@rollup/rollup-android-arm-eabi@4.60.4":
     resolution:
-      { integrity: sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A== }
+      { integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ== }
     cpu: [arm]
     os: [android]
 
-  "@rollup/rollup-android-arm64@4.50.2":
+  "@rollup/rollup-android-arm64@4.60.4":
     resolution:
-      { integrity: sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g== }
+      { integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw== }
     cpu: [arm64]
     os: [android]
 
-  "@rollup/rollup-darwin-arm64@4.50.2":
+  "@rollup/rollup-darwin-arm64@4.60.4":
     resolution:
-      { integrity: sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q== }
+      { integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA== }
     cpu: [arm64]
     os: [darwin]
 
-  "@rollup/rollup-darwin-x64@4.50.2":
+  "@rollup/rollup-darwin-x64@4.60.4":
     resolution:
-      { integrity: sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A== }
+      { integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg== }
     cpu: [x64]
     os: [darwin]
 
-  "@rollup/rollup-freebsd-arm64@4.50.2":
+  "@rollup/rollup-freebsd-arm64@4.60.4":
     resolution:
-      { integrity: sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow== }
+      { integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g== }
     cpu: [arm64]
     os: [freebsd]
 
-  "@rollup/rollup-freebsd-x64@4.50.2":
+  "@rollup/rollup-freebsd-x64@4.60.4":
     resolution:
-      { integrity: sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog== }
+      { integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw== }
     cpu: [x64]
     os: [freebsd]
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.50.2":
+  "@rollup/rollup-linux-arm-gnueabihf@4.60.4":
     resolution:
-      { integrity: sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w== }
+      { integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA== }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-arm-musleabihf@4.50.2":
+  "@rollup/rollup-linux-arm-musleabihf@4.60.4":
     resolution:
-      { integrity: sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw== }
+      { integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w== }
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-arm64-gnu@4.50.2":
+  "@rollup/rollup-linux-arm64-gnu@4.60.4":
     resolution:
-      { integrity: sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg== }
+      { integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg== }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-arm64-musl@4.50.2":
+  "@rollup/rollup-linux-arm64-musl@4.60.4":
     resolution:
-      { integrity: sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ== }
+      { integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A== }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-loong64-gnu@4.50.2":
+  "@rollup/rollup-linux-loong64-gnu@4.60.4":
     resolution:
-      { integrity: sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw== }
+      { integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ== }
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-ppc64-gnu@4.50.2":
+  "@rollup/rollup-linux-loong64-musl@4.60.4":
     resolution:
-      { integrity: sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag== }
+      { integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw== }
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-ppc64-gnu@4.60.4":
+    resolution:
+      { integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg== }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-riscv64-gnu@4.50.2":
+  "@rollup/rollup-linux-ppc64-musl@4.60.4":
     resolution:
-      { integrity: sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ== }
+      { integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A== }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-riscv64-gnu@4.60.4":
+    resolution:
+      { integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA== }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-riscv64-musl@4.50.2":
+  "@rollup/rollup-linux-riscv64-musl@4.60.4":
     resolution:
-      { integrity: sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw== }
+      { integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw== }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-s390x-gnu@4.50.2":
+  "@rollup/rollup-linux-s390x-gnu@4.60.4":
     resolution:
-      { integrity: sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w== }
+      { integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ== }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-x64-gnu@4.50.2":
+  "@rollup/rollup-linux-x64-gnu@4.60.4":
     resolution:
-      { integrity: sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA== }
+      { integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ== }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-x64-musl@4.50.2":
+  "@rollup/rollup-linux-x64-musl@4.60.4":
     resolution:
-      { integrity: sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw== }
+      { integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg== }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-openharmony-arm64@4.50.2":
+  "@rollup/rollup-openbsd-x64@4.60.4":
     resolution:
-      { integrity: sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA== }
+      { integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA== }
+    cpu: [x64]
+    os: [openbsd]
+
+  "@rollup/rollup-openharmony-arm64@4.60.4":
+    resolution:
+      { integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg== }
     cpu: [arm64]
     os: [openharmony]
 
-  "@rollup/rollup-win32-arm64-msvc@4.50.2":
+  "@rollup/rollup-win32-arm64-msvc@4.60.4":
     resolution:
-      { integrity: sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA== }
+      { integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw== }
     cpu: [arm64]
     os: [win32]
 
-  "@rollup/rollup-win32-ia32-msvc@4.50.2":
+  "@rollup/rollup-win32-ia32-msvc@4.60.4":
     resolution:
-      { integrity: sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA== }
+      { integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA== }
     cpu: [ia32]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-msvc@4.50.2":
+  "@rollup/rollup-win32-x64-gnu@4.60.4":
     resolution:
-      { integrity: sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA== }
+      { integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw== }
+    cpu: [x64]
+    os: [win32]
+
+  "@rollup/rollup-win32-x64-msvc@4.60.4":
+    resolution:
+      { integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw== }
     cpu: [x64]
     os: [win32]
 
@@ -3164,9 +3192,9 @@ packages:
     resolution:
       { integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg== }
 
-  esbuild@0.25.9:
+  esbuild@0.27.7:
     resolution:
-      { integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g== }
+      { integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w== }
     engines: { node: ">=18" }
     hasBin: true
 
@@ -3464,9 +3492,9 @@ packages:
       { integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw== }
     engines: { node: ">=16" }
 
-  flatted@3.3.3:
+  flatted@3.4.2:
     resolution:
-      { integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg== }
+      { integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA== }
 
   for-each@0.3.5:
     resolution:
@@ -3786,10 +3814,10 @@ packages:
     resolution:
       { integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw== }
 
-  immutable@3.7.6:
+  immutable@3.8.3:
     resolution:
-      { integrity: sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw== }
-    engines: { node: ">=0.8.0" }
+      { integrity: sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg== }
+    engines: { node: ">=0.10.0" }
 
   import-fresh@3.3.1:
     resolution:
@@ -4245,9 +4273,9 @@ packages:
       { integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw== }
     engines: { node: ">=10" }
 
-  lodash-es@4.17.23:
+  lodash-es@4.18.1:
     resolution:
-      { integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg== }
+      { integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A== }
 
   lodash.clonedeep@4.5.0:
     resolution:
@@ -4262,9 +4290,9 @@ packages:
     resolution:
       { integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ== }
 
-  lodash@4.17.23:
+  lodash@4.18.1:
     resolution:
-      { integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w== }
+      { integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q== }
 
   log-symbols@4.1.0:
     resolution:
@@ -4412,18 +4440,18 @@ packages:
       { integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg== }
     engines: { node: ">=4" }
 
-  minimatch@3.1.2:
+  minimatch@3.1.5:
     resolution:
-      { integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw== }
+      { integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w== }
 
-  minimatch@4.2.3:
+  minimatch@4.2.6:
     resolution:
-      { integrity: sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng== }
+      { integrity: sha512-i35PeWjrW3Kv6/Jken0yeuByzK4YWer7UWba3yWg8+v+5WQQtcKiQ1GqGP7Jc3jhUdlviU3gQf89ON+69eD8RA== }
     engines: { node: ">=10" }
 
-  minimatch@9.0.5:
+  minimatch@9.0.9:
     resolution:
-      { integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow== }
+      { integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg== }
     engines: { node: ">=16 || 14 >=14.17" }
 
   minimist@1.2.8:
@@ -4472,9 +4500,9 @@ packages:
       { integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA== }
     engines: { node: ^18.17.0 || >=20.5.0 }
 
-  nanoid@3.3.11:
+  nanoid@3.3.12:
     resolution:
-      { integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w== }
+      { integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ== }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
@@ -4793,14 +4821,14 @@ packages:
     resolution:
       { integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA== }
 
-  picomatch@2.3.1:
+  picomatch@2.3.2:
     resolution:
-      { integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA== }
+      { integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA== }
     engines: { node: ">=8.6" }
 
-  picomatch@4.0.3:
+  picomatch@4.0.4:
     resolution:
-      { integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q== }
+      { integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A== }
     engines: { node: ">=12" }
 
   pidtree@0.3.1:
@@ -4842,9 +4870,9 @@ packages:
       { integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg== }
     engines: { node: ">= 0.4" }
 
-  postcss@8.5.6:
+  postcss@8.5.15:
     resolution:
-      { integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg== }
+      { integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A== }
     engines: { node: ^10 || ^12 || >=14 }
 
   prelude-ls@1.2.1:
@@ -4906,9 +4934,9 @@ packages:
       { integrity: sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ== }
     engines: { node: ">=6.0.0" }
 
-  qs@6.14.1:
+  qs@6.15.2:
     resolution:
-      { integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ== }
+      { integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw== }
     engines: { node: ">=0.6" }
 
   querystringify@2.2.0:
@@ -5174,9 +5202,9 @@ packages:
     resolution:
       { integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA== }
 
-  rollup@4.50.2:
+  rollup@4.60.4:
     resolution:
-      { integrity: sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w== }
+      { integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g== }
     engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
 
@@ -5854,9 +5882,9 @@ packages:
     resolution:
       { integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw== }
 
-  uuid@11.1.0:
+  uuid@11.1.1:
     resolution:
-      { integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A== }
+      { integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ== }
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -5893,9 +5921,9 @@ packages:
       vite:
         optional: true
 
-  vite@7.2.2:
+  vite@7.3.3:
     resolution:
-      { integrity: sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ== }
+      { integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA== }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
@@ -6118,14 +6146,14 @@ packages:
     resolution:
       { integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A== }
 
-  yaml@1.10.2:
+  yaml@1.10.3:
     resolution:
-      { integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg== }
+      { integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA== }
     engines: { node: ">= 6" }
 
-  yaml@2.8.0:
+  yaml@2.9.0:
     resolution:
-      { integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ== }
+      { integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA== }
     engines: { node: ">= 14.6" }
     hasBin: true
 
@@ -6216,7 +6244,7 @@ snapshots:
       fbjs: 3.0.5
       glob: 7.2.3
       graphql: 16.11.0
-      immutable: 3.7.6
+      immutable: 3.8.3
       invariant: 2.2.4
       nullthrows: 1.1.1
       relay-runtime: 12.0.0
@@ -6726,82 +6754,82 @@ snapshots:
 
   "@emotion/weak-memoize@0.4.0": {}
 
-  "@esbuild/aix-ppc64@0.25.9":
+  "@esbuild/aix-ppc64@0.27.7":
     optional: true
 
-  "@esbuild/android-arm64@0.25.9":
+  "@esbuild/android-arm64@0.27.7":
     optional: true
 
-  "@esbuild/android-arm@0.25.9":
+  "@esbuild/android-arm@0.27.7":
     optional: true
 
-  "@esbuild/android-x64@0.25.9":
+  "@esbuild/android-x64@0.27.7":
     optional: true
 
-  "@esbuild/darwin-arm64@0.25.9":
+  "@esbuild/darwin-arm64@0.27.7":
     optional: true
 
-  "@esbuild/darwin-x64@0.25.9":
+  "@esbuild/darwin-x64@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.25.9":
+  "@esbuild/freebsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-x64@0.25.9":
+  "@esbuild/freebsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm64@0.25.9":
+  "@esbuild/linux-arm64@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm@0.25.9":
+  "@esbuild/linux-arm@0.27.7":
     optional: true
 
-  "@esbuild/linux-ia32@0.25.9":
+  "@esbuild/linux-ia32@0.27.7":
     optional: true
 
-  "@esbuild/linux-loong64@0.25.9":
+  "@esbuild/linux-loong64@0.27.7":
     optional: true
 
-  "@esbuild/linux-mips64el@0.25.9":
+  "@esbuild/linux-mips64el@0.27.7":
     optional: true
 
-  "@esbuild/linux-ppc64@0.25.9":
+  "@esbuild/linux-ppc64@0.27.7":
     optional: true
 
-  "@esbuild/linux-riscv64@0.25.9":
+  "@esbuild/linux-riscv64@0.27.7":
     optional: true
 
-  "@esbuild/linux-s390x@0.25.9":
+  "@esbuild/linux-s390x@0.27.7":
     optional: true
 
-  "@esbuild/linux-x64@0.25.9":
+  "@esbuild/linux-x64@0.27.7":
     optional: true
 
-  "@esbuild/netbsd-arm64@0.25.9":
+  "@esbuild/netbsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/netbsd-x64@0.25.9":
+  "@esbuild/netbsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/openbsd-arm64@0.25.9":
+  "@esbuild/openbsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/openbsd-x64@0.25.9":
+  "@esbuild/openbsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/openharmony-arm64@0.25.9":
+  "@esbuild/openharmony-arm64@0.27.7":
     optional: true
 
-  "@esbuild/sunos-x64@0.25.9":
+  "@esbuild/sunos-x64@0.27.7":
     optional: true
 
-  "@esbuild/win32-arm64@0.25.9":
+  "@esbuild/win32-arm64@0.27.7":
     optional: true
 
-  "@esbuild/win32-ia32@0.25.9":
+  "@esbuild/win32-ia32@0.27.7":
     optional: true
 
-  "@esbuild/win32-x64@0.25.9":
+  "@esbuild/win32-x64@0.27.7":
     optional: true
 
   "@eslint-community/eslint-utils@4.9.0(eslint@9.35.0(jiti@1.21.7))":
@@ -6815,7 +6843,7 @@ snapshots:
     dependencies:
       "@eslint/object-schema": 2.1.6
       debug: 4.4.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -6834,7 +6862,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -6917,7 +6945,7 @@ snapshots:
       string-env-interpolation: 1.0.1
       ts-log: 2.2.7
       tslib: 2.8.1
-      yaml: 1.10.2
+      yaml: 1.10.3
       yargs: 17.7.2
     transitivePeerDependencies:
       - "@babel/core"
@@ -6957,7 +6985,7 @@ snapshots:
       common-tags: 1.8.2
       graphql: 16.11.0
       import-from: 4.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.4.1
 
   "@graphql-codegen/plugin-helpers@3.1.2(graphql@16.11.0)":
@@ -6967,7 +6995,7 @@ snapshots:
       common-tags: 1.8.2
       graphql: 16.11.0
       import-from: 4.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.4.1
 
   "@graphql-codegen/plugin-helpers@4.2.0(graphql@16.11.0)":
@@ -6977,7 +7005,7 @@ snapshots:
       common-tags: 1.8.2
       graphql: 16.11.0
       import-from: 4.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.5.3
 
   "@graphql-codegen/schema-ast@3.0.1(graphql@16.11.0)":
@@ -7262,7 +7290,7 @@ snapshots:
       jose: 4.15.9
       js-yaml: 4.1.1
       json-stable-stringify: 1.3.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       scuid: 1.1.0
       tslib: 2.8.1
       yaml-ast-parser: 0.0.43
@@ -7594,75 +7622,87 @@ snapshots:
 
   "@rolldown/pluginutils@1.0.0-beta.35": {}
 
-  "@rollup/pluginutils@5.3.0(rollup@4.50.2)":
+  "@rollup/pluginutils@5.3.0(rollup@4.60.4)":
     dependencies:
       "@types/estree": 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.50.2
+      rollup: 4.60.4
 
-  "@rollup/rollup-android-arm-eabi@4.50.2":
+  "@rollup/rollup-android-arm-eabi@4.60.4":
     optional: true
 
-  "@rollup/rollup-android-arm64@4.50.2":
+  "@rollup/rollup-android-arm64@4.60.4":
     optional: true
 
-  "@rollup/rollup-darwin-arm64@4.50.2":
+  "@rollup/rollup-darwin-arm64@4.60.4":
     optional: true
 
-  "@rollup/rollup-darwin-x64@4.50.2":
+  "@rollup/rollup-darwin-x64@4.60.4":
     optional: true
 
-  "@rollup/rollup-freebsd-arm64@4.50.2":
+  "@rollup/rollup-freebsd-arm64@4.60.4":
     optional: true
 
-  "@rollup/rollup-freebsd-x64@4.50.2":
+  "@rollup/rollup-freebsd-x64@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.50.2":
+  "@rollup/rollup-linux-arm-gnueabihf@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-arm-musleabihf@4.50.2":
+  "@rollup/rollup-linux-arm-musleabihf@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-arm64-gnu@4.50.2":
+  "@rollup/rollup-linux-arm64-gnu@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-arm64-musl@4.50.2":
+  "@rollup/rollup-linux-arm64-musl@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-loong64-gnu@4.50.2":
+  "@rollup/rollup-linux-loong64-gnu@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-ppc64-gnu@4.50.2":
+  "@rollup/rollup-linux-loong64-musl@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-riscv64-gnu@4.50.2":
+  "@rollup/rollup-linux-ppc64-gnu@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-riscv64-musl@4.50.2":
+  "@rollup/rollup-linux-ppc64-musl@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-s390x-gnu@4.50.2":
+  "@rollup/rollup-linux-riscv64-gnu@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-x64-gnu@4.50.2":
+  "@rollup/rollup-linux-riscv64-musl@4.60.4":
     optional: true
 
-  "@rollup/rollup-linux-x64-musl@4.50.2":
+  "@rollup/rollup-linux-s390x-gnu@4.60.4":
     optional: true
 
-  "@rollup/rollup-openharmony-arm64@4.50.2":
+  "@rollup/rollup-linux-x64-gnu@4.60.4":
     optional: true
 
-  "@rollup/rollup-win32-arm64-msvc@4.50.2":
+  "@rollup/rollup-linux-x64-musl@4.60.4":
     optional: true
 
-  "@rollup/rollup-win32-ia32-msvc@4.50.2":
+  "@rollup/rollup-openbsd-x64@4.60.4":
     optional: true
 
-  "@rollup/rollup-win32-x64-msvc@4.50.2":
+  "@rollup/rollup-openharmony-arm64@4.60.4":
+    optional: true
+
+  "@rollup/rollup-win32-arm64-msvc@4.60.4":
+    optional: true
+
+  "@rollup/rollup-win32-ia32-msvc@4.60.4":
+    optional: true
+
+  "@rollup/rollup-win32-x64-gnu@4.60.4":
+    optional: true
+
+  "@rollup/rollup-win32-x64-msvc@4.60.4":
     optional: true
 
   "@rtsao/scc@1.1.0": {}
@@ -7982,7 +8022,7 @@ snapshots:
       debug: 4.4.1
       fast-glob: 3.3.3
       is-glob: 4.0.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       semver: 7.7.2
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
@@ -8058,7 +8098,7 @@ snapshots:
   "@unrs/resolver-binding-win32-x64-msvc@1.7.2":
     optional: true
 
-  "@vitejs/plugin-react@5.0.3(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))":
+  "@vitejs/plugin-react@5.0.3(vite@7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0))":
     dependencies:
       "@babel/core": 7.28.4
       "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.28.4)
@@ -8066,11 +8106,11 @@ snapshots:
       "@rolldown/pluginutils": 1.0.0-beta.35
       "@types/babel__core": 7.20.5
       react-refresh: 0.17.0
-      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.8.0))":
+  "@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.9.0))":
     dependencies:
       "@ampproject/remapping": 2.3.0
       "@bcoe/v8-coverage": 1.0.2
@@ -8085,7 +8125,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.8.0)
+      vitest: 3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8097,14 +8137,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  "@vitest/mocker@3.2.4(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))":
+  "@vitest/mocker@3.2.4(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(vite@7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0))":
     dependencies:
       "@vitest/spy": 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.11.6(@types/node@22.18.5)(typescript@5.9.2)
-      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0)
 
   "@vitest/pretty-format@3.2.4":
     dependencies:
@@ -8610,7 +8650,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.2
+      yaml: 1.10.3
 
   cosmiconfig@8.0.0:
     dependencies:
@@ -8927,34 +8967,34 @@ snapshots:
 
   es6-error@4.1.1: {}
 
-  esbuild@0.25.9:
+  esbuild@0.27.7:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.9
-      "@esbuild/android-arm": 0.25.9
-      "@esbuild/android-arm64": 0.25.9
-      "@esbuild/android-x64": 0.25.9
-      "@esbuild/darwin-arm64": 0.25.9
-      "@esbuild/darwin-x64": 0.25.9
-      "@esbuild/freebsd-arm64": 0.25.9
-      "@esbuild/freebsd-x64": 0.25.9
-      "@esbuild/linux-arm": 0.25.9
-      "@esbuild/linux-arm64": 0.25.9
-      "@esbuild/linux-ia32": 0.25.9
-      "@esbuild/linux-loong64": 0.25.9
-      "@esbuild/linux-mips64el": 0.25.9
-      "@esbuild/linux-ppc64": 0.25.9
-      "@esbuild/linux-riscv64": 0.25.9
-      "@esbuild/linux-s390x": 0.25.9
-      "@esbuild/linux-x64": 0.25.9
-      "@esbuild/netbsd-arm64": 0.25.9
-      "@esbuild/netbsd-x64": 0.25.9
-      "@esbuild/openbsd-arm64": 0.25.9
-      "@esbuild/openbsd-x64": 0.25.9
-      "@esbuild/openharmony-arm64": 0.25.9
-      "@esbuild/sunos-x64": 0.25.9
-      "@esbuild/win32-arm64": 0.25.9
-      "@esbuild/win32-ia32": 0.25.9
-      "@esbuild/win32-x64": 0.25.9
+      "@esbuild/aix-ppc64": 0.27.7
+      "@esbuild/android-arm": 0.27.7
+      "@esbuild/android-arm64": 0.27.7
+      "@esbuild/android-x64": 0.27.7
+      "@esbuild/darwin-arm64": 0.27.7
+      "@esbuild/darwin-x64": 0.27.7
+      "@esbuild/freebsd-arm64": 0.27.7
+      "@esbuild/freebsd-x64": 0.27.7
+      "@esbuild/linux-arm": 0.27.7
+      "@esbuild/linux-arm64": 0.27.7
+      "@esbuild/linux-ia32": 0.27.7
+      "@esbuild/linux-loong64": 0.27.7
+      "@esbuild/linux-mips64el": 0.27.7
+      "@esbuild/linux-ppc64": 0.27.7
+      "@esbuild/linux-riscv64": 0.27.7
+      "@esbuild/linux-s390x": 0.27.7
+      "@esbuild/linux-x64": 0.27.7
+      "@esbuild/netbsd-arm64": 0.27.7
+      "@esbuild/netbsd-x64": 0.27.7
+      "@esbuild/openbsd-arm64": 0.27.7
+      "@esbuild/openbsd-x64": 0.27.7
+      "@esbuild/openharmony-arm64": 0.27.7
+      "@esbuild/sunos-x64": 0.27.7
+      "@esbuild/win32-arm64": 0.27.7
+      "@esbuild/win32-ia32": 0.27.7
+      "@esbuild/win32-x64": 0.27.7
 
   escalade@3.2.0: {}
 
@@ -9016,7 +9056,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -9044,7 +9084,7 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -9074,7 +9114,7 @@ snapshots:
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -9127,7 +9167,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -9231,13 +9271,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  fdir@6.4.4(picomatch@4.0.3):
+  fdir@6.4.4(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   figures@3.2.0:
     dependencies:
@@ -9265,10 +9305,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.5:
     dependencies:
@@ -9356,7 +9396,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -9366,7 +9406,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -9409,7 +9449,7 @@ snapshots:
       cosmiconfig: 8.0.0
       graphql: 16.11.0
       jiti: 1.17.1
-      minimatch: 4.2.3
+      minimatch: 4.2.6
       string-env-interpolation: 1.0.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -9550,7 +9590,7 @@ snapshots:
 
   immer@10.1.1: {}
 
-  immutable@3.7.6: {}
+  immutable@3.8.3: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -9578,7 +9618,7 @@ snapshots:
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
@@ -9928,7 +9968,7 @@ snapshots:
       micromatch: 4.0.8
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.8.0
+      yaml: 2.9.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9967,7 +10007,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.23: {}
+  lodash-es@4.18.1: {}
 
   lodash.clonedeep@4.5.0: {}
 
@@ -9975,7 +10015,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -10060,7 +10100,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -10079,15 +10119,15 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@3.1.2:
+  minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@4.2.3:
+  minimatch@4.2.6:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@9.0.5:
+  minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.0.2
 
@@ -10134,7 +10174,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   napi-postinstall@0.2.4: {}
 
@@ -10180,7 +10220,7 @@ snapshots:
       chalk: 2.4.2
       cross-spawn: 6.0.6
       memorystream: 0.3.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
       shell-quote: 1.8.2
@@ -10400,9 +10440,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pidtree@0.3.1: {}
 
@@ -10423,9 +10463,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -10472,7 +10512,7 @@ snapshots:
 
   pvutils@1.1.3: {}
 
-  qs@6.14.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -10489,7 +10529,7 @@ snapshots:
   quill@2.0.3:
     dependencies:
       eventemitter3: 5.0.1
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       parchment: 3.0.0
       quill-delta: 5.1.0
 
@@ -10515,7 +10555,7 @@ snapshots:
 
   react-quill-new@3.4.6(quill-delta@5.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       quill: 2.0.3
       quill-delta: 5.1.0
       react: 19.1.0
@@ -10606,19 +10646,21 @@ snapshots:
       history: 4.10.1
       redux: 5.0.1
 
-  redux-form@8.3.10(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1):
+  redux-form@8.3.10(immutable@3.8.3)(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1):
     dependencies:
       "@babel/runtime": 7.27.1
       es6-error: 4.1.1
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       is-promise: 2.2.2
-      lodash: 4.17.23
+      lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.1.0
       react-is: 16.13.1
       react-redux: 9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1)
       redux: 5.0.1
+    optionalDependencies:
+      immutable: 3.8.3
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
@@ -10715,31 +10757,35 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup@4.50.2:
+  rollup@4.60.4:
     dependencies:
       "@types/estree": 1.0.8
     optionalDependencies:
-      "@rollup/rollup-android-arm-eabi": 4.50.2
-      "@rollup/rollup-android-arm64": 4.50.2
-      "@rollup/rollup-darwin-arm64": 4.50.2
-      "@rollup/rollup-darwin-x64": 4.50.2
-      "@rollup/rollup-freebsd-arm64": 4.50.2
-      "@rollup/rollup-freebsd-x64": 4.50.2
-      "@rollup/rollup-linux-arm-gnueabihf": 4.50.2
-      "@rollup/rollup-linux-arm-musleabihf": 4.50.2
-      "@rollup/rollup-linux-arm64-gnu": 4.50.2
-      "@rollup/rollup-linux-arm64-musl": 4.50.2
-      "@rollup/rollup-linux-loong64-gnu": 4.50.2
-      "@rollup/rollup-linux-ppc64-gnu": 4.50.2
-      "@rollup/rollup-linux-riscv64-gnu": 4.50.2
-      "@rollup/rollup-linux-riscv64-musl": 4.50.2
-      "@rollup/rollup-linux-s390x-gnu": 4.50.2
-      "@rollup/rollup-linux-x64-gnu": 4.50.2
-      "@rollup/rollup-linux-x64-musl": 4.50.2
-      "@rollup/rollup-openharmony-arm64": 4.50.2
-      "@rollup/rollup-win32-arm64-msvc": 4.50.2
-      "@rollup/rollup-win32-ia32-msvc": 4.50.2
-      "@rollup/rollup-win32-x64-msvc": 4.50.2
+      "@rollup/rollup-android-arm-eabi": 4.60.4
+      "@rollup/rollup-android-arm64": 4.60.4
+      "@rollup/rollup-darwin-arm64": 4.60.4
+      "@rollup/rollup-darwin-x64": 4.60.4
+      "@rollup/rollup-freebsd-arm64": 4.60.4
+      "@rollup/rollup-freebsd-x64": 4.60.4
+      "@rollup/rollup-linux-arm-gnueabihf": 4.60.4
+      "@rollup/rollup-linux-arm-musleabihf": 4.60.4
+      "@rollup/rollup-linux-arm64-gnu": 4.60.4
+      "@rollup/rollup-linux-arm64-musl": 4.60.4
+      "@rollup/rollup-linux-loong64-gnu": 4.60.4
+      "@rollup/rollup-linux-loong64-musl": 4.60.4
+      "@rollup/rollup-linux-ppc64-gnu": 4.60.4
+      "@rollup/rollup-linux-ppc64-musl": 4.60.4
+      "@rollup/rollup-linux-riscv64-gnu": 4.60.4
+      "@rollup/rollup-linux-riscv64-musl": 4.60.4
+      "@rollup/rollup-linux-s390x-gnu": 4.60.4
+      "@rollup/rollup-linux-x64-gnu": 4.60.4
+      "@rollup/rollup-linux-x64-musl": 4.60.4
+      "@rollup/rollup-openbsd-x64": 4.60.4
+      "@rollup/rollup-openharmony-arm64": 4.60.4
+      "@rollup/rollup-win32-arm64-msvc": 4.60.4
+      "@rollup/rollup-win32-ia32-msvc": 4.60.4
+      "@rollup/rollup-win32-x64-gnu": 4.60.4
+      "@rollup/rollup-win32-x64-msvc": 4.60.4
       fsevents: 2.3.3
 
   rrweb-cssom@0.6.0: {}
@@ -11079,7 +11125,7 @@ snapshots:
     dependencies:
       "@istanbuljs/schema": 0.1.3
       glob: 10.5.0
-      minimatch: 9.0.5
+      minimatch: 9.0.9
 
   through@2.3.8: {}
 
@@ -11095,13 +11141,13 @@ snapshots:
 
   tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.4(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.4.4(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 
@@ -11307,7 +11353,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.0: {}
+  uuid@11.1.1: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -11318,13 +11364,13 @@ snapshots:
 
   value-or-promise@1.0.12: {}
 
-  vite-node@3.2.4(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - "@types/node"
       - jiti
@@ -11339,48 +11385,48 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-svgr@4.5.0(rollup@4.50.2)(typescript@5.9.2)(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)):
+  vite-plugin-svgr@4.5.0(rollup@4.60.4)(typescript@5.9.2)(vite@7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0)):
     dependencies:
-      "@rollup/pluginutils": 5.3.0(rollup@4.50.2)
+      "@rollup/pluginutils": 5.3.0(rollup@4.60.4)
       "@svgr/core": 8.1.0(typescript@5.9.2)
       "@svgr/plugin-jsx": 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
-      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)):
+  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0):
+  vite@7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.25.9
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.50.2
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.4
       tinyglobby: 0.2.15
     optionalDependencies:
       "@types/node": 22.18.5
       fsevents: 2.3.3
       jiti: 1.21.7
       less: 4.4.1
-      yaml: 2.8.0
+      yaml: 2.9.0
 
-  vitest@3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.8.0):
+  vitest@3.2.4(@types/node@22.18.5)(jiti@1.21.7)(jsdom@22.1.0)(less@4.4.1)(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(yaml@2.9.0):
     dependencies:
       "@types/chai": 5.2.2
       "@vitest/expect": 3.2.4
-      "@vitest/mocker": 3.2.4(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(vite@7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0))
+      "@vitest/mocker": 3.2.4(msw@2.11.6(@types/node@22.18.5)(typescript@5.9.2))(vite@7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0))
       "@vitest/pretty-format": 3.2.4
       "@vitest/runner": 3.2.4
       "@vitest/snapshot": 3.2.4
@@ -11391,15 +11437,15 @@ snapshots:
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.2.2(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.8.0)
+      vite: 7.3.3(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.18.5)(jiti@1.21.7)(less@4.4.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 22.18.5
@@ -11554,9 +11600,9 @@ snapshots:
 
   yaml-ast-parser@0.0.43: {}
 
-  yaml@1.10.2: {}
+  yaml@1.10.3: {}
 
-  yaml@2.8.0: {}
+  yaml@2.9.0: {}
 
   yargs-parser@18.1.3:
     dependencies:


### PR DESCRIPTION
Oppdaterer sårbare npm-avhengigheter for å lukke 21 av 22 åpne Dependabot-varsler.

https://github.com/navikt/melosys-web/security/dependabot

Varslene skyldtes hovedsakelig en utdatert `pnpm-lock.yaml` der patchede versjoner allerede lå innenfor eksisterende semver-ranger. Bumpet 4 direkte avhengigheter og dro inn patchede transitive pakker via lockfile-refresh og to scoped overrides. Faktisk eksponering var lav: lodash `_.template` brukes ikke, og Quills HTML-eksport er ikke i bruk.

- Bumpet lodash, qs, uuid og vite (direkte deps)
- Patchet transitive lodash-es, rollup, immutable, minimatch, flatted, postcss, picomatch, yaml
- La til scoped overrides for immutable og minimatch (graphql-codegen-verktøy)

## Testing
- [x] Build (vite 7.3.3) + tsc + eslint (0 errors)
- [x] Enhetstester (532 filer, 3250 tester grønne)
- [x] Playwright-tester (55, passed, 0 errors)

## Notater
quill #174 (LOW XSS via HTML-eksport) gjenstår — ingen patched versjon finnes oppstrøms, og den sårbare funksjonen brukes ikke. Anbefales dismisset i Dependabot.