### PR TITLE
8099 G4P La til unmount-cleanup for debouncede kall i stegkomponenter

### DIFF
--- a/src/felleskomponenter/menypanelForm/soknad.tsx
+++ b/src/felleskomponenter/menypanelForm/soknad.tsx
@@ -199,7 +199,7 @@ function Soknad({
 
   useEffect(() => {
     if (redigerbart && validertOk) debouncedLagreMottatteOpplysninger();
-    else debouncedLagreMottatteOpplysninger.cancel();
+    return () => debouncedLagreMottatteOpplysninger.cancel();
   }, [formValues, redigerbart, validertOk]);
 
   const submitHandler: FormEventHandler<HTMLFormElement> = (event) => {

--- a/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/aarsavregning/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -302,6 +302,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         debouncedOppdaterFritekster(currentValues);
       }
     }
+    return () => debouncedOppdaterFritekster.cancel();
   }, [
     aktivtSteg,
     formValues,

--- a/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingBekreftelse/vurderingBekreftelse.tsx
+++ b/src/sider/eu_eøs/pensjonist/stegKomponenter/vurderingBekreftelse/vurderingBekreftelse.tsx
@@ -168,6 +168,7 @@ function VurderingBekreftelse({ tilbake, aktivtSteg }: Props) {
 
   useEffect(() => {
     debouncedOppdaterFritekster(formValues);
+    return () => debouncedOppdaterFritekster.cancel();
   }, [formValues?.begrunnelseFritekst]);
 
   const hentTrygdeavgiftMottaker = () => {
@@ -233,6 +234,7 @@ function VurderingBekreftelse({ tilbake, aktivtSteg }: Props) {
     debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus, formValues });
 
     return () => {
+      debouncedKontrollerBehandling.cancel();
       dispatch(kontrollOperations.resetKontrollFeil());
     };
   }, [aktivtSteg, redigerbart, mottatteOpplysningerStatus]);

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
@@ -235,6 +235,7 @@ export function VurderingArbeidTjenestepersonEllerFlyVedtak({
 
   useEffect(() => {
     debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus, formValues });
+    return () => debouncedKontrollerBehandling.cancel();
   }, [aktivtSteg, formValues?.vedtakstype, formValues?.kopiTilArbeidsgiver, mottatteOpplysningerStatus]);
 
   const onSubmit = async () => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak_Legacy/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArbeidTjenestepersonEllerFlyVedtak_Legacy/vurderingArbeidTjenestepersonEllerFlyVedtak.jsx
@@ -284,6 +284,7 @@ export function VurderingArbeidTjenestepersonEllerFlyVedtak({
 
   useEffect(() => {
     debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus, formValues });
+    return () => debouncedKontrollerBehandling.cancel();
   }, [aktivtSteg, formIsValid, formValues?.kopiTilArbeidsgiver, mottatteOpplysningerStatus]);
 
   const onSubmit = async (values, dispatch, props) => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel13_x_vedtak/vurderingArtikkel13_x_vedtak.jsx
@@ -84,6 +84,7 @@ export function VurderingArtikkel13_x_vedtak({
 
   useEffect(() => {
     debouncedKontrollerBehandling({ aktivtSteg, formIsValid, formValues, mottatteOpplysningerStatus });
+    return () => debouncedKontrollerBehandling.cancel();
   }, [aktivtSteg, formIsValid, mottatteOpplysningerStatus]);
 
   const oppdaterLovvalgsperiode = async (fomdato, tomdato) => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Anmodning/vurderingArtikkel16Anmodning.tsx
@@ -172,6 +172,7 @@ export function VurderingArtikkel16Anmodning({
 
   useEffect(() => {
     debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus });
+    return () => debouncedKontrollerBehandling.cancel();
   }, [aktivtSteg, mottatteOpplysningerStatus]);
 
   const handleEndretUnntakFraBestemmelse = async (event: ChangeEvent<HTMLSelectElement>) => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16MottaSvar/formKomponent.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16MottaSvar/formKomponent.tsx
@@ -83,6 +83,7 @@ function FormKomponent({ redigerbart, formValues, oppdaterData, formIsValid }: F
     if (redigerbart) {
       debouncedLagreSvar({ ...formValues, formIsValid });
     }
+    return () => debouncedLagreSvar.cancel();
   }, [formValues, formIsValid]);
 
   if (!formValues) return null;

--- a/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/vurderingArtikkel16Vedtak.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingArtikkel16Vedtak/vurderingArtikkel16Vedtak.tsx
@@ -141,6 +141,7 @@ export function VurderingArtikkel16Vedtak({
 
   useEffect(() => {
     debouncedKontrollerBehandling({ aktivtSteg, formValues, mottatteOpplysningerStatus, formIsValid });
+    return () => debouncedKontrollerBehandling.cancel();
   }, [aktivtSteg, formIsValid, mottatteOpplysningerStatus]);
 
   const validerForm = () => {

--- a/src/sider/eu_eøs/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/eu_eøs/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -224,6 +224,7 @@ function VurderingVedtak({
 
   useEffect(() => {
     debouncedKontrollerBehandling({ aktivtSteg, formValues, mottatteOpplysningerStatus });
+    return () => debouncedKontrollerBehandling.cancel();
   }, [redigerbart, formIsValid, aktivtSteg, formValues?.kopiTilArbeidsgiver, mottatteOpplysningerStatus]);
 
   const validerForm = () => {

--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingPeriode/vurderingPerioder.tsx
@@ -235,6 +235,7 @@ export function VurderingPerioder({ bekreft, tilbake, aktivtSteg, oppdaterStatus
     if (redigerbart && aktivtSteg) {
       debouncedLagreMedlemskapsperioder(formValues.medlemskapsperioder, stegErGyldig, undefined);
     }
+    return () => debouncedLagreMedlemskapsperioder.cancel();
   }, [stegErGyldig]);
 
   if (!aktivtSteg || !formValues) return null;

--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -146,6 +146,7 @@ export function VurderingVedtak({ aktivtSteg, tilbake }: Props) {
     ) {
       debouncedOppdaterFritekster(formValues);
     }
+    return () => debouncedOppdaterFritekster.cancel();
   }, [formValues?.innledningFritekst, formValues?.begrunnelseFritekst]);
 
   const oppdaterNyVurderingBakgrunn = (nyVurderingBakgrunn?: string) => {

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingInngang/vurderingInngang.tsx
@@ -145,6 +145,7 @@ function VurderingInngang({
       oppdaterSoeknadsland(formValues?.arbeidsland ? [formValues.arbeidsland] : []);
       debouncedLagremottatteOpplysningerOgOppdaterFlyt();
     }
+    return () => debouncedLagremottatteOpplysningerOgOppdaterFlyt.cancel();
   }, [formValues?.fom, formValues?.tom, formValues?.arbeidsland, formIsValid]);
 
   useEffect(() => {

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -224,6 +224,7 @@ function VurderingVedtak({
 
   useEffect(() => {
     debouncedKontrollerBehandling({ aktivtSteg, mottatteOpplysningerStatus });
+    return () => debouncedKontrollerBehandling.cancel();
   }, [aktivtSteg, resultat.lovvalgsperiodeTom, mottatteOpplysningerStatus]);
 
   const hentProduserbartDokument = (): string => {
@@ -276,6 +277,7 @@ function VurderingVedtak({
     } else {
       debouncedHentMuligeMottakereOgStandardvedlegg.cancel();
     }
+    return () => debouncedHentMuligeMottakereOgStandardvedlegg.cancel();
   }, [steg.status, resultat.bestemmelse, resultat.virksomhet]);
 
   useEffect(() => {
@@ -289,6 +291,7 @@ function VurderingVedtak({
     } else {
       debouncedOppdaterFlyten.cancel();
     }
+    return () => debouncedOppdaterFlyten.cancel();
   }, [
     formValues?.innledningFritekst,
     formValues?.begrunnelseFritekst,

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -274,8 +274,6 @@ function VurderingVedtak({
   useEffect(() => {
     if (steg.status === StegStatus.FERDIG) {
       debouncedHentMuligeMottakereOgStandardvedlegg();
-    } else {
-      debouncedHentMuligeMottakereOgStandardvedlegg.cancel();
     }
     return () => debouncedHentMuligeMottakereOgStandardvedlegg.cancel();
   }, [steg.status, resultat.bestemmelse, resultat.virksomhet]);
@@ -288,8 +286,6 @@ function VurderingVedtak({
         begrunnelseFritekst: formValues.begrunnelseFritekst,
         nyVurderingBakgrunn: getNyVurderingBakgrunn(),
       });
-    } else {
-      debouncedOppdaterFlyten.cancel();
     }
     return () => debouncedOppdaterFlyten.cancel();
   }, [

--- a/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
+++ b/src/sider/unntaksregistrering/vurderingUnntakMedlemskap/vurderingUnntakMedlemskap.tsx
@@ -105,6 +105,7 @@ function VurderingUnntakMedlemskap({ oppdaterStatus, tilbake, aktivtSteg }: Vurd
     if (aktivtSteg && redigerbart) {
       debouncedLagreLovvalgsperiodeOgKontroller(formValues, formState?.isValid, []);
     }
+    return () => debouncedLagreLovvalgsperiodeOgKontroller.cancel();
   }, [formState?.isValid]);
 
   const lagreUtfallRegistreringUnntak = (utfall: string) => {


### PR DESCRIPTION
Legger til unmount-cleanup som kansellerer debouncede kontroll-/lagre-/hente-kall i stegkomponenter, så de ikke fyrer etter at komponenten er avmontert.

Auto-fyrte useEffect-er som trigger en debounced funksjon manglet cleanup. Unmountes komponenten innenfor debounce-vinduet (typisk 500 ms), fyrer kallet etter unmount og kaller setState/dispatch på en avmontert komponent. 

Det gir flaky tester med rød CI (Vitest fanger en unhandled rejection uten at en navngitt test feiler) og overflødige backend-kall ved navigasjon. Oppfølger av MELOSYS-7938 som dekket submit-stien, men ikke unmount-stien.
[MELOSYS-8099](https://jira.adeo.no/browse/MELOSYS-8099)

- `return () => debouncedX.cancel()` i berørte useEffect-er i 14 stegkomponenter (gruppe A + B)
- Inkluderer tre forekomster avdekket ved kodelesing (bl.a. `trygdeavtale/vurderingVedtak` som manglet cancel helt)
- `vurderingAvslag12_x_og_16` holdt utenfor — dekkes av PR #3067

## Testing
- [x] Enhetstester (3250 passert, ingen unhandled rejections)
- [x] tsc + eslint grønt
- [x] Grønn CI (endelig bekreftelse — flaken er timing-avhengig)