### PR TITLE
8098 Inputfelt som ikke kan endres skal være read-only

### DIFF
--- a/src/felleskomponenter/fagsakVelger/knyttTilSak.test.tsx
+++ b/src/felleskomponenter/fagsakVelger/knyttTilSak.test.tsx
@@ -378,8 +378,8 @@ describe("KnyttTilSak", () => {
     });
   });
 
-  describe("Behandlingstema disabled ved årsavregning", () => {
-    it("behandlingstema-dropdown er disabled når behandlingstype er årsavregning og saken har eksisterende behandlinger", async () => {
+  describe("Behandlingstema readOnly ved årsavregning", () => {
+    it("behandlingstema-dropdown er readOnly når behandlingstype er årsavregning og saken har eksisterende behandlinger", async () => {
       props.formValues.opprettBehandling = true;
       props.formValues.behandlingstema = "YRKESAKTIV";
       props.formValues.behandlingstype = MKV.Koder.behandlinger.behandlingstyper.ÅRSAVREGNING;
@@ -391,12 +391,14 @@ describe("KnyttTilSak", () => {
       await renderWithProvidersAsync(<WrappedKnyttTilSak {...(props as any)} />);
 
       await waitFor(() => {
-        const behandlingstemaSelect = screen.getByLabelText("Behandlingstema");
-        expect(behandlingstemaSelect).toBeDisabled();
+        // Låseikonet legger "Skrivebeskyttet" i label-teksten, derfor regex
+        const behandlingstemaSelect = screen.getByLabelText(/Behandlingstema/);
+        expect(behandlingstemaSelect).not.toBeDisabled();
+        expect(behandlingstemaSelect.closest(".navds-form-field")).toHaveClass("navds-form-field--readonly");
       });
     });
 
-    it("behandlingstema-dropdown er IKKE disabled når behandlingstype ikke er årsavregning", async () => {
+    it("behandlingstema-dropdown er IKKE readOnly når behandlingstype ikke er årsavregning", async () => {
       props.formValues.opprettBehandling = true;
       props.formValues.behandlingstema = "YRKESAKTIV";
       props.formValues.behandlingstype = MKV.Koder.behandlinger.behandlingstyper.NY_VURDERING;
@@ -410,6 +412,7 @@ describe("KnyttTilSak", () => {
       await waitFor(() => {
         const behandlingstemaSelect = screen.getByLabelText("Behandlingstema");
         expect(behandlingstemaSelect).not.toBeDisabled();
+        expect(behandlingstemaSelect.closest(".navds-form-field")).not.toHaveClass("navds-form-field--readonly");
       });
     });
 
@@ -444,8 +447,10 @@ describe("KnyttTilSak", () => {
       await renderWithProvidersAsync(<WrappedKnyttTilSak {...(props as any)} />);
 
       await waitFor(() => {
-        const behandlingstemaSelect = screen.getByLabelText("Behandlingstema");
-        expect(behandlingstemaSelect).toBeDisabled();
+        // Låseikonet legger "Skrivebeskyttet" i label-teksten, derfor regex
+        const behandlingstemaSelect = screen.getByLabelText(/Behandlingstema/);
+        expect(behandlingstemaSelect).not.toBeDisabled();
+        expect(behandlingstemaSelect.closest(".navds-form-field")).toHaveClass("navds-form-field--readonly");
         expect(
           screen.getByText(/Du kan ikke endre behandlingstema når saken har en tilknyttet fakturaserie eller/),
         ).toBeInTheDocument();

--- a/src/felleskomponenter/fagsakVelger/knyttTilSak.tsx
+++ b/src/felleskomponenter/fagsakVelger/knyttTilSak.tsx
@@ -204,7 +204,7 @@ export function KnyttTilSak(props: KnyttTilSakProps) {
               feltNavn={feltNavn.behandlingstema}
               label="Behandlingstema"
               emptyFieldDisabled={!!(behandlingstema as { kode?: string })?.kode}
-              disabled={state.harBehandlingMedTrygdeavgift || erAndregangsÅrsavregning}
+              readonly={state.harBehandlingMedTrygdeavgift || erAndregangsÅrsavregning}
               className={state.harBehandlingMedTrygdeavgift || erAndregangsÅrsavregning ? "select__slim" : undefined}
             >
               {state.muligeBehandlingstemaer?.map((elem) => (

--- a/src/felleskomponenter/fagsakVelger/opprettSak.jsx
+++ b/src/felleskomponenter/fagsakVelger/opprettSak.jsx
@@ -150,7 +150,7 @@ export function OpprettSak(props) {
         feltNavn={feltNavn.sakstype}
         label="Sakstype"
         onChange={() => nullstillVerdier(feltNavn.sakstype, settFeltInnhold, feltNavn)}
-        disabled={disableSakstype}
+        readonly={disableSakstype}
       >
         {sakstyper.map((elem) => (
           <option key={elem.kode} value={elem.kode}>

--- a/src/felleskomponenter/fagsakVelger/opprettSak.test.tsx
+++ b/src/felleskomponenter/fagsakVelger/opprettSak.test.tsx
@@ -60,6 +60,7 @@ interface OpprettSakProps {
     journalforingSoknadsland?: string;
     opprettnysak_behandlingstema?: string;
     opprettnysak_behandlingstype?: string;
+    utenlandskTrygdemyndighetLandkode?: string;
   };
   feltNavn: {
     sakstype: string;
@@ -187,6 +188,29 @@ describe("OpprettSak - journalføring", () => {
     expect(getByLabelText("Til")).toBeInTheDocument();
     expect(getByRole("combobox", { name: "I hvilke land skal arbeidet/næringen utføres i?" })).toBeInTheDocument(); // MultiSelect har tom label
     expect(getAllByRole("radio")).toHaveLength(2);
+  });
+
+  it("Sakstype-dropdown er readOnly når utenlandsk trygdemyndighet er utenfor tillatte landkombinasjoner", () => {
+    // "AF" er ikke trygdeavtaleland/EU-EØS-land, så sakstype låses (settes automatisk i avsenderflyten)
+    props.formValues.sakstype = MKV.Koder.sakstyper.EU_EOS;
+    props.formValues.utenlandskTrygdemyndighetLandkode = "AF";
+
+    const { getByLabelText } = renderWithProviders(<WrappedOpprettSak {...props} />);
+
+    // Låseikonet legger "Skrivebeskyttet" i label-teksten, derfor regex
+    const sakstypeSelect = getByLabelText(/Sakstype/);
+    expect(sakstypeSelect).not.toBeDisabled();
+    expect(sakstypeSelect.closest(".navds-form-field")).toHaveClass("navds-form-field--readonly");
+  });
+
+  it("Sakstype-dropdown er IKKE readOnly uten utenlandsk trygdemyndighet", () => {
+    props.formValues.sakstype = MKV.Koder.sakstyper.EU_EOS;
+
+    const { getByLabelText } = renderWithProviders(<WrappedOpprettSak {...props} />);
+
+    const sakstypeSelect = getByLabelText("Sakstype");
+    expect(sakstypeSelect).not.toBeDisabled();
+    expect(sakstypeSelect.closest(".navds-form-field")).not.toHaveClass("navds-form-field--readonly");
   });
 });
 

--- a/tests/e2e/pages/opprett-ny-sak/opprett-ny-sak.page.ts
+++ b/tests/e2e/pages/opprett-ny-sak/opprett-ny-sak.page.ts
@@ -549,6 +549,21 @@ export class OpprettNySakPage {
   }
 
   /**
+   * Verifiser at Behandlingstema-feltet er read-only (låst), ikke disabled.
+   * Aksel read-only gjør feltet ikke-`disabled`, men gir wrapperen klassen
+   * `navds-form-field--readonly` og viser et låseikon. (MELOSYS-8098)
+   */
+  async verifiserBehandlingstemaReadOnly(): Promise<void> {
+    // Låseikonet legger "Skrivebeskyttet" i label-teksten, derfor regex på navnet
+    const behandlingstema = this.page.getByRole("combobox", { name: /Behandlingstema/ });
+    await expect(behandlingstema, "Behandlingstema-feltet skal være synlig").toBeVisible();
+    await expect(behandlingstema, "Behandlingstema skal være read-only, ikke disabled").not.toBeDisabled();
+
+    const readOnlyFelt = this.page.locator(".navds-form-field--readonly", { has: behandlingstema });
+    await expect(readOnlyFelt, "Behandlingstema skal rendres som read-only").toBeVisible();
+  }
+
+  /**
    * Verifiser feilmelding for EØS-sak med aktiv behandling
    */
   async verifiserEosFeilmelding(): Promise<void> {

--- a/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/eos-pensjonist-aarsavregning.spec.ts
+++ b/tests/e2e/specs/opprett-ny-sak/knytt-til-eksisterende/eos-pensjonist-aarsavregning.spec.ts
@@ -32,6 +32,10 @@ test.describe("EØS pensjonist med trygdeavgift - årsavregning", () => {
     // Verifiser at årsavregning er tilgjengelig (unntak fra vanlig EØS-regel)
     await opprettNySakPage.verifiserTilgjengeligeBehandlingstyper(valgtSak, ["Årsavregning"]);
 
+    // Når kun årsavregning er tilgjengelig på en sak med eksisterende behandling,
+    // skal Behandlingstema være read-only (låst med låseikon), ikke disabled (MELOSYS-8098)
+    await opprettNySakPage.verifiserBehandlingstemaReadOnly();
+
     // Verifiser at ingen feilmelding vises
     const harFeilmelding = await opprettNySakPage.harFeilmelding();
     expect(harFeilmelding, `Ingen feilmelding skal vises for EØS pensjonist-sak ${sakId}`).toBe(false);


### PR DESCRIPTION
Endrer låste, ikke-redigerbare felt fra `disabled` til `readOnly` (Aksel), slik at de viser låseikon og lesbar verdi.

Aksel skiller mellom disabled og read-only — read-only skal brukes for felt som skal være lesbare men ikke redigerbare. Det er også et tilgjengelighetspoeng: disabled tas ut av tab-rekkefølgen og leses dårlig av skjermlesere, mens read-only forblir fokuserbart og annonseres.
[MELOSYS-8098](https://jira.adeo.no/browse/MELOSYS-8098)

- Behandlingstema («Knytt til eksisterende sak») fra disabled til read-only
- Sakstype («Opprett ny sak» i journalpost-/journalføringsflyten) fra disabled til read-only — felt funnet i tillegg til eksempelet i saken
- Oppdaterte enhetstester (readOnly i stedet for disabled) og la til en frontend PW-test (Playwright) for Behandlingstema

## Testing
- [x] Enhetstester (begge felt)
- [x] Frontend PW-test (Playwright) — Behandlingstema, mock-sak MEL-1062
- [x] Manuell verifisering lokalt — Sakstype tilhører journalpost-/journalføringsflyten som ikke er PW-dekket, og ble verifisert via lokal simulering
