### PR TITLE
NOJIRA G4P Bump @tootallnate/once for å lukke Dependabot-varsel

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,8 @@
       "lodash": "^4.18.0",
       "lodash-es": "^4.18.0",
       "@ardatan/relay-compiler>immutable": "^3.8.3",
-      "graphql-config>minimatch": "^4.2.5"
+      "graphql-config>minimatch": "^4.2.5",
+      "http-proxy-agent>@tootallnate/once": "^2.0.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   lodash-es: ^4.18.0
   "@ardatan/relay-compiler>immutable": ^3.8.3
   graphql-config>minimatch: ^4.2.5
+  http-proxy-agent>@tootallnate/once: ^2.0.1
 
 importers:
   .:
@@ -1968,9 +1969,9 @@ packages:
     peerDependencies:
       "@testing-library/dom": ">=7.21.4"
 
-  "@tootallnate/once@2.0.0":
+  "@tootallnate/once@2.0.1":
     resolution:
-      { integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A== }
+      { integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ== }
     engines: { node: ">= 10" }
 
   "@tybys/wasm-util@0.9.0":
@@ -7830,7 +7831,7 @@ snapshots:
     dependencies:
       "@testing-library/dom": 10.4.1
 
-  "@tootallnate/once@2.0.0": {}
+  "@tootallnate/once@2.0.1": {}
 
   "@tybys/wasm-util@0.9.0":
     dependencies:
@@ -9540,7 +9541,7 @@ snapshots:
 
   http-proxy-agent@5.0.0:
     dependencies:
-      "@tootallnate/once": 2.0.0
+      "@tootallnate/once": 2.0.1
       agent-base: 6.0.2
       debug: 4.4.1
     transitivePeerDependencies:


### PR DESCRIPTION
Lukker det siste fiksbare Dependabot-varselet (#220, low) ved å tvinge `@tootallnate/once` til patchet `2.0.1`.

Pakken dras inn transitivt via `http-proxy-agent` ← `jsdom` ← `vitest` — altså en ren test-avhengighet. `http-proxy-agent@5.0.0` godtar `^2.0.0`, så en scoped override er tilstrekkelig.

- Scoped override `http-proxy-agent>@tootallnate/once: ^2.0.1`

## Testing
- [x] Enhetstester (532 filer, 3250 tester grønne)

## Notater
Oppfølging til #3079. quill #174 (low) gjenstår — ingen patch finnes oppstrøms; dismisses i Dependabot som "not used".