### PR TITLE
NOJIRA G4P Oppdater caniuse-lite til 1.0.30001793

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2670,9 +2670,9 @@ packages:
       { integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA== }
     engines: { node: ">=10" }
 
-  caniuse-lite@1.0.30001753:
+  caniuse-lite@1.0.30001793:
     resolution:
-      { integrity: sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw== }
+      { integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA== }
 
   capital-case@1.0.4:
     resolution:
@@ -8439,7 +8439,7 @@ snapshots:
 
   browserslist@4.24.5:
     dependencies:
-      caniuse-lite: 1.0.30001753
+      caniuse-lite: 1.0.30001793
       electron-to-chromium: 1.5.157
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.5)
@@ -8487,7 +8487,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001753: {}
+  caniuse-lite@1.0.30001793: {}
 
   capital-case@1.0.4:
     dependencies:


### PR DESCRIPTION
Oppdaterer caniuse-lite fra 1.0.30001753 til 1.0.30001793 (nyeste).

caniuse-lite er datagrunnlaget browserslist bruker for å avgjøre nettleserstøtte, og lå flere måneder bak. Det ga en «caniuse-lite is outdated»-advarsel ved bygg. Pakken er en transitiv avhengighet som ikke fanges av Dependabot, så den ble oppdatert manuelt med `update-browserslist-db`. Diffen er holdt kirurgisk – kun caniuse-lite, ingen reformatering av resten av lockfilen.

- Bumpet `caniuse-lite` til `1.0.30001793` i `pnpm-lock.yaml`

## Testing
- [x] `pnpm install --frozen-lockfile` bekrefter at lockfilen er konsistent
- [ ] Ingen kildekodeendring – ingen enhets-/E2E-tester relevante