### PR TITLE
NOJIRA Cancel debounced kontroll ved unmount i artikkel16-anmodning

### DIFF
--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
@@ -172,6 +172,7 @@ export function VurderingArtikkel16Anmodning({
 
   useEffect(() => {
     debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus });
+    return () => debouncedKontrollerBehandling.cancel();
   }, [aktivtSteg, mottatteOpplysningerStatus]);
 
   const handleEndretUnntakFraBestemmelse = async (event: ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
Fikser en unhandled rejection som gjør CI rød på PR-er selv om alle tester passerer.

`vurderingArtikkel16Anmodning` har en debounced `kontrollerBehandling` (500ms), men `useEffect`-en som trigger den mangler cleanup. Unmountes komponenten innenfor debounce-vinduet, fyrer kallet `setPending(...)` på en unmountet komponent → unhandled rejection som Vitest fanger og lar CI feile. Speiler den etablerte fiksen fra [MELOSYS-7938](https://jira.adeo.no/browse/MELOSYS-7938) / #3022 (Rune sin commit `55effab37` i `vurderingAvslag12_x_og_16`) og de øvrige EU/EØS-vedtakskomponentene.

- La til `return () => debouncedKontrollerBehandling.cancel()` i useEffect

## Testing
- [x] Enhetstester (532 filer, 3250 tester grønne, 0 unhandled rejections)
- [x] tsc + eslint

## Notater
Den opprinnelige flaken var timing-avhengig og reproduserte ikke pålitelig lokalt — CI på denne PR-en blir endelig bekreftelse. Oppdaget ifm. #3080 (Dependabot-oppfølging).