### PR TITLE
8141 Send innledningFritekst fra opphørsvedtak-steget ved autolagring

### DIFF
--- a/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtakOpphoer/vurderingVedtakOpphoer.tsx
+++ b/src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtakOpphoer/vurderingVedtakOpphoer.tsx
@@ -80,6 +80,7 @@ export function VurderingVedtakOpphoer({ tilbake, aktivtSteg }: Props) {
   const oppdaterFritekster = (values: FormValuesProps) => {
     if (values && redigerbart && !vedtakPending) {
       Api.Behandlinger.resultat.oppdaterFritekster(behandlingID, {
+        innledningFritekst: "",
         begrunnelseFritekst: values.begrunnelseFritekst,
       });
     }


### PR DESCRIPTION
Legger til `innledningFritekst: ""` i autolagrings-payloaden fra
opphørsvedtak-steget, slik at API-et ikke lenger får null for feltet.

Opphørsvedtak-skjermen (ftrl § 2-15, manglende innbetaling) autolagrer
fritekst med kun `begrunnelseFritekst`, mens melosys-api forventer
`innledningFritekst` som non-null Kotlin-streng. Resultatet er 500/NPE
i prod-loggene ved hver autolagring (UI-et er upåvirket siden kallet er
fire-and-forget). Skjermen har ikke innledningsfelt — innledningen er
standardisert for opphørsvedtak — så tom streng sendes eksplisitt,
samme mønster som pensjonist-bekreftelsen (`vurderingBekreftelse.tsx`).
[MELOSYS-8141](https://jira.adeo.no/browse/MELOSYS-8141)

- `innledningFritekst: ""` lagt til i payloaden i `vurderingVedtakOpphoer.tsx`

## Testing
- [x] Enhetstester (komponentens 3 tester grønne, tsc/eslint/prettier ok)
- [ ] Manuell testing lokalt
- [x] E2E: `ftrl-manglende-innbetaling-opphor.spec.ts` — fjern
  `@expect-docker-errors` i melosys-e2e-tests etter at fiksen er ute

## Notater
Søsterendring i melosys-api (gjøre `innledningFritekst` nullable i
`oppdaterFritekster`) håndteres separat som defence in depth.