### PR TITLE
8052 TOGGLE Oppdater visning av innbetalt trygdeavgift

### DIFF
--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
@@ -22,9 +22,7 @@ export function SumArsavregningTabell({
   const erÅrsavregningEøsPensjonistToggleEnabled = useFeatureToggle(ÅRSAVREGNING_EØS_PENSJONIST);
 
   const skalViseInnbetaltTrygdeavgift =
-    erÅrsavregningEøsPensjonistToggleEnabled &&
-    tidligereInnbetaltTrygdeavgift !== undefined &&
-    tidligereInnbetaltTrygdeavgift !== null;
+    tidligereInnbetaltTrygdeavgift !== undefined && tidligereInnbetaltTrygdeavgift !== null;
 
   const skalViseTidligereBeregnetTrygdeavgift = erÅrsavregningEøsPensjonistToggleEnabled
     ? !skalViseInnbetaltTrygdeavgift && (harGrunnlagIMelosys || tidligereTrygdeavgift) !== undefined
@@ -52,7 +50,7 @@ export function SumArsavregningTabell({
     ? "Tidligere innbetalt trygdeavgift"
     : "Tidligere trygdeavgift fra Avgiftssystemet";
 
-  const tigligereBeregnetTrygdeavgiftLabel = erÅrsavregningEøsPensjonistToggleEnabled
+  const tidligereBeregnetTrygdeavgiftLabel = erÅrsavregningEøsPensjonistToggleEnabled
     ? "Innbetalt trygdeavgift"
     : "Tidligere beregnet trygdeavgift";
 
@@ -72,7 +70,7 @@ export function SumArsavregningTabell({
           {skalViseTidligereBeregnetTrygdeavgift && (
             <Nav.Table.Row>
               <Nav.Table.DataCell scope="col">-</Nav.Table.DataCell>
-              <Nav.Table.DataCell scope="col">{tigligereBeregnetTrygdeavgiftLabel}</Nav.Table.DataCell>
+              <Nav.Table.DataCell scope="col">{tidligereBeregnetTrygdeavgiftLabel}</Nav.Table.DataCell>
               <Nav.Table.DataCell align="right" key={Utils._uuid()}>
                 {formaterTilNorskBelop(tidligereTrygdeavgift || 0)} kr
               </Nav.Table.DataCell>

--- a/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingAarsavregning/komponenter/sumArsavregningTabell.tsx
@@ -21,11 +21,10 @@ export function SumArsavregningTabell({
 }) {
   const erÅrsavregningEøsPensjonistToggleEnabled = useFeatureToggle(ÅRSAVREGNING_EØS_PENSJONIST);
 
-  const skalViseInnbetaltTrygdeavgift = erÅrsavregningEøsPensjonistToggleEnabled
-    ? tidligereInnbetaltTrygdeavgift !== undefined &&
-      tidligereInnbetaltTrygdeavgift !== null &&
-      tidligereInnbetaltTrygdeavgift !== 0
-    : tidligereInnbetaltTrygdeavgift !== undefined && tidligereInnbetaltTrygdeavgift !== null;
+  const skalViseInnbetaltTrygdeavgift =
+    erÅrsavregningEøsPensjonistToggleEnabled &&
+    tidligereInnbetaltTrygdeavgift !== undefined &&
+    tidligereInnbetaltTrygdeavgift !== null;
 
   const skalViseTidligereBeregnetTrygdeavgift = erÅrsavregningEøsPensjonistToggleEnabled
     ? !skalViseInnbetaltTrygdeavgift && (harGrunnlagIMelosys || tidligereTrygdeavgift) !== undefined
@@ -53,6 +52,10 @@ export function SumArsavregningTabell({
     ? "Tidligere innbetalt trygdeavgift"
     : "Tidligere trygdeavgift fra Avgiftssystemet";
 
+  const tigligereBeregnetTrygdeavgiftLabel = erÅrsavregningEøsPensjonistToggleEnabled
+    ? "Innbetalt trygdeavgift"
+    : "Tidligere beregnet trygdeavgift";
+
   return (
     <Nav.Box className="sumArsavregningTabell" background="surface-subtle">
       <Nav.Table size="small" width={500} className="periode_tabell">
@@ -69,7 +72,7 @@ export function SumArsavregningTabell({
           {skalViseTidligereBeregnetTrygdeavgift && (
             <Nav.Table.Row>
               <Nav.Table.DataCell scope="col">-</Nav.Table.DataCell>
-              <Nav.Table.DataCell scope="col">Tidligere beregnet trygdeavgift</Nav.Table.DataCell>
+              <Nav.Table.DataCell scope="col">{tigligereBeregnetTrygdeavgiftLabel}</Nav.Table.DataCell>
               <Nav.Table.DataCell align="right" key={Utils._uuid()}>
                 {formaterTilNorskBelop(tidligereTrygdeavgift || 0)} kr
               </Nav.Table.DataCell>


### PR DESCRIPTION
Oppdaterer årsavregningstabellen slik at innbetalt trygdeavgift vises med riktig logikk og tekst når EØS-pensjonist-toggle er aktiv.

Endringen sikrer at årsavregningen bruker riktig begrep for innbetalt trygdeavgift og ikke viser tidligere innbetalt trygdeavgift uten aktiv toggle.
[MELOSYS-8052](https://jira.adeo.no/browse/MELOSYS-8052)

- Viser innbetalt trygdeavgift kun når EØS-pensjonist-toggle er aktiv
- Oppdaterer label for tidligere beregnet trygdeavgift ved aktiv toggle

## Testing
- [ ] Enhetstester
- [x] Manuell testing lokalt
- [ ] E2E-tester