### PR TITLE
7866 Fikset ugyldig HTML-nesting (div i p) i vedtak-steg

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -533,7 +533,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
         <>
           {!erDelvisOpphør && (
             <>
-              <Nav.BodyLong weight="semibold" size="small" className="fritekst_overskrift">
+              <Nav.BodyLong as="div" weight="semibold" size="small" className="fritekst_overskrift">
                 <LabelMedHjelpetekst label="Fritekst til innledning" hjelpetekst={innledningFritekstHjelpetekst} />
               </Nav.BodyLong>
               <Forms.HtmlEditor
@@ -545,7 +545,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
             </>
           )}
 
-          <Nav.BodyLong weight="semibold" size="small" className="fritekst_overskrift">
+          <Nav.BodyLong as="div" weight="semibold" size="small" className="fritekst_overskrift">
             <LabelMedHjelpetekst label="Fritekst til begrunnelse" hjelpetekst={begrunnelseFritekstHjelpetekst} />
           </Nav.BodyLong>
           <Forms.HtmlEditor
@@ -557,7 +557,7 @@ export function VurderingVedtak({ tilbake, aktivtSteg }: Props) {
 
           {!erIkkeYrkesaktiv && !erDelvisOpphør && (
             <>
-              <Nav.BodyLong weight="semibold" size="small" className="fritekst_overskrift">
+              <Nav.BodyLong as="div" weight="semibold" size="small" className="fritekst_overskrift">
                 <LabelMedHjelpetekst
                   label="Fritekst til avsnitt om trygdeavgift"
                   hjelpetekst={trygdeavgiftFritekstHjelpetekst}

--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingVedtak/lovvalgsperiode.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingVedtak/lovvalgsperiode.tsx
@@ -88,7 +88,7 @@ export function Lovvalgsperiode({ kontrollerFerdigbehandling, onRedigeringErAkti
 
   return (
     <Nav.Column>
-      <Nav.BodyLong weight="semibold" size="small" className="info">
+      <Nav.BodyLong as="div" weight="semibold" size="small" className="info">
         <LabelMedHjelpetekst label="Periode" hjelpetekst={PERIODE_HJELPETEKST} />
       </Nav.BodyLong>
 

--- a/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/ikkeYrkesaktiv/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -247,7 +247,7 @@ export function VurderingVedtak({ aktivtSteg, tilbake }: Props) {
       )}
 
       <Nav.Row>
-        <Nav.BodyLong weight="semibold" size="small" className="fritekst_overskrift">
+        <Nav.BodyLong as="div" weight="semibold" size="small" className="fritekst_overskrift">
           <LabelMedHjelpetekst label="Fritekst til innledning" hjelpetekst={INNLEDNING_FRITEKST_HJELPETEKST} />
         </Nav.BodyLong>
         <Forms.HtmlEditor
@@ -260,7 +260,7 @@ export function VurderingVedtak({ aktivtSteg, tilbake }: Props) {
       </Nav.Row>
 
       <Nav.Row>
-        <Nav.BodyLong weight="semibold" size="small" className="fritekst_overskrift">
+        <Nav.BodyLong as="div" weight="semibold" size="small" className="fritekst_overskrift">
           <LabelMedHjelpetekst label="Fritekst til begrunnelse" hjelpetekst={BEGRUNNELSE_FRITEKST_HJELPETEKST} />
         </Nav.BodyLong>
         <Forms.HtmlEditor

--- a/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
+++ b/src/sider/trygdeavtale/stegKomponenter/vurderingVedtak/vurderingVedtak.tsx
@@ -387,7 +387,7 @@ function VurderingVedtak({
         </Nav.Column>
 
         <Nav.Column xs="5">
-          <Nav.BodyLong weight="semibold" size="small" className={vurderingVedtakCls.element("info")}>
+          <Nav.BodyLong as="div" weight="semibold" size="small" className={vurderingVedtakCls.element("info")}>
             <LabelMedHjelpetekst label="Periode" hjelpetekst={PERIODE_HJELPETEKST} />
           </Nav.BodyLong>
           <Nav.BodyLong size="small" className={vurderingVedtakCls.element("datofelt_wrapper")}>
@@ -463,7 +463,12 @@ function VurderingVedtak({
         </>
       )}
 
-      <Nav.BodyLong weight="semibold" size="small" className={vurderingVedtakCls.element("fritekst_overskrift")}>
+      <Nav.BodyLong
+        as="div"
+        weight="semibold"
+        size="small"
+        className={vurderingVedtakCls.element("fritekst_overskrift")}
+      >
         <LabelMedHjelpetekst label="Fritekst til innledning" hjelpetekst={INNLEDNING_FRITEKST} />
       </Nav.BodyLong>
       <Skjema.HTMLEditor
@@ -472,7 +477,7 @@ function VurderingVedtak({
         disabled={!redigerbart}
       />
 
-      <Nav.BodyLong size="small" className={vurderingVedtakCls.element("fritekst_overskrift")}>
+      <Nav.BodyLong as="div" size="small" className={vurderingVedtakCls.element("fritekst_overskrift")}>
         <LabelMedHjelpetekst label="Fritekst til begrunnelse" hjelpetekst={BEGRUNNELSE_FRITEKST_HJELPETEKST} />
       </Nav.BodyLong>
       <Skjema.HTMLEditor


### PR DESCRIPTION
Fikser ugyldig HTML-nesting der `LabelMedHjelpetekst` (som inneholder `Nav.HelpText`) lå inne i `Nav.BodyLong`. `Nav.BodyLong` rendrer `<p>`, mens `Nav.HelpText` sin popover rendrer `<div>` — `<div>` inne i `<p>` er ugyldig HTML og ga hydration-warning i konsollen på vedtak-stegene.

Løst ved å sette `as="div"` på de berørte `Nav.BodyLong`. Da rendres `<div>` i stedet for `<p>`, samtidig som alle Aksel-typografiklasser, `weight`, `size` og `className` beholdes automatisk — ingen visuell endring.
[MELOSYS-7866](https://jira.adeo.no/browse/MELOSYS-7866)

- `as="div"` på 9 `Nav.BodyLong` som wrapper `LabelMedHjelpetekst`
- Berører FTRL-, ikke-yrkesaktiv- og trygdeavtale-vedtak

## Testing
- [x] Enhetstester (3258 grønne, tsc + eslint rene)
- [x] Manuell testing lokalt
- [ ] E2E-tester (ikke relevant)